### PR TITLE
lint: relax tslint rules on jsdoc and some typedef

### DIFF
--- a/demo/constants.d.ts
+++ b/demo/constants.d.ts
@@ -15,19 +15,11 @@ declare type Theme = Themes;
 
 /**
  * The available themes in the demo site.
- *
- * @type {Object}
- * @constant
- * @readonly
  */
-declare const THEMES: { [key: Theme]: Theme };
+declare const THEMES: { [key in Themes]: Theme };
 
 /**
  * The default theme to use in the demo site at startup.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 declare const DEFAULT_THEME: Theme;
 

--- a/demo/react/App.tsx
+++ b/demo/react/App.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, ReactElement, useEffect, useState } from 'react';
 
 import last from 'lodash/last';
 
@@ -18,9 +18,9 @@ import { SubNav } from './layout/SubNav';
  * It also handle the changes of the theme and the changes of the active component demo page (which will be displayed
  * in the main display component).
  *
- * @return {React.ReactNode} The main application component.
+ * @return The main application component.
  */
-const App: React.FC = (): React.ReactNode => {
+const App: React.FC = (): ReactElement => {
     const [activeComponent, setActiveComponent]: [string, (activeComponent: string) => void] = useState(
         last(window.location.pathname.split('/')) || '',
     );

--- a/demo/react/ErrorBoundary.tsx
+++ b/demo/react/ErrorBoundary.tsx
@@ -19,8 +19,8 @@ class ErrorBoundary extends React.Component<{}, IState> {
     /**
      * When an error occurred, save the error in the state so that we can display it in the fallback display.
      *
-     * @param  {Error}  error The error that occurred.
-     * @return {IState} The new state of the component.
+     * @param  error The error that occurred.
+     * @return The new state of the component.
      */
     public static getDerivedStateFromError(error: Error): IState {
         return { error, hasError: true };

--- a/demo/react/components/avatar/default.tsx
+++ b/demo/react/components/avatar/default.tsx
@@ -21,7 +21,7 @@ interface IProps {
 /**
  * The demo for the default <Avatar>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/avatar/index.tsx
+++ b/demo/react/components/avatar/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Avatars';
+const title = 'Avatars';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string = 'Enables user to quickly identify people.';
+const description = 'Enables user to quickly identify people.';
 
 const demos: { [demoName: string]: DemoObject } = {
     /* tslint:disable: object-literal-sort-keys */

--- a/demo/react/components/button/default.tsx
+++ b/demo/react/components/button/default.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <Button>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/button/disabled.tsx
+++ b/demo/react/components/button/disabled.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the disabled <Button>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/button/dropdown.tsx
+++ b/demo/react/components/button/dropdown.tsx
@@ -17,7 +17,7 @@ interface IProps {
 /**
  * The demo for the <DropdownButton>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const onClick: (splitted: boolean) => void = (splitted: boolean = false): (() => void) => {

--- a/demo/react/components/button/index.tsx
+++ b/demo/react/components/button/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Buttons';
+const title = 'Buttons';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/button/sizes.tsx
+++ b/demo/react/components/button/sizes.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the all the <Button>s sizes.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/button/with-icons.tsx
+++ b/demo/react/components/button/with-icons.tsx
@@ -17,7 +17,7 @@ interface IProps {
 /**
  * The demo for the <Button>s with icons and <IconButton>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/checkbox/default.tsx
+++ b/demo/react/components/checkbox/default.tsx
@@ -18,7 +18,7 @@ interface IProps {
 /**
  * The demo for the default <Checkbox>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const [checkboxes, setCheckboxes]: [boolean[], React.Dispatch<React.SetStateAction<boolean[]>>] = useState([

--- a/demo/react/components/checkbox/index.tsx
+++ b/demo/react/components/checkbox/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Checkbox';
+const title = 'Checkbox';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string = 'Checkboxes allow users to set a boolean parameter.';
+const description = 'Checkboxes allow users to set a boolean parameter.';
 
 const demos: { [demoName: string]: DemoObject } = {
     /* tslint:disable: object-literal-sort-keys */

--- a/demo/react/components/chip/default.tsx
+++ b/demo/react/components/chip/default.tsx
@@ -19,7 +19,7 @@ interface IProps {
 /**
  * The demo for the default <Chip>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/chip/index.tsx
+++ b/demo/react/components/chip/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Chips';
+const title = 'Chips';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/image-block/default.tsx
+++ b/demo/react/components/image-block/default.tsx
@@ -33,7 +33,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
 /**
  * The demo for the default <ImageBlock>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/image-block/index.tsx
+++ b/demo/react/components/image-block/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'ImageBlocks';
+const title = 'ImageBlocks';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -26,7 +26,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
 /**
  * The demo for the default <Lightbox>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const [isOpened, setIsOpened]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);

--- a/demo/react/components/lightbox/index.tsx
+++ b/demo/react/components/lightbox/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Lightboxs';
+const title = 'Lightboxs';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/list/big.tsx
+++ b/demo/react/components/list/big.tsx
@@ -31,7 +31,7 @@ interface IProps {
 /**
  * The demo for the default <List>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/list/default.tsx
+++ b/demo/react/components/list/default.tsx
@@ -30,7 +30,7 @@ interface IProps {
 /**
  * The demo for the default <List>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/list/huge.tsx
+++ b/demo/react/components/list/huge.tsx
@@ -32,7 +32,7 @@ interface IProps {
 /**
  * The demo for the default <List>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/list/index.tsx
+++ b/demo/react/components/list/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Lists';
+const title = 'Lists';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string = 'List displays related content grouped together and organized vertically.';
+const description = 'List displays related content grouped together and organized vertically.';
 
 const demos: { [demoName: string]: DemoObject } = {
     /* tslint:disable: object-literal-sort-keys */

--- a/demo/react/components/list/tiny.tsx
+++ b/demo/react/components/list/tiny.tsx
@@ -42,7 +42,7 @@ const onItemSelectedHandler: (data: any) => void = (data: any): void => {
 /**
  * The demo for the default <List>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda typedef
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (

--- a/demo/react/components/popover/controled.tsx
+++ b/demo/react/components/popover/controled.tsx
@@ -47,7 +47,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
 /**
  * The demo for the default <Popover>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => {

--- a/demo/react/components/popover/default.tsx
+++ b/demo/react/components/popover/default.tsx
@@ -55,7 +55,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
 /**
  * The demo for the default <Popover>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 // tslint:disable-next-line: typedef
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => {

--- a/demo/react/components/popover/index.tsx
+++ b/demo/react/components/popover/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Popovers';
+const title = 'Popovers';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Popovers can be used as a component to position floating elements over the UI but also as a based element to build advanced behavior like tooltips, dropdown selectors, on hover details ... Etc.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/popover/matchParentWidth.tsx
+++ b/demo/react/components/popover/matchParentWidth.tsx
@@ -53,7 +53,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
 /**
  * The demo for the default <Popover>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
@@ -62,7 +62,7 @@ const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
 
     /**
      * Switch tooltip visibility
-     * @param {boolean} newVisibleState Tooltip visibility
+     * @param newVisibleState Tooltip visibility
      */
     const toggleTooltipDisplay: (newVisibleState: boolean) => void = (newVisibleState: boolean): void => {
         setTooltipDisplayed(newVisibleState);

--- a/demo/react/components/popover/offsets.tsx
+++ b/demo/react/components/popover/offsets.tsx
@@ -61,7 +61,7 @@ const offsets: PopperOffsets = { horizontal: -60, vertical: 30 };
 /**
  * The demo for the default <Popover>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 // tslint:disable-next-line: typedef
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => {

--- a/demo/react/components/popover/placements.tsx
+++ b/demo/react/components/popover/placements.tsx
@@ -42,7 +42,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
 /**
  * The demo for the default <Popover>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => {

--- a/demo/react/components/popover/realCase.tsx
+++ b/demo/react/components/popover/realCase.tsx
@@ -71,7 +71,7 @@ const createMultipleActions: React.FC<ButtonThemes> = (theme: any): any => (
 /**
  * The demo for the default <UserBlock>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     // tslint:disable-next-line: typedef
@@ -83,7 +83,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement 
 
     /**
      * Switch tooltip visibility
-     * @param {boolean} newVisibleState Tooltip visibility
+     * @param newVisibleState Tooltip visibility
      */
     const toggleCardDisplay: (newVisibleState: boolean) => void = (newVisibleState: boolean): void => {
         // tslint:disable-next-line: early-exit

--- a/demo/react/components/popover/tooltip.tsx
+++ b/demo/react/components/popover/tooltip.tsx
@@ -36,7 +36,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
 /**
  * The demo for the default <Popover>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 // tslint:disable-next-line: typedef
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => {

--- a/demo/react/components/progress-tracker/default.tsx
+++ b/demo/react/components/progress-tracker/default.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <ProgressTracker>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     // tslint:disable-next-line: typedef

--- a/demo/react/components/progress-tracker/index.tsx
+++ b/demo/react/components/progress-tracker/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'ProgressTrackers';
+const title = 'ProgressTrackers';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/progress/default.tsx
+++ b/demo/react/components/progress/default.tsx
@@ -11,7 +11,7 @@ interface IProps {}
 /**
  * The demo for the default <Progress>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/progress/index.tsx
+++ b/demo/react/components/progress/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Progress';
+const title = 'Progress';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string = '';
+const description = '';
 
 const demos: { [demoName: string]: DemoObject } = {
     /* tslint:disable: object-literal-sort-keys */

--- a/demo/react/components/progress/linear.tsx
+++ b/demo/react/components/progress/linear.tsx
@@ -11,7 +11,7 @@ interface IProps {}
 /**
  * The demo for the default <Progress>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = (): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/slideshow/default.tsx
+++ b/demo/react/components/slideshow/default.tsx
@@ -32,7 +32,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
 /**
  * The demo for the default <Slideshow>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <div style={slideshowWrapperStyle}>

--- a/demo/react/components/slideshow/index.tsx
+++ b/demo/react/components/slideshow/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Slideshows';
+const title = 'Slideshows';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/switch/default.tsx
+++ b/demo/react/components/switch/default.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <Switch>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/switch/index.tsx
+++ b/demo/react/components/switch/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Switchs';
+const title = 'Switchs';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/switch/with-helpers.tsx
+++ b/demo/react/components/switch/with-helpers.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <Switch>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/table/default.tsx
+++ b/demo/react/components/table/default.tsx
@@ -49,8 +49,6 @@ interface IHead {
 /**
  * The body of the table.
  * This represents the data to display in the table.
- *
- * @type {Object}
  */
 const tableBody: IBody[] = [
     {
@@ -82,10 +80,6 @@ const tableBody: IBody[] = [
 /**
  * The head of the table.
  * This represents the cells of the table.
- *
- * @type {Array}
- * @constant
- * @readonly
  */
 const tableHead: IHead[] = [
     {
@@ -124,7 +118,7 @@ const tableHead: IHead[] = [
 /**
  * The demo for the default <Table>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const [dataTableBody, setTable]: [IBody[], Dispatch<SetStateAction<IBody[]>>] = useState(tableBody);
@@ -132,7 +126,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement 
     /**
      * Update the sorting of the table.
      *
-     * @param {Object} headSource The head cell to sort the table by.
+     * @param headSource The head cell to sort the table by.
      */
     const handleSort: (headSource: IHead) => void = useCallback(
         (headSource: IHead) => {

--- a/demo/react/components/table/index.tsx
+++ b/demo/react/components/table/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Tables';
+const title = 'Tables';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Use table to show tabular information that are easy comparable and scannable, such a statistical data.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/tabs/clustered-center.tsx
+++ b/demo/react/components/tabs/clustered-center.tsx
@@ -19,7 +19,7 @@ interface IProps {
 /**
  * The demo for the clustered and centered <Tabs>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(

--- a/demo/react/components/tabs/clustered.tsx
+++ b/demo/react/components/tabs/clustered.tsx
@@ -19,7 +19,7 @@ interface IProps {
 /**
  * The demo for the clustered <Tabs>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(

--- a/demo/react/components/tabs/default.tsx
+++ b/demo/react/components/tabs/default.tsx
@@ -18,7 +18,7 @@ interface IProps {
 /**
  * The demo for the default <Tabs>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(

--- a/demo/react/components/tabs/index.tsx
+++ b/demo/react/components/tabs/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Tabs';
+const title = 'Tabs';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/text-field/default.tsx
+++ b/demo/react/components/text-field/default.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <TextField>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/text-field/disabled.tsx
+++ b/demo/react/components/text-field/disabled.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <TextField>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/text-field/helperText.tsx
+++ b/demo/react/components/text-field/helperText.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <TextField>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/text-field/icon.tsx
+++ b/demo/react/components/text-field/icon.tsx
@@ -17,7 +17,7 @@ interface IProps {
 /**
  * The demo for the default <TextField>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/text-field/index.tsx
+++ b/demo/react/components/text-field/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'TextFields';
+const title = 'TextFields';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/text-field/invalid.tsx
+++ b/demo/react/components/text-field/invalid.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <TextField>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/text-field/placeholder.tsx
+++ b/demo/react/components/text-field/placeholder.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <TextField>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/text-field/valid.tsx
+++ b/demo/react/components/text-field/valid.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <TextField>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/thumbnail/default.tsx
+++ b/demo/react/components/thumbnail/default.tsx
@@ -22,7 +22,7 @@ const componentHolder: CSSProperties = {
 /**
  * The demo for the default <Thumbnail>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/thumbnail/index.tsx
+++ b/demo/react/components/thumbnail/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Thumbnails';
+const title = 'Thumbnails';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string =
+const description =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu sem et mauris convallis tempor. Mauris placerat enim eget ligula fermentum, in aliquam lorem congue. Vivamus lacinia consectetur mollis.';
 
 const demos: { [demoName: string]: DemoObject } = {

--- a/demo/react/components/thumbnail/rounded.tsx
+++ b/demo/react/components/thumbnail/rounded.tsx
@@ -22,7 +22,7 @@ const componentHolder: CSSProperties = {
 /**
  * The demo for the default <Thumbnail>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/tooltip/default.tsx
+++ b/demo/react/components/tooltip/default.tsx
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <Tooltip>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
     const anchorRefTop: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);

--- a/demo/react/components/tooltip/index.tsx
+++ b/demo/react/components/tooltip/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'Tooltips';
+const title = 'Tooltips';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string = '';
+const description = '';
 
 const demos: { [demoName: string]: DemoObject } = {
     /* Tslint:disable: object-literal-sort-keys. */

--- a/demo/react/components/user-block/default.tsx
+++ b/demo/react/components/user-block/default.tsx
@@ -56,7 +56,7 @@ const createMultipleActions: React.FC<ButtonThemes> = (
 /**
  * The demo for the default <UserBlock>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>

--- a/demo/react/components/user-block/horizontal.tsx
+++ b/demo/react/components/user-block/horizontal.tsx
@@ -27,8 +27,8 @@ const fakeUsers: IFakeUser[] = [
 /**
  * This action button should not be rendered in horizontal layout.
  *
- * @param {ButtonThemes} theme Theme to be used
- * @return {React.ReactElement} an action button
+ * @param theme Theme to be used
+ * @return an action button
  */
 const createSimpleAction: React.FC<ButtonThemes> = (
     theme: ButtonThemes,
@@ -48,7 +48,7 @@ const createSimpleAction: React.FC<ButtonThemes> = (
 /**
  * The demo for the default <UserBlock>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <div style={{ display: 'flex', justifyContent: 'space-around' }}>

--- a/demo/react/components/user-block/index.tsx
+++ b/demo/react/components/user-block/index.tsx
@@ -5,7 +5,7 @@ import { Categories, Category, DemoObject } from 'LumX/demo/react/constants';
 /**
  * The title of the demo.
  */
-const title: string = 'UserBlocks';
+const title = 'UserBlocks';
 
 /**
  * The category of the demo.
@@ -15,7 +15,7 @@ const category: Category = Categories.components;
 /**
  * The description of the component.
  */
-const description: string = 'TODO: Add the component description here';
+const description = 'TODO: Add the component description here';
 
 const demos: { [demoName: string]: DemoObject } = {
     /* tslint:disable: object-literal-sort-keys */

--- a/demo/react/layout/DemoBlock.tsx
+++ b/demo/react/layout/DemoBlock.tsx
@@ -70,9 +70,9 @@ interface IESModule {
 /**
  * Load the demo component corresponding to the given demo name.
  *
- * @param  {string}             demoPath The path to the demo folder.
- * @param  {string}             demoName The name of the demo to load the component of.
- * @return {Promise<IESModule>} The promise of the load of the demo component.
+ * @param             demoPath The path to the demo folder.
+ * @param             demoName The name of the demo to load the component of.
+ * @return The promise of the load of the demo component.
  */
 async function _loadDemoComponent(demoPath: string, demoName: string): Promise<IESModule> {
     if (isEmpty(demoPath) || isEmpty(demoName)) {
@@ -85,9 +85,9 @@ async function _loadDemoComponent(demoPath: string, demoName: string): Promise<I
 /**
  * Load the source code of the demo component corresponding to the given demo name.
  *
- * @param  {string}             demoPath The path to the demo folder.
- * @param  {string}             file     The name of the demo to load the source code of.
- * @return {Promise<IESModule>} The promise of the load of the source code of the demo.
+ * @param             demoPath The path to the demo folder.
+ * @param             file     The name of the demo to load the source code of.
+ * @return The promise of the load of the source code of the demo.
  */
 async function _loadSourceCode(demoPath: string, file: string): Promise<IESModule> {
     if (isEmpty(demoPath) || isEmpty(file)) {
@@ -100,12 +100,12 @@ async function _loadSourceCode(demoPath: string, file: string): Promise<IESModul
 /**
  * Wrap a dynamic loading in a promise to be used in the component.
  *
- * @param  {Function} load           The loading function to wrap.
- * @param  {string}   path           The path to the demo folder.
- * @param  {string}   file           The name of the file to load.
- * @param  {Function} setState       The set state function to use with the response of the load.
- * @param  {string}   [defaultValue] The default value to set when an error occurred.
- * @return {Promise} The promise of the load that will resolve with the loaded value (or the default one in case of
+ * @param load           The loading function to wrap.
+ * @param   path           The path to the demo folder.
+ * @param   file           The name of the file to load.
+ * @param setState       The set state function to use with the response of the load.
+ * @param   [defaultValue] The default value to set when an error occurred.
+ * @return The promise of the load that will resolve with the loaded value (or the default one in case of
  *                   error).
  */
 async function _load(
@@ -138,7 +138,7 @@ async function _load(
  * This component will display an interactive demo but also allow to display the source code of this demo.
  * You only have to provide the path to the wanted file (a valid path for the serving server of the demo site).
  *
- * @return {React.ReactElement} The demo block component.
+ * @return The demo block component.
  */
 const DemoBlock: React.FC<IProps> = ({
     blockTitle: title,
@@ -153,7 +153,7 @@ const DemoBlock: React.FC<IProps> = ({
      * Enable/disable the dark theme.
      * This is the callback function of the `onClick` event of the theme <Switch>.
      *
-     * @param {boolean} enabled Indicates if the dark theme should be enabled or not.
+     * @param enabled Indicates if the dark theme should be enabled or not.
      */
     const setDarkTheme: (enabled: boolean) => void = (enabled: boolean): void => {
         setTheme(enabled ? Themes.dark : Themes.light);

--- a/demo/react/layout/DemoHeader.tsx
+++ b/demo/react/layout/DemoHeader.tsx
@@ -36,7 +36,7 @@ interface IProps extends IGenericProps {
  * This component will display the header with information like the category of the demo, the title of the page and a
  * description of the demo.
  *
- * @return {React.ReactElement} The demo header component.
+ * @return The demo header component.
  */
 const DemoHeader: React.FC<IProps> = ({
     category,

--- a/demo/react/layout/Main.tsx
+++ b/demo/react/layout/Main.tsx
@@ -59,8 +59,8 @@ interface IESModule {
 /**
  * Load the demo component corresponding to the currently active component.
  *
- * @param  {string}             componentFolderName The name of the component to load.
- * @return {Promise<IESModule>} The promise of the dynamic load of the component.
+ * @param             componentFolderName The name of the component to load.
+ * @return The promise of the dynamic load of the component.
  */
 async function _loadComponent(componentFolderName: IProps['activeComponent']): Promise<IESModule> {
     if (isEmpty(componentFolderName)) {
@@ -78,7 +78,7 @@ async function _loadComponent(componentFolderName: IProps['activeComponent']): P
  * To do so, it will receive the name of the active component and will dynamically load the demo component from this
  * name.
  *
- * @return {React.ReactElement} The main component.
+ * @return The main component.
  */
 const Main: React.FC<IProps> = ({ activeComponent }: IProps): React.ReactElement => {
     const [demo, setDemo]: [IESModule | undefined, (demo: IESModule | undefined) => void] = useState();

--- a/demo/react/layout/MainNav.tsx
+++ b/demo/react/layout/MainNav.tsx
@@ -8,7 +8,7 @@ import { LumXLogo } from '../../assets/images';
  * The main navigation component.
  * This component will display the main navigation bar.
  *
- * @return {React.ReactElement} The main navigation component.
+ * @return The main navigation component.
  */
 const MainNav: React.FC = (): React.ReactElement => (
     <div className="main-nav">

--- a/demo/react/layout/SubNav.tsx
+++ b/demo/react/layout/SubNav.tsx
@@ -35,10 +35,6 @@ interface IProps {
 /**
  * The list of all sub nav items displayed in the sub navigation.
  * Each item correspond to a component.
- *
- * @type {Array<string>}
- * @constant
- * @readonly
  */
 const NAV_ITEMS: string[] = [
     'Avatar',
@@ -76,7 +72,7 @@ const NAV_ITEMS: string[] = [
  * This component will display the navigation bar for selecting the component the user wants the demo of.
  * It will also display the theme selector to switch the theme of both the demo site and the components in the demo.
  *
- * @return {React.ReactElement} The sub navigation component.
+ * @return The sub navigation component.
  */
 const SubNav: React.FC<IProps> = ({ activeComponent, changeTheme, handleNavigate }: IProps): React.ReactElement => (
     <div className="sub-nav">

--- a/demo/react/layout/SubNavItem.tsx
+++ b/demo/react/layout/SubNavItem.tsx
@@ -43,7 +43,7 @@ interface IProps {
  * This component will display a link with the name of the component it will activate upon click.
  * It will also highlight if it's component matche the activated one.
  *
- * @return {React.ReactElement} The sub navigation item component.
+ * @return The sub navigation item component.
  */
 const SubNavItem: React.FC<IProps> = ({
     children,

--- a/demo/react/layout/ThemeSelector.tsx
+++ b/demo/react/layout/ThemeSelector.tsx
@@ -22,13 +22,13 @@ interface IProps {
  * Display a select with the list of all available themes.
  * When a theme is selected, update the theme throughout the demo site and the components being demoed.
  *
- * @return {React.ReactElement} The theme selector component.
+ * @return The theme selector component.
  */
 const ThemeSelector: React.FC<IProps> = ({ changeTheme }: IProps): React.ReactElement => {
     /**
      * When the select is changed, call the function to change the theme.
      *
-     * @param {ChangeEvent<HTMLSelectElement>} evt The change event of the select element.
+     * @param evt The change event of the select element.
      */
     const handleChange: (evt: React.ChangeEvent<HTMLSelectElement>) => void = (
         evt: ChangeEvent<HTMLSelectElement>,

--- a/demo/utils.d.ts
+++ b/demo/utils.d.ts
@@ -13,8 +13,8 @@ import { Theme } from './constants';
  *
  * @see {@link /demo/constants.d.ts} for the possible value for the theme.
  *
- * @param  {Theme}          theme The theme to enable.
- * @return {Promise<Theme>} The promise of the change.
+ * @param          theme The theme to enable.
+ * @return The promise of the change.
  */
 declare function changeTheme(theme: Theme): Promise<Theme>;
 

--- a/src/components/avatar/react/Avatar.tsx
+++ b/src/components/avatar/react/Avatar.tsx
@@ -51,28 +51,16 @@ interface IDefaultPropsType extends Partial<AvatarProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Avatar`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Avatar`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     size: Sizes.m,
@@ -83,7 +71,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Simple component used to identify user.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Avatar: React.FC<AvatarProps> = ({
     className = '',

--- a/src/components/button/react/Button.test.tsx
+++ b/src/components/button/react/Button.test.tsx
@@ -45,12 +45,8 @@ interface ISetup extends ICommonSetup {
 
 /**
  * The default label to use for the tests.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const DEFAULT_LABEL: string = 'Label';
+const DEFAULT_LABEL = 'Label';
 
 /////////////////////////////
 //                         //
@@ -62,8 +58,8 @@ const DEFAULT_LABEL: string = 'Label';
  * Get the default value of the given prop of a <Button>, depending on the effective props of the component (some
  * default value depends on the value of another prop).
  *
- * @param {string}      prop  The name of the prop you want the default value of.
- * @param {ISetupProps} props The current props of the <Button>.
+ * @param      prop  The name of the prop you want the default value of.
+ * @param props The current props of the <Button>.
  */
 function _getDefaultPropValue({ prop, props }: { prop: string; props?: ISetupProps }): string {
     return prop === 'color'
@@ -77,9 +73,9 @@ function _getDefaultPropValue({ prop, props }: { prop: string; props?: ISetupPro
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/button/react/Button.tsx
+++ b/src/components/button/react/Button.tsx
@@ -113,28 +113,16 @@ interface IDefaultPropsType extends Partial<Omit<ButtonProps, 'color'>> {
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Button`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Button`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     buttonRef: undefined,
@@ -157,8 +145,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Globally validate the component after transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
+ * @param params The children, their number and the props of the component.
+ * @return     If a string, the error message.
  *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
  *                              lead to throw a basic error message).
  *                              You can also return nothing if there is no special problem (i.e. a successful
@@ -182,8 +170,8 @@ function _postValidate({ childrenCount, props }: ValidateParameters): string | b
 /**
  * Globally validate the component before transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
+ * @param params The children, their number and the props of the component.
+ * @return     If a string, the error message.
  *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
  *                              lead to throw a basic error message).
  *                              You can also return nothing if there is no special problem (i.e. a successful
@@ -211,8 +199,8 @@ function _preValidate({ childrenCount, props }: ValidateParameters): string | bo
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {ButtonProps}     props The children and props of the component.
- * @return {React.ReactNode} The processed children of the component.
+ * @param     props The children and props of the component.
+ * @return The processed children of the component.
  */
 function _validate(props: ButtonProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -229,7 +217,7 @@ function _validate(props: ButtonProps): React.ReactNode {
  * Displays a button.
  * If the `href` property is set, it will display a `<a>` HTML tag. If not, it will use a `<button>` HTML tag instead.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Button: React.FC<ButtonProps> = ({
     buttonRef = DEFAULT_PROPS.buttonRef,

--- a/src/components/button/react/ButtonGroup.test.tsx
+++ b/src/components/button/react/ButtonGroup.test.tsx
@@ -36,9 +36,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of
+ * @param props The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of
  *                       the component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/button/react/ButtonGroup.tsx
+++ b/src/components/button/react/ButtonGroup.tsx
@@ -30,28 +30,16 @@ interface IDefaultPropsType extends Partial<ButtonGroupProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ButtonGroup`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ButtonGroup`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 
@@ -65,8 +53,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {ButtonGroupProps} props The children and props of the component.
- * @return {React.ReactNode}    The processed children of the component.
+ * @param props The children and props of the component.
+ * @return    The processed children of the component.
  */
 function _validate(props: ButtonGroupProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -84,7 +72,7 @@ function _validate(props: ButtonGroupProps): React.ReactNode {
  *
  * @see {@link Button} for more information on <Button>.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const ButtonGroup: React.FC<ButtonGroupProps> = ({
     children,

--- a/src/components/button/react/ButtonRoot.test.tsx
+++ b/src/components/button/react/ButtonRoot.test.tsx
@@ -10,12 +10,8 @@ import { ButtonRoot, ButtonRootProps } from './ButtonRoot';
 
 /**
  * The URL to use as test URL.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const TEST_URL: string = 'https://www.lumapps.com';
+const TEST_URL = 'https://www.lumapps.com';
 
 /////////////////////////////
 
@@ -46,9 +42,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
@@ -116,7 +112,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
         });
 
         it('should use the given `href`', (): void => {
-            const testedProp: string = 'href';
+            const testedProp = 'href';
             const modifiedProps: ISetupProps = {
                 [testedProp]: TEST_URL,
             };
@@ -127,7 +123,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
         });
 
         it('should use the given `target`', (): void => {
-            const testedProp: string = 'href';
+            const testedProp = 'target';
             const modifiedProps: ISetupProps = {
                 [testedProp]: '_blank',
                 href: TEST_URL,
@@ -157,7 +153,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
         });
 
         it('should forward any other prop', (): void => {
-            const testedProp: string = 'winter';
+            const testedProp = 'winter';
             const modifiedProps: ISetupProps = {
                 [testedProp]: 'is coming',
             };

--- a/src/components/button/react/ButtonRoot.tsx
+++ b/src/components/button/react/ButtonRoot.tsx
@@ -44,19 +44,11 @@ interface IDefaultPropsType extends Partial<ButtonRootProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ButtonRoot`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ButtonRoot`;
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     buttonRef: undefined,
@@ -72,8 +64,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {ButtonRootProps} props The children and props of the component.
- * @return {React.ReactNode} The processed children of the component.
+ * @param props The children and props of the component.
+ * @return The processed children of the component.
  */
 function _validate(props: ButtonRootProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -88,7 +80,7 @@ function _validate(props: ButtonRootProps): React.ReactNode {
  * The root of the <Button> component.
  * Conditionally adds a `<a>` or a `<button>` HTML tag whether there is an `href` attribute or not.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const ButtonRoot: React.FC<ButtonRootProps> = ({
     buttonRef = DEFAULT_PROPS.buttonRef,

--- a/src/components/button/react/DropdownButton.test.tsx
+++ b/src/components/button/react/DropdownButton.test.tsx
@@ -59,9 +59,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props                   The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of
+ * @param props                   The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of
  *                       the component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
@@ -184,7 +184,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
         it("should use 'button' `variant` whatever the given `variant` prop is", (): void => {
             mockConsole();
 
-            const testedProp: string = 'variant';
+            const testedProp = 'variant' as string;
             const modifiedProps: ISetupProps = {
                 [testedProp]: ButtonVariants.button,
             };
@@ -248,7 +248,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
         });
 
         it('should forward any other props', (): void => {
-            const testedProp: string = 'winter';
+            const testedProp = 'winter';
             const modifiedProps: ISetupProps = {
                 [testedProp]: 'is coming',
             };

--- a/src/components/button/react/DropdownButton.tsx
+++ b/src/components/button/react/DropdownButton.tsx
@@ -82,28 +82,16 @@ interface IDefaultPropsType extends Partial<DropdownButtonProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}DropdownButton`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}DropdownButton`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     splitted: false,
@@ -118,8 +106,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Globally validate the component after transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
+ * @param params The children, their number and the props of the component.
+ * @return     If a string, the error message.
  *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
  *                              lead to throw a basic error message).
  *                              You can also return nothing if there is no special problem (i.e. a successful
@@ -150,8 +138,8 @@ function _postValidate({ props }: ValidateParameters): string | boolean | void {
 /**
  * Globally validate the component before transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
+ * @param params The children, their number and the props of the component.
+ * @return     If a string, the error message.
  *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
  *                              lead to throw a basic error message).
  *                              You can also return nothing if there is no special problem (i.e. a successful
@@ -167,8 +155,8 @@ function _preValidate({ props }: ValidateParameters): string | boolean | void {
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {DropdownButtonProps} props The children and props of the component.
- * @return {React.ReactNode}     The processed children of the component.
+ * @param props The children and props of the component.
+ * @return     The processed children of the component.
  */
 function _validate(props: DropdownButtonProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -191,7 +179,7 @@ function _validate(props: DropdownButtonProps): React.ReactNode {
  * @see {@link IconButton} for more information on <IconButton>.
  * @see {@link ButtonGroup} for more information on <ButtonGroup>.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const DropdownButton: React.FC<DropdownButtonProps> = ({
     children,
@@ -222,8 +210,8 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
     /**
      * Open the dropdown contained in the dropdown button.
      *
-     * @param  {Event}   evt The click event.
-     * @return {boolean} If we should propagate the event or not.
+     * @param   evt The click event.
+     * @return If we should propagate the event or not.
      */
     const openDropdown: (evt: React.MouseEvent<HTMLElement>) => boolean | void = (
         evt: React.MouseEvent<HTMLElement>,

--- a/src/components/button/react/IconButton.test.tsx
+++ b/src/components/button/react/IconButton.test.tsx
@@ -37,9 +37,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of
+ * @param props The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of
  *                       the component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/button/react/IconButton.tsx
+++ b/src/components/button/react/IconButton.tsx
@@ -55,28 +55,16 @@ interface IDefaultPropsType extends Partial<IconButtonProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}IconButton`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}IconButton`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 
@@ -89,8 +77,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * Globally validate the component after transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
+ * @param params The children, their number and the props of the component.
+ * @return     If a string, the error message.
  *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
  *                              lead to throw a basic error message).
  *                              You can also return nothing if there is no special problem (i.e. a successful
@@ -111,8 +99,8 @@ function _postValidate({ props }: ValidateParameters): string | boolean | void {
 /**
  * Globally validate the component before transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
+ * @param params The children, their number and the props of the component.
+ * @return     If a string, the error message.
  *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
  *                              lead to throw a basic error message).
  *                              You can also return nothing if there is no special problem (i.e. a successful
@@ -136,8 +124,8 @@ function _preValidate({ props }: ValidateParameters): string | boolean | void {
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {IconButtonProps} props The children and props of the component.
- * @return {React.ReactNode} The processed children of the component.
+ * @param props The children and props of the component.
+ * @return The processed children of the component.
  */
 function _validate(props: IconButtonProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -158,7 +146,7 @@ function _validate(props: IconButtonProps): React.ReactNode {
  *
  * @see {@link Button} for more information on <Button>.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const IconButton: React.FC<IconButtonProps> = ({
     children,

--- a/src/components/checkbox/react/Checkbox.test.tsx
+++ b/src/components/checkbox/react/Checkbox.test.tsx
@@ -35,9 +35,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/checkbox/react/Checkbox.tsx
+++ b/src/components/checkbox/react/Checkbox.tsx
@@ -51,28 +51,16 @@ interface IDefaultPropsType extends Partial<CheckboxProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Checkbox`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Checkbox`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     checked: false,
@@ -85,7 +73,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Defines a checkbox.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Checkbox: React.FC<CheckboxProps> = ({
     checked = DEFAULT_PROPS.checked,

--- a/src/components/checkbox/react/CheckboxHelper.test.tsx
+++ b/src/components/checkbox/react/CheckboxHelper.test.tsx
@@ -31,9 +31,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/checkbox/react/CheckboxHelper.tsx
+++ b/src/components/checkbox/react/CheckboxHelper.tsx
@@ -31,28 +31,16 @@ interface IDefaultPropsType extends Partial<CheckboxHelperProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}CheckboxHelper`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}CheckboxHelper`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const CLASSNAME: string = `${CSS_PREFIX}-checkbox__helper`;
+const CLASSNAME = `${CSS_PREFIX}-checkbox__helper`;
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 
@@ -61,7 +49,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * Define a checkbox helper component.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const CheckboxHelper: React.FC<CheckboxHelperProps> = ({
     children,

--- a/src/components/checkbox/react/CheckboxLabel.test.tsx
+++ b/src/components/checkbox/react/CheckboxLabel.test.tsx
@@ -31,9 +31,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/checkbox/react/CheckboxLabel.tsx
+++ b/src/components/checkbox/react/CheckboxLabel.tsx
@@ -34,28 +34,16 @@ interface IDefaultPropsType extends Partial<CheckboxLabelProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}CheckboxLabel`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}CheckboxLabel`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const CLASSNAME: string = `${CSS_PREFIX}-checkbox__label`;
+const CLASSNAME = `${CSS_PREFIX}-checkbox__label`;
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     children: '',
@@ -66,7 +54,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Define a checkbox label component.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const CheckboxLabel: React.FC<CheckboxLabelProps> = ({
     checkboxId,

--- a/src/components/chip/react/Chip.test.tsx
+++ b/src/components/chip/react/Chip.test.tsx
@@ -1,15 +1,21 @@
-import { shallow } from 'enzyme';
+import { ShallowWrapper, shallow } from 'enzyme';
 import React from 'react';
 
-import { Chip } from './Chip';
+import { ICommonSetup } from 'LumX/core/testing/utils.test';
+import { Chip, ChipProps } from './Chip';
+
+interface ISetup extends ICommonSetup {
+    after: ShallowWrapper;
+    before: ShallowWrapper;
+}
 
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {Object} propOverrides An object that will extend the default properties.
- * @return {Object} An object with some shortcuts to elements or data required in tests.
+ * @param propOverrides An object that will extend the default properties.
+ * @return An object with some shortcuts to elements or data required in tests.
  */
-const setup = (propOverrides = {}) => {
+const setup = (propOverrides: Partial<ChipProps> = {}): ISetup => {
     const props = {
         LabelComponent: 'Hello World!',
         ...propOverrides,
@@ -127,7 +133,7 @@ describe('<Chip />', () => {
             expect(before).toHaveLength(1);
             expect(before.hasClass('lumx-chip__before--is-clickable')).toEqual(false);
 
-            ({ before } = setup({ before: 'before 2', onBeforeClick: () => true }));
+            ({ before } = setup({ before: 'before 2', onBeforeClick: (): boolean => true }));
             expect(before).toHaveLength(1);
             expect(before.hasClass('lumx-chip__before--is-clickable')).toEqual(true);
         });
@@ -137,7 +143,7 @@ describe('<Chip />', () => {
             expect(after).toHaveLength(1);
             expect(after.hasClass('lumx-chip__after--is-clickable')).toEqual(false);
 
-            ({ after } = setup({ after: 'after 2', onAfterClick: () => true }));
+            ({ after } = setup({ after: 'after 2', onAfterClick: (): boolean => true }));
             expect(after).toHaveLength(1);
             expect(after.hasClass('lumx-chip__after--is-clickable')).toEqual(true);
         });

--- a/src/components/chip/react/Chip.tsx
+++ b/src/components/chip/react/Chip.tsx
@@ -61,28 +61,16 @@ interface IDefaultPropsType extends Partial<ChipProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Chip`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Chip`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     after: null,
@@ -99,7 +87,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Displays information or allow an action on a compact element.
  * This is the base component for all variations of the chips see https://material.io/design/components/chips.html.
  *
- * @return {Component} The Chip component.
+ * @return The Chip component.
  */
 const Chip: React.FC<IChipProps> = ({
     after = DEFAULT_PROPS.after,
@@ -123,7 +111,7 @@ const Chip: React.FC<IChipProps> = ({
     /**
      * Execute the onBeforeClick method passed as a prop but stop propagation to avoid triggering the onClick method.
      *
-     * @param {SyntheticEvent} evt The click event on the before element that triggers this method.
+     * @param evt The click event on the before element that triggers this method.
      */
     const handleOnBeforeClick: (evt: SyntheticEvent) => void = (evt: SyntheticEvent): void => {
         if (!evt) {
@@ -140,7 +128,7 @@ const Chip: React.FC<IChipProps> = ({
     /**
      * Execute the onAfterClick method passed as a prop but stop propagation to avoid triggering the onClick method.
      *
-     * @param {SyntheticEvent} evt The click event on the after element that triggers this method.
+     * @param evt The click event on the after element that triggers this method.
      */
     const handleOnAfterClick: (evt: SyntheticEvent) => void = (evt: SyntheticEvent): void => {
         if (!evt) {

--- a/src/components/chip/react/Chip.tsx
+++ b/src/components/chip/react/Chip.tsx
@@ -99,7 +99,7 @@ const Chip: React.FC<IChipProps> = ({
     isDisabled = DEFAULT_PROPS.isDisabled,
     onAfterClick,
     onBeforeClick,
-    onClick = null,
+    onClick,
     size = DEFAULT_PROPS.size,
     theme = DEFAULT_PROPS.theme,
     ...props
@@ -161,8 +161,8 @@ const Chip: React.FC<IChipProps> = ({
             )}
             role="button"
             tabIndex={isDisabled || !hasOnClick ? -1 : 0}
-            onClick={onClick ? onClick : null}
-            onKeyDown={onClick ? onEnterPressed(onClick) : null}
+            onClick={hasOnClick ? onClick : undefined}
+            onKeyDown={hasOnClick ? onEnterPressed(onClick) : undefined}
             {...props}
         >
             {before && (

--- a/src/components/chip/react/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/chip/react/__snapshots__/Chip.test.tsx.snap
@@ -4,8 +4,6 @@ exports[`<Chip /> Snapshot should render correctly Chip component 1`] = `
 <a
   LabelComponent="Hello World!"
   className="lumx-chip lumx-chip--color-dark lumx-chip--size-m lumx-chip--is-unselected"
-  onClick={null}
-  onKeyDown={null}
   role="button"
   tabIndex={-1}
 >

--- a/src/components/divider/react/Divider.test.tsx
+++ b/src/components/divider/react/Divider.test.tsx
@@ -31,9 +31,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
@@ -86,7 +86,7 @@ describe(`<${Divider.displayName}>`, (): void => {
         });
 
         it('should use the given `theme`', (): void => {
-            const testedProp: string = 'theme';
+            const testedProp = 'theme';
             const modifiedProps: ISetupProps = {
                 [testedProp]: Themes.dark,
             };

--- a/src/components/divider/react/Divider.tsx
+++ b/src/components/divider/react/Divider.tsx
@@ -35,28 +35,16 @@ interface IDefaultPropsType extends Partial<DividerProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Divider`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Divider`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     theme: Themes.light,
@@ -68,7 +56,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Displays a divider.
  * This simply wraps a <hr> element.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Divider: React.FC<DividerProps> = ({
     className = '',

--- a/src/components/dropdown/react/Dropdown.test.tsx
+++ b/src/components/dropdown/react/Dropdown.test.tsx
@@ -31,9 +31,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/dropdown/react/Dropdown.tsx
+++ b/src/components/dropdown/react/Dropdown.tsx
@@ -29,28 +29,16 @@ interface IDefaultPropsType extends Partial<DropdownProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Dropdown`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Dropdown`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 
@@ -59,7 +47,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * Displays a dropdown.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Dropdown: React.FC<DropdownProps> = ({
     children,

--- a/src/components/icon/react/Icon.test.tsx
+++ b/src/components/icon/react/Icon.test.tsx
@@ -43,9 +43,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/icon/react/Icon.tsx
+++ b/src/components/icon/react/Icon.tsx
@@ -53,28 +53,16 @@ interface IDefaultPropsType extends Partial<IconProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Icon`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Icon`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     iconRef: undefined,
@@ -89,7 +77,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Globally validate the component before validating the children.
  *
- * @param {ValidateParameters} props The properties of the component.
+ * @param props The properties of the component.
  */
 function _preValidate({ props }: ValidateParameters): void {
     if (!isEmpty(props.icon)) {
@@ -102,8 +90,8 @@ function _preValidate({ props }: ValidateParameters): void {
 /**
  * Validate the component props.
  *
- * @param  {IconProps}       props The props of the component.
- * @return {React.ReactNode} The processed children of the component.
+ * @param       props The props of the component.
+ * @return The processed children of the component.
  */
 function _validate(props: IconProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -117,7 +105,7 @@ function _validate(props: IconProps): React.ReactNode {
 /**
  * Displays an icon in the form of a HTML <svg> tag with the wanted icon path.
  *
- * @return {React.ReactElement} The component
+ * @return The component
  */
 const Icon: React.FC<IconProps> = ({
     className,

--- a/src/components/image-block/react/ImageBlock.tsx
+++ b/src/components/image-block/react/ImageBlock.tsx
@@ -68,28 +68,16 @@ interface IDefaultPropsType extends Partial<ImageBlockProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ImageBlock`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ImageBlock`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     align: Alignments.left,
@@ -108,7 +96,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Displays an properly structured image block.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const ImageBlock: React.FC<ImageBlockProps> = ({
     align = DEFAULT_PROPS.align,

--- a/src/components/lightbox/react/Lightbox.tsx
+++ b/src/components/lightbox/react/Lightbox.tsx
@@ -58,28 +58,16 @@ interface IDefaultPropsType extends Partial<LightboxProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Lightbox`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Lightbox`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     ariaLabel: 'Lightbox',
@@ -94,7 +82,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Displays content within a modal.
  *
- * @return {JSX.Element | null} Lightbox.
+ * @return Lightbox.
  */
 const Lightbox: React.FC<LightboxProps> = ({
     ariaLabel = DEFAULT_PROPS.ariaLabel,
@@ -161,7 +149,7 @@ const Lightbox: React.FC<LightboxProps> = ({
     /**
      * Desactivate trap and modal.
      *
-     * @param {React.MouseEvent<HTMLDivElement, MouseEvent>} evt Click event.
+     * @param evt Click event.
      */
     const handleClose: (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => void = useCallback(
         (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
@@ -174,7 +162,7 @@ const Lightbox: React.FC<LightboxProps> = ({
     /**
      * Prevent click bubbling to parent.
      *
-     * @param {React.MouseEvent<HTMLDivElement, MouseEvent>} evt Click event.
+     * @param evt Click event.
      */
     const preventClick: (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => void = (
         evt: React.MouseEvent<HTMLDivElement, MouseEvent>,

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -46,28 +46,16 @@ interface IDefaultPropsType extends Partial<ListProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}List`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}List`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     isClickable: false,
@@ -78,7 +66,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * List component - Use vertical layout to display elements
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const List: React.FC<ListProps> = ({
     children,
@@ -97,9 +85,9 @@ const List: React.FC<ListProps> = ({
 
     /**
      * Override the mouse down event - forward the event if needed
-     * @param {MouseEvent}  evt       Mouse event
-     * @param {number}      idx       Index of the target in the list
-     * @param {object}      itemProps Base props
+     * @param  evt       Mouse event
+     * @param      idx       Index of the target in the list
+     * @param      itemProps Base props
      */
     // tslint:disable-next-line: typedef
     const mouseDownHandler = (evt, idx, itemProps) => {
@@ -111,7 +99,7 @@ const List: React.FC<ListProps> = ({
 
     /**
      * Handle the blur event on the list -> we should reset the selection
-     * @param {FocusEvent}  evt Focus event
+     * @param  evt Focus event
      */
     // tslint:disable-next-line: typedef no-unused
     const onListBlured = (evt: React.FocusEvent<HTMLUListElement>) => {
@@ -120,7 +108,7 @@ const List: React.FC<ListProps> = ({
 
     /**
      * Handle the focus event on the list -> we should reset the selection
-     * @param {KeyboardEvent}  evt Focus input event
+     * @param  evt Focus input event
      */
     // tslint:disable-next-line: typedef no-unused
     const onListFocused = (evt: React.FocusEvent<HTMLUListElement>) => {
@@ -129,7 +117,7 @@ const List: React.FC<ListProps> = ({
 
     /**
      * Reset the active element
-     * @param {boolean} fromBlur Is request from blur event
+     * @param fromBlur Is request from blur event
      */
     const resetActiveIndex: (fromBlur: boolean) => void = (fromBlur: boolean): void => {
         if (!isClickable || preventResetOnBlurOrFocus.current) {
@@ -144,7 +132,7 @@ const List: React.FC<ListProps> = ({
 
     /**
      * Handle keyboard interactions
-     * @param {KeyboardEvent}  evt Keybord input event
+     * @param  evt Keybord input event
      */
     // tslint:disable-next-line: typedef
     const onKeyInteraction = (evt: React.KeyboardEvent<HTMLUListElement>) => {
@@ -173,8 +161,8 @@ const List: React.FC<ListProps> = ({
     /**
      * Returns the index of the list item to activate. By default we search for the next
      * available element.
-     * @param  {boolean}  previous Flag which indicates if we should search for the previous list item
-     * @return {number}            Index of the element to activate.
+     * @param  previous Flag which indicates if we should search for the previous list item
+     * @return            Index of the element to activate.
      */
     // tslint:disable-next-line: typedef
     const selectItemOnKeyDown = (previous: boolean): number => {

--- a/src/components/list/react/ListDivider.tsx
+++ b/src/components/list/react/ListDivider.tsx
@@ -30,28 +30,16 @@ interface IDefaultPropsType extends Partial<ListDividerProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ListDivider`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ListDivider`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 /////////////////////////////
@@ -59,7 +47,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * Renders a thin line that will acts as a divider in List
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const ListDivider: React.FC<ListDividerProps> = ({
     className = '',

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -61,28 +61,16 @@ interface IDefaultPropsType extends Partial<ListItemProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ListItem`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ListItem`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     isActive: false,
@@ -96,7 +84,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Component used in List element.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const ListItem: React.FC<ListItemProps> = ({
     after,
@@ -122,7 +110,7 @@ const ListItem: React.FC<ListItemProps> = ({
     /**
      * Prevent the focus event to be trigger on the parent.
      *
-     * @param {FocusEvent} evt Focus event
+     * @param evt Focus event
      */
     // tslint:disable-next-line: typedef
     const preventParentFocus = (evt: React.FocusEvent<HTMLLIElement>): void => {
@@ -132,7 +120,7 @@ const ListItem: React.FC<ListItemProps> = ({
 
     /**
      * Currying the on entre press behavior.
-     * @return {Object} Returns either undefined or a callback
+     * @return Returns either undefined or a callback
      */
     // tslint:disable-next-line: typedef
     const onKeyDown = () => {

--- a/src/components/list/react/ListSubheader.tsx
+++ b/src/components/list/react/ListSubheader.tsx
@@ -33,28 +33,16 @@ interface IDefaultPropsType extends Partial<ListSubheaderProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ListSubheader`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ListSubheader`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 /////////////////////////////
@@ -62,7 +50,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * Component used in List to display some separator / title section.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 // tslint:disable: no-unused
 const ListSubheader: React.FC<ListSubheaderProps> = ({

--- a/src/components/popover/react/Popover.tsx
+++ b/src/components/popover/react/Popover.tsx
@@ -10,10 +10,10 @@ import { handleBasicClasses } from 'LumX/core/utils';
 
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from 'react-popper';
 
-const SHOW_HIDE_DELAY: number = 500;
+const SHOW_HIDE_DELAY = 500;
 
 // Margin applied when using the fillWidth / fillHeight props
-const SAFE_ZONE: number = 8;
+const SAFE_ZONE = 8;
 
 // Reference to the anchor element
 let anchorRef: HTMLDivElement | null;
@@ -107,28 +107,16 @@ interface IDefaultPropsType extends Partial<PopoverProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Popover`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Popover`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     elevation: 3,
@@ -140,7 +128,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 
 /**
  * Helper method that returns a simple boolean value from different source format.
- * @param {any} inputValue The input to extract the boolean value from
+ * @param inputValue The input to extract the boolean value from
  */
 const unwrap: (inputValue: boolean | string | (() => boolean) | undefined) => boolean = (
     inputValue: boolean | string | (() => boolean) | undefined,
@@ -150,10 +138,10 @@ const unwrap: (inputValue: boolean | string | (() => boolean) | undefined) => bo
 
 /**
  * Get the popover offset base on its placement.
- * @param {string}          placement       The prefered placement
- * @param {Placements}      popperPlacement The actual platform
- * @param {PopperOffsets}   popperOffset    An offset to be applied on the popper
- * @return {Position}                       The css position.
+ * @param          placement       The prefered placement
+ * @param      popperPlacement The actual platform
+ * @param   popperOffset    An offset to be applied on the popper
+ * @return                       The css position.
  */
 function computeOffsets(
     placement: string,
@@ -189,11 +177,11 @@ function computeOffsets(
 
 /**
  * Get the size for the popper holder
- * @param {boolean} fillHeight          Should the holder use full available height
- * @param {boolean} fillwidth           Should the holder use full available width
- * @param {string}  transform           The computed CSS transform
- * @param {boolean} matchAnchorWidth    Should the popper match the anchor width
- * @return {Size}                       The size of the popper holder
+ * @param fillHeight          Should the holder use full available height
+ * @param fillwidth           Should the holder use full available width
+ * @param  transform           The computed CSS transform
+ * @param matchAnchorWidth    Should the popper match the anchor width
+ * @return                       The size of the popper holder
  */
 // tslint:disable: no-shadowed-variable
 function computeSize(
@@ -235,7 +223,7 @@ function computeSize(
  * Basically it binds an anchor element and a popper element and regarding the space available on the screen
  * + the selected placement the popper elem. will be displayed.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Popover: React.FC<PopoverProps> = ({
     anchorElement,
@@ -265,7 +253,7 @@ const Popover: React.FC<PopoverProps> = ({
 
     /**
      * Drives the visibility of the popper/tooltip element.
-     * @param {boolean} visibility Whether the tooltip show be visible or not
+     * @param visibility Whether the tooltip show be visible or not
      */
     function toggleAutoShowPopper(visibility: boolean): void {
         clearTimeout(autoShowDelayer.current);

--- a/src/components/progress-tracker/react/ProgressTracker.tsx
+++ b/src/components/progress-tracker/react/ProgressTracker.tsx
@@ -36,28 +36,16 @@ interface IDefaultPropsType extends Partial<ProgressTrackerProps> {
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ProgressTracker`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ProgressTracker`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     activeStep: 0,
@@ -72,7 +60,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Each step can have multiple attributes defining their current state to keep the user
  * aware of it's position in the process.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const ProgressTracker: React.FC<ProgressTrackerProps> = ({
     activeStep = DEFAULT_PROPS.activeStep,

--- a/src/components/progress-tracker/react/ProgressTrackerStep.tsx
+++ b/src/components/progress-tracker/react/ProgressTrackerStep.tsx
@@ -58,28 +58,16 @@ interface IDefaultPropsType extends Partial<ProgressTrackerStepProps> {
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}ProgressTrackerStep`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ProgressTrackerStep`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     hasError: false,
@@ -94,7 +82,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Defines a step for the `ProgressTracker` element.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
     className = '',
@@ -113,7 +101,7 @@ const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
     /**
      * Provides correct icon depending on step's current status.
      *
-     * @return {string} The correct svg path.
+     * @return The correct svg path.
      */
     const getIcon: () => string = (): string => {
         if (isComplete) {

--- a/src/components/progress/react/Progress.tsx
+++ b/src/components/progress/react/Progress.tsx
@@ -42,28 +42,16 @@ interface IDefaultPropsType extends Partial<ProgressProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Progress`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Progress`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     variant: Variants.circular,
@@ -73,7 +61,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Simple Progress component that can be displayed as a linear or circular element
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Progress: React.FC<ProgressProps> = ({
     className = '',

--- a/src/components/slideshow/constants.ts
+++ b/src/components/slideshow/constants.ts
@@ -1,42 +1,27 @@
 /**
  * The autoplay default interval in ms.
- *
- * @type {number}
- * @constant
  */
-const AUTOPLAY_DEFAULT_INTERVAL: number = 5000;
+const AUTOPLAY_DEFAULT_INTERVAL = 5000;
 
 /**
  * The full width size in percent.
- *
- * @type {number}
- * @constant
  */
-const FULL_WIDTH_PERCENT: number = 100;
+const FULL_WIDTH_PERCENT = 100;
 
 /**
  * The edge from the active index.
- *
- * @type {number}
- * @constant
  */
-const EDGE_FROM_ACTIVE_INDEX: number = 2;
+const EDGE_FROM_ACTIVE_INDEX = 2;
 
 /**
  * The max number of pagination items.
- *
- * @type {number}
- * @constant
  */
-const PAGINATION_ITEMS_MAX: number = 5;
+const PAGINATION_ITEMS_MAX = 5;
 
 /**
  * The size of a pagination item. Used to translate wrapper.
- *
- * @type {number}
- * @constant
  */
-const PAGINATION_ITEM_SIZE: number = 12;
+const PAGINATION_ITEM_SIZE = 12;
 
 export {
     AUTOPLAY_DEFAULT_INTERVAL,

--- a/src/components/slideshow/react/Slideshow.tsx
+++ b/src/components/slideshow/react/Slideshow.tsx
@@ -49,28 +49,16 @@ interface IDefaultPropsType extends Partial<SlideshowProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Slideshow`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Slideshow`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     activeIndex: 0,
@@ -92,8 +80,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {SlideshowProps} props The children and props of the component.
- * @return {React.ReactNode}    The processed children of the component.
+ * @param props The children and props of the component.
+ * @return    The processed children of the component.
  */
 function _validate(props: SlideshowProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -105,9 +93,6 @@ function _validate(props: SlideshowProps): React.ReactNode {
 
 /**
  * Displays a slideshow.
- *
- * @param {SlideshowProps} props
- * @return {(React.ReactElement | null)}
  */
 const Slideshow: React.FC<SlideshowProps> = ({
     activeIndex = DEFAULT_PROPS.activeIndex,
@@ -133,7 +118,6 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * The number of slideshow items.
      *
-     * @type {number}
      */
     const itemsCount: number = React.Children.count(newChildren);
 

--- a/src/components/slideshow/react/SlideshowControls.tsx
+++ b/src/components/slideshow/react/SlideshowControls.tsx
@@ -60,28 +60,16 @@ interface IDefaultPropsType extends Partial<SlideshowControlsProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}SlideshowControls`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}SlideshowControls`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     activeIndex: 0,
@@ -95,9 +83,6 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 
 /**
  * Controls for the slideshow component.
- *
- * @param {SlideshowControlsProps} props
- * @return {(React.ReactElement | null)}
  */
 const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /** Index of the current slide */
@@ -125,7 +110,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Handle keyboard shortcuts to navigate through slideshow.
      *
-     * @param {KeyboardEvent} evt Keyboard event.
+     * @param evt Keyboard event.
      */
     const handleKeyPressed: (evt: KeyboardEvent) => void = (evt: KeyboardEvent): void => {
         if (evt.keyCode === LEFT_KEY_CODE) {
@@ -141,8 +126,8 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Determines initial state of the visible range of pagination.
      *
-     * @param {number} index Index used to determinate position in slides.
-     * @return {PaginationRange} Min and max for pagination position.
+     * @param index Index used to determinate position in slides.
+     * @return Min and max for pagination position.
      */
     const initVisibleRange: (index: number) => PaginationRange = (index: number): PaginationRange => {
         const deltaItems: number = PAGINATION_ITEMS_MAX - 1;
@@ -163,7 +148,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Updates state of the visible range of pagination.
      *
-     * @param {number} index Index used to determinate position in slides.
+     * @param index Index used to determinate position in slides.
      */
     const updateVisibleRange: (index: number) => void = (index: number): void => {
         if (index === visibleRange.maxRange && index < lastSlide) {
@@ -178,13 +163,13 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Build an array of navigation items (bullets for example).
      *
-     * @param {number} lastIndex Index of last item.
-     * @return {JSX.Element[]} Array of nabiagtion items.
+     * @param lastIndex Index of last item.
+     * @return Array of nabiagtion items.
      */
     const buildItemsArray: (lastIndex: number) => JSX.Element[] = (lastIndex: number): JSX.Element[] => {
         const items: JSX.Element[] = [];
 
-        for (let i: number = 0; i <= lastIndex; i++) {
+        for (let i = 0; i <= lastIndex; i++) {
             items.push(
                 <button
                     className={classNames({
@@ -207,7 +192,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Handle click on an item to go to a specific slide.
      *
-     * @param {number} index Index of the slide to go to.
+     * @param index Index of the slide to go to.
      */
     const handleItemClick: (index: number) => void = useCallback(
         (index: number) => {
@@ -239,8 +224,8 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Determine if a navigation item is visible.
      *
-     * @param {number} index Index of navigation item.
-     * @return {boolean} Whether navigation item is visble or not.
+     * @param index Index of navigation item.
+     * @return Whether navigation item is visble or not.
      */
     const isPaginationItemOutVisibleRange: (index: number) => boolean = (index: number): boolean => {
         return index < visibleRange.minRange || index > visibleRange.maxRange;
@@ -249,8 +234,8 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Check if the pagination item is on edge, indicating other slides after or before.
      *
-     * @param  {number}  index The index of the pagination item to check.
-     * @return {boolean} Whether the pagination item is on edge or not.
+     * @param  index The index of the pagination item to check.
+     * @return Whether the pagination item is on edge or not.
      */
     const isPaginationItemOnEdge: (index: number) => boolean = (index: number): boolean => {
         return (

--- a/src/components/slideshow/react/SlideshowItem.tsx
+++ b/src/components/slideshow/react/SlideshowItem.tsx
@@ -14,19 +14,11 @@ import { handleBasicClasses } from 'LumX/core/utils';
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}SlideshowItem`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}SlideshowItem`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
@@ -40,8 +32,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {IGenericProps} props The children and props of the component.
- * @return {React.ReactNode}    The processed children of the component.
+ * @param props The children and props of the component.
+ * @return    The processed children of the component.
  */
 function _validate(props: IGenericProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -56,7 +48,7 @@ function _validate(props: IGenericProps): React.ReactNode {
 /**
  * Item of slideshow.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const SlideshowItem: React.FC<IGenericProps> = ({
     className = '',

--- a/src/components/switch/react/Switch.test.tsx
+++ b/src/components/switch/react/Switch.test.tsx
@@ -60,9 +60,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/switch/react/Switch.tsx
+++ b/src/components/switch/react/Switch.tsx
@@ -68,28 +68,16 @@ interface IDefaultPropsType extends Partial<SwitchProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Switch`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Switch`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     checked: false,
@@ -107,8 +95,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {SwitchProps} props The children and props of the component.
- * @return {React.ReactNode}    The processed children of the component.
+ * @param props The children and props of the component.
+ * @return    The processed children of the component.
  */
 function _validate(props: SwitchProps): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -124,7 +112,7 @@ function _validate(props: SwitchProps): React.ReactNode {
 /**
  * [Enter the description of the component here].
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Switch: React.FC<SwitchProps> = ({
     className = '',

--- a/src/components/table/react/Table.tsx
+++ b/src/components/table/react/Table.tsx
@@ -39,25 +39,16 @@ interface IDefaultPropsType extends Partial<TableProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Table`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Table`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     hasDividers: false,
@@ -69,7 +60,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * The Table component displays an HTML table, composed by a Table-head and a Table-body with Table-cells in Table Rows.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Table: React.FC<TableProps> = ({
     children,

--- a/src/components/table/react/TableBody.tsx
+++ b/src/components/table/react/TableBody.tsx
@@ -29,25 +29,16 @@ interface IDefaultPropsType extends Partial<TableBodyProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}TableBody`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}TableBody`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 
@@ -56,7 +47,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * The TableBody component displays an HTML Table Body, composed TableBody-cells in TableBody Rows.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const TableBody: React.FC<TableBodyProps> = ({
     children,

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -97,28 +97,16 @@ interface IDefaultPropsType extends Partial<TableCellProps> {
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}TableCell`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}TableCell`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     onHeaderClick: undefined,
@@ -130,7 +118,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * The TableCell component displays an HTML Table Header Cell.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const TableCell: React.FC<TableCellProps> = ({
     children,

--- a/src/components/table/react/TableHeader.tsx
+++ b/src/components/table/react/TableHeader.tsx
@@ -29,26 +29,16 @@ interface IDefaultPropsType extends Partial<TableHeaderProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}TableHeader`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}TableHeader`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 
@@ -57,7 +47,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * The TableHeader component displays an HTML Table Head, composed TableHeader-cells in TableHeader Rows.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const TableHeader: React.FC<TableHeaderProps> = ({
     children,

--- a/src/components/table/react/TableRow.tsx
+++ b/src/components/table/react/TableRow.tsx
@@ -29,28 +29,16 @@ interface IDefaultPropsType extends Partial<TableRowProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}TableRow`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}TableRow`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 
@@ -59,7 +47,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * The TableRow component displays an HTML Table Row, which contains table cells.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const TableRow: React.FC<TableRowProps> = ({
     children,

--- a/src/components/tabs/react/Tab.test.tsx
+++ b/src/components/tabs/react/Tab.test.tsx
@@ -33,9 +33,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/tabs/react/Tab.tsx
+++ b/src/components/tabs/react/Tab.tsx
@@ -48,28 +48,16 @@ interface IDefaultPropsType extends Partial<TabProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Tab`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Tab`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const CLASSNAME: string = `${CSS_PREFIX}-tabs__link`;
+const CLASSNAME = `${CSS_PREFIX}-tabs__link`;
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     icon: undefined,
@@ -83,7 +71,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Define a single Tab for Tabs component.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Tab: React.FC<TabProps> = ({
     className = '',

--- a/src/components/tabs/react/Tabs.test.tsx
+++ b/src/components/tabs/react/Tabs.test.tsx
@@ -35,9 +35,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (

--- a/src/components/tabs/react/Tabs.tsx
+++ b/src/components/tabs/react/Tabs.tsx
@@ -62,28 +62,16 @@ interface IDefaultPropsType extends Partial<TabsProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Tabs`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Tabs`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     activeTab: 0,
@@ -98,7 +86,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Defines a Tabs component.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Tabs: React.FC<TabsProps> = ({
     activeTab = DEFAULT_PROPS.activeTab,

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -59,28 +59,16 @@ interface IDefaultPropsType extends Partial<TextFieldProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}TextField`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}TextField`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {};
 /////////////////////////////
@@ -88,7 +76,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * Text field
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const TextField: React.FC<TextFieldProps> = ({
     className = '',
@@ -109,7 +97,7 @@ const TextField: React.FC<TextFieldProps> = ({
     /**
      * Handle change event on input.
      *
-     * @param {React.ChangeEvent<HTMLInputElement>} event Event of HTML Element
+     * @param event Event of HTML Element
      */
     const handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void = (
         event: React.ChangeEvent<HTMLInputElement>,

--- a/src/components/thumbnail/react/Thumbnail.tsx
+++ b/src/components/thumbnail/react/Thumbnail.tsx
@@ -81,28 +81,16 @@ interface IDefaultPropsType extends Partial<ThumbnailProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Thumbnail`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Thumbnail`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     align: Alignments.left,
@@ -118,7 +106,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Simple component used to display image with square or round shape.
  * Convenient to display image previews or user avatar.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Thumbnail: React.FC<ThumbnailProps> = ({
     className = '',

--- a/src/components/tooltip/react/Tooltip.tsx
+++ b/src/components/tooltip/react/Tooltip.tsx
@@ -15,8 +15,6 @@ type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left';
 
 /**
  * Position for arrow or tooltip.
- *
- * @interface IPosition.
  */
 interface IPosition {
     x: number;
@@ -56,28 +54,16 @@ interface IDefaultPropsType extends Partial<TooltipProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}Tooltip`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Tooltip`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     delay: 0,
@@ -89,11 +75,11 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Calculate the position of the tooltip relative to the anchor element.
  *
- * @param {TooltipPlacement} placement Placement of tooltip.
- * @param {React.RefObject<HTMLElement>} anchorRef Ref of anchor element.
- * @param {React.RefObject<HTMLDivElement>} tooltipRef Ref of tooltip.
- * @param {any[]} [dependencies=[placement, anchorRef, tooltipRef]] Dependencies of hook.
- * @return {Position} Position of the arrow on the tooltip.
+ * @param placement Placement of tooltip.
+ * @param anchorRef Ref of anchor element.
+ * @param tooltipRef Ref of tooltip.
+ * @param [dependencies=[placement, anchorRef, tooltipRef]] Dependencies of hook.
+ * @return Position of the arrow on the tooltip.
  */
 const useTooltipPosition: (
     placement: TooltipPlacement,
@@ -154,10 +140,10 @@ const useTooltipPosition: (
 /**
  * Calculate arrow position on the tooltip.
  *
- * @param {TooltipPlacement} placement Placement of tooltip.
- * @param {React.RefObject<HTMLDivElement>} tooltipRef Ref of tooltip.
- * @param {any[]} [dependencies=[placement, tooltipRef]] Dependencies of hook.
- * @return {Position} Position of the arrow on the tooltip.
+ * @param placement Placement of tooltip.
+ * @param tooltipRef Ref of tooltip.
+ * @param [dependencies=[placement, tooltipRef]] Dependencies of hook.
+ * @return Position of the arrow on the tooltip.
  */
 const useArrowPosition: (
     placement: TooltipPlacement,
@@ -184,9 +170,9 @@ const useArrowPosition: (
             width: widthTooltip,
             height: heightTooltip,
         }: ClientRect | DOMRect = tooltipRef.current!.getBoundingClientRect();
-        const arrowHeight: number = 5;
-        const arrowBorder: number = 5;
-        const arrowWidth: number = 10;
+        const arrowHeight = 5;
+        const arrowBorder = 5;
+        const arrowWidth = 10;
 
         switch (placement) {
             case 'top':
@@ -213,7 +199,7 @@ const useArrowPosition: (
 /**
  * Tooltip.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const Tooltip: React.FC<TooltipProps> = ({
     anchorRef,

--- a/src/components/user-block/react/UserBlock.tsx
+++ b/src/components/user-block/react/UserBlock.tsx
@@ -67,28 +67,16 @@ interface IDefaultPropsType extends Partial<UserBlockProps> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}UserBlock`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}UserBlock`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     orientation: Orientations.horizontal,
@@ -100,7 +88,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * Render a user information as a card if orientation is vertical or no action user info block if horizontal.
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const UserBlock: React.FC<IUserBlockProps> = ({
     avatar,

--- a/src/core/constants.d.ts
+++ b/src/core/constants.d.ts
@@ -6,58 +6,36 @@
 
 /**
  * The prefix to use for the CSS classes.
- *
- * @type {string}
- * @constant
- * @readonly
  */
 declare const CSS_PREFIX: string;
 
 /**
  * The enter/return key code.
- *
- * @type {number}
- * @constant
  */
 declare const ENTER_KEY_CODE: number;
 
 /**
  * The left key code.
- *
- * @type {number}
- * @constant
  */
 declare const LEFT_KEY_CODE: number;
 
 /**
  * The right key code.
- *
- * @type {number}
- * @constant
  */
 declare const RIGHT_KEY_CODE: number;
 
 /**
  * The down arrow key code.
- *
- * @type {number}
- * @constant
  */
 declare const DOWN_KEY_CODE: number;
 
 /**
  * The up arrow key code.
- *
- * @type {number}
- * @constant
  */
 declare const UP_KEY_CODE: number;
 
 /**
  * The TAB key code.
- *
- * @type {number}
- * @constant
  */
 declare const TAB_KEY_CODE: number;
 

--- a/src/core/react/constants.ts
+++ b/src/core/react/constants.ts
@@ -6,12 +6,8 @@
 
 /**
  * The prefix to use to name the React component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_PREFIX: string = '';
+const COMPONENT_PREFIX = '';
 
 /////////////////////////////
 

--- a/src/core/react/hooks/useInterval.tsx
+++ b/src/core/react/hooks/useInterval.tsx
@@ -8,8 +8,8 @@ import isFunction from 'lodash/isFunction';
  * Making setInterval Declarative with React Hooks.
  * Credits: https://overreacted.io/making-setinterval-declarative-with-react-hooks/
  *
- * @param {() => void} callback Function called by setInterval.
- * @param {number}     delay    Delay for setInterval.
+ * @param callback Function called by setInterval.
+ * @param     delay    Delay for setInterval.
  */
 function useInterval(callback: () => void, delay: number | null): void {
     const savedCallback: React.MutableRefObject<(() => void) | undefined> = useRef();

--- a/src/core/react/utils.ts
+++ b/src/core/react/utils.ts
@@ -22,10 +22,6 @@ import { COMPONENT_PREFIX } from './constants';
 /**
  * The properties of a component to use to determine it's name.
  * In the order of preference.
- *
- * @type {Array<string>}
- * @constant
- * @readonly
  */
 const NAME_PROPERTIES: string[] = ['displayName', 'name', 'type', 'type.name', '_reactInternalFiber.elementType.name'];
 
@@ -83,15 +79,15 @@ type ValidateParameters = IValidateParameters;
 /**
  * Get the name of the root CSS class of a component based on its name.
  *
- * @param {string}  componentName The name of the component. This name should contains the component prefix and be
+ * @param componentName The name of the component. This name should contains the component prefix and be
  *                               written in PascalCase.
- * @param {boolean} subComponent Whether the current component is a sub component, if true, define the class according
+ * @param subComponent Whether the current component is a sub component, if true, define the class according
  *                               to BEM standards.
- * @return {string} The name of the root CSS class. This classname include the CSS classname prefix and is written in
+ * @return The name of the root CSS class. This classname include the CSS classname prefix and is written in
  *                  lower-snake-case.
  */
 function getRootClassName(componentName: string, subComponent?: boolean): string {
-    const formattedClassName: string = `${CSS_PREFIX}-${kebabCase(trimStart(componentName, COMPONENT_PREFIX))}`;
+    const formattedClassName = `${CSS_PREFIX}-${kebabCase(trimStart(componentName, COMPONENT_PREFIX))}`;
 
     if (subComponent) {
         // See https://regex101.com/r/YjS1uI/3
@@ -108,8 +104,8 @@ function getRootClassName(componentName: string, subComponent?: boolean): string
  * The type can either be a string ('Button', 'span', ...) or a component whose name will be computed from its
  * `displayName`, its React internal name (`_reactInternalFiber.elementType.name`) or its `name`.
  *
- * @param  {string|ComponentType} type The type to get the name of.
- * @return {string|ComponentType} The name of the type.
+ * @param type The type to get the name of.
+ * @return The name of the type.
  */
 function getTypeName(type: string | ComponentType): string | ComponentType {
     if (isString(type)) {
@@ -130,9 +126,9 @@ function getTypeName(type: string | ComponentType): string | ComponentType {
 /**
  * Check if a ReactElement is of the given type.
  *
- * @param  {React.ReactNode}   el   The ReactElement we want to check the type of.
- * @param  {string|ComponentType} type The type we want to check if the ReactElement is of.
- * @return {boolean}              If the ReactElement is of the given type or not.
+ * @param el   The ReactElement we want to check the type of.
+ * @param type The type we want to check if the ReactElement is of.
+ * @return     If the ReactElement is of the given type or not.
  */
 function isElementOfType(el: React.ReactNode, type: string | ComponentType): boolean {
     const typeName: string | ComponentType = getTypeName(type);
@@ -163,8 +159,8 @@ function isElementOfType(el: React.ReactNode, type: string | ComponentType): boo
  * Check if a ReactElement is a text (i.e. either a pure text node or a <span>).
  * Simply check if the ReactElement is a string or if its type is 'span'.
  *
- * @param  {React.ReactNode} el The ReactElement to check if it's a text.
- * @return {boolean}            If the ReactElement is a text or not.
+ * @param el The ReactElement to check if it's a text.
+ * @return   If the ReactElement is a text or not.
  */
 function isElementText(el: React.ReactNode): boolean {
     return isString(el);
@@ -173,8 +169,8 @@ function isElementText(el: React.ReactNode): boolean {
 /**
  * Unwrap the children contained in a fragment.
  *
- * @param  {React.ReactNode} children The children to unwrap (there should be only 1 child of React.Fragment type).
- * @return {React.reactNode} The unwrapped children (or the origin children if it wasn't a fragment).
+ * @param children The children to unwrap (there should be only 1 child of React.Fragment type).
+ * @return The unwrapped children (or the origin children if it wasn't a fragment).
  */
 function unwrapFragment(children: React.ReactNode): React.ReactNode {
     let newChildren: React.ReactNode = children;
@@ -195,27 +191,27 @@ function unwrapFragment(children: React.ReactNode): React.ReactNode {
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {string}                      componentName    The name of the component being validated.
- * @param  {Array<string|ComponentType>} [allowedTypes]   The allowed types of children.
- * @param  {number}                      [maxChildren]    The maximum expected number of children.
- * @param  {number}                      [minChildren=0]  The minimum expected number of children.
- * @param  {Function}                    [postValidate]   A function to run after all the transformation and validation
+ * @param componentName    The name of the component being validated.
+ * @param [allowedTypes]   The allowed types of children.
+ * @param [maxChildren]    The maximum expected number of children.
+ * @param [minChildren=0]  The minimum expected number of children.
+ * @param [postValidate]   A function to run after all the transformation and validation
  *                                                        of the children and the props.
  *                                                        This function can return a string (the error message), a
  *                                                        boolean (`true` for a successful validation, `false` for a bad
  *                                                        validation which will lead to throw a basic error message) or
  *                                                        nothing if there is no special problem (i.e. a successful
  *                                                        validation).
- * @param  {Function}                    [preValidate]    A function to run before global validation of the props and
+ * @param [preValidate]    A function to run before global validation of the props and
  *                                                        any transformation or validation of the children.
  *                                                        This function can return a string (the error message), a
  *                                                        boolean (`true` for a successful validation, `false` for a bad
  *                                                        validation which will lead to throw a basic error message) or
  *                                                        nothing if there is no special problem (i.e. a successful
  *                                                        validation).
- * @param  {IGenericProps}               props            The props of the component (should contain a `children` prop).
- * @param  {Function}                    [transformChild] A function to transform a child to something else.
- * @param  {Function}                    [validateChild]  A function to check if a child is valid after that its type
+ * @param props            The props of the component (should contain a `children` prop).
+ * @param [transformChild] A function to transform a child to something else.
+ * @param [validateChild]  A function to check if a child is valid after that its type
  *                                                        has been validated (if `allowedTypes` is provided) and after
  *                                                        it has been transformed..
  *                                                        This function can return a string (the error message), a
@@ -223,7 +219,7 @@ function unwrapFragment(children: React.ReactNode): React.ReactNode {
  *                                                        validation which will lead to throw a basic error message) or
  *                                                        nothing if there is nothing special (i.e. a successful
  *                                                        validation).
- * @return {React.ReactNode}             The processed children of the component.
+ * @return                 The processed children of the component.
  */
 function validateComponent(
     componentName: string,
@@ -293,7 +289,7 @@ function validateComponent(
         }
         validateChild = validateChild || noop;
 
-        let index: number = -1;
+        let index = -1;
         const transformedChildren: React.ReactNode = Children[childrenFunctionName](
             newChildren,
             (child: React.ReactNode): React.ReactNode => {
@@ -318,7 +314,7 @@ function validateComponent(
                     );
 
                     if (!isOfOneAllowedType) {
-                        let allowedTypesString: string = '';
+                        let allowedTypesString = '';
                         allowedTypes.forEach(
                             (allowedType: string | ComponentType, idx: number): void => {
                                 if (!isEmpty(allowedTypesString)) {

--- a/src/core/testing/utils.test.ts
+++ b/src/core/testing/utils.test.ts
@@ -41,11 +41,11 @@ interface ICommonSetup {
 /**
  * Run the common tests suite: CSS class forwarding, prop forwarding, ...
  *
- * @param {Function} setup  The setup function.
- * @param {Object}   tests  The tests to enable.
+ * @param setup  The setup function.
+ * @param   tests  The tests to enable.
  *                          The key is the name of the test, the value is the name of the wrapper in the object returned
  *                          by the `setup` function.
- * @param {Object}   params The params that can be used by the tests.
+ * @param   params The params that can be used by the tests.
  */
 function commonTestsSuite(
     setup: (props?: IGenericProps, shallowRendering?: boolean) => ICommonSetup,

--- a/src/core/utils.d.ts
+++ b/src/core/utils.d.ts
@@ -5,10 +5,10 @@ import { Color, Size, Theme } from 'LumX/components';
 /**
  * Get the basic CSS class for the given type.
  *
- * @param  {string}         prefix The class name prefix for the generated CSS class.
- * @param  {string}         type   The type of CSS class we want to generate (e.g.: 'color', 'variant', ...).
- * @param  {string|boolean} value  The value of the type of the CSS class (e.g.: 'primary', 'button', ...).
- * @return {string}         The basic CSS class.
+ * @param         prefix The class name prefix for the generated CSS class.
+ * @param         type   The type of CSS class we want to generate (e.g.: 'color', 'variant', ...).
+ * @param value   The value of the type of the CSS class (e.g.: 'primary', 'button', ...).
+ * @return        The basic CSS class.
  */
 declare function getBasicClass({
     prefix,
@@ -17,7 +17,7 @@ declare function getBasicClass({
 }: {
     prefix: string;
     type: string;
-    value: string | boolean;
+    value: string | boolean | undefined;
 }): string;
 
 /**
@@ -25,11 +25,11 @@ declare function getBasicClass({
  *
  * @see {@link /src/components/index.d.ts} for the possible values of each parameter.
  *
- * @param  {string} prefix The class name prefix for the generated CSS class.
- * @param  {Object} props  All the other props you want to generate a class.
+ * @param prefix The class name prefix for the generated CSS class.
+ * @param props  All the other props you want to generate a class.
  *                         The rule of thumb: the key is the name of the prop in the class, the value a string that will
  *                         be used in the classname to represent the value of the given prop.
- * @return {string} All LumX basic CSS classes.
+ * @return All LumX basic CSS classes.
  */
 declare function handleBasicClasses({ prefix, ...props }: { prefix: string; [prop: string]: any }): string;
 
@@ -37,9 +37,9 @@ declare function handleBasicClasses({ prefix, ...props }: { prefix: string; [pro
  * Detects swipe direction.
  * Credits: http://javascriptkit.com/javatutors/touchevents2.shtml.
  *
- * @param {Element} el Element that will hold touch events.
- * @param {(swipeDirection: SwipeDirection) => void} cb Callback function.
- * @return {() => void)} Function to remove listeners.
+ * @param el Element that will hold touch events.
+ * @param cb Callback function.
+ * @return Function to remove listeners.
  */
 declare function detectSwipe(el: Element, cb: (swipeDirection: SwipeDirection) => void): () => void;
 
@@ -48,10 +48,10 @@ declare type SwipeDirection = 'none' | 'up' | 'down' | 'left' | 'right';
 /**
  * Make sure the pressed key is the enter key before calling the callbac.
  *
- * @param  {Function}   cb The callback to call on enter/return press.
- * @return {() => void} The decorated function.
+ * @param  cb The callback to call on enter/return press.
+ * @return The decorated function.
  */
-declare function onEnterPressed(cb: () => void);
+declare function onEnterPressed(cb: () => void): () => void;
 
 /////////////////////////////
 

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,7 @@
         ],
         "no-empty-interface": false,
         "no-for-in-array": true,
-        "no-inferrable-types": false,
+        "no-inferrable-types": [true, "ignore-params", "ignore-properties"],
         "no-inferred-empty-object-type": true,
         "no-object-literal-type-assertion": true,
         "no-return-await": true,
@@ -52,15 +52,12 @@
         "strict-type-predicates": false,
         "typedef": {
             "options": [
-                "array-destructuring",
                 "arrow-call-signature",
                 "arrow-parameter",
                 "call-signature",
                 "member-variable-declaration",
-                "object-destructuring",
                 "parameter",
-                "property-declaration",
-                "variable-declaration"
+                "property-declaration"
             ],
             "severity": "warning"
         },
@@ -101,6 +98,8 @@
                 "allowUnboundThis": true
             }
         ],
+
+        "no-redundant-jsdoc": true,
         "valid-jsdoc": [
             true,
             {
@@ -114,24 +113,11 @@
                     "returns": "return",
                     "throw": "throws"
                 },
-                "preferType": {
-                    "array": "Array",
-                    "Boolean": "boolean",
-                    "date": "Date",
-                    "Float": "number",
-                    "float": "number",
-                    "function": "Function",
-                    "integer": "number",
-                    "Integer": "number",
-                    "Number": "number",
-                    "object": "Object",
-                    "String": "string"
-                },
                 "requireParamDescription": true,
-                "requireParamType": true,
+                "requireParamType": false,
                 "requireReturn": false,
                 "requireReturnDescription": true,
-                "requireReturnType": true
+                "requireReturnType": false
             }
         ],
         "valid-typeof": true,

--- a/yo-generators/generator-lumx-component/generators/component/templates/ClassComponent.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/component/templates/ClassComponent.tsx.ejs
@@ -42,11 +42,6 @@ interface IState {}
 
 /////////////////////////////
 
-/**
- * Define the types of the default props.
- */
-interface IDefaultPropsType extends Partial<<%= componentName %>Props> {}
-
 /////////////////////////////
 //                         //
 //    Public attributes    //
@@ -55,30 +50,18 @@ interface IDefaultPropsType extends Partial<<%= componentName %>Props> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}<%= componentName %>`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}<%= componentName %>`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
-const DEFAULT_PROPS: IDefaultPropsType = {};
+const DEFAULT_PROPS: Partial<<%= componentName %>Props> = {};
 
 /////////////////////////////
 
@@ -110,12 +93,11 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
     /**
      * Globally validate the component after transforming and/or validating the children.
      *
-     * @param  {ValidateParameters} params The children, their number and the props of the component.
-     * @return {string|boolean}     If a string, the error message.
-     *                              If a boolean, `true` means a successful validation, `false` a bad validation (which
-     *                              will lead to throw a basic error message).
-     *                              You can also return nothing if there is no special problem (i.e. a successful
-     *                              validation).
+     * @param  params The children, their number and the props of the component.
+     * @return If a string, the error message.
+     *         If a boolean, `true` means a successful validation, `false` a bad validation (which
+     *         will lead to throw a basic error message).
+     *         You can also return nothing if there is no special problem (i.e. a successful validation).
      */
     private postValidate({ children, childrenCount }: ValidateParameters): string | boolean | void {
         // Do your post-validation here.
@@ -128,12 +110,11 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
     /**
      * Globally validate the component before transforming and/or validating the children.
      *
-     * @param  {ValidateParameters} params The children, their number and the props of the component.
-     * @return {string|boolean}     If a string, the error message.
-     *                              If a boolean, `true` means a successful validation, `false` a bad validation (which
-     *                              will lead to throw a basic error message).
-     *                              You can also return nothing if there is no special problem (i.e. a successful
-     *                              validation).
+     * @param  params The children, their number and the props of the component.
+     * @return If a string, the error message.
+     *         If a boolean, `true` means a successful validation, `false` a bad validation (which
+     *         will lead to throw a basic error message).
+     *         You can also return nothing if there is no special problem (i.e. a successful validation).
      */
     private preValidate({ children, childrenCount }: ValidateParameters): string | boolean | void {
         // Do your pre-validation here.
@@ -146,9 +127,8 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
     /**
      * Transform a child of the component.
      *
-     * @param  {ChildTransformParameters} params The parameters received from the `validateComponent` function.
-     * @return {React.ReactNode}          The transformed child (or the original one if there is no transformation to
-     *                                    do).
+     * @param  params The parameters received from the `validateComponent` function.
+     * @return The transformed child (or the original one if there is no transformation to do).
      */
     private transformChild({ child, children, childrenCount, index }: ChildTransformParameters): React.ReactNode {
         // Do your transformation here. Here is an example:
@@ -164,12 +144,11 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
     /**
      * Validate a child of the component after its transformation.
      *
-     * @param  {ChildValidateParameters} params The parameters received from the `validateComponent` function.
-     * @return {string|boolean}     If a string, the error message.
-     *                              If a boolean, `true` means a successful validation, `false` a bad validation (which
-     *                              will lead to throw a basic error message).
-     *                              You can also return nothing if there is no special problem (i.e. a successful
-     *                              validation).
+     * @param  params The parameters received from the `validateComponent` function.
+     * @return If a string, the error message.
+     *         If a boolean, `true` means a successful validation, `false` a bad validation (which
+     *         will lead to throw a basic error message).
+     *         You can also return nothing if there is no special problem (i.e. a successful validation).
      */
     private validateChild({ child, children, childrenCount, index }: ChildValidateParameters): string | boolean | void {
         // Do your validation here.
@@ -182,8 +161,8 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
      * Validate the component props and children.
      * Also, sanitize, cleanup and format the children and return the processed ones.
      *
-     * @param  {<%= componentName %>Props} props The children and props of the component.
-     * @return {React.ReactNode}    The processed children of the component.
+     * @param  props The children and props of the component.
+     * @return The processed children of the component.
      */
     private validate(props: <%= componentName %>Props): React.ReactNode {
         return validateComponent(COMPONENT_NAME, {

--- a/yo-generators/generator-lumx-component/generators/component/templates/FunctionalComponent.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/component/templates/FunctionalComponent.tsx.ejs
@@ -37,11 +37,6 @@ type <%= componentName %>Props = I<%= componentName %>Props;
 
 /////////////////////////////
 
-/**
- * Define the types of the default props.
- */
-interface IDefaultPropsType extends Partial<<%= componentName %>Props> {}
-
 /////////////////////////////
 //                         //
 //    Public attributes    //
@@ -50,30 +45,18 @@ interface IDefaultPropsType extends Partial<<%= componentName %>Props> {}
 
 /**
  * The display name of the component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const COMPONENT_NAME: string = `${COMPONENT_PREFIX}<%= componentName %>`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}<%= componentName %>`;
 
 /**
  * The default class name and classes prefix for this component.
- *
- * @type {string}
- * @constant
- * @readonly
  */
-const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
 /**
  * The default value of props.
- *
- * @type {IDefaultPropsType}
- * @constant
- * @readonly
  */
-const DEFAULT_PROPS: IDefaultPropsType = {};
+const DEFAULT_PROPS: Partial<<%= componentName %>Props> = {};
 <% if (validateComponent) { -%>
 
 /////////////////////////////
@@ -86,12 +69,11 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
 /**
  * Globally validate the component after transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
- *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
- *                              lead to throw a basic error message).
- *                              You can also return nothing if there is no special problem (i.e. a successful
- *                              validation).
+ * @param   params The children, their number and the props of the component.
+ * @return  If a string, the error message.
+ *          If a boolean, `true` means a successful validation, `false` a bad validation (which will
+ *          lead to throw a basic error message).
+ *          You can also return nothing if there is no special problem (i.e. a successful validation).
  */
 function _postValidate({ children, childrenCount, props }: ValidateParameters): string | boolean | void {
     // Do your post-validation here.
@@ -104,12 +86,11 @@ function _postValidate({ children, childrenCount, props }: ValidateParameters): 
 /**
  * Globally validate the component before transforming and/or validating the children.
  *
- * @param  {ValidateParameters} params The children, their number and the props of the component.
- * @return {string|boolean}     If a string, the error message.
- *                              If a boolean, `true` means a successful validation, `false` a bad validation (which will
- *                              lead to throw a basic error message).
- *                              You can also return nothing if there is no special problem (i.e. a successful
- *                              validation).
+ * @param   params The children, their number and the props of the component.
+ * @return  If a string, the error message.
+ *          If a boolean, `true` means a successful validation, `false` a bad validation (which will
+ *          lead to throw a basic error message).
+ *          You can also return nothing if there is no special problem (i.e. a successful validation).
  */
 function _preValidate({ children, childrenCount, props }: ValidateParameters): string | boolean | void {
     // Do your pre-validation here.
@@ -122,8 +103,8 @@ function _preValidate({ children, childrenCount, props }: ValidateParameters): s
 /**
  * Transform a child of the component.
  *
- * @param  {ChildTransformParameters} params The parameters received from the `validateComponent` function.
- * @return {React.ReactNode}          The transformed child (or the original one if there is no transformation to do).
+ * @param  params The parameters received from the `validateComponent` function.
+ * @return The transformed child (or the original one if there is no transformation to do).
  */
 function _transformChild({
     child,
@@ -145,12 +126,11 @@ function _transformChild({
 /**
  * Validate a child of the component after its transformation.
  *
- * @param  {ChildValidateParameters} params The parameters received from the `validateComponent` function.
- * @return {string|boolean}          If a string, the error message.
- *                                   If a boolean, `true` means a successful validation, `false` a bad validation (which
- *                                   will lead to throw a basic error message).
- *                                   You can also return nothing if there is no special problem (i.e. a successful
- *                                   validation).
+ * @param  params The parameters received from the `validateComponent` function.
+ * @return If a string, the error message.
+ *         If a boolean, `true` means a successful validation, `false` a bad validation (which
+ *         will lead to throw a basic error message).
+ *         You can also return nothing if there is no special problem (i.e. a successful validation).
  */
 function _validateChild({
     child,
@@ -169,8 +149,8 @@ function _validateChild({
  * Validate the component props and children.
  * Also, sanitize, cleanup and format the children and return the processed ones.
  *
- * @param  {<%= componentName %>Props} props The children and props of the component.
- * @return {React.ReactNode}    The processed children of the component.
+ * @param  props The children and props of the component.
+ * @return The processed children of the component.
  */
 function _validate(props: <%= componentName %>Props): React.ReactNode {
     return validateComponent(COMPONENT_NAME, {
@@ -209,7 +189,7 @@ function _validate(props: <%= componentName %>Props): React.ReactNode {
 /**
  * [Enter the description of the component here].
  *
- * @return {React.ReactElement} The component.
+ * @return The component.
  */
 const <%= componentName %>: React.FC<<%= componentName %>Props> = ({ children, className = '', ...props }: <%= componentName %>Props): React.ReactElement => {
     <%_ if (validateComponent) { -%>

--- a/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
@@ -16,7 +16,7 @@ interface IProps {
 /**
  * The demo for the default <<%= componentName %>>s.
  *
- * @return {React.ReactElement} The demo component.
+ * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
     <Fragment>


### PR DESCRIPTION
Changing the tslint rules to prevent redundant type annontations in JSDoc and in 

Changes:
- Activate [`no-redundant-jsdoc`](https://palantir.github.io/tslint/rules/no-redundant-jsdoc/) to avoid redundancy with typescript types
- Disable jsdoc required types for params and returns (see [`valid-jsdoc`](https://eslint.org/docs/rules/valid-jsdoc))
- Disable required typedef for array and object destructuring (see [`typedef`](https://palantir.github.io/tslint/rules/typedef/))
- Disable required typedef for variable declaration (see [`typedef`](https://palantir.github.io/tslint/rules/typedef/))
- Activate [`no-inferrable-types`](https://palantir.github.io/tslint/rules/no-inferrable-types) to prevent typedef of obviously inferred values
- Update code when required to pass lint and compiler
- Fix Chip test because of type checking error trying to assign `null` to `onClick` and `onKeyDown` instead of `undefined`
- Fix yeoman templates