### PR TITLE
fix(util): always use kebab-case for basic computed css properties

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 
 import isBoolean from 'lodash/isBoolean';
 import isEmpty from 'lodash/isEmpty';
+import kebabCase from 'lodash/kebabCase';
 
 /////////////////////////////
 //                         //
@@ -19,10 +20,10 @@ import isEmpty from 'lodash/isEmpty';
  */
 function getBasicClass({ prefix, type, value }) {
     if (isBoolean(value)) {
-        return `${prefix}--is-${type}`;
+        return `${prefix}--is-${kebabCase(type)}`;
     }
 
-    return `${prefix}--${type}-${value}`;
+    return `${prefix}--${kebabCase(type)}-${value}`;
 }
 
 /**


### PR DESCRIPTION
# Description

By passing camelCased properties to the `handleBasicClasses` function (https://github.com/lumapps/design-system/blob/master/src/core/utils.js#L39), className was computed as is.

This PR always transforms computed css properties to match BEM naming standards.

