### PR TITLE
fix(table): avoid bad style on header with long label

### DIFF
--- a/src/components/table/angularjs/table-cell-head.html
+++ b/src/components/table/angularjs/table-cell-head.html
@@ -5,26 +5,28 @@
     scope="{{ lumx.scope }}"
     tabindex="{{ lumx.isSortable ? 0 : -1 }}"
 >
-    <lumx-icon
-        class="lumx-table__cell-icon"
-        lumx-path="{{ lumx.icon }}"
-        lumx-size="xxs"
-        ng-if="lumx.icon && !lumx.isSortable"
-    ></lumx-icon>
+    <div class="lumx-table__cell-content">
+        <lumx-icon
+            class="lumx-table__cell-icon"
+            lumx-path="{{ lumx.icon }}"
+            lumx-size="xxs"
+            ng-if="lumx.icon && !lumx.isSortable"
+        ></lumx-icon>
 
-    <lumx-icon
-        class="lumx-table__cell-icon"
-        lumx-path="{{ lumx.icons.mdiArrowUp }}"
-        lumx-size="xxs"
-        ng-if="lumx.isSortable && lumx.sortOrder === 'asc'"
-    ></lumx-icon>
+        <lumx-icon
+            class="lumx-table__cell-icon"
+            lumx-path="{{ lumx.icons.mdiArrowUp }}"
+            lumx-size="xxs"
+            ng-if="lumx.isSortable && lumx.sortOrder === 'asc'"
+        ></lumx-icon>
 
-    <lumx-icon
-        class="lumx-table__cell-icon"
-        lumx-path="{{ lumx.icons.mdiArrowDown }}"
-        lumx-size="xxs"
-        ng-if="lumx.isSortable && lumx.sortOrder === 'desc'"
-    ></lumx-icon>
+        <lumx-icon
+            class="lumx-table__cell-icon"
+            lumx-path="{{ lumx.icons.mdiArrowDown }}"
+            lumx-size="xxs"
+            ng-if="lumx.isSortable && lumx.sortOrder === 'desc'"
+        ></lumx-icon>
 
-    <div class="lumx-table__cell-content" ng-transclude></div>
+        <ng-transclude></ng-transclude>
+    </div>
 </th>

--- a/src/components/table/angularjs/table-cell-head.html
+++ b/src/components/table/angularjs/table-cell-head.html
@@ -5,7 +5,7 @@
     scope="{{ lumx.scope }}"
     tabindex="{{ lumx.isSortable ? 0 : -1 }}"
 >
-    <div class="lumx-table__cell-content">
+    <div class="lumx-table__cell-wrapper">
         <lumx-icon
             class="lumx-table__cell-icon"
             lumx-path="{{ lumx.icon }}"
@@ -27,6 +27,6 @@
             ng-if="lumx.isSortable && lumx.sortOrder === 'desc'"
         ></lumx-icon>
 
-        <ng-transclude></ng-transclude>
+        <div class="lumx-table__cell-content" ng-transclude></div>
     </div>
 </th>

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -163,7 +163,7 @@ const TableCell: React.FC<TableCellProps> = ({
                             [`${CLASSNAME}--is-sorted`]: isSortable && sortOrder,
                         },
                     )}
-                    tabIndex={isSortable && isFunction(onHeaderClick) ? 1 : undefined}
+                    tabIndex={isSortable && isFunction(onHeaderClick) ? 0 : -1}
                     onClick={handleOnHeaderClick}
                     onKeyDown={onEnterPressed(handleOnHeaderClick)}
                     {...props}

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -163,22 +163,26 @@ const TableCell: React.FC<TableCellProps> = ({
                             [`${CLASSNAME}--is-sorted`]: isSortable && sortOrder,
                         },
                     )}
-                    tabIndex={isSortable && isFunction(onHeaderClick) ? 1 : 0}
+                    tabIndex={isSortable && isFunction(onHeaderClick) ? 1 : undefined}
                     onClick={handleOnHeaderClick}
                     onKeyDown={onEnterPressed(handleOnHeaderClick)}
                     {...props}
                 >
-                    {icon && !isSortable && <Icon className={`${CLASSNAME}-icon`} icon={icon} size={IconSizes.xxs} />}
+                    <div className={`${CLASSNAME}-content`}>
+                        {icon && !isSortable && (
+                            <Icon className={`${CLASSNAME}-icon`} icon={icon} size={IconSizes.xxs} />
+                        )}
 
-                    {isSortable && sortOrder === Orders.asc && (
-                        <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowUp} size={IconSizes.xxs} />
-                    )}
+                        {isSortable && sortOrder === Orders.asc && (
+                            <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowUp} size={IconSizes.xxs} />
+                        )}
 
-                    {isSortable && sortOrder === Orders.desc && (
-                        <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowDown} size={IconSizes.xxs} />
-                    )}
+                        {isSortable && sortOrder === Orders.desc && (
+                            <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowDown} size={IconSizes.xxs} />
+                        )}
 
-                    <div className={`${CLASSNAME}-content`}>{children}</div>
+                        {children}
+                    </div>
                 </th>
             )}
 

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -168,7 +168,7 @@ const TableCell: React.FC<TableCellProps> = ({
                     onKeyDown={onEnterPressed(handleOnHeaderClick)}
                     {...props}
                 >
-                    <div className={`${CLASSNAME}-content`}>
+                    <div className={`${CLASSNAME}-wrapper`}>
                         {icon && !isSortable && (
                             <Icon className={`${CLASSNAME}-icon`} icon={icon} size={IconSizes.xxs} />
                         )}
@@ -181,7 +181,7 @@ const TableCell: React.FC<TableCellProps> = ({
                             <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowDown} size={IconSizes.xxs} />
                         )}
 
-                        {children}
+                        <div className={`${CLASSNAME}-content`}>{children}</div>
                     </div>
                 </th>
             )}

--- a/src/components/table/style/lumapps/_index.scss
+++ b/src/components/table/style/lumapps/_index.scss
@@ -78,6 +78,7 @@
 
         thead & {
             @include lumx-typography(caption);
+
             display: inline-block;
             vertical-align: middle;
         }

--- a/src/components/table/style/lumapps/_index.scss
+++ b/src/components/table/style/lumapps/_index.scss
@@ -11,7 +11,7 @@
 
     &__cell {
         height: 56px;
-        padding: $lumx-spacing-unit $lumx-spacing-unit * 4 $lumx-spacing-unit 0;
+        padding: $lumx-spacing-unit $lumx-spacing-unit * 3 $lumx-spacing-unit 0;
         text-align: left;
 
         thead & {
@@ -65,22 +65,26 @@
         }
     }
 
+    &__cell-wrapper {
+        thead & {
+            display: flex;
+            align-items: flex-start;
+        }
+    }
+
     &__cell-icon {
         thead & {
-            display: inline-block;
+            margin-top: 1px;
             margin-right: $lumx-spacing-unit / 2;
-            vertical-align: middle;
         }
     }
 
     &__cell-content {
+        hyphens: auto;
         word-break: break-word;
 
         thead & {
             @include lumx-typography(caption);
-
-            display: inline-block;
-            vertical-align: middle;
         }
 
         tbody & {

--- a/src/components/table/style/lumapps/_index.scss
+++ b/src/components/table/style/lumapps/_index.scss
@@ -74,12 +74,10 @@
     }
 
     &__cell-content {
-        hyphens: auto;
-        word-break: break-all;
+        word-break: break-word;
 
         thead & {
             @include lumx-typography(caption);
-
             display: inline-block;
             vertical-align: middle;
         }


### PR DESCRIPTION
En cas de long label, les icons doivent rester au niveau du texte. Ils doivent être wrappés dans la même div.

Un header non sortable (donc non cliquable) ne doit pas avoir de tabindex

