### PR TITLE
refactor: react and typescript conventions

### DIFF
--- a/demo/constants.d.ts
+++ b/demo/constants.d.ts
@@ -7,16 +7,15 @@
 /**
  * Defines the allowed themes.
  */
-declare enum Themes {
+declare enum Theme {
     lumapps = 'lumapps',
     material = 'material',
 }
-declare type Theme = Themes;
 
 /**
  * The available themes in the demo site.
  */
-declare const THEMES: { [key in Themes]: Theme };
+declare const THEMES: { [key in Theme]: Theme };
 
 /**
  * The default theme to use in the demo site at startup.
@@ -25,4 +24,4 @@ declare const DEFAULT_THEME: Theme;
 
 /////////////////////////////
 
-export { THEMES, DEFAULT_THEME, Theme, Themes };
+export { THEMES, DEFAULT_THEME, Theme };

--- a/demo/react/App.tsx
+++ b/demo/react/App.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, ReactElement, useEffect, useState } from 'react';
 
 import last from 'lodash/last';
 
-import { DEFAULT_THEME, Theme } from '../constants';
+import { DEFAULT_THEME } from '../constants';
 import { changeTheme as _changeTheme } from '../utils';
 
 import { ErrorBoundary } from './ErrorBoundary';
@@ -21,11 +21,9 @@ import { SubNav } from './layout/SubNav';
  * @return The main application component.
  */
 const App: React.FC = (): ReactElement => {
-    const [activeComponent, setActiveComponent]: [string, (activeComponent: string) => void] = useState(
-        last(window.location.pathname.split('/')) || '',
-    );
-    const [theme, changeTheme]: [Theme, (theme: Theme) => void] = useState(DEFAULT_THEME);
-    const [themeLoaded, setThemeLoaded]: [boolean, (isThemeLoaded: boolean) => void] = useState<boolean>(false);
+    const [activeComponent, setActiveComponent] = useState(last(window.location.pathname.split('/')) || '');
+    const [theme, changeTheme] = useState(DEFAULT_THEME);
+    const [themeLoaded, setThemeLoaded] = useState(false);
 
     useEffect((): void => {
         _changeTheme(theme).then(

--- a/demo/react/App.tsx
+++ b/demo/react/App.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 
 import last from 'lodash/last';
 
@@ -39,7 +39,7 @@ const App: React.FC = (): ReactElement => {
 
     if (themeLoaded) {
         return (
-            <Fragment>
+            <>
                 <MainNav />
                 <SubNav
                     handleNavigate={setActiveComponent}
@@ -50,7 +50,7 @@ const App: React.FC = (): ReactElement => {
                 <ErrorBoundary>
                     <Main activeComponent={activeComponent} />
                 </ErrorBoundary>
-            </Fragment>
+            </>
         );
     }
 

--- a/demo/react/ErrorBoundary.tsx
+++ b/demo/react/ErrorBoundary.tsx
@@ -36,7 +36,7 @@ class ErrorBoundary extends React.Component<{}, IState> {
     }
 
     public render(): ReactElement {
-        const { error, hasError }: IState = this.state;
+        const { error, hasError } = this.state;
 
         if (hasError) {
             return (

--- a/demo/react/ErrorBoundary.tsx
+++ b/demo/react/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 /////////////////////////////
 
@@ -35,7 +35,7 @@ class ErrorBoundary extends React.Component<{}, IState> {
         // Nothing to do here, the error is already logged in the console and in the fallback display.
     }
 
-    public render(): React.ReactNode {
+    public render(): ReactElement {
         const { error, hasError }: IState = this.state;
 
         if (hasError) {

--- a/demo/react/ErrorBoundary.tsx
+++ b/demo/react/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 /////////////////////////////
 
@@ -48,7 +48,7 @@ class ErrorBoundary extends React.Component<{}, IState> {
             );
         }
 
-        return <Fragment>{this.props.children}</Fragment>;
+        return <>{this.props.children}</>;
     }
 }
 

--- a/demo/react/components/avatar/default.tsx
+++ b/demo/react/components/avatar/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment } from 'react';
+import React, { CSSProperties, Fragment, ReactElement } from 'react';
 
 import { Avatar, AvatarSize, AvatarTheme } from 'LumX';
 
@@ -23,7 +23,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <div style={demoContainerStyle}>
             <Avatar theme={theme} image="http://i.pravatar.cc/40" size={AvatarSize.xs} />

--- a/demo/react/components/avatar/default.tsx
+++ b/demo/react/components/avatar/default.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Avatar, AvatarSize, AvatarTheme } from 'LumX';
+import { Avatar, Size, Theme } from 'LumX';
 
 const demoContainerStyle: CSSProperties = {
     display: 'flex',
@@ -13,7 +13,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: AvatarTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -26,11 +26,11 @@ interface IProps {
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <>
         <div style={demoContainerStyle}>
-            <Avatar theme={theme} image="http://i.pravatar.cc/40" size={AvatarSize.xs} />
-            <Avatar theme={theme} image="http://i.pravatar.cc/48" size={AvatarSize.s} />
-            <Avatar theme={theme} image="http://i.pravatar.cc/72" size={AvatarSize.m} />
-            <Avatar theme={theme} image="http://i.pravatar.cc/128" size={AvatarSize.l} />
-            <Avatar theme={theme} image="http://i.pravatar.cc/256" size={AvatarSize.xl} />
+            <Avatar theme={theme} image="http://i.pravatar.cc/40" size={Size.xs} />
+            <Avatar theme={theme} image="http://i.pravatar.cc/48" size={Size.s} />
+            <Avatar theme={theme} image="http://i.pravatar.cc/72" size={Size.m} />
+            <Avatar theme={theme} image="http://i.pravatar.cc/128" size={Size.l} />
+            <Avatar theme={theme} image="http://i.pravatar.cc/256" size={Size.xl} />
         </div>
     </>
 );

--- a/demo/react/components/avatar/default.tsx
+++ b/demo/react/components/avatar/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment, ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { Avatar, AvatarSize, AvatarTheme } from 'LumX';
 
@@ -24,7 +24,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <div style={demoContainerStyle}>
             <Avatar theme={theme} image="http://i.pravatar.cc/40" size={AvatarSize.xs} />
             <Avatar theme={theme} image="http://i.pravatar.cc/48" size={AvatarSize.s} />
@@ -32,7 +32,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             <Avatar theme={theme} image="http://i.pravatar.cc/128" size={AvatarSize.l} />
             <Avatar theme={theme} image="http://i.pravatar.cc/256" size={AvatarSize.xl} />
         </div>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/button/default.tsx
+++ b/demo/react/components/button/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes } from 'LumX';
 
@@ -19,7 +19,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <Button
             className="mr"
             emphasis={ButtonEmphasises.low}
@@ -39,7 +39,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         </Button>
 
         <Button theme={theme}>High emphasis (default)</Button>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/button/default.tsx
+++ b/demo/react/components/button/default.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes } from 'LumX';
+import { Button, ButtonEmphasis, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ButtonTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -22,8 +22,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <>
         <Button
             className="mr"
-            emphasis={ButtonEmphasises.low}
-            color={theme === ButtonThemes.dark ? 'light' : undefined}
+            emphasis={ButtonEmphasis.low}
+            color={theme === Theme.dark ? 'light' : undefined}
             theme={theme}
         >
             Low emphasis
@@ -31,8 +31,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
 
         <Button
             className="mr"
-            emphasis={ButtonEmphasises.medium}
-            color={theme === ButtonThemes.dark ? 'light' : undefined}
+            emphasis={ButtonEmphasis.medium}
+            color={theme === Theme.dark ? 'light' : undefined}
             theme={theme}
         >
             Medium emphasis

--- a/demo/react/components/button/default.tsx
+++ b/demo/react/components/button/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <Button
             className="mr"

--- a/demo/react/components/button/disabled.tsx
+++ b/demo/react/components/button/disabled.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes } from 'LumX';
+import { Button, ButtonEmphasis, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ButtonTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -23,8 +23,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <Button
             className="mr"
             disabled={true}
-            emphasis={ButtonEmphasises.low}
-            color={theme === ButtonThemes.dark ? 'light' : undefined}
+            emphasis={ButtonEmphasis.low}
+            color={theme === Theme.dark ? 'light' : undefined}
             theme={theme}
         >
             Low emphasis
@@ -33,8 +33,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <Button
             className="mr"
             disabled={true}
-            emphasis={ButtonEmphasises.medium}
-            color={theme === ButtonThemes.dark ? 'light' : undefined}
+            emphasis={ButtonEmphasis.medium}
+            color={theme === Theme.dark ? 'light' : undefined}
             theme={theme}
         >
             Medium emphasis

--- a/demo/react/components/button/disabled.tsx
+++ b/demo/react/components/button/disabled.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <Button
             className="mr"

--- a/demo/react/components/button/disabled.tsx
+++ b/demo/react/components/button/disabled.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes } from 'LumX';
 
@@ -19,7 +19,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <Button
             className="mr"
             disabled={true}
@@ -43,7 +43,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <Button disabled={true} theme={theme}>
             High emphasis (default)
         </Button>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/button/dropdown.tsx
+++ b/demo/react/components/button/dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { ButtonEmphasises, ButtonTheme, ButtonThemes, DropdownButton } from 'LumX';
 import { Callback } from 'LumX/core/react/utils';
@@ -37,7 +37,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     };
 
     return (
-        <Fragment>
+        <>
             <div className="mb+">
                 <DropdownButton
                     className="mr"
@@ -122,7 +122,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     Splitted Dropdown button with left icon
                 </DropdownButton>
             </div>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/button/dropdown.tsx
+++ b/demo/react/components/button/dropdown.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, ReactElement } from 'react';
 
 import { ButtonEmphasises, ButtonTheme, ButtonThemes, DropdownButton } from 'LumX';
+import { Callback } from 'LumX/core/react/utils';
 import { mdiPencil } from 'LumX/icons';
 
 /////////////////////////////
@@ -20,7 +21,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const onClick = (splitted: boolean = false): (() => void) => {
+    const onClick = (splitted: boolean = false): Callback => {
         return (): void => {
             console.info(`You click on a ${splitted ? 'splitted' : 'non-splitted'} dropdown button`);
             if (splitted) {

--- a/demo/react/components/button/dropdown.tsx
+++ b/demo/react/components/button/dropdown.tsx
@@ -20,7 +20,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const onClick: (splitted: boolean) => void = (splitted: boolean = false): (() => void) => {
+    const onClick = (splitted: boolean = false): (() => void) => {
         return (): void => {
             console.info(`You click on a ${splitted ? 'splitted' : 'non-splitted'} dropdown button`);
             if (splitted) {

--- a/demo/react/components/button/dropdown.tsx
+++ b/demo/react/components/button/dropdown.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { ButtonEmphasises, ButtonTheme, ButtonThemes, DropdownButton } from 'LumX';
+import { ButtonEmphasis, DropdownButton, Theme } from 'LumX';
 import { Callback } from 'LumX/core/react/utils';
 import { mdiPencil } from 'LumX/icons';
 
@@ -10,7 +10,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ButtonTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -42,8 +42,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                 <DropdownButton
                     className="mr"
                     dropdown={<span>Content of the Dropdown</span>}
-                    emphasis={ButtonEmphasises.low}
-                    color={theme === ButtonThemes.dark ? 'light' : undefined}
+                    emphasis={ButtonEmphasis.low}
+                    color={theme === Theme.dark ? 'light' : undefined}
                     theme={theme}
                     onClick={onClick(false)}
                 >
@@ -53,8 +53,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                 <DropdownButton
                     className="mr"
                     dropdown={<span>Content of the Dropdown</span>}
-                    emphasis={ButtonEmphasises.medium}
-                    color={theme === ButtonThemes.dark ? 'light' : undefined}
+                    emphasis={ButtonEmphasis.medium}
+                    color={theme === Theme.dark ? 'light' : undefined}
                     theme={theme}
                     onClick={onClick(false)}
                 >
@@ -71,8 +71,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     className="mr"
                     dropdown={<span>Content of the Dropdown</span>}
                     splitted={true}
-                    emphasis={ButtonEmphasises.low}
-                    color={theme === ButtonThemes.dark ? 'light' : undefined}
+                    emphasis={ButtonEmphasis.low}
+                    color={theme === Theme.dark ? 'light' : undefined}
                     theme={theme}
                     onClick={onClick(true)}
                 >
@@ -83,8 +83,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     className="mr"
                     dropdown={<span>Content of the Dropdown</span>}
                     splitted={true}
-                    emphasis={ButtonEmphasises.medium}
-                    color={theme === ButtonThemes.dark ? 'light' : undefined}
+                    emphasis={ButtonEmphasis.medium}
+                    color={theme === Theme.dark ? 'light' : undefined}
                     theme={theme}
                     onClick={onClick(true)}
                 >

--- a/demo/react/components/button/dropdown.tsx
+++ b/demo/react/components/button/dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { ButtonEmphasises, ButtonTheme, ButtonThemes, DropdownButton } from 'LumX';
 import { mdiPencil } from 'LumX/icons';
@@ -19,7 +19,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const onClick: (splitted: boolean) => void = (splitted: boolean = false): (() => void) => {
         return (): void => {
             console.info(`You click on a ${splitted ? 'splitted' : 'non-splitted'} dropdown button`);

--- a/demo/react/components/button/sizes.tsx
+++ b/demo/react/components/button/sizes.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonSizes, ButtonTheme, ButtonThemes } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <div className="mb+">
             <Button

--- a/demo/react/components/button/sizes.tsx
+++ b/demo/react/components/button/sizes.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Button, ButtonEmphasises, ButtonSizes, ButtonTheme, ButtonThemes } from 'LumX';
+import { Button, ButtonEmphasis, Size, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ButtonTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -23,9 +23,9 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div className="mb+">
             <Button
                 className="mr"
-                size={ButtonSizes.s}
-                emphasis={ButtonEmphasises.low}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                size={Size.s}
+                emphasis={ButtonEmphasis.low}
+                color={theme === Theme.dark ? 'light' : undefined}
                 theme={theme}
             >
                 <div>
@@ -35,9 +35,9 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
 
             <Button
                 className="mr"
-                size={ButtonSizes.s}
-                emphasis={ButtonEmphasises.medium}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                size={Size.s}
+                emphasis={ButtonEmphasis.medium}
+                color={theme === Theme.dark ? 'light' : undefined}
                 theme={theme}
             >
                 <div>
@@ -45,7 +45,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </Button>
 
-            <Button size={ButtonSizes.s} theme={theme}>
+            <Button size={Size.s} theme={theme}>
                 <div>
                     Small - <code>s</code>
                 </div>
@@ -55,9 +55,9 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div className="mb+">
             <Button
                 className="mr"
-                size={ButtonSizes.m}
-                emphasis={ButtonEmphasises.low}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                size={Size.m}
+                emphasis={ButtonEmphasis.low}
+                color={theme === Theme.dark ? 'light' : undefined}
                 theme={theme}
             >
                 <div>
@@ -67,9 +67,9 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
 
             <Button
                 className="mr"
-                size={ButtonSizes.m}
-                emphasis={ButtonEmphasises.medium}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                size={Size.m}
+                emphasis={ButtonEmphasis.medium}
+                color={theme === Theme.dark ? 'light' : undefined}
                 theme={theme}
             >
                 <div>
@@ -77,7 +77,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </Button>
 
-            <Button size={ButtonSizes.m} theme={theme}>
+            <Button size={Size.m} theme={theme}>
                 <div>
                     Medium - <code>m</code> (default)
                 </div>

--- a/demo/react/components/button/sizes.tsx
+++ b/demo/react/components/button/sizes.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonSizes, ButtonTheme, ButtonThemes } from 'LumX';
 
@@ -19,7 +19,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <div className="mb+">
             <Button
                 className="mr"
@@ -83,7 +83,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </Button>
         </div>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/button/with-icons.tsx
+++ b/demo/react/components/button/with-icons.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes, IconButton } from 'LumX';
 import { mdiCheck, mdiPencil } from 'LumX/icons';
@@ -19,7 +19,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <div className="mb+">
             <Button

--- a/demo/react/components/button/with-icons.tsx
+++ b/demo/react/components/button/with-icons.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes, IconButton } from 'LumX';
 import { mdiCheck, mdiPencil } from 'LumX/icons';
@@ -20,7 +20,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <div className="mb+">
             <Button
                 className="mr"
@@ -140,7 +140,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
 
             <IconButton icon={mdiPencil} theme={theme} />
         </div>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/button/with-icons.tsx
+++ b/demo/react/components/button/with-icons.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Button, ButtonEmphasises, ButtonTheme, ButtonThemes, IconButton } from 'LumX';
+import { Button, ButtonEmphasis, IconButton, Theme } from 'LumX';
 import { mdiCheck, mdiPencil } from 'LumX/icons';
 
 /////////////////////////////
@@ -9,7 +9,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ButtonTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -24,8 +24,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div className="mb+">
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.low}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.low}
+                color={theme === Theme.dark ? 'light' : undefined}
                 leftIcon={mdiPencil}
                 theme={theme}
             >
@@ -34,8 +34,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
 
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.medium}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.medium}
+                color={theme === Theme.dark ? 'light' : undefined}
                 leftIcon={mdiPencil}
                 theme={theme}
             >
@@ -50,8 +50,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div className="mb+">
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.low}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.low}
+                color={theme === Theme.dark ? 'light' : undefined}
                 rightIcon={mdiCheck}
                 theme={theme}
             >
@@ -60,8 +60,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
 
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.medium}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.medium}
+                color={theme === Theme.dark ? 'light' : undefined}
                 rightIcon={mdiCheck}
                 theme={theme}
             >
@@ -76,8 +76,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div className="mb+">
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.low}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.low}
+                color={theme === Theme.dark ? 'light' : undefined}
                 leftIcon={mdiPencil}
                 rightIcon={mdiCheck}
                 theme={theme}
@@ -87,8 +87,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
 
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.medium}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.medium}
+                color={theme === Theme.dark ? 'light' : undefined}
                 leftIcon={mdiPencil}
                 rightIcon={mdiCheck}
                 theme={theme}
@@ -104,16 +104,16 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div className="mb+">
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.low}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.low}
+                color={theme === Theme.dark ? 'light' : undefined}
                 leftIcon={mdiPencil}
                 theme={theme}
             />
 
             <Button
                 className="mr"
-                emphasis={ButtonEmphasises.medium}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.medium}
+                color={theme === Theme.dark ? 'light' : undefined}
                 leftIcon={mdiPencil}
                 theme={theme}
             />
@@ -124,16 +124,16 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div>
             <IconButton
                 className="mr"
-                emphasis={ButtonEmphasises.low}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.low}
+                color={theme === Theme.dark ? 'light' : undefined}
                 icon={mdiPencil}
                 theme={theme}
             />
 
             <IconButton
                 className="mr"
-                emphasis={ButtonEmphasises.medium}
-                color={theme === ButtonThemes.dark ? 'light' : undefined}
+                emphasis={ButtonEmphasis.medium}
+                color={theme === Theme.dark ? 'light' : undefined}
                 icon={mdiPencil}
                 theme={theme}
             />

--- a/demo/react/components/checkbox/default.tsx
+++ b/demo/react/components/checkbox/default.tsx
@@ -19,7 +19,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [checkboxes, setCheckboxes] = useState<boolean[]>([true, false]);
+    const [checkboxes, setCheckboxes] = useState([true, false]);
     const handleChange: CallableFunction = (index: number): CallableFunction => ({
         checked,
     }: {

--- a/demo/react/components/checkbox/default.tsx
+++ b/demo/react/components/checkbox/default.tsx
@@ -21,10 +21,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [checkboxes, setCheckboxes]: [boolean[], React.Dispatch<React.SetStateAction<boolean[]>>] = useState([
-        true,
-        false,
-    ]);
+    const [checkboxes, setCheckboxes] = useState<boolean[]>([true, false]);
     const handleChange: CallableFunction = (index: number): CallableFunction => ({
         checked,
     }: {

--- a/demo/react/components/checkbox/default.tsx
+++ b/demo/react/components/checkbox/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import { Checkbox, CheckboxTheme } from 'LumX';
 import { CheckboxHelper } from 'LumX/components/checkbox/react/CheckboxHelper';
@@ -34,7 +34,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     };
 
     return (
-        <Fragment>
+        <>
             <div className="mb+">
                 <Checkbox checked={checkboxes[0]} onChange={handleChange(0)} theme={theme}>
                     <CheckboxLabel>Checkbox</CheckboxLabel>
@@ -58,7 +58,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     </CheckboxHelper>
                 </Checkbox>
             </div>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/checkbox/default.tsx
+++ b/demo/react/components/checkbox/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, ReactElement, useState } from 'react';
 
 import { Checkbox, CheckboxTheme } from 'LumX';
 import { CheckboxHelper } from 'LumX/components/checkbox/react/CheckboxHelper';
@@ -20,7 +20,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const [checkboxes, setCheckboxes]: [boolean[], React.Dispatch<React.SetStateAction<boolean[]>>] = useState([
         true,
         false,

--- a/demo/react/components/checkbox/default.tsx
+++ b/demo/react/components/checkbox/default.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 
-import { Checkbox, CheckboxTheme } from 'LumX';
-import { CheckboxHelper } from 'LumX/components/checkbox/react/CheckboxHelper';
-import { CheckboxLabel } from 'LumX/components/checkbox/react/CheckboxLabel';
+import { Checkbox, CheckboxHelper, CheckboxLabel, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -10,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: CheckboxTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/chip/default.tsx
+++ b/demo/react/components/chip/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Chip, ChipSizes, ChipTheme, Colors, Icon } from 'LumX';
 import { mdiClose, mdiEmail } from 'LumX/icons';
@@ -20,7 +20,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <Chip theme={theme} LabelComponent="Medium">
             Label
         </Chip>
@@ -59,7 +59,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         >
             Label
         </Chip>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/chip/default.tsx
+++ b/demo/react/components/chip/default.tsx
@@ -1,6 +1,6 @@
 // tslint:disable: jsx-no-lambda no-console
 
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Chip, ChipSizes, ChipTheme, Colors, Icon } from 'LumX';
 import { mdiClose, mdiEmail } from 'LumX/icons';
@@ -21,7 +21,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <Chip theme={theme} LabelComponent="Medium">
             Label

--- a/demo/react/components/chip/default.tsx
+++ b/demo/react/components/chip/default.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Chip, ChipSizes, ChipTheme, Colors, Icon } from 'LumX';
+import { Chip, ColorPalette, Icon, Size, Theme } from 'LumX';
 import { mdiClose, mdiEmail } from 'LumX/icons';
 
 /////////////////////////////
@@ -9,7 +9,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ChipTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -24,7 +24,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <Chip theme={theme} LabelComponent="Medium">
             Label
         </Chip>
-        <Chip color={Colors.red} theme={theme} size={ChipSizes.s} LabelComponent="Small">
+        <Chip color={ColorPalette.red} theme={theme} size={Size.s} LabelComponent="Small">
             Label
         </Chip>
         <Chip
@@ -38,7 +38,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <Chip
             after={<Icon icon={mdiClose} />}
             before={<Icon icon={mdiEmail} />}
-            color={Colors.green}
+            color={ColorPalette.green}
             theme={theme}
             LabelComponent="Rich"
             onAfterClick={(): void => console.log('After component triggered.')}

--- a/demo/react/components/chip/default.tsx
+++ b/demo/react/components/chip/default.tsx
@@ -1,5 +1,3 @@
-// tslint:disable: jsx-no-lambda no-console
-
 import React, { Fragment, ReactElement } from 'react';
 
 import { Chip, ChipSizes, ChipTheme, Colors, Icon } from 'LumX';

--- a/demo/react/components/image-block/default.tsx
+++ b/demo/react/components/image-block/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment } from 'react';
+import React, { CSSProperties, Fragment, ReactElement } from 'react';
 
 import { ImageBlock, ImageBlockCaptionPositions, ImageBlockProps, ImageBlockTheme, ThumbnailAspectRatios } from 'LumX';
 import { Alignments } from 'LumX/components';
@@ -35,7 +35,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <ImageBlock theme={theme} image="https://picsum.photos/640/480/?random" style={imageBlockDemoStyle} />
         <ImageBlock

--- a/demo/react/components/image-block/default.tsx
+++ b/demo/react/components/image-block/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment, ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { ImageBlock, ImageBlockCaptionPositions, ImageBlockProps, ImageBlockTheme, ThumbnailAspectRatios } from 'LumX';
 import { Alignments } from 'LumX/components';
@@ -36,7 +36,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <ImageBlock theme={theme} image="https://picsum.photos/640/480/?random" style={imageBlockDemoStyle} />
         <ImageBlock
             aspectRatio={ThumbnailAspectRatios.vertical}
@@ -111,7 +111,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             theme={theme}
             {...imageBlockDemoProps}
         />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/image-block/default.tsx
+++ b/demo/react/components/image-block/default.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { ImageBlock, ImageBlockCaptionPositions, ImageBlockProps, ImageBlockTheme, ThumbnailAspectRatios } from 'LumX';
-import { Alignments } from 'LumX/components';
+import { Alignment, ImageBlock, ImageBlockCaptionPosition, ImageBlockProps, Theme, ThumbnailAspectRatio } from 'LumX';
 
 /////////////////////////////
 
@@ -9,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ImageBlockTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -39,73 +38,73 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <>
         <ImageBlock theme={theme} image="https://picsum.photos/640/480/?random" style={imageBlockDemoStyle} />
         <ImageBlock
-            aspectRatio={ThumbnailAspectRatios.vertical}
+            aspectRatio={ThumbnailAspectRatio.vertical}
             theme={theme}
             image="https://picsum.photos/640/480/?random"
             style={imageBlockDemoStyle}
         />
         <ImageBlock
-            aspectRatio={ThumbnailAspectRatios.horizontal}
+            aspectRatio={ThumbnailAspectRatio.horizontal}
             theme={theme}
             image="https://picsum.photos/640/480/?random"
             style={imageBlockDemoStyle}
         />
         <ImageBlock
-            theme={theme}
-            image="https://picsum.photos/640/480/?random"
-            style={imageBlockDemoStyle}
-            {...imageBlockDemoProps}
-        />
-        <ImageBlock
-            aspectRatio={ThumbnailAspectRatios.vertical}
             theme={theme}
             image="https://picsum.photos/640/480/?random"
             style={imageBlockDemoStyle}
             {...imageBlockDemoProps}
         />
         <ImageBlock
-            aspectRatio={ThumbnailAspectRatios.horizontal}
+            aspectRatio={ThumbnailAspectRatio.vertical}
             theme={theme}
             image="https://picsum.photos/640/480/?random"
             style={imageBlockDemoStyle}
             {...imageBlockDemoProps}
         />
         <ImageBlock
-            captionPosition={ImageBlockCaptionPositions.over}
+            aspectRatio={ThumbnailAspectRatio.horizontal}
+            theme={theme}
+            image="https://picsum.photos/640/480/?random"
+            style={imageBlockDemoStyle}
+            {...imageBlockDemoProps}
+        />
+        <ImageBlock
+            captionPosition={ImageBlockCaptionPosition.over}
             image="https://picsum.photos/640/480/?random"
             style={imageBlockDemoStyle}
             theme={theme}
             {...imageBlockDemoProps}
         />
         <ImageBlock
-            aspectRatio={ThumbnailAspectRatios.vertical}
-            captionPosition={ImageBlockCaptionPositions.over}
+            aspectRatio={ThumbnailAspectRatio.vertical}
+            captionPosition={ImageBlockCaptionPosition.over}
             image="https://picsum.photos/640/480/?random"
             style={imageBlockDemoStyle}
             theme={theme}
             {...imageBlockDemoProps}
         />
         <ImageBlock
-            aspectRatio={ThumbnailAspectRatios.horizontal}
-            captionPosition={ImageBlockCaptionPositions.over}
+            aspectRatio={ThumbnailAspectRatio.horizontal}
+            captionPosition={ImageBlockCaptionPosition.over}
             image="https://picsum.photos/640/480/?random"
             style={imageBlockDemoStyle}
             theme={theme}
             {...imageBlockDemoProps}
         />
         <ImageBlock
-            align={Alignments.center}
-            aspectRatio={ThumbnailAspectRatios.horizontal}
-            captionPosition={ImageBlockCaptionPositions.over}
+            align={Alignment.center}
+            aspectRatio={ThumbnailAspectRatio.horizontal}
+            captionPosition={ImageBlockCaptionPosition.over}
             image="https://picsum.photos/640/480/?random"
             style={{ ...imageBlockDemoStyle, width: '95%' }}
             theme={theme}
             {...imageBlockDemoProps}
         />
         <ImageBlock
-            align={Alignments.right}
-            aspectRatio={ThumbnailAspectRatios.horizontal}
-            captionPosition={ImageBlockCaptionPositions.over}
+            align={Alignment.right}
+            aspectRatio={ThumbnailAspectRatio.horizontal}
+            captionPosition={ImageBlockCaptionPosition.over}
             image="https://picsum.photos/640/480/?random"
             style={{ ...imageBlockDemoStyle, width: '95%' }}
             theme={theme}

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -31,8 +31,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const [isOpened, setIsOpened] = useState<boolean>(false);
 
-    // tslint:disable-next-line: no-any
-    const triggerElement: React.RefObject<any> = useRef(null);
+    const triggerElement = useRef<Button>(null);
 
     const onOpenModal = useCallback(() => {
         // Do something.

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useCallback, useRef, useState } from 'react';
+import React, { ReactElement, useCallback, useRef, useState } from 'react';
 
 import { Button, ImageBlock, ImageBlockProps, Lightbox, LightboxTheme, Slideshow, SlideshowItem, Themes } from 'LumX';
 import { Alignments } from 'LumX/components';
@@ -47,7 +47,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     }, [isOpened]);
 
     return (
-        <Fragment>
+        <>
             <Button
                 buttonRef={triggerElement}
                 aria-label="Close Modal"
@@ -92,7 +92,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     </SlideshowItem>
                 </Slideshow>
             </Lightbox>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -34,16 +34,16 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     // tslint:disable-next-line: no-any
     const triggerElement: React.RefObject<any> = useRef(null);
 
-    const onOpenModal: () => void = useCallback(() => {
+    const onOpenModal = useCallback(() => {
         // Do something.
     }, []);
 
-    const onCloseModal: () => void = useCallback(() => {
+    const onCloseModal = useCallback(() => {
         // Do something.
         setIsOpened(false);
     }, []);
 
-    const handleClick: () => void = useCallback(() => {
+    const handleClick = useCallback(() => {
         setIsOpened(!isOpened);
     }, [isOpened]);
 

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -29,7 +29,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [isOpened, setIsOpened]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);
+    const [isOpened, setIsOpened] = useState<boolean>(false);
 
     // tslint:disable-next-line: no-any
     const triggerElement: React.RefObject<any> = useRef(null);

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useRef, useState } from 'react';
+import React, { Fragment, ReactElement, useCallback, useRef, useState } from 'react';
 
 import { Button, ImageBlock, ImageBlockProps, Lightbox, LightboxTheme, Slideshow, SlideshowItem, Themes } from 'LumX';
 import { Alignments } from 'LumX/components';
@@ -28,7 +28,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const [isOpened, setIsOpened]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);
 
     // tslint:disable-next-line: no-any

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useCallback, useRef, useState } from 'react';
 
-import { Button, ImageBlock, ImageBlockProps, Lightbox, LightboxTheme, Slideshow, SlideshowItem, Themes } from 'LumX';
-import { Alignments } from 'LumX/components';
+import { Alignment, Button, ImageBlock, ImageBlockProps, Lightbox, Slideshow, SlideshowItem, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -9,17 +8,17 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: LightboxTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
 
 const imageBlockDemoProps: Partial<ImageBlockProps> = {
-    align: Alignments.center,
+    align: Alignment.center,
     description: 'What an image',
     fillHeight: true,
     tags: ['#tag1', '#tag2', '#tag3'],
-    theme: Themes.dark,
+    theme: Theme.dark,
     title: 'Nice Image',
 };
 
@@ -65,7 +64,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                 onOpen={onOpenModal}
                 theme={theme}
             >
-                <Slideshow hasControls={true} autoPlay={true} fillHeight={true} theme={Themes.dark}>
+                <Slideshow hasControls={true} autoPlay={true} fillHeight={true} theme={Theme.dark}>
                     <SlideshowItem>
                         <ImageBlock image="https://picsum.photos/640/480/?image=24" {...imageBlockDemoProps} />
                     </SlideshowItem>

--- a/demo/react/components/lightbox/default.tsx
+++ b/demo/react/components/lightbox/default.tsx
@@ -28,7 +28,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [isOpened, setIsOpened] = useState<boolean>(false);
+    const [isOpened, setIsOpened] = useState(false);
 
     const triggerElement = useRef<Button>(null);
 

--- a/demo/react/components/list/big.tsx
+++ b/demo/react/components/list/big.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import {
     Button,
@@ -34,7 +34,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>
             <ListItem size={ListItemSizes.big}>
@@ -77,7 +77,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </ListItem>
         </List>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/list/big.tsx
+++ b/demo/react/components/list/big.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import {
     Button,
@@ -33,7 +33,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>

--- a/demo/react/components/list/big.tsx
+++ b/demo/react/components/list/big.tsx
@@ -2,20 +2,19 @@ import React, { ReactElement } from 'react';
 
 import {
     Button,
-    ButtonEmphasises,
+    ButtonEmphasis,
     Icon,
     List,
     ListItem,
-    ListItemSizes,
+    ListItemSize,
     ListSubheader,
-    ListTheme,
+    Size,
+    Theme,
     Thumbnail,
-    ThumbnailSizes,
+    ThumbnailVariant,
 } from 'LumX';
 
 import { mdiSend } from 'LumX/icons';
-
-import { Variants } from 'LumX/components/thumbnail/react/Thumbnail';
 
 /////////////////////////////
 
@@ -23,7 +22,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ListTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -37,7 +36,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>
-            <ListItem size={ListItemSizes.big}>
+            <ListItem size={ListItemSize.big}>
                 <div>
                     <span>Two-line item</span>
                 </div>
@@ -47,13 +46,13 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             </ListItem>
             <ListSubheader>rich</ListSubheader>
             <ListItem
-                size={ListItemSizes.big}
+                size={ListItemSize.big}
                 before={
                     <Thumbnail
                         theme={theme}
-                        variant={Variants.rounded}
+                        variant={ThumbnailVariant.rounded}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
+                        size={Size.m}
                     />
                 }
             >
@@ -65,9 +64,9 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </ListItem>
             <ListItem
-                size={ListItemSizes.big}
+                size={ListItemSize.big}
                 before={<Icon icon={mdiSend} />}
-                after={<Button emphasis={ButtonEmphasises.low}>Button</Button>}
+                after={<Button emphasis={ButtonEmphasis.low}>Button</Button>}
             >
                 <div>
                     <span>Two-line item</span>

--- a/demo/react/components/list/default.tsx
+++ b/demo/react/components/list/default.tsx
@@ -2,19 +2,18 @@ import React, { ReactElement } from 'react';
 
 import {
     Button,
-    ButtonEmphasises,
+    ButtonEmphasis,
     Icon,
     List,
     ListItem,
     ListSubheader,
-    ListTheme,
+    Size,
+    Theme,
     Thumbnail,
-    ThumbnailSizes,
+    ThumbnailVariant,
 } from 'LumX';
 
 import { mdiSend } from 'LumX/icons';
-
-import { Variants } from 'LumX/components/thumbnail/react/Thumbnail';
 
 /////////////////////////////
 
@@ -22,7 +21,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ListTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -45,15 +44,15 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 before={
                     <Thumbnail
                         theme={theme}
-                        variant={Variants.rounded}
+                        variant={ThumbnailVariant.rounded}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
+                        size={Size.m}
                     />
                 }
             >
                 Single-line item
             </ListItem>
-            <ListItem before={<Icon icon={mdiSend} />} after={<Button emphasis={ButtonEmphasises.low}>Button</Button>}>
+            <ListItem before={<Icon icon={mdiSend} />} after={<Button emphasis={ButtonEmphasis.low}>Button</Button>}>
                 Single-line item
             </ListItem>
         </List>

--- a/demo/react/components/list/default.tsx
+++ b/demo/react/components/list/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import {
     Button,
@@ -32,7 +32,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>

--- a/demo/react/components/list/default.tsx
+++ b/demo/react/components/list/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import {
     Button,
@@ -33,7 +33,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>
             <ListItem>Single-line item</ListItem>
@@ -57,7 +57,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 Single-line item
             </ListItem>
         </List>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/list/huge.tsx
+++ b/demo/react/components/list/huge.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import {
     Button,
@@ -35,7 +35,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>
             <ListItem size={ListItemSizes.huge}>
@@ -88,7 +88,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </ListItem>
         </List>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/list/huge.tsx
+++ b/demo/react/components/list/huge.tsx
@@ -2,21 +2,20 @@ import React, { ReactElement } from 'react';
 
 import {
     Button,
-    ButtonEmphasises,
+    ButtonEmphasis,
     Icon,
     List,
     ListDivider,
     ListItem,
-    ListItemSizes,
+    ListItemSize,
     ListSubheader,
-    ListTheme,
+    Size,
+    Theme,
     Thumbnail,
-    ThumbnailSizes,
+    ThumbnailVariant,
 } from 'LumX';
 
 import { mdiSend } from 'LumX/icons';
-
-import { Variants } from 'LumX/components/thumbnail/react/Thumbnail';
 
 /////////////////////////////
 
@@ -24,7 +23,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ListTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -38,7 +37,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>
-            <ListItem size={ListItemSizes.huge}>
+            <ListItem size={ListItemSize.huge}>
                 <div>
                     <span>Multi-line item</span>
                 </div>
@@ -52,13 +51,13 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             <ListDivider />
             <ListSubheader>rich</ListSubheader>
             <ListItem
-                size={ListItemSizes.huge}
+                size={ListItemSize.huge}
                 before={
                     <Thumbnail
                         theme={theme}
-                        variant={Variants.rounded}
+                        variant={ThumbnailVariant.rounded}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
+                        size={Size.m}
                     />
                 }
             >
@@ -73,9 +72,9 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </ListItem>
             <ListItem
-                size={ListItemSizes.huge}
+                size={ListItemSize.huge}
                 before={<Icon icon={mdiSend} />}
-                after={<Button emphasis={ButtonEmphasises.low}>Button</Button>}
+                after={<Button emphasis={ButtonEmphasis.low}>Button</Button>}
             >
                 <div>
                     <span>Multi-line item</span>

--- a/demo/react/components/list/huge.tsx
+++ b/demo/react/components/list/huge.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import {
     Button,
@@ -34,7 +34,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <List theme={theme}>
             <ListSubheader>text only</ListSubheader>

--- a/demo/react/components/list/tiny.tsx
+++ b/demo/react/components/list/tiny.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import {
     Button,
@@ -45,7 +45,7 @@ const onItemSelectedHandler: (data: any) => void = (data: any): void => {
  * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda typedef
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <List theme={theme} isClickable onListItemSelected={onListItemSelectedHandler}>
             <ListSubheader>text only</ListSubheader>

--- a/demo/react/components/list/tiny.tsx
+++ b/demo/react/components/list/tiny.tsx
@@ -29,13 +29,10 @@ interface IProps {
 /////////////////////////////
 
 const onListItemSelectedHandler = (selectedEntry: ListItem): void => {
-    // tslint:disable-next-line: no-console
     console.log(selectedEntry);
 };
 
-// tslint:disable-next-line: no-any
-const onItemSelectedHandler = (data: any): void => {
-    // tslint:disable-next-line: no-console
+const onItemSelectedHandler = (data: string): void => {
     console.log(data);
 };
 
@@ -44,12 +41,11 @@ const onItemSelectedHandler = (data: any): void => {
  *
  * @return The demo component.
  */
-// tslint:disable: jsx-no-lambda typedef
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <List theme={theme} isClickable onListItemSelected={onListItemSelectedHandler}>
             <ListSubheader>text only</ListSubheader>
-            <ListItem size={ListItemSizes.tiny} onItemSelected={() => onItemSelectedHandler('Some data')}>
+            <ListItem size={ListItemSizes.tiny} onItemSelected={(): void => onItemSelectedHandler('Some data')}>
                 Single-line item 1
             </ListItem>
             <ListItem size={ListItemSizes.tiny}>Single-line item 2</ListItem>

--- a/demo/react/components/list/tiny.tsx
+++ b/demo/react/components/list/tiny.tsx
@@ -2,20 +2,19 @@ import React, { ReactElement } from 'react';
 
 import {
     Button,
-    ButtonEmphasises,
+    ButtonEmphasis,
     Icon,
     List,
     ListItem,
-    ListItemSizes,
+    ListItemSize,
     ListSubheader,
-    ListTheme,
+    Size,
+    Theme,
     Thumbnail,
-    ThumbnailSizes,
+    ThumbnailVariant,
 } from 'LumX';
 
 import { mdiSend } from 'LumX/icons';
-
-import { Variants } from 'LumX/components/thumbnail/react/Thumbnail';
 
 /////////////////////////////
 
@@ -23,7 +22,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ListTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -45,33 +44,33 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <>
         <List theme={theme} isClickable onListItemSelected={onListItemSelectedHandler}>
             <ListSubheader>text only</ListSubheader>
-            <ListItem size={ListItemSizes.tiny} onItemSelected={(): void => onItemSelectedHandler('Some data')}>
+            <ListItem size={ListItemSize.tiny} onItemSelected={(): void => onItemSelectedHandler('Some data')}>
                 Single-line item 1
             </ListItem>
-            <ListItem size={ListItemSizes.tiny}>Single-line item 2</ListItem>
-            <ListItem size={ListItemSizes.tiny}>Single-line item 3</ListItem>
+            <ListItem size={ListItemSize.tiny}>Single-line item 2</ListItem>
+            <ListItem size={ListItemSize.tiny}>Single-line item 3</ListItem>
             <ListSubheader>rich</ListSubheader>
-            <ListItem size={ListItemSizes.tiny} before={<Icon icon={mdiSend} />}>
+            <ListItem size={ListItemSize.tiny} before={<Icon icon={mdiSend} />}>
                 Single-line item 4
             </ListItem>
             <ListItem
                 isSelected
-                size={ListItemSizes.tiny}
+                size={ListItemSize.tiny}
                 before={
                     <Thumbnail
                         theme={theme}
-                        variant={Variants.rounded}
+                        variant={ThumbnailVariant.rounded}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
+                        size={Size.m}
                     />
                 }
             >
                 Single-line item 5
             </ListItem>
             <ListItem
-                size={ListItemSizes.tiny}
+                size={ListItemSize.tiny}
                 before={<Icon icon={mdiSend} />}
-                after={<Button emphasis={ButtonEmphasises.low}>Button</Button>}
+                after={<Button emphasis={ButtonEmphasis.low}>Button</Button>}
             >
                 Single-line item 6
             </ListItem>

--- a/demo/react/components/list/tiny.tsx
+++ b/demo/react/components/list/tiny.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import {
     Button,
@@ -42,7 +42,7 @@ const onItemSelectedHandler = (data: string): void => {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <List theme={theme} isClickable onListItemSelected={onListItemSelectedHandler}>
             <ListSubheader>text only</ListSubheader>
             <ListItem size={ListItemSizes.tiny} onItemSelected={(): void => onItemSelectedHandler('Some data')}>
@@ -76,7 +76,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 Single-line item 6
             </ListItem>
         </List>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/list/tiny.tsx
+++ b/demo/react/components/list/tiny.tsx
@@ -28,13 +28,13 @@ interface IProps {
 
 /////////////////////////////
 
-const onListItemSelectedHandler: (selectedEntry: ListItem) => void = (selectedEntry: ListItem): void => {
+const onListItemSelectedHandler = (selectedEntry: ListItem): void => {
     // tslint:disable-next-line: no-console
     console.log(selectedEntry);
 };
 
 // tslint:disable-next-line: no-any
-const onItemSelectedHandler: (data: any) => void = (data: any): void => {
+const onItemSelectedHandler = (data: any): void => {
     // tslint:disable-next-line: no-console
     console.log(data);
 };

--- a/demo/react/components/popover/controled.tsx
+++ b/demo/react/components/popover/controled.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, useState } from 'react';
+import React, { CSSProperties, ReactElement, useState } from 'react';
 
 import { Button, ButtonEmphasises, ButtonSizes, Placements, Popover } from 'LumX';
 
@@ -32,11 +32,11 @@ const demoPopoverHolderStyle: CSSProperties = {
     justifyContent: 'center',
 };
 
-const createDemoAnchor: () => ReactNode = (): ReactNode => {
+const createDemoAnchor = (): ReactElement => {
     return <div style={demoAnchorStyle}>{`This element will act as the anchor`}</div>;
 };
 
-const createPopper: () => ReactNode = (): ReactNode => {
+const createPopper = (): ReactElement => {
     return (
         <div style={demoPopperStyle}>
             {`Lorem ipsum dolor sit amet, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,consequat. `}
@@ -50,7 +50,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
  * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = (): ReactElement => {
     // tslint:disable-next-line: typedef
     const [isTooltipDisplayed, setTooltipDisplayed] = useState(false);
 

--- a/demo/react/components/popover/controled.tsx
+++ b/demo/react/components/popover/controled.tsx
@@ -49,9 +49,7 @@ const createPopper = (): ReactElement => {
  *
  * @return The demo component.
  */
-// tslint:disable: jsx-no-lambda
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
-    // tslint:disable-next-line: typedef
     const [isTooltipDisplayed, setTooltipDisplayed] = useState(false);
 
     /**

--- a/demo/react/components/popover/controled.tsx
+++ b/demo/react/components/popover/controled.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement, useState } from 'react';
 
-import { Button, ButtonEmphasises, ButtonSizes, Placements, Popover } from 'LumX';
+import { Button, ButtonEmphasis, Popover, PopperPlacement, Size } from 'LumX';
 
 /////////////////////////////
 
@@ -61,14 +61,14 @@ const DemoComponent: React.FC<IProps> = (): ReactElement => {
 
     return (
         <div>
-            <Button size={ButtonSizes.s} emphasis={ButtonEmphasises.medium} onClick={toggleTooltipDisplay}>
+            <Button size={Size.s} emphasis={ButtonEmphasis.medium} onClick={toggleTooltipDisplay}>
                 Toggle visibility
             </Button>
             <div style={demoPopoverHolderStyle}>
                 <Popover
                     anchorElement={createDemoAnchor()}
                     popperElement={createPopper()}
-                    popperPlacement={Placements.AUTO}
+                    popperPlacement={PopperPlacement.AUTO}
                     showPopper={isTooltipDisplayed}
                 />
             </div>

--- a/demo/react/components/popover/controled.tsx
+++ b/demo/react/components/popover/controled.tsx
@@ -57,7 +57,7 @@ const DemoComponent: React.FC<IProps> = (): ReactElement => {
     /**
      * Switch tooltip visibility
      */
-    const toggleTooltipDisplay: (evt?: React.MouseEvent<HTMLElement>) => void = (): void => {
+    const toggleTooltipDisplay = (): void => {
         setTooltipDisplayed(!isTooltipDisplayed);
     };
 

--- a/demo/react/components/popover/default.tsx
+++ b/demo/react/components/popover/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { Placements, Popover } from 'LumX';
 
@@ -42,11 +42,11 @@ const demoPopoverHolderStyle: CSSProperties = {
     justifyContent: 'center',
 };
 
-const createDemoAnchor: () => ReactNode = (): ReactNode => {
+const createDemoAnchor = (): ReactElement => {
     return <div style={demoAnchorStyle}>{`This element will act as the anchor`}</div>;
 };
 
-const createPopper: () => ReactNode = (): ReactNode => {
+const createPopper = (): ReactElement => {
     return <div style={demoPopperStyle}>{`This element is the popper and is flying above the UI.`}</div>;
 };
 
@@ -58,7 +58,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
  * @return The demo component.
  */
 // tslint:disable-next-line: typedef
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = (): ReactElement => {
     return (
         <div style={demoPopoverHolderStyle}>
             <div style={{ ...demoAnchorStyle, ...demoRandomElementStyle }}>{`Ramdom element`}</div>

--- a/demo/react/components/popover/default.tsx
+++ b/demo/react/components/popover/default.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Placements, Popover } from 'LumX';
+import { Popover, PopperPlacement } from 'LumX';
 
 /////////////////////////////
 
@@ -65,7 +65,7 @@ const DemoComponent: React.FC<IProps> = (): ReactElement => {
             <Popover
                 anchorElement={createDemoAnchor()}
                 popperElement={createPopper()}
-                popperPlacement={Placements.RIGHT}
+                popperPlacement={PopperPlacement.RIGHT}
                 showPopper
             />
             <div style={{ ...demoAnchorStyle, ...demoRandomElementStyle }}>{`Random element`}</div>

--- a/demo/react/components/popover/default.tsx
+++ b/demo/react/components/popover/default.tsx
@@ -57,7 +57,6 @@ const createPopper = (): ReactElement => {
  *
  * @return The demo component.
  */
-// tslint:disable-next-line: typedef
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
     return (
         <div style={demoPopoverHolderStyle}>

--- a/demo/react/components/popover/matchParentWidth.tsx
+++ b/demo/react/components/popover/matchParentWidth.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, useState } from 'react';
+import React, { CSSProperties, ReactElement, useState } from 'react';
 
 import { Placements, Popover } from 'LumX';
 
@@ -34,11 +34,11 @@ const demoPopoverHolderStyle: CSSProperties = {
     justifyContent: 'space-around',
 };
 
-const createDemoAnchor: (width: number) => ReactNode = (width: number): ReactNode => {
+const createDemoAnchor = (width: number): ReactElement => {
     return <div style={{ ...demoAnchorStyle, width }}>{'This element will act as the anchor'}</div>;
 };
 
-const createPopper: () => ReactNode = (): ReactNode => {
+const createPopper = (): ReactElement => {
     return (
         <div style={demoPopperStyle}>
             {
@@ -56,7 +56,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
  * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = (): ReactElement => {
     // tslint:disable-next-line: typedef
     const [isTooltipDisplayed, setTooltipDisplayed] = useState(false);
 

--- a/demo/react/components/popover/matchParentWidth.tsx
+++ b/demo/react/components/popover/matchParentWidth.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement, useState } from 'react';
 
-import { Placements, Popover } from 'LumX';
+import { Popover, PopperPlacement } from 'LumX';
 
 /////////////////////////////
 
@@ -72,7 +72,7 @@ const DemoComponent: React.FC<IProps> = (): ReactElement => {
                 <Popover
                     anchorElement={createDemoAnchor(230)}
                     popperElement={createPopper()}
-                    popperPlacement={Placements.BOTTOM}
+                    popperPlacement={PopperPlacement.BOTTOM}
                     showPopper={isTooltipDisplayed}
                     lockFlip
                     matchAnchorWidth

--- a/demo/react/components/popover/matchParentWidth.tsx
+++ b/demo/react/components/popover/matchParentWidth.tsx
@@ -64,7 +64,7 @@ const DemoComponent: React.FC<IProps> = (): ReactElement => {
      * Switch tooltip visibility
      * @param newVisibleState Tooltip visibility
      */
-    const toggleTooltipDisplay: (newVisibleState: boolean) => void = (newVisibleState: boolean): void => {
+    const toggleTooltipDisplay = (newVisibleState: boolean): void => {
         setTooltipDisplayed(newVisibleState);
     };
 

--- a/demo/react/components/popover/matchParentWidth.tsx
+++ b/demo/react/components/popover/matchParentWidth.tsx
@@ -55,9 +55,7 @@ const createPopper = (): ReactElement => {
  *
  * @return The demo component.
  */
-// tslint:disable: jsx-no-lambda
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
-    // tslint:disable-next-line: typedef
     const [isTooltipDisplayed, setTooltipDisplayed] = useState(false);
 
     /**

--- a/demo/react/components/popover/offsets.tsx
+++ b/demo/react/components/popover/offsets.tsx
@@ -63,7 +63,6 @@ const offsets: PopperOffsets = { horizontal: -60, vertical: 30 };
  *
  * @return The demo component.
  */
-// tslint:disable-next-line: typedef
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
     return (
         <div style={demoPopoverHolderStyle}>

--- a/demo/react/components/popover/offsets.tsx
+++ b/demo/react/components/popover/offsets.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Placements, Popover, PopperOffsets } from 'LumX';
+import { Popover, PopperOffsets, PopperPlacement } from 'LumX';
 
 /////////////////////////////
 
@@ -71,7 +71,7 @@ const DemoComponent: React.FC<IProps> = (): ReactElement => {
             <Popover
                 anchorElement={createDemoAnchor()}
                 popperElement={createPopper()}
-                popperPlacement={Placements.RIGHT}
+                popperPlacement={PopperPlacement.RIGHT}
                 popperOffset={offsets}
                 showPopper
             />

--- a/demo/react/components/popover/offsets.tsx
+++ b/demo/react/components/popover/offsets.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { Placements, Popover, PopperOffsets } from 'LumX';
 
@@ -46,11 +46,11 @@ const demoPopoverHolderStyle: CSSProperties = {
     justifyContent: 'center',
 };
 
-const createDemoAnchor: () => ReactNode = (): ReactNode => {
+const createDemoAnchor = (): ReactElement => {
     return <div style={demoAnchorStyle}>{`This element will act as the anchor`}</div>;
 };
 
-const createPopper: () => ReactNode = (): ReactNode => {
+const createPopper = (): ReactElement => {
     return <div style={demoPopperStyle}>{`This popper is placed using a 'vertical' and a 'horizontal' offset`}</div>;
 };
 
@@ -64,7 +64,7 @@ const offsets: PopperOffsets = { horizontal: -60, vertical: 30 };
  * @return The demo component.
  */
 // tslint:disable-next-line: typedef
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = (): ReactElement => {
     return (
         <div style={demoPopoverHolderStyle}>
             <div style={{ ...demoAnchorStyle, ...demoRandomElementStyle }}>{`Ramdom element`}</div>

--- a/demo/react/components/popover/placements.tsx
+++ b/demo/react/components/popover/placements.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, useState } from 'react';
+import React, { CSSProperties, ReactElement, useState } from 'react';
 
 import { Placements, Popover } from 'LumX';
 
@@ -27,11 +27,11 @@ const demoPopperStyle: CSSProperties = {
     width: '266px',
 };
 
-const createDemoAnchor: () => ReactNode = (): ReactNode => {
+const createDemoAnchor = (): ReactElement => {
     return <div style={demoAnchorStyle}>{`This element will act as the anchor`}</div>;
 };
 
-const createPopper: () => ReactNode = (): ReactNode => {
+const createPopper = (): ReactElement => {
     return (
         <div style={demoPopperStyle}>
             {`Lorem ipsum dolor sit amet, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,consequat. `}
@@ -45,7 +45,7 @@ const createPopper: () => ReactNode = (): ReactNode => {
  * @return The demo component.
  */
 // tslint:disable: jsx-no-lambda
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = (): ReactElement => {
     // tslint:disable-next-line: typedef
     const [selectedPlacement, setSelectedPlacement] = useState(Placements.AUTO);
     // tslint:disable-next-line: typedef

--- a/demo/react/components/popover/placements.tsx
+++ b/demo/react/components/popover/placements.tsx
@@ -44,11 +44,8 @@ const createPopper = (): ReactElement => {
  *
  * @return The demo component.
  */
-// tslint:disable: jsx-no-lambda
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
-    // tslint:disable-next-line: typedef
     const [selectedPlacement, setSelectedPlacement] = useState(Placements.AUTO);
-    // tslint:disable-next-line: typedef
     const [isTooltipDisplayed, setTooltipDisplayed] = useState(false);
     const availablePlacements: string[] = [
         Placements.AUTO,

--- a/demo/react/components/popover/placements.tsx
+++ b/demo/react/components/popover/placements.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement, useState } from 'react';
 
-import { Placements, Popover } from 'LumX';
+import { Popover, PopperPlacement } from 'LumX';
 
 /////////////////////////////
 
@@ -45,24 +45,24 @@ const createPopper = (): ReactElement => {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
-    const [selectedPlacement, setSelectedPlacement] = useState(Placements.AUTO);
+    const [selectedPlacement, setSelectedPlacement] = useState(PopperPlacement.AUTO);
     const [isTooltipDisplayed, setTooltipDisplayed] = useState(false);
-    const availablePlacements: string[] = [
-        Placements.AUTO,
-        Placements.AUTO_END,
-        Placements.AUTO_START,
-        Placements.BOTTOM,
-        Placements.BOTTOM_END,
-        Placements.BOTTOM_START,
-        Placements.LEFT,
-        Placements.LEFT_END,
-        Placements.LEFT_START,
-        Placements.RIGHT,
-        Placements.RIGHT_END,
-        Placements.RIGHT_START,
-        Placements.TOP,
-        Placements.TOP_END,
-        Placements.TOP_START,
+    const availablePopperPlacement: string[] = [
+        PopperPlacement.AUTO,
+        PopperPlacement.AUTO_END,
+        PopperPlacement.AUTO_START,
+        PopperPlacement.BOTTOM,
+        PopperPlacement.BOTTOM_END,
+        PopperPlacement.BOTTOM_START,
+        PopperPlacement.LEFT,
+        PopperPlacement.LEFT_END,
+        PopperPlacement.LEFT_START,
+        PopperPlacement.RIGHT,
+        PopperPlacement.RIGHT_END,
+        PopperPlacement.RIGHT_START,
+        PopperPlacement.TOP,
+        PopperPlacement.TOP_END,
+        PopperPlacement.TOP_START,
     ];
 
     function toggleTooltipDisplay(newVisibleState: boolean): void {
@@ -73,10 +73,10 @@ const DemoComponent: React.FC<IProps> = (): ReactElement => {
         <div onMouseOver={(): void => toggleTooltipDisplay(true)} onMouseOut={(): void => toggleTooltipDisplay(false)}>
             <select
                 onChange={(evt: React.ChangeEvent<HTMLSelectElement>): void =>
-                    setSelectedPlacement(evt.target.value as Placements)
+                    setSelectedPlacement(evt.target.value as PopperPlacement)
                 }
             >
-                {availablePlacements.map((pos: string) => (
+                {availablePopperPlacement.map((pos: string) => (
                     <option>{pos}</option>
                 ))}
             </select>

--- a/demo/react/components/popover/realCase.tsx
+++ b/demo/react/components/popover/realCase.tsx
@@ -85,7 +85,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
      * Switch tooltip visibility
      * @param newVisibleState Tooltip visibility
      */
-    const toggleCardDisplay: (newVisibleState: boolean) => void = (newVisibleState: boolean): void => {
+    const toggleCardDisplay = (newVisibleState: boolean): void => {
         // tslint:disable-next-line: early-exit
         if (!newVisibleState) {
             delayer = setTimeout(() => setCardDisplayed(false), 500);

--- a/demo/react/components/popover/realCase.tsx
+++ b/demo/react/components/popover/realCase.tsx
@@ -1,19 +1,16 @@
 import React, { CSSProperties, ReactElement, useState } from 'react';
 
-import { Orientations } from 'LumX/components';
-
 import {
     Button,
-    ButtonEmphasises,
-    ButtonSizes,
-    ButtonThemes,
+    ButtonEmphasis,
     IconButton,
-    Placements,
+    Orientation,
     Popover,
     PopperOffsets,
+    PopperPlacement,
+    Size,
+    Theme,
     UserBlock,
-    UserBlockSize,
-    UserBlockTheme,
 } from 'LumX';
 
 import { mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiPhone, mdiSlack } from 'LumX/icons';
@@ -24,7 +21,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: UserBlockTheme;
+    theme: Theme;
 }
 
 const demoPopoverHolderStyle: CSSProperties = {
@@ -34,11 +31,11 @@ const demoPopoverHolderStyle: CSSProperties = {
     paddingTop: 100,
 };
 
-const createSimpleAction = (theme: ButtonThemes): ReactElement => (
+const createSimpleAction = (theme: Theme): ReactElement => (
     <Button
-        emphasis={ButtonEmphasises.medium}
-        color={theme === ButtonThemes.dark ? 'light' : undefined}
-        size={ButtonSizes.s}
+        emphasis={ButtonEmphasis.medium}
+        color={theme === Theme.dark ? 'light' : undefined}
+        size={Size.s}
         theme={theme}
     >
         Follow
@@ -47,14 +44,14 @@ const createSimpleAction = (theme: ButtonThemes): ReactElement => (
 
 const demoActions: string[] = [mdiPhone, mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiSlack];
 
-const createMultipleActions = (theme: ButtonThemes): ReactElement => (
+const createMultipleActions = (theme: Theme): ReactElement => (
     <>
         {demoActions.map(
             (demoAction: string, idx: number): IconButton => (
                 <IconButton
                     key={`ubAction${idx}`}
-                    emphasis={ButtonEmphasises.low}
-                    color={theme === ButtonThemes.dark ? 'light' : undefined}
+                    emphasis={ButtonEmphasis.low}
+                    color={theme === Theme.dark ? 'light' : undefined}
                     icon={demoAction}
                     theme={theme}
                 />
@@ -99,10 +96,10 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
             name="Guillaume Nachury"
             fields={['Bidouilleur', 'Meyzieu']}
             avatar={'http://i.pravatar.cc/139'}
-            orientation={Orientations.horizontal}
+            orientation={Orientation.horizontal}
             onMouseEnter={(): void => toggleCardDisplay(true)}
             onMouseLeave={(): void => toggleCardDisplay(false)}
-            size={UserBlockSize.m}
+            size={Size.m}
         />
     );
 
@@ -124,7 +121,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                 name="Guillaume Nachury"
                 fields={['Bidouilleur', 'Meyzieu']}
                 avatar={'http://i.pravatar.cc/139'}
-                orientation={Orientations.vertical}
+                orientation={Orientation.vertical}
                 simpleAction={createSimpleAction(theme)}
                 multipleActions={createMultipleActions(theme)}
             />
@@ -139,7 +136,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                 popperOffset={offsets}
                 showPopper={isCardDisplayed}
                 popperElement={popper}
-                popperPlacement={Placements.TOP_START}
+                popperPlacement={PopperPlacement.TOP_START}
                 elevation={5}
             />
         </div>

--- a/demo/react/components/popover/realCase.tsx
+++ b/demo/react/components/popover/realCase.tsx
@@ -1,5 +1,5 @@
 // tslint:disable: jsx-no-lambda
-import React, { CSSProperties, Fragment, ReactNode, useState } from 'react';
+import React, { CSSProperties, Fragment, ReactElement, useState } from 'react';
 
 import { Orientations } from 'LumX/components';
 
@@ -73,7 +73,7 @@ const createMultipleActions: React.FC<ButtonThemes> = (theme: any): any => (
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     // tslint:disable-next-line: typedef
     const [isCardDisplayed, setCardDisplayed] = useState(false);
     // tslint:disable-next-line: typedef
@@ -98,7 +98,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement 
         }
     };
 
-    const anchor: ReactNode = (
+    const anchor: ReactElement = (
         <UserBlock
             ref={anchorRef}
             theme={theme}
@@ -112,7 +112,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement 
         />
     );
 
-    const popper: ReactNode = (
+    const popper: ReactElement = (
         <div
             style={{
                 display: 'flex',

--- a/demo/react/components/popover/realCase.tsx
+++ b/demo/react/components/popover/realCase.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment, ReactElement, useState } from 'react';
+import React, { CSSProperties, ReactElement, useState } from 'react';
 
 import { Orientations } from 'LumX/components';
 
@@ -48,7 +48,7 @@ const createSimpleAction = (theme: ButtonThemes): ReactElement => (
 const demoActions: string[] = [mdiPhone, mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiSlack];
 
 const createMultipleActions = (theme: ButtonThemes): ReactElement => (
-    <Fragment>
+    <>
         {demoActions.map(
             (demoAction: string, idx: number): IconButton => (
                 <IconButton
@@ -60,7 +60,7 @@ const createMultipleActions = (theme: ButtonThemes): ReactElement => (
                 />
             ),
         )}
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/popover/realCase.tsx
+++ b/demo/react/components/popover/realCase.tsx
@@ -1,4 +1,3 @@
-// tslint:disable: jsx-no-lambda
 import React, { CSSProperties, Fragment, ReactElement, useState } from 'react';
 
 import { Orientations } from 'LumX/components';
@@ -35,8 +34,7 @@ const demoPopoverHolderStyle: CSSProperties = {
     paddingTop: 100,
 };
 
-// tslint:disable-next-line: no-any
-const createSimpleAction: React.FC<ButtonThemes> = (theme: ButtonThemes): any => (
+const createSimpleAction = (theme: ButtonThemes): ReactElement => (
     <Button
         emphasis={ButtonEmphasises.medium}
         color={theme === ButtonThemes.dark ? 'light' : undefined}
@@ -49,8 +47,7 @@ const createSimpleAction: React.FC<ButtonThemes> = (theme: ButtonThemes): any =>
 
 const demoActions: string[] = [mdiPhone, mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiSlack];
 
-// tslint:disable-next-line: no-any
-const createMultipleActions: React.FC<ButtonThemes> = (theme: any): any => (
+const createMultipleActions = (theme: ButtonThemes): ReactElement => (
     <Fragment>
         {demoActions.map(
             (demoAction: string, idx: number): IconButton => (
@@ -74,11 +71,8 @@ const createMultipleActions: React.FC<ButtonThemes> = (theme: any): any => (
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    // tslint:disable-next-line: typedef
     const [isCardDisplayed, setCardDisplayed] = useState(false);
-    // tslint:disable-next-line: typedef
     let delayer: NodeJS.Timeout | null;
-    // tslint:disable-next-line: typedef
     const anchorRef = React.createRef();
 
     /**

--- a/demo/react/components/popover/tooltip.tsx
+++ b/demo/react/components/popover/tooltip.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Placements, Popover } from 'LumX';
+import { Popover, PopperPlacement } from 'LumX';
 
 /////////////////////////////
 
@@ -39,7 +39,12 @@ const createPopper = (): ReactElement => {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
-    const placementDemo: string[] = [Placements.LEFT, Placements.TOP, Placements.RIGHT, Placements.BOTTOM];
+    const placementDemo: string[] = [
+        PopperPlacement.LEFT,
+        PopperPlacement.TOP,
+        PopperPlacement.RIGHT,
+        PopperPlacement.BOTTOM,
+    ];
 
     return (
         <div style={{ height: 200, display: 'flex', alignItems: 'center', justifyContent: 'space-around ' }}>

--- a/demo/react/components/popover/tooltip.tsx
+++ b/demo/react/components/popover/tooltip.tsx
@@ -38,7 +38,6 @@ const createPopper = (): ReactElement => {
  *
  * @return The demo component.
  */
-// tslint:disable-next-line: typedef
 const DemoComponent: React.FC<IProps> = (): ReactElement => {
     const placementDemo: string[] = [Placements.LEFT, Placements.TOP, Placements.RIGHT, Placements.BOTTOM];
 

--- a/demo/react/components/popover/tooltip.tsx
+++ b/demo/react/components/popover/tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { Placements, Popover } from 'LumX';
 
@@ -23,11 +23,11 @@ const demoPopperStyle: CSSProperties = {
     padding: '5px',
 };
 
-const createDemoAnchor: (placement: string) => ReactNode = (placement: string): ReactNode => {
+const createDemoAnchor = (placement: string): ReactElement => {
     return <div style={demoAnchorStyle}>{`Hovering will show a tooltip using placement : ${placement}`}</div>;
 };
 
-const createPopper: () => ReactNode = (): ReactNode => {
+const createPopper = (): ReactElement => {
     return <div style={demoPopperStyle}>{`Tooltip`}</div>;
 };
 
@@ -39,13 +39,13 @@ const createPopper: () => ReactNode = (): ReactNode => {
  * @return The demo component.
  */
 // tslint:disable-next-line: typedef
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = (): ReactElement => {
     const placementDemo: string[] = [Placements.LEFT, Placements.TOP, Placements.RIGHT, Placements.BOTTOM];
 
     return (
         <div style={{ height: 200, display: 'flex', alignItems: 'center', justifyContent: 'space-around ' }}>
             {placementDemo.map(
-                (placement: string): React.ReactNode => (
+                (placement: string): ReactElement => (
                     <Popover
                         anchorElement={createDemoAnchor(placement)}
                         popperElement={createPopper()}

--- a/demo/react/components/progress-tracker/default.tsx
+++ b/demo/react/components/progress-tracker/default.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, ReactElement, useState } from 'react';
 
-import { ProgressTracker, ProgressTrackerStep, Theme } from 'LumX';
+import { ProgressTracker, ProgressTrackerStep, ProgressTrackerStepProps, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -19,10 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    // tslint:disable-next-line: typedef
     const [activeIndex, setActiveIndex] = useState(2);
 
-    const stepProps = [
+    const stepProps: ProgressTrackerStepProps[] = [
         { isComplete: true },
         { isComplete: true },
         { hasError: true },
@@ -34,7 +33,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
         <Fragment>
             Default ProgressTracker
             <ProgressTracker activeStep={activeIndex} theme={theme}>
-                {stepProps.map((step, index: number) => (
+                {stepProps.map((step: ProgressTrackerStepProps, index: number) => (
                     <ProgressTrackerStep
                         isActive={activeIndex === index}
                         theme={theme}

--- a/demo/react/components/progress-tracker/default.tsx
+++ b/demo/react/components/progress-tracker/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, ReactElement, useState } from 'react';
 
 import { ProgressTracker, ProgressTrackerStep, Theme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     // tslint:disable-next-line: typedef
     const [activeIndex, setActiveIndex] = useState(2);
 

--- a/demo/react/components/progress-tracker/default.tsx
+++ b/demo/react/components/progress-tracker/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import { ProgressTracker, ProgressTrackerStep, ProgressTrackerStepProps, Theme } from 'LumX';
 
@@ -30,7 +30,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     ];
 
     return (
-        <Fragment>
+        <>
             Default ProgressTracker
             <ProgressTracker activeStep={activeIndex} theme={theme}>
                 {stepProps.map((step: ProgressTrackerStepProps, index: number) => (
@@ -44,7 +44,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     />
                 ))}
             </ProgressTracker>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/progress/default.tsx
+++ b/demo/react/components/progress/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Progress } from 'LumX';
 
@@ -14,9 +14,9 @@ interface IProps {}
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = (): ReactElement => (
-    <Fragment>
+    <>
         <Progress />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/progress/default.tsx
+++ b/demo/react/components/progress/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Progress } from 'LumX';
 
@@ -13,7 +13,7 @@ interface IProps {}
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = (): ReactElement => (
     <Fragment>
         <Progress />
     </Fragment>

--- a/demo/react/components/progress/linear.tsx
+++ b/demo/react/components/progress/linear.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Progress, Variants } from 'LumX';
+import { Progress, ProgressVariant } from 'LumX';
 
 /////////////////////////////
 
@@ -15,7 +15,7 @@ interface IProps {}
  */
 const DemoComponent: React.FC<IProps> = (): ReactElement => (
     <>
-        <Progress variant={Variants.linear} />
+        <Progress variant={ProgressVariant.linear} />
     </>
 );
 

--- a/demo/react/components/progress/linear.tsx
+++ b/demo/react/components/progress/linear.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Progress, Variants } from 'LumX';
 
@@ -14,9 +14,9 @@ interface IProps {}
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = (): ReactElement => (
-    <Fragment>
+    <>
         <Progress variant={Variants.linear} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/progress/linear.tsx
+++ b/demo/react/components/progress/linear.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Progress, Variants } from 'LumX';
 
@@ -13,7 +13,7 @@ interface IProps {}
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = (): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = (): ReactElement => (
     <Fragment>
         <Progress variant={Variants.linear} />
     </Fragment>

--- a/demo/react/components/slideshow/default.tsx
+++ b/demo/react/components/slideshow/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { ImageBlock, ImageBlockCaptionPositions, ImageBlockProps, Slideshow, Theme, ThumbnailAspectRatios } from 'LumX';
 import { SlideshowItem } from 'LumX/components/slideshow/react/SlideshowItem';
@@ -34,7 +34,7 @@ const imageBlockDemoProps: Partial<ImageBlockProps> = {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <div style={slideshowWrapperStyle}>
         <Slideshow activeIndex={3} hasControls={true} theme={theme} autoPlay={true} groupBy={1} style={slideshowStyle}>
             <SlideshowItem>

--- a/demo/react/components/slideshow/default.tsx
+++ b/demo/react/components/slideshow/default.tsx
@@ -1,7 +1,14 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { ImageBlock, ImageBlockCaptionPositions, ImageBlockProps, Slideshow, Theme, ThumbnailAspectRatios } from 'LumX';
-import { SlideshowItem } from 'LumX/components/slideshow/react/SlideshowItem';
+import {
+    ImageBlock,
+    ImageBlockCaptionPosition,
+    ImageBlockProps,
+    Slideshow,
+    SlideshowItem,
+    Theme,
+    ThumbnailAspectRatio,
+} from 'LumX';
 
 /////////////////////////////
 
@@ -42,14 +49,14 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             </SlideshowItem>
             <SlideshowItem>
                 <ImageBlock
-                    aspectRatio={ThumbnailAspectRatios.vertical}
+                    aspectRatio={ThumbnailAspectRatio.vertical}
                     theme={theme}
                     image="https://picsum.photos/640/480/?image=24"
                 />
             </SlideshowItem>
             <SlideshowItem>
                 <ImageBlock
-                    aspectRatio={ThumbnailAspectRatios.horizontal}
+                    aspectRatio={ThumbnailAspectRatio.horizontal}
                     theme={theme}
                     image="https://picsum.photos/640/480/?image=25"
                 />
@@ -59,7 +66,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             </SlideshowItem>
             <SlideshowItem>
                 <ImageBlock
-                    aspectRatio={ThumbnailAspectRatios.vertical}
+                    aspectRatio={ThumbnailAspectRatio.vertical}
                     theme={theme}
                     image="https://picsum.photos/640/480/?image=27"
                     {...imageBlockDemoProps}
@@ -67,7 +74,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             </SlideshowItem>
             <SlideshowItem>
                 <ImageBlock
-                    aspectRatio={ThumbnailAspectRatios.horizontal}
+                    aspectRatio={ThumbnailAspectRatio.horizontal}
                     theme={theme}
                     image="https://picsum.photos/640/480/?image=28"
                     {...imageBlockDemoProps}
@@ -75,7 +82,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             </SlideshowItem>
             <SlideshowItem>
                 <ImageBlock
-                    captionPosition={ImageBlockCaptionPositions.over}
+                    captionPosition={ImageBlockCaptionPosition.over}
                     image="https://picsum.photos/640/480/?image=29"
                     theme={theme}
                     {...imageBlockDemoProps}
@@ -83,8 +90,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             </SlideshowItem>
             <SlideshowItem>
                 <ImageBlock
-                    aspectRatio={ThumbnailAspectRatios.vertical}
-                    captionPosition={ImageBlockCaptionPositions.over}
+                    aspectRatio={ThumbnailAspectRatio.vertical}
+                    captionPosition={ImageBlockCaptionPosition.over}
                     image="https://picsum.photos/640/480/?image=30"
                     theme={theme}
                     {...imageBlockDemoProps}
@@ -92,8 +99,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             </SlideshowItem>
             <SlideshowItem>
                 <ImageBlock
-                    aspectRatio={ThumbnailAspectRatios.horizontal}
-                    captionPosition={ImageBlockCaptionPositions.over}
+                    aspectRatio={ThumbnailAspectRatio.horizontal}
+                    captionPosition={ImageBlockCaptionPosition.over}
                     image="https://picsum.photos/640/480/?image=31"
                     theme={theme}
                     {...imageBlockDemoProps}

--- a/demo/react/components/switch/default.tsx
+++ b/demo/react/components/switch/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Switch, SwitchTheme } from 'LumX';
 
@@ -19,7 +19,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <Switch className="mb+" theme={theme} />
 
         <Switch className="mb+" theme={theme}>
@@ -31,7 +31,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <Switch checked={true} theme={theme}>
             Checked by default
         </Switch>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/switch/default.tsx
+++ b/demo/react/components/switch/default.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Switch, SwitchTheme } from 'LumX';
+import { Switch, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: SwitchTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/switch/default.tsx
+++ b/demo/react/components/switch/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Switch, SwitchTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <Switch className="mb+" theme={theme} />
 

--- a/demo/react/components/switch/with-helpers.tsx
+++ b/demo/react/components/switch/with-helpers.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Switch, SwitchTheme } from 'LumX';
+import { Switch, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: SwitchTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/switch/with-helpers.tsx
+++ b/demo/react/components/switch/with-helpers.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Switch, SwitchTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <Switch className="mb+" helper="Click on the switch to check it" theme={theme}>
             Label

--- a/demo/react/components/switch/with-helpers.tsx
+++ b/demo/react/components/switch/with-helpers.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Switch, SwitchTheme } from 'LumX';
 
@@ -19,7 +19,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <Switch className="mb+" helper="Click on the switch to check it" theme={theme}>
             Label
         </Switch>
@@ -27,7 +27,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <Switch helper="Click on the switch to uncheck it" checked={true} theme={theme}>
             Checked by default
         </Switch>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/table/default.tsx
+++ b/demo/react/components/table/default.tsx
@@ -128,7 +128,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
      *
      * @param headSource The head cell to sort the table by.
      */
-    const handleSort: (headSource: IHead) => void = useCallback(
+    const handleSort = useCallback(
         (headSource: IHead) => {
             tableHead.map((head: IHead) => {
                 if (head !== headSource) {

--- a/demo/react/components/table/default.tsx
+++ b/demo/react/components/table/default.tsx
@@ -10,7 +10,7 @@ import {
     ThScope,
 } from 'LumX';
 
-import React, { Dispatch, ReactElement, SetStateAction, useCallback, useState } from 'react';
+import React, { ReactElement, useCallback, useState } from 'react';
 
 import orderBy from 'lodash/orderBy';
 
@@ -121,7 +121,7 @@ const tableHead: IHead[] = [
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [dataTableBody, setTable]: [IBody[], Dispatch<SetStateAction<IBody[]>>] = useState(tableBody);
+    const [dataTableBody, setTable] = useState(tableBody);
 
     /**
      * Update the sorting of the table.

--- a/demo/react/components/table/default.tsx
+++ b/demo/react/components/table/default.tsx
@@ -1,14 +1,4 @@
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableCellVariant,
-    TableHeader,
-    TableRow,
-    TableTheme,
-    ThOrder,
-    ThScope,
-} from 'LumX';
+import { Table, TableBody, TableCell, TableCellVariant, TableHeader, TableRow, ThOrder, ThScope, Theme } from 'LumX';
 
 import React, { ReactElement, useCallback, useState } from 'react';
 
@@ -22,7 +12,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TableTheme;
+    theme: Theme;
 }
 
 interface IBody {

--- a/demo/react/components/table/default.tsx
+++ b/demo/react/components/table/default.tsx
@@ -10,7 +10,7 @@ import {
     ThScope,
 } from 'LumX';
 
-import React, { Dispatch, SetStateAction, useCallback, useState } from 'react';
+import React, { Dispatch, ReactElement, SetStateAction, useCallback, useState } from 'react';
 
 import orderBy from 'lodash/orderBy';
 
@@ -120,7 +120,7 @@ const tableHead: IHead[] = [
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const [dataTableBody, setTable]: [IBody[], Dispatch<SetStateAction<IBody[]>>] = useState(tableBody);
 
     /**

--- a/demo/react/components/table/default.tsx
+++ b/demo/react/components/table/default.tsx
@@ -160,7 +160,6 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                                 scope={head.scope}
                                 sortOrder={head.sortOrder}
                                 variant={head.variant}
-                                // tslint:disable-next-line: jsx-no-lambda
                                 onHeaderClick={(): void => handleSort(head)}
                             >
                                 {head.label}

--- a/demo/react/components/tabs/clustered-center.tsx
+++ b/demo/react/components/tabs/clustered-center.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
 import { Tabs, TabsTheme } from 'LumX';
@@ -29,7 +29,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     };
 
     return (
-        <Fragment>
+        <>
             <Tabs
                 theme={theme}
                 layout={Layouts.clustered}
@@ -49,7 +49,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     <p className="p+">Bowl</p>
                 </Tab>
             </Tabs>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/tabs/clustered-center.tsx
+++ b/demo/react/components/tabs/clustered-center.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
 import { Tabs, TabsProps, TabsTheme } from 'LumX';
@@ -21,7 +21,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(
         0,
     );

--- a/demo/react/components/tabs/clustered-center.tsx
+++ b/demo/react/components/tabs/clustered-center.tsx
@@ -1,9 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
-import { Tabs, TabsTheme } from 'LumX';
-import { Tab } from 'LumX/components/tabs/react/Tab';
-import { Layouts, Positions } from 'LumX/components/tabs/react/Tabs';
+import { Tab, Tabs, TabsLayout, TabsPosition, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -11,7 +9,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TabsTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -32,8 +30,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
         <>
             <Tabs
                 theme={theme}
-                layout={Layouts.clustered}
-                position={Positions.center}
+                layout={TabsLayout.clustered}
+                position={TabsPosition.center}
                 activeTab={activeTab}
                 onTabClick={handleTabClick}
             >

--- a/demo/react/components/tabs/clustered-center.tsx
+++ b/demo/react/components/tabs/clustered-center.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
-import { Tabs, TabsProps, TabsTheme } from 'LumX';
+import { Tabs, TabsTheme } from 'LumX';
 import { Tab } from 'LumX/components/tabs/react/Tab';
 import { Layouts, Positions } from 'LumX/components/tabs/react/Tabs';
 
@@ -22,9 +22,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(
-        0,
-    );
+    const [activeTab, setActiveTab] = useState(0);
 
     const handleTabClick: CallableFunction = ({ index }: { index: number }): void => {
         setActiveTab(index);

--- a/demo/react/components/tabs/clustered.tsx
+++ b/demo/react/components/tabs/clustered.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
 import { Tabs, TabsProps, TabsTheme } from 'LumX';
@@ -21,7 +21,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(
         0,
     );

--- a/demo/react/components/tabs/clustered.tsx
+++ b/demo/react/components/tabs/clustered.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
-import { Tabs, TabsProps, TabsTheme } from 'LumX';
+import { Tabs, TabsTheme } from 'LumX';
 import { Tab } from 'LumX/components/tabs/react/Tab';
 import { Layouts } from 'LumX/components/tabs/react/Tabs';
 
@@ -22,9 +22,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(
-        0,
-    );
+    const [activeTab, setActiveTab] = useState(0);
 
     const handleTabClick: CallableFunction = ({ index }: { index: number }): void => {
         setActiveTab(index);

--- a/demo/react/components/tabs/clustered.tsx
+++ b/demo/react/components/tabs/clustered.tsx
@@ -1,9 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
-import { Tabs, TabsTheme } from 'LumX';
-import { Tab } from 'LumX/components/tabs/react/Tab';
-import { Layouts } from 'LumX/components/tabs/react/Tabs';
+import { Tab, Tabs, TabsLayout, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -11,7 +9,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TabsTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -30,7 +28,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
 
     return (
         <>
-            <Tabs theme={theme} layout={Layouts.clustered} activeTab={activeTab} onTabClick={handleTabClick}>
+            <Tabs theme={theme} layout={TabsLayout.clustered} activeTab={activeTab} onTabClick={handleTabClick}>
                 <Tab label="First Tab" icon={mdiBreadSliceOutline}>
                     <p className="p+">Bread</p>
                 </Tab>

--- a/demo/react/components/tabs/clustered.tsx
+++ b/demo/react/components/tabs/clustered.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import { mdiBowl, mdiBreadSliceOutline } from '@mdi/js';
 import { Tabs, TabsTheme } from 'LumX';
@@ -29,7 +29,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     };
 
     return (
-        <Fragment>
+        <>
             <Tabs theme={theme} layout={Layouts.clustered} activeTab={activeTab} onTabClick={handleTabClick}>
                 <Tab label="First Tab" icon={mdiBreadSliceOutline}>
                     <p className="p+">Bread</p>
@@ -43,7 +43,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
                     <p className="p+">Bowl</p>
                 </Tab>
             </Tabs>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/tabs/default.tsx
+++ b/demo/react/components/tabs/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import { Button, Tabs, TabsTheme } from 'LumX';
 import { Tab } from 'LumX/components/tabs/react/Tab';
@@ -32,7 +32,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     };
 
     return (
-        <Fragment>
+        <>
             <Tabs theme={theme} activeTab={activeTab} onTabClick={handleTabClick}>
                 <Tab label="First Tab" icon={mdiBreadSliceOutline}>
                     <p className="p+">Bread</p>
@@ -48,7 +48,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
             </Tabs>
 
             <Button onClick={setFirstTabActive}>Set first tab as active tab</Button>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/tabs/default.tsx
+++ b/demo/react/components/tabs/default.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, ReactElement, useState } from 'react';
 
-import { Button, Tabs, TabsProps, TabsTheme } from 'LumX';
+import { Button, Tabs, TabsTheme } from 'LumX';
 import { Tab } from 'LumX/components/tabs/react/Tab';
 import { mdiBowl, mdiBreadSliceOutline } from 'LumX/icons';
 
@@ -21,9 +21,7 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(
-        0,
-    );
+    const [activeTab, setActiveTab] = useState(0);
 
     const handleTabClick: CallableFunction = ({ index }: { index: number }): void => {
         setActiveTab(index);

--- a/demo/react/components/tabs/default.tsx
+++ b/demo/react/components/tabs/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, ReactElement, useState } from 'react';
 
 import { Button, Tabs, TabsProps, TabsTheme } from 'LumX';
 import { Tab } from 'LumX/components/tabs/react/Tab';
@@ -20,7 +20,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const [activeTab, setActiveTab]: [TabsProps['activeTab'], React.Dispatch<React.SetStateAction<number>>] = useState(
         0,
     );

--- a/demo/react/components/tabs/default.tsx
+++ b/demo/react/components/tabs/default.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useState } from 'react';
 
-import { Button, Tabs, TabsTheme } from 'LumX';
-import { Tab } from 'LumX/components/tabs/react/Tab';
+import { Button, Tab, Tabs, Theme } from 'LumX';
 import { mdiBowl, mdiBreadSliceOutline } from 'LumX/icons';
 
 /////////////////////////////
@@ -10,7 +9,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TabsTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/text-field/default.tsx
+++ b/demo/react/components/text-field/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -19,9 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <TextField label="Texfield label" theme={theme} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/text-field/default.tsx
+++ b/demo/react/components/text-field/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <TextField label="Texfield label" theme={theme} />
     </Fragment>

--- a/demo/react/components/text-field/default.tsx
+++ b/demo/react/components/text-field/default.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { TextField, TextFieldTheme } from 'LumX';
+import { TextField, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TextFieldTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/text-field/disabled.tsx
+++ b/demo/react/components/text-field/disabled.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -19,9 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <TextField isDisabled={true} label="Texfield label" theme={theme} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/text-field/disabled.tsx
+++ b/demo/react/components/text-field/disabled.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <TextField isDisabled={true} label="Texfield label" theme={theme} />
     </Fragment>

--- a/demo/react/components/text-field/disabled.tsx
+++ b/demo/react/components/text-field/disabled.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { TextField, TextFieldTheme } from 'LumX';
+import { TextField, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TextFieldTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/text-field/helperText.tsx
+++ b/demo/react/components/text-field/helperText.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <TextField helper="Helper text" label="Texfield label" theme={theme} />
     </Fragment>

--- a/demo/react/components/text-field/helperText.tsx
+++ b/demo/react/components/text-field/helperText.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -19,9 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <TextField helper="Helper text" label="Texfield label" theme={theme} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/text-field/helperText.tsx
+++ b/demo/react/components/text-field/helperText.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { TextField, TextFieldTheme } from 'LumX';
+import { TextField, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TextFieldTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/text-field/icon.tsx
+++ b/demo/react/components/text-field/icon.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 import { mdiMagnify } from 'LumX/icons';
@@ -20,9 +20,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <TextField icon={mdiMagnify} theme={theme} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/text-field/icon.tsx
+++ b/demo/react/components/text-field/icon.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 import { mdiMagnify } from 'LumX/icons';
@@ -19,7 +19,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <TextField icon={mdiMagnify} theme={theme} />
     </Fragment>

--- a/demo/react/components/text-field/icon.tsx
+++ b/demo/react/components/text-field/icon.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { TextField, TextFieldTheme } from 'LumX';
+import { TextField, Theme } from 'LumX';
 import { mdiMagnify } from 'LumX/icons';
 
 /////////////////////////////
@@ -9,7 +9,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TextFieldTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/text-field/invalid.tsx
+++ b/demo/react/components/text-field/invalid.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -19,9 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <TextField hasError={true} label="Texfield label" theme={theme} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/text-field/invalid.tsx
+++ b/demo/react/components/text-field/invalid.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { TextField, TextFieldTheme } from 'LumX';
+import { TextField, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TextFieldTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/text-field/invalid.tsx
+++ b/demo/react/components/text-field/invalid.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <TextField hasError={true} label="Texfield label" theme={theme} />
     </Fragment>

--- a/demo/react/components/text-field/placeholder.tsx
+++ b/demo/react/components/text-field/placeholder.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -19,9 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <TextField label="Texfield label" placeholder="Placeholder label" theme={theme} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/text-field/placeholder.tsx
+++ b/demo/react/components/text-field/placeholder.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <TextField label="Texfield label" placeholder="Placeholder label" theme={theme} />
     </Fragment>

--- a/demo/react/components/text-field/placeholder.tsx
+++ b/demo/react/components/text-field/placeholder.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { TextField, TextFieldTheme } from 'LumX';
+import { TextField, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TextFieldTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/text-field/valid.tsx
+++ b/demo/react/components/text-field/valid.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <TextField isValid={true} label="Texfield label" theme={theme} />
     </Fragment>

--- a/demo/react/components/text-field/valid.tsx
+++ b/demo/react/components/text-field/valid.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { TextField, TextFieldTheme } from 'LumX';
 
@@ -19,9 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <TextField isValid={true} label="Texfield label" theme={theme} />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/text-field/valid.tsx
+++ b/demo/react/components/text-field/valid.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { TextField, TextFieldTheme } from 'LumX';
+import { TextField, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: TextFieldTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/thumbnail/default.tsx
+++ b/demo/react/components/thumbnail/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment, ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { Thumbnail, ThumbnailAspectRatios, ThumbnailSizes, ThumbnailTheme } from 'LumX';
 
@@ -25,7 +25,7 @@ const componentHolder: CSSProperties = {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <h2>Aspect-ratio : original</h2>
         <div style={{ display: 'flex', justifyContent: 'space-around' }}>
             <div style={{ display: 'flex' }}>
@@ -170,7 +170,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </div>
         </div>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/thumbnail/default.tsx
+++ b/demo/react/components/thumbnail/default.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Thumbnail, ThumbnailAspectRatios, ThumbnailSizes, ThumbnailTheme } from 'LumX';
+import { Size, Theme, Thumbnail, ThumbnailAspectRatio } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ThumbnailTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -30,24 +30,24 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         <div style={{ display: 'flex', justifyContent: 'space-around' }}>
             <div style={{ display: 'flex' }}>
                 <div style={componentHolder}>
-                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={ThumbnailSizes.xxs} />
+                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={Size.xxs} />
                     xxs
                 </div>
                 <div style={componentHolder}>
-                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={ThumbnailSizes.xs} />
+                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={Size.xs} />
                     xs
                 </div>
                 <div style={componentHolder}>
-                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={ThumbnailSizes.s} />s
+                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={Size.s} />s
                 </div>
                 <div style={componentHolder}>
-                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={ThumbnailSizes.m} />m
+                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={Size.m} />m
                 </div>
                 <div style={componentHolder}>
-                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={ThumbnailSizes.l} />l
+                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={Size.l} />l
                 </div>
                 <div style={componentHolder}>
-                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={ThumbnailSizes.xl} />
+                    <Thumbnail theme={theme} image="http://i.pravatar.cc/200" size={Size.xl} />
                     xl
                 </div>
             </div>
@@ -57,55 +57,55 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             <div style={{ display: 'flex' }}>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xxs}
+                        size={Size.xxs}
                     />
                     xxs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xs}
+                        size={Size.xs}
                     />
                     xs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.s}
+                        size={Size.s}
                     />
                     s
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
+                        size={Size.m}
                     />
                     m
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.l}
+                        size={Size.l}
                     />
                     l
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xl}
+                        size={Size.xl}
                     />
                     xl
                 </div>
@@ -116,55 +116,55 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             <div style={{ display: 'flex' }}>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xxs}
+                        size={Size.xxs}
                     />
                     xxs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xs}
+                        size={Size.xs}
                     />
                     xs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.s}
+                        size={Size.s}
                     />
                     s
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
+                        size={Size.m}
                     />
                     m
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.l}
+                        size={Size.l}
                     />
                     l
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xl}
+                        size={Size.xl}
                     />
                     xl
                 </div>

--- a/demo/react/components/thumbnail/default.tsx
+++ b/demo/react/components/thumbnail/default.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment } from 'react';
+import React, { CSSProperties, Fragment, ReactElement } from 'react';
 
 import { Thumbnail, ThumbnailAspectRatios, ThumbnailSizes, ThumbnailTheme } from 'LumX';
 
@@ -24,7 +24,7 @@ const componentHolder: CSSProperties = {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <h2>Aspect-ratio : original</h2>
         <div style={{ display: 'flex', justifyContent: 'space-around' }}>

--- a/demo/react/components/thumbnail/rounded.tsx
+++ b/demo/react/components/thumbnail/rounded.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Thumbnail, ThumbnailAspectRatios, ThumbnailSizes, ThumbnailTheme, ThumbnailVariants } from 'LumX';
+import { Size, Theme, Thumbnail, ThumbnailAspectRatio, ThumbnailVariant } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ThumbnailTheme;
+    theme: Theme;
 }
 
 /////////////////////////////
@@ -33,8 +33,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                     <Thumbnail
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xxs}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xxs}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xxs
                 </div>
@@ -42,8 +42,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                     <Thumbnail
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xs}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xs}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xs
                 </div>
@@ -51,8 +51,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                     <Thumbnail
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.s}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.s}
+                        variant={ThumbnailVariant.rounded}
                     />
                     s
                 </div>
@@ -60,8 +60,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                     <Thumbnail
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.m}
+                        variant={ThumbnailVariant.rounded}
                     />
                     m
                 </div>
@@ -69,8 +69,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                     <Thumbnail
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.l}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.l}
+                        variant={ThumbnailVariant.rounded}
                     />
                     l
                 </div>
@@ -78,8 +78,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                     <Thumbnail
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xl}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xl}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xl
                 </div>
@@ -90,61 +90,61 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             <div style={{ display: 'flex' }}>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xxs}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xxs}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xxs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xs}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xs}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.s}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.s}
+                        variant={ThumbnailVariant.rounded}
                     />
                     s
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.m}
+                        variant={ThumbnailVariant.rounded}
                     />
                     m
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.l}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.l}
+                        variant={ThumbnailVariant.rounded}
                     />
                     l
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.horizontal}
+                        aspectRatio={ThumbnailAspectRatio.horizontal}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xl}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xl}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xl
                 </div>
@@ -155,61 +155,61 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             <div style={{ display: 'flex' }}>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xxs}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xxs}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xxs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xs}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xs}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xs
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.s}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.s}
+                        variant={ThumbnailVariant.rounded}
                     />
                     s
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.m}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.m}
+                        variant={ThumbnailVariant.rounded}
                     />
                     m
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.l}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.l}
+                        variant={ThumbnailVariant.rounded}
                     />
                     l
                 </div>
                 <div style={componentHolder}>
                     <Thumbnail
-                        aspectRatio={ThumbnailAspectRatios.vertical}
+                        aspectRatio={ThumbnailAspectRatio.vertical}
                         theme={theme}
                         image="http://i.pravatar.cc/200"
-                        size={ThumbnailSizes.xl}
-                        variant={ThumbnailVariants.rounded}
+                        size={Size.xl}
+                        variant={ThumbnailVariant.rounded}
                     />
                     xl
                 </div>

--- a/demo/react/components/thumbnail/rounded.tsx
+++ b/demo/react/components/thumbnail/rounded.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment, ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { Thumbnail, ThumbnailAspectRatios, ThumbnailSizes, ThumbnailTheme, ThumbnailVariants } from 'LumX';
 
@@ -25,7 +25,7 @@ const componentHolder: CSSProperties = {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <h2>Aspect-ratio : original</h2>
         <div style={{ display: 'flex', justifyContent: 'space-around' }}>
             <div style={{ display: 'flex' }}>
@@ -215,7 +215,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                 </div>
             </div>
         </div>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/thumbnail/rounded.tsx
+++ b/demo/react/components/thumbnail/rounded.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, Fragment } from 'react';
+import React, { CSSProperties, Fragment, ReactElement } from 'react';
 
 import { Thumbnail, ThumbnailAspectRatios, ThumbnailSizes, ThumbnailTheme, ThumbnailVariants } from 'LumX';
 
@@ -24,7 +24,7 @@ const componentHolder: CSSProperties = {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <h2>Aspect-ratio : original</h2>
         <div style={{ display: 'flex', justifyContent: 'space-around' }}>

--- a/demo/react/components/tooltip/default.tsx
+++ b/demo/react/components/tooltip/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useRef } from 'react';
+import React, { ReactElement, useRef } from 'react';
 
 import { Button, ButtonTheme, Tooltip } from 'LumX';
 
@@ -26,7 +26,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const anchorRefDelay: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
 
     return (
-        <Fragment>
+        <>
             <Button buttonRef={anchorRefTop} theme={theme}>
                 Top
             </Button>{' '}
@@ -57,7 +57,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
             <Tooltip anchorRef={anchorRefDelay} delay={2000} placement="bottom" theme={theme}>
                 Tooltip with delay
             </Tooltip>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/components/tooltip/default.tsx
+++ b/demo/react/components/tooltip/default.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useRef } from 'react';
 
-import { Button, ButtonTheme, Tooltip } from 'LumX';
+import { Button, Theme, Tooltip } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: ButtonTheme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/demo/react/components/tooltip/default.tsx
+++ b/demo/react/components/tooltip/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useRef } from 'react';
+import React, { Fragment, ReactElement, useRef } from 'react';
 
 import { Button, ButtonTheme, Tooltip } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => {
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
     const anchorRefTop: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
     const anchorRefRight: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
     const anchorRefBottom: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);

--- a/demo/react/components/tooltip/default.tsx
+++ b/demo/react/components/tooltip/default.tsx
@@ -19,11 +19,11 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
-    const anchorRefTop: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
-    const anchorRefRight: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
-    const anchorRefBottom: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
-    const anchorRefLeft: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
-    const anchorRefDelay: React.RefObject<HTMLElement> = useRef<HTMLElement>(null);
+    const anchorRefTop: React.RefObject<HTMLElement> = useRef(null);
+    const anchorRefRight: React.RefObject<HTMLElement> = useRef(null);
+    const anchorRefBottom: React.RefObject<HTMLElement> = useRef(null);
+    const anchorRefLeft: React.RefObject<HTMLElement> = useRef(null);
+    const anchorRefDelay: React.RefObject<HTMLElement> = useRef(null);
 
     return (
         <>

--- a/demo/react/components/user-block/default.tsx
+++ b/demo/react/components/user-block/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Orientations } from 'LumX/components';
 
@@ -31,7 +31,7 @@ const createSimpleAction = (theme: ButtonThemes): ReactElement => (
 const demoActions: string[] = [mdiPhone, mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiSlack];
 
 const createMultipleActions = (theme: ButtonThemes): ReactElement => (
-    <Fragment>
+    <>
         {demoActions.map(
             (demoAction: string, idx: number): IconButton => (
                 <IconButton
@@ -43,7 +43,7 @@ const createMultipleActions = (theme: ButtonThemes): ReactElement => (
                 />
             ),
         )}
-    </Fragment>
+    </>
 );
 
 /////////////////////////////
@@ -54,7 +54,7 @@ const createMultipleActions = (theme: ButtonThemes): ReactElement => (
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <UserBlock
             theme={theme}
             name="Emmitt O. Lum"
@@ -67,7 +67,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             simpleAction={createSimpleAction(theme)}
             multipleActions={createMultipleActions(theme)}
         />
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/components/user-block/default.tsx
+++ b/demo/react/components/user-block/default.tsx
@@ -17,9 +17,7 @@ interface IProps {
 
 const demoFields: string[] = ['Creative developer', 'Denpasar'];
 
-const createSimpleAction: React.FC<ButtonThemes> = (
-    theme: ButtonThemes,
-): any => ( // tslint:disable-line
+const createSimpleAction = (theme: ButtonThemes): ReactElement => (
     <Button
         emphasis={ButtonEmphasises.medium}
         color={theme === ButtonThemes.dark ? 'light' : undefined}
@@ -32,9 +30,7 @@ const createSimpleAction: React.FC<ButtonThemes> = (
 
 const demoActions: string[] = [mdiPhone, mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiSlack];
 
-const createMultipleActions: React.FC<ButtonThemes> = (
-    theme: any, // tslint:disable-line
-) => (
+const createMultipleActions = (theme: ButtonThemes): ReactElement => (
     <Fragment>
         {demoActions.map(
             (demoAction: string, idx: number): IconButton => (
@@ -52,7 +48,6 @@ const createMultipleActions: React.FC<ButtonThemes> = (
 
 /////////////////////////////
 
-// tslint:disable
 /**
  * The demo for the default <UserBlock>s.
  *
@@ -74,7 +69,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
         />
     </Fragment>
 );
-/* tslint:enable. */
+
 /////////////////////////////
 
 export default {

--- a/demo/react/components/user-block/default.tsx
+++ b/demo/react/components/user-block/default.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { Orientations } from 'LumX/components';
 
@@ -58,7 +58,7 @@ const createMultipleActions: React.FC<ButtonThemes> = (
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <UserBlock
             theme={theme}

--- a/demo/react/components/user-block/default.tsx
+++ b/demo/react/components/user-block/default.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Orientations } from 'LumX/components';
-
-import { Button, ButtonEmphasises, ButtonSizes, ButtonThemes, IconButton, UserBlock, UserBlockTheme } from 'LumX';
+import { Button, ButtonEmphasis, IconButton, Orientation, Size, Theme, UserBlock } from 'LumX';
 
 import { mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiPhone, mdiSlack } from 'LumX/icons';
 
@@ -12,16 +10,16 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: UserBlockTheme;
+    theme: Theme;
 }
 
 const demoFields: string[] = ['Creative developer', 'Denpasar'];
 
-const createSimpleAction = (theme: ButtonThemes): ReactElement => (
+const createSimpleAction = (theme: Theme): ReactElement => (
     <Button
-        emphasis={ButtonEmphasises.medium}
-        color={theme === ButtonThemes.dark ? 'light' : undefined}
-        size={ButtonSizes.s}
+        emphasis={ButtonEmphasis.medium}
+        color={theme === Theme.dark ? 'light' : undefined}
+        size={Size.s}
         theme={theme}
     >
         Follow
@@ -30,14 +28,14 @@ const createSimpleAction = (theme: ButtonThemes): ReactElement => (
 
 const demoActions: string[] = [mdiPhone, mdiCellphone, mdiEmail, mdiGoogleHangouts, mdiSlack];
 
-const createMultipleActions = (theme: ButtonThemes): ReactElement => (
+const createMultipleActions = (theme: Theme): ReactElement => (
     <>
         {demoActions.map(
             (demoAction: string, idx: number): IconButton => (
                 <IconButton
                     key={`ubAction${idx}`}
-                    emphasis={ButtonEmphasises.low}
-                    color={theme === ButtonThemes.dark ? 'light' : undefined}
+                    emphasis={ButtonEmphasis.low}
+                    color={theme === Theme.dark ? 'light' : undefined}
                     icon={demoAction}
                     theme={theme}
                 />
@@ -60,7 +58,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
             name="Emmitt O. Lum"
             fields={demoFields}
             avatar="http://i.pravatar.cc/128"
-            orientation={Orientations.vertical}
+            orientation={Orientation.vertical}
             onMouseEnter={(): void => console.log('Mouse entered')}
             onMouseLeave={(): void => console.log('Mouse left')}
             onClick={(): void => console.log('UserBlock clicked')}

--- a/demo/react/components/user-block/horizontal.tsx
+++ b/demo/react/components/user-block/horizontal.tsx
@@ -30,9 +30,7 @@ const fakeUsers: IFakeUser[] = [
  * @param theme Theme to be used
  * @return an action button
  */
-const createSimpleAction: React.FC<ButtonThemes> = (
-    theme: ButtonThemes,
-): any => ( // tslint:disable-line
+const createSimpleAction = (theme: ButtonThemes): Button => (
     <Button
         emphasis={ButtonEmphasises.medium}
         color={theme === ButtonThemes.dark ? 'light' : undefined}

--- a/demo/react/components/user-block/horizontal.tsx
+++ b/demo/react/components/user-block/horizontal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { Orientations } from 'LumX/components';
 
@@ -50,7 +50,7 @@ const createSimpleAction: React.FC<ButtonThemes> = (
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <div style={{ display: 'flex', justifyContent: 'space-around' }}>
         <div>
             <pre>size: s</pre>

--- a/demo/react/components/user-block/horizontal.tsx
+++ b/demo/react/components/user-block/horizontal.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { Orientations } from 'LumX/components';
-
-import { Button, ButtonEmphasises, ButtonSizes, ButtonThemes, UserBlock, UserBlockSize, UserBlockTheme } from 'LumX';
+import { Button, ButtonEmphasis, Orientation, Size, Theme, UserBlock } from 'LumX';
 
 /////////////////////////////
 
@@ -10,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: UserBlockTheme;
+    theme: Theme;
 }
 
 interface IFakeUser {
@@ -30,11 +28,11 @@ const fakeUsers: IFakeUser[] = [
  * @param theme Theme to be used
  * @return an action button
  */
-const createSimpleAction = (theme: ButtonThemes): Button => (
+const createSimpleAction = (theme: Theme): Button => (
     <Button
-        emphasis={ButtonEmphasises.medium}
-        color={theme === ButtonThemes.dark ? 'light' : undefined}
-        size={ButtonSizes.s}
+        emphasis={ButtonEmphasis.medium}
+        color={theme === Theme.dark ? 'light' : undefined}
+        size={Size.s}
         theme={theme}
     >
         Follow
@@ -59,8 +57,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                         name={aUser.name}
                         fields={aUser.fields}
                         avatar={`http://i.pravatar.cc/13${idx}`}
-                        orientation={Orientations.horizontal}
-                        size={UserBlockSize.s}
+                        orientation={Orientation.horizontal}
+                        size={Size.s}
                         simpleAction={createSimpleAction(theme)}
                     />
                 </div>
@@ -75,8 +73,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                         name={aUser.name}
                         fields={aUser.fields}
                         avatar={`http://i.pravatar.cc/13${idx}`}
-                        orientation={Orientations.horizontal}
-                        size={UserBlockSize.m}
+                        orientation={Orientation.horizontal}
+                        size={Size.m}
                     />
                 </div>
             ))}
@@ -90,8 +88,8 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
                         name={aUser.name}
                         fields={aUser.fields}
                         avatar={`http://i.pravatar.cc/13${idx}`}
-                        orientation={Orientations.horizontal}
-                        size={UserBlockSize.l}
+                        orientation={Orientation.horizontal}
+                        size={Size.l}
                     />
                 </div>
             ))}

--- a/demo/react/constants.ts
+++ b/demo/react/constants.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 /////////////////////////////
 //                         //
 //    Public attributes    //
@@ -13,7 +15,7 @@ interface IDemoObject {
     /**
      * The description of the demo.
      */
-    description?: React.ReactNode;
+    description?: ReactNode;
 
     /**
      * A list of complementary files to load when displaying the source code.

--- a/demo/react/layout/DemoBlock.tsx
+++ b/demo/react/layout/DemoBlock.tsx
@@ -57,8 +57,7 @@ interface IESModule {
     /**
      * The component of the demo.
      */
-    // tslint:disable-next-line: no-any
-    default: { view(props: { [prop: string]: any }): JSX.Element };
+    default: { view(props: IGenericProps): JSX.Element };
 }
 
 /////////////////////////////

--- a/demo/react/layout/DemoBlock.tsx
+++ b/demo/react/layout/DemoBlock.tsx
@@ -155,7 +155,7 @@ const DemoBlock: React.FC<IProps> = ({
      *
      * @param enabled Indicates if the dark theme should be enabled or not.
      */
-    const setDarkTheme: (enabled: boolean) => void = (enabled: boolean): void => {
+    const setDarkTheme = (enabled: boolean): void => {
         setTheme(enabled ? Themes.dark : Themes.light);
     };
 
@@ -163,7 +163,7 @@ const DemoBlock: React.FC<IProps> = ({
     /**
      * Toggle the display of the code in the demo block.
      */
-    const toggleDisplayCode: () => void = (): void => {
+    const toggleDisplayCode = (): void => {
         setDisplayCode(!shouldDisplayCode);
     };
 

--- a/demo/react/layout/DemoBlock.tsx
+++ b/demo/react/layout/DemoBlock.tsx
@@ -10,7 +10,7 @@ import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
 import noop from 'lodash/noop';
 
-import { Button, ButtonEmphasises, Switch, SwitchPositions, Theme, Themes } from 'LumX';
+import { Button, ButtonEmphasises, Switch, SwitchPositions, Themes } from 'LumX';
 import { IGenericProps } from 'LumX/core/react/utils';
 import { mdiCodeTags } from 'LumX/icons';
 
@@ -148,7 +148,7 @@ const DemoBlock: React.FC<IProps> = ({
     demoPath,
     files = [],
 }: IProps): ReactElement => {
-    const [theme, setTheme]: [Theme, (theme: Theme) => void] = useState(Themes.light);
+    const [theme, setTheme] = useState(Themes.light);
     /**
      * Enable/disable the dark theme.
      * This is the callback function of the `onClick` event of the theme <Switch>.
@@ -159,7 +159,7 @@ const DemoBlock: React.FC<IProps> = ({
         setTheme(enabled ? Themes.dark : Themes.light);
     };
 
-    const [shouldDisplayCode, setDisplayCode]: [boolean, (shouldDisplayCode: boolean) => void] = useState(false);
+    const [shouldDisplayCode, setDisplayCode] = useState(false);
     /**
      * Toggle the display of the code in the demo block.
      */
@@ -171,9 +171,7 @@ const DemoBlock: React.FC<IProps> = ({
         IESModule['default'] | undefined,
         (demoComponent: IESModule['default'] | undefined) => void
     ] = useState();
-    const [demoSources, setDemoSources]: [string[], (demoSources: string[]) => void] = useState([
-        'No source code for this demo...',
-    ]);
+    const [demoSources, setDemoSources] = useState(['No source code for this demo...']);
 
     const isThemeDark: boolean = theme === Themes.dark;
 

--- a/demo/react/layout/DemoBlock.tsx
+++ b/demo/react/layout/DemoBlock.tsx
@@ -10,7 +10,7 @@ import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
 import noop from 'lodash/noop';
 
-import { Button, ButtonEmphasises, Switch, SwitchPositions, Themes } from 'LumX';
+import { Button, ButtonEmphasis, Switch, SwitchPosition, Theme } from 'LumX';
 import { IGenericProps } from 'LumX/core/react/utils';
 import { mdiCodeTags } from 'LumX/icons';
 
@@ -147,7 +147,7 @@ const DemoBlock: React.FC<IProps> = ({
     demoPath,
     files = [],
 }: IProps): ReactElement => {
-    const [theme, setTheme] = useState(Themes.light);
+    const [theme, setTheme] = useState(Theme.light);
     /**
      * Enable/disable the dark theme.
      * This is the callback function of the `onClick` event of the theme <Switch>.
@@ -155,7 +155,7 @@ const DemoBlock: React.FC<IProps> = ({
      * @param enabled Indicates if the dark theme should be enabled or not.
      */
     const setDarkTheme = (enabled: boolean): void => {
-        setTheme(enabled ? Themes.dark : Themes.light);
+        setTheme(enabled ? Theme.dark : Theme.light);
     };
 
     const [shouldDisplayCode, setDisplayCode] = useState(false);
@@ -172,7 +172,7 @@ const DemoBlock: React.FC<IProps> = ({
     ] = useState();
     const [demoSources, setDemoSources] = useState(['No source code for this demo...']);
 
-    const isThemeDark: boolean = theme === Themes.dark;
+    const isThemeDark: boolean = theme === Theme.dark;
 
     const sourceFilesToLoad: string[] = [`${demoName}.tsx`].concat(files);
     useEffect((): void => {
@@ -207,13 +207,13 @@ const DemoBlock: React.FC<IProps> = ({
 
                     <div className="main-block__toolbar">
                         <div className="main-block__code-toggle">
-                            <Button leftIcon={mdiCodeTags} emphasis={ButtonEmphasises.low} onClick={toggleDisplayCode}>
+                            <Button leftIcon={mdiCodeTags} emphasis={ButtonEmphasis.low} onClick={toggleDisplayCode}>
                                 {shouldDisplayCode ? 'Hide code' : 'Show code'}
                             </Button>
                         </div>
 
                         <div className="main-block__theme-toggle">
-                            <Switch position={SwitchPositions.right} label="Dark background" onToggle={setDarkTheme} />
+                            <Switch position={SwitchPosition.right} label="Dark background" onToggle={setDarkTheme} />
                         </div>
                     </div>
 

--- a/demo/react/layout/DemoBlock.tsx
+++ b/demo/react/layout/DemoBlock.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, ReactNode, useEffect, useState } from 'react';
+import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -192,7 +192,7 @@ const DemoBlock: React.FC<IProps> = ({
     }, [demoPath, demoName]);
 
     return (
-        <Fragment>
+        <>
             <div className={classNames('main-block', className)}>
                 {!isEmpty(title) && <h2 className="main-block__title">{title}</h2>}
 
@@ -244,7 +244,7 @@ const DemoBlock: React.FC<IProps> = ({
                     )}
                 </div>
             </div>
-        </Fragment>
+        </>
     );
 };
 

--- a/demo/react/layout/DemoBlock.tsx
+++ b/demo/react/layout/DemoBlock.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, ReactElement, ReactNode, useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -31,7 +31,7 @@ interface IProps extends IGenericProps {
     /**
      * The description of the demo block.
      */
-    children?: React.ReactNode;
+    children?: ReactNode;
 
     /**
      * The full name of the demo. When adding the '.tsx' extension, this will give the name of the file to load to
@@ -147,7 +147,7 @@ const DemoBlock: React.FC<IProps> = ({
     demoName,
     demoPath,
     files = [],
-}: IProps): React.ReactElement => {
+}: IProps): ReactElement => {
     const [theme, setTheme]: [Theme, (theme: Theme) => void] = useState(Themes.light);
     /**
      * Enable/disable the dark theme.
@@ -223,7 +223,7 @@ const DemoBlock: React.FC<IProps> = ({
                     {shouldDisplayCode && (
                         <div className="main-block__code">
                             {demoSources.map(
-                                (demoSource: string, index: number): React.ReactNode => {
+                                (demoSource: string, index: number): ReactElement => {
                                     return (
                                         <div
                                             key={sourceFilesToLoad[index]}

--- a/demo/react/layout/DemoHeader.tsx
+++ b/demo/react/layout/DemoHeader.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 
-import { Button, ButtonEmphasises, ButtonSizes } from 'LumX';
+import { Button, ButtonEmphasis, Size } from 'LumX';
 import { IGenericProps } from 'LumX/core/react/utils';
 import { mdiAngular } from 'LumX/icons';
 
@@ -48,7 +48,7 @@ const DemoHeader: React.FC<IProps> = ({ category, children: description, demoTit
             )}
 
             <div>
-                <Button leftIcon={mdiAngular} emphasis={ButtonEmphasises.low} size={ButtonSizes.s}>
+                <Button leftIcon={mdiAngular} emphasis={ButtonEmphasis.low} size={Size.s}>
                     View AngularJS version
                 </Button>
             </div>

--- a/demo/react/layout/DemoHeader.tsx
+++ b/demo/react/layout/DemoHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement, ReactNode } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 
@@ -21,7 +21,7 @@ interface IProps extends IGenericProps {
     /**
      * The description of the demo.
      */
-    children?: React.ReactNode;
+    children?: ReactNode;
 
     /**
      * The title of the demo.
@@ -38,11 +38,7 @@ interface IProps extends IGenericProps {
  *
  * @return The demo header component.
  */
-const DemoHeader: React.FC<IProps> = ({
-    category,
-    children: description,
-    demoTitle: title,
-}: IProps): React.ReactElement => (
+const DemoHeader: React.FC<IProps> = ({ category, children: description, demoTitle: title }: IProps): ReactElement => (
     <Fragment>
         <div lumx-grid-container="row">
             {!isEmpty(category) && (

--- a/demo/react/layout/DemoHeader.tsx
+++ b/demo/react/layout/DemoHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 
@@ -39,7 +39,7 @@ interface IProps extends IGenericProps {
  * @return The demo header component.
  */
 const DemoHeader: React.FC<IProps> = ({ category, children: description, demoTitle: title }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <div lumx-grid-container="row">
             {!isEmpty(category) && (
                 <div lumx-grid-item="true">
@@ -57,7 +57,7 @@ const DemoHeader: React.FC<IProps> = ({ category, children: description, demoTit
         <h1 className="lumx-typography-display1 mt+">{title}</h1>
 
         {!isEmpty(description) && <div className="lumx-typography-subtitle2 mt+">{description}</div>}
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/demo/react/layout/Main.tsx
+++ b/demo/react/layout/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -35,7 +35,7 @@ interface IESModule {
      * The `description` export of our fake ESModule loaded by the dynamic component loader.
      * This export contains the description of the demo.
      */
-    description?: React.ReactNode;
+    description?: ReactElement;
 
     /**
      * The `title` export of our fake ESModule loaded by the dynamic component loader.
@@ -80,7 +80,7 @@ async function _loadComponent(componentFolderName: IProps['activeComponent']): P
  *
  * @return The main component.
  */
-const Main: React.FC<IProps> = ({ activeComponent }: IProps): React.ReactElement => {
+const Main: React.FC<IProps> = ({ activeComponent }: IProps): ReactElement => {
     const [demo, setDemo]: [IESModule | undefined, (demo: IESModule | undefined) => void] = useState();
 
     useEffect((): void => {
@@ -108,7 +108,7 @@ const Main: React.FC<IProps> = ({ activeComponent }: IProps): React.ReactElement
         );
     }
 
-    const demoHeader: React.ReactNode = !isEmpty(demo.title) ? (
+    const demoHeader: ReactElement | null = !isEmpty(demo.title) ? (
         <DemoHeader category={demo.category} demoTitle={demo.title}>
             {demo.description}
         </DemoHeader>
@@ -121,7 +121,7 @@ const Main: React.FC<IProps> = ({ activeComponent }: IProps): React.ReactElement
 
                 <div className="mt++">
                     {Object.keys(demo.demos).map(
-                        (key: string, index: number): React.ReactNode => {
+                        (key: string, index: number): ReactElement => {
                             const { description, files, title }: DemoObject = demo.demos[key];
 
                             return (

--- a/demo/react/layout/Main.tsx
+++ b/demo/react/layout/Main.tsx
@@ -81,7 +81,7 @@ async function _loadComponent(componentFolderName: IProps['activeComponent']): P
  * @return The main component.
  */
 const Main: React.FC<IProps> = ({ activeComponent }: IProps): ReactElement => {
-    const [demo, setDemo]: [IESModule | undefined, (demo: IESModule | undefined) => void] = useState();
+    const [demo, setDemo] = useState<IESModule>();
 
     useEffect((): void => {
         const loadComponent: () => Promise<void> = async (): Promise<void> => {
@@ -122,7 +122,7 @@ const Main: React.FC<IProps> = ({ activeComponent }: IProps): ReactElement => {
                 <div className="mt++">
                     {Object.keys(demo.demos).map(
                         (key: string, index: number): ReactElement => {
-                            const { description, files, title }: DemoObject = demo.demos[key];
+                            const { description, files, title } = demo.demos[key];
 
                             return (
                                 <DemoBlock

--- a/demo/react/layout/Main.tsx
+++ b/demo/react/layout/Main.tsx
@@ -84,7 +84,7 @@ const Main: React.FC<IProps> = ({ activeComponent }: IProps): ReactElement => {
     const [demo, setDemo] = useState<IESModule>();
 
     useEffect((): void => {
-        const loadComponent: () => Promise<void> = async (): Promise<void> => {
+        const loadComponent = async (): Promise<void> => {
             try {
                 const loadedDemo: IESModule = await _loadComponent(activeComponent);
                 setDemo(loadedDemo);

--- a/demo/react/layout/MainNav.tsx
+++ b/demo/react/layout/MainNav.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { LumXLogo } from '../../assets/images';
 
@@ -10,7 +10,7 @@ import { LumXLogo } from '../../assets/images';
  *
  * @return The main navigation component.
  */
-const MainNav: React.FC = (): React.ReactElement => (
+const MainNav: React.FC = (): ReactElement => (
     <div className="main-nav">
         <ul className="main-nav__wrapper">
             <li className="main-nav__logo">

--- a/demo/react/layout/SubNav.tsx
+++ b/demo/react/layout/SubNav.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { Theme } from 'LumX/demo/constants';
 
@@ -74,7 +74,7 @@ const NAV_ITEMS: string[] = [
  *
  * @return The sub navigation component.
  */
-const SubNav: React.FC<IProps> = ({ activeComponent, changeTheme, handleNavigate }: IProps): React.ReactElement => (
+const SubNav: React.FC<IProps> = ({ activeComponent, changeTheme, handleNavigate }: IProps): ReactElement => (
     <div className="sub-nav">
         <ul className="sub-nav__wrapper ph++ pv+">
             <li>
@@ -95,7 +95,7 @@ const SubNav: React.FC<IProps> = ({ activeComponent, changeTheme, handleNavigate
             <li className="sub-nav__subheader">Components</li>
 
             {NAV_ITEMS.map(
-                (navItemLabel: string): React.ReactNode => (
+                (navItemLabel: string): ReactElement => (
                     <SubNavItem key={navItemLabel} handleClick={handleNavigate} activeComponent={activeComponent}>
                         {navItemLabel}
                     </SubNavItem>

--- a/demo/react/layout/SubNavItem.tsx
+++ b/demo/react/layout/SubNavItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 import slugify from 'slugify';
@@ -20,7 +20,7 @@ interface IProps {
     /**
      * The label of the sub navigation item.
      */
-    children: React.ReactNode;
+    children: ReactNode;
 
     /**
      * The name of the component this sub navigation item will activate when clicked.
@@ -45,12 +45,7 @@ interface IProps {
  *
  * @return The sub navigation item component.
  */
-const SubNavItem: React.FC<IProps> = ({
-    children,
-    component,
-    handleClick,
-    activeComponent,
-}: IProps): React.ReactElement => {
+const SubNavItem: React.FC<IProps> = ({ children, component, handleClick, activeComponent }: IProps): ReactElement => {
     component = slugify(component || children!.toString(), {
         lower: true,
     });

--- a/demo/react/layout/SubNavItem.tsx
+++ b/demo/react/layout/SubNavItem.tsx
@@ -50,7 +50,7 @@ const SubNavItem: React.FC<IProps> = ({ children, component, handleClick, active
         lower: true,
     });
 
-    const onClick: () => void = (): void => {
+    const onClick = (): void => {
         if (component !== undefined && !isEmpty(component)) {
             handleClick(component);
         }

--- a/demo/react/layout/ThemeSelector.tsx
+++ b/demo/react/layout/ThemeSelector.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, ReactElement } from 'react';
 
 import { Theme } from '../../constants';
 
@@ -24,7 +24,7 @@ interface IProps {
  *
  * @return The theme selector component.
  */
-const ThemeSelector: React.FC<IProps> = ({ changeTheme }: IProps): React.ReactElement => {
+const ThemeSelector: React.FC<IProps> = ({ changeTheme }: IProps): ReactElement => {
     /**
      * When the select is changed, call the function to change the theme.
      *

--- a/demo/tslint.json
+++ b/demo/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "jsx-no-lambda": false,
+        "no-console": false
+    }
+}

--- a/examples/react/index.html
+++ b/examples/react/index.html
@@ -52,7 +52,7 @@
                                 &lt;script src="node_modules/@lumx/dist/lumx.react.min.js" type="text/javascript"&gt;&lt;/script&gt;
 
                                 &lt;script type="text/babel"&gt;
-                                    const { Fragment, PureComponent } = React;
+                                    const { PureComponent } = React;
                                     const { Button } = LumX;
 
                                     class MyButton extends PureComponent {
@@ -120,7 +120,7 @@
                                 &lt;script src="node_modules/@lumx/dist/lumx.react.min.js" type="text/javascript"&gt;&lt;/script&gt;
 
                                 &lt;script type="text/javascript"&gt;
-                                    const { Fragment, PureComponent } = React;
+                                    const { PureComponent } = React;
                                     const { Button } = require('@lumx/react');
 
                                     class MyButton extends PureComponent {
@@ -189,7 +189,7 @@
 
                                 &lt;script type="text/javascript"&gt;
                                     require(['@lumx/react'], (LumX) => {
-                                        const { Fragment, PureComponent } = React;
+                                        const { PureComponent } = React;
                                         const { Button } = LumX;
 
                                         class MyButton extends PureComponent {
@@ -258,7 +258,7 @@
                                 &lt;script src="node_modules/@lumx/dist/lumx.react.min.js" type="text/javascript"&gt;&lt;/script&gt;
 
                                 &lt;script type="text/javascript"&gt;
-                                    import { Fragment, PureComponent } from 'react';
+                                    import { PureComponent } from 'react';
                                     import { Button } from '@lumx/react';
 
                                     class MyButton extends PureComponent {
@@ -299,7 +299,7 @@
 
         <script src="../lumx.react.min.js" type="text/javascript"></script>
         <script data-presets="es2015,react" type="text/babel">
-            const { Fragment, PureComponent } = React;
+            const { PureComponent } = React;
             const { Button } = LumX;
 
             class Nice extends PureComponent {
@@ -323,7 +323,7 @@
             };
 
             ReactDOM.render(
-                <Fragment>
+                <>
                     {' '}
                     <div class="lumx-typography-title mb+++">This is a basic example</div>
                     {''}
@@ -332,7 +332,7 @@
                     <GotItButton color="green" onClick={() => console.info('Glad you got it!')}>
                         I got it!
                     </GotItButton>
-                </Fragment>,
+                </>,
                 document.getElementById('root'),
                 () => {
                     const message = 'LumX Example React Application successfully started!';

--- a/src/components/avatar/react/Avatar.tsx
+++ b/src/components/avatar/react/Avatar.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -79,7 +79,7 @@ const Avatar: React.FC<AvatarProps> = ({
     theme = DEFAULT_PROPS.theme,
     image,
     ...props
-}: AvatarProps): React.ReactElement => {
+}: AvatarProps): ReactElement => {
     const style: CSSProperties = {
         backgroundImage: `url(${image})`,
     };

--- a/src/components/avatar/react/Avatar.tsx
+++ b/src/components/avatar/react/Avatar.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Theme, Themes } from 'LumX/components';
+import { Size, Theme } from 'LumX';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
@@ -12,14 +12,7 @@ import { handleBasicClasses } from 'LumX/core/utils';
 /**
  * Authorized size values.
  */
-enum Sizes {
-    xs = 'xs',
-    s = 's',
-    m = 'm',
-    l = 'l',
-    xl = 'xl',
-}
-type Size = Sizes;
+type AvatarSize = Size.xs | Size.s | Size.m | Size.l | Size.xl;
 
 /////////////////////////////
 
@@ -28,7 +21,7 @@ type Size = Sizes;
  */
 interface IAvatarProps extends IGenericProps {
     /* Size. */
-    size?: Size;
+    size?: AvatarSize;
     /* Theme. */
     theme?: Theme;
     /* Avatar image */
@@ -63,8 +56,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
-    size: Sizes.m,
-    theme: Themes.light,
+    size: Size.m,
+    theme: Theme.light,
 };
 /////////////////////////////
 
@@ -98,4 +91,4 @@ Avatar.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Avatar, AvatarProps, Theme, Themes, Sizes };
+export { CLASSNAME, DEFAULT_PROPS, Avatar, AvatarProps };

--- a/src/components/button/react/Button.test.tsx
+++ b/src/components/button/react/Button.test.tsx
@@ -78,10 +78,7 @@ function _getDefaultPropValue({ prop, props }: { prop: string; props?: ISetupPro
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: ButtonProps = {
         children: DEFAULT_LABEL,
         ...propsOverrides,

--- a/src/components/button/react/Button.test.tsx
+++ b/src/components/button/react/Button.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -87,7 +87,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<Button {...props} />);
 
@@ -117,7 +117,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should render correctly a <span> label', (): void => {
-            const children: React.ReactNode = <span>{DEFAULT_LABEL}</span>;
+            const children: ReactNode = <span>{DEFAULT_LABEL}</span>;
 
             const { buttonRoot, icon, wrapper }: ISetup = setup({ children });
             expect(wrapper).toMatchSnapshot();

--- a/src/components/button/react/Button.test.tsx
+++ b/src/components/button/react/Button.test.tsx
@@ -11,7 +11,8 @@ import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils
 import { getBasicClass } from 'LumX/core/utils';
 import { mdiCheck, mdiChevronDown, mdiPlus } from 'LumX/icons';
 
-import { Button, ButtonProps, CLASSNAME, DEFAULT_PROPS, Emphasises, Sizes, Themes, Variants } from './Button';
+import { Size, Theme } from 'LumX';
+import { Button, ButtonEmphasis, ButtonProps, ButtonVariant, CLASSNAME, DEFAULT_PROPS } from './Button';
 
 /////////////////////////////
 
@@ -243,7 +244,7 @@ describe(`<${Button.displayName}>`, (): void => {
             let { buttonRoot, icon, wrapper } = setup({
                 children: null,
                 leftIcon: mdiPlus,
-                variant: Variants.icon,
+                variant: ButtonVariant.icon,
             });
             expect(wrapper).toMatchSnapshot();
 
@@ -258,7 +259,7 @@ describe(`<${Button.displayName}>`, (): void => {
             ({ buttonRoot, icon, wrapper } = setup({
                 children: null,
                 rightIcon: mdiChevronDown,
-                variant: Variants.icon,
+                variant: ButtonVariant.icon,
             }));
             expect(wrapper).toMatchSnapshot();
 
@@ -294,11 +295,11 @@ describe(`<${Button.displayName}>`, (): void => {
             const modifiedPropsBuilder: () => ISetupProps = build('props').fields({
                 // tslint:disable-next-line: no-any
                 color: fake((fakeData: any): string => fakeData.commerce.color()),
-                emphasis: oneOf(...without(Object.values(Emphasises), DEFAULT_PROPS.emphasis)),
+                emphasis: oneOf(...without(Object.values(ButtonEmphasis), DEFAULT_PROPS.emphasis)),
                 leftIcon: oneOf(mdiPlus, mdiCheck),
-                size: oneOf(...without(Object.values(Sizes), DEFAULT_PROPS.size)),
-                theme: oneOf(...without(Object.values(Themes), DEFAULT_PROPS.theme)),
-                variant: Variants.icon,
+                size: oneOf(...without(Object.values(Size), DEFAULT_PROPS.size)),
+                theme: oneOf(...without(Object.values(Theme), DEFAULT_PROPS.theme)),
+                variant: ButtonVariant.icon,
             });
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
@@ -350,8 +351,8 @@ describe(`<${Button.displayName}>`, (): void => {
 
             /////////////////////////////
 
-            modifiedProps.emphasis = Emphasises.high;
-            modifiedProps.variant = Variants.button;
+            modifiedProps.emphasis = ButtonEmphasis.high;
+            modifiedProps.variant = ButtonVariant.button;
 
             ({ buttonRoot } = setup({ ...modifiedProps }));
 
@@ -406,7 +407,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it("should not have any `theme` in 'low' or 'medium' `emphasis` but one in 'high'", (): void => {
-            let { buttonRoot } = setup({ emphasis: Emphasises.high });
+            let { buttonRoot } = setup({ emphasis: ButtonEmphasis.high });
 
             expect(buttonRoot.prop('className') as string).toContain(
                 getBasicClass({ prefix: CLASSNAME, type: 'theme', value: '' }),
@@ -414,7 +415,7 @@ describe(`<${Button.displayName}>`, (): void => {
 
             /////////////////////////////
 
-            ({ buttonRoot } = setup({ emphasis: Emphasises.medium }));
+            ({ buttonRoot } = setup({ emphasis: ButtonEmphasis.medium }));
 
             expect(buttonRoot.prop('className') as string).not.toContain(
                 getBasicClass({ prefix: CLASSNAME, type: 'theme', value: '' }),
@@ -422,7 +423,7 @@ describe(`<${Button.displayName}>`, (): void => {
 
             /////////////////////////////
 
-            ({ buttonRoot } = setup({ emphasis: Emphasises.low }));
+            ({ buttonRoot } = setup({ emphasis: ButtonEmphasis.low }));
 
             expect(buttonRoot.prop('className') as string).not.toContain(
                 getBasicClass({ prefix: CLASSNAME, type: 'theme', value: '' }),
@@ -500,7 +501,7 @@ describe(`<${Button.displayName}>`, (): void => {
         it("should fail when a label is given in the 'icon' `variant`", (): void => {
             expect(
                 (): void => {
-                    setup({ leftIcon: mdiPlus, variant: Variants.icon });
+                    setup({ leftIcon: mdiPlus, variant: ButtonVariant.icon });
                 },
             ).toThrowErrorMatchingSnapshot();
         });
@@ -508,7 +509,12 @@ describe(`<${Button.displayName}>`, (): void => {
         it("should fail when more than 1 icon is given in the 'icon' `variant`", (): void => {
             expect(
                 (): void => {
-                    setup({ children: null, leftIcon: mdiPlus, rightIcon: mdiChevronDown, variant: Variants.icon });
+                    setup({
+                        children: null,
+                        leftIcon: mdiPlus,
+                        rightIcon: mdiChevronDown,
+                        variant: ButtonVariant.icon,
+                    });
                 },
             ).toThrowErrorMatchingSnapshot();
         });
@@ -531,7 +537,7 @@ describe(`<${Button.displayName}>`, (): void => {
         it("should not inform the user when rendering an icon button with the 'icon' `variant`", (): void => {
             global.console.info = jest.fn();
 
-            setup({ children: null, leftIcon: mdiPlus, variant: Variants.icon });
+            setup({ children: null, leftIcon: mdiPlus, variant: ButtonVariant.icon });
             expect(global.console.info).not.toHaveBeenCalled();
 
             /////////////////////////////
@@ -539,13 +545,13 @@ describe(`<${Button.displayName}>`, (): void => {
             // @ts-ignore
             global.console.info.mockClear();
 
-            setup({ children: null, rightIcon: mdiChevronDown, variant: Variants.icon });
+            setup({ children: null, rightIcon: mdiChevronDown, variant: ButtonVariant.icon });
             expect(global.console.info).not.toHaveBeenCalled();
         });
 
         it("should have no `theme` in any other `emphasis` than 'high'", (): void => {
             let modifiedProps: ISetupProps = {
-                emphasis: Emphasises.high,
+                emphasis: ButtonEmphasis.high,
             };
 
             let { buttonRoot } = setup(modifiedProps);
@@ -556,7 +562,7 @@ describe(`<${Button.displayName}>`, (): void => {
             /////////////////////////////
 
             modifiedProps = {
-                emphasis: Emphasises.medium,
+                emphasis: ButtonEmphasis.medium,
             };
 
             ({ buttonRoot } = setup(modifiedProps));
@@ -567,7 +573,7 @@ describe(`<${Button.displayName}>`, (): void => {
             /////////////////////////////
 
             modifiedProps = {
-                emphasis: Emphasises.low,
+                emphasis: ButtonEmphasis.low,
             };
 
             ({ buttonRoot } = setup(modifiedProps));

--- a/src/components/button/react/Button.test.tsx
+++ b/src/components/button/react/Button.test.tsx
@@ -105,7 +105,7 @@ describe(`<${Button.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly a text label', (): void => {
-            const { buttonRoot, icon, wrapper }: ISetup = setup();
+            const { buttonRoot, icon, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(buttonRoot).toExist();
@@ -119,7 +119,7 @@ describe(`<${Button.displayName}>`, (): void => {
         it('should render correctly a <span> label', (): void => {
             const children: ReactNode = <span>{DEFAULT_LABEL}</span>;
 
-            const { buttonRoot, icon, wrapper }: ISetup = setup({ children });
+            const { buttonRoot, icon, wrapper } = setup({ children });
             expect(wrapper).toMatchSnapshot();
 
             expect(buttonRoot).toExist();
@@ -131,7 +131,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should render correctly a left icon and a text label', (): void => {
-            const { buttonRoot, icon, wrapper }: ISetup = setup({ leftIcon: mdiPlus });
+            const { buttonRoot, icon, wrapper } = setup({ leftIcon: mdiPlus });
             expect(wrapper).toMatchSnapshot();
 
             expect(buttonRoot).toExist();
@@ -144,7 +144,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should render correctly a left icon and a <span> label', (): void => {
-            const { buttonRoot, icon, wrapper }: ISetup = setup({
+            const { buttonRoot, icon, wrapper } = setup({
                 children: <span>{DEFAULT_LABEL}</span>,
                 leftIcon: mdiPlus,
             });
@@ -160,7 +160,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should render correctly a text label and a right icon', (): void => {
-            const { buttonRoot, icon, wrapper }: ISetup = setup({ rightIcon: mdiChevronDown });
+            const { buttonRoot, icon, wrapper } = setup({ rightIcon: mdiChevronDown });
             expect(wrapper).toMatchSnapshot();
 
             expect(buttonRoot).toExist();
@@ -173,7 +173,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should render correctly a <span> label and a right icon', (): void => {
-            const { buttonRoot, icon, wrapper }: ISetup = setup({
+            const { buttonRoot, icon, wrapper } = setup({
                 children: <span>{DEFAULT_LABEL}</span>,
                 rightIcon: mdiChevronDown,
             });
@@ -189,7 +189,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should render correctly two icons and a text label', (): void => {
-            const { buttonRoot, icon, wrapper }: ISetup = setup({ leftIcon: mdiPlus, rightIcon: mdiChevronDown });
+            const { buttonRoot, icon, wrapper } = setup({ leftIcon: mdiPlus, rightIcon: mdiChevronDown });
             expect(wrapper).toMatchSnapshot();
 
             expect(buttonRoot).toExist();
@@ -202,7 +202,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should render correctly two icons and a <span> label', (): void => {
-            const { buttonRoot, icon, wrapper }: ISetup = setup({
+            const { buttonRoot, icon, wrapper } = setup({
                 children: <span>{DEFAULT_LABEL}</span>,
                 leftIcon: mdiPlus,
                 rightIcon: mdiChevronDown,
@@ -221,7 +221,7 @@ describe(`<${Button.displayName}>`, (): void => {
         it("should render correctly an icon button with the 'button' `variant`", (): void => {
             mockConsole('info');
 
-            let { buttonRoot, icon, wrapper }: ISetup = setup({ children: null, leftIcon: mdiPlus });
+            let { buttonRoot, icon, wrapper } = setup({ children: null, leftIcon: mdiPlus });
             expect(wrapper).toMatchSnapshot();
 
             expect(buttonRoot).toExist();
@@ -243,7 +243,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it("should render correctly an icon button with the 'icon' `variant`", (): void => {
-            let { buttonRoot, icon, wrapper }: ISetup = setup({
+            let { buttonRoot, icon, wrapper } = setup({
                 children: null,
                 leftIcon: mdiPlus,
                 variant: Variants.icon,
@@ -278,7 +278,7 @@ describe(`<${Button.displayName}>`, (): void => {
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
         it('should use default props', (): void => {
-            const { buttonRoot }: ISetup = setup();
+            const { buttonRoot } = setup();
 
             Object.keys(DEFAULT_PROPS).forEach(
                 (prop: string): void => {
@@ -306,7 +306,7 @@ describe(`<${Button.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            let { buttonRoot }: ISetup = setup({ children: null, ...modifiedProps });
+            let { buttonRoot } = setup({ children: null, ...modifiedProps });
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {
@@ -409,7 +409,7 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it("should not have any `theme` in 'low' or 'medium' `emphasis` but one in 'high'", (): void => {
-            let { buttonRoot }: ISetup = setup({ emphasis: Emphasises.high });
+            let { buttonRoot } = setup({ emphasis: Emphasises.high });
 
             expect(buttonRoot.prop('className') as string).toContain(
                 getBasicClass({ prefix: CLASSNAME, type: 'theme', value: '' }),
@@ -437,7 +437,7 @@ describe(`<${Button.displayName}>`, (): void => {
                 className: 'component component--is-tested',
             };
 
-            let { buttonRoot }: ISetup = setup({ leftIcon: mdiPlus, ...modifiedProps });
+            let { buttonRoot } = setup({ leftIcon: mdiPlus, ...modifiedProps });
 
             expect(buttonRoot).toHaveClassName(modifiedProps.className);
 
@@ -551,7 +551,7 @@ describe(`<${Button.displayName}>`, (): void => {
                 emphasis: Emphasises.high,
             };
 
-            let { buttonRoot }: ISetup = setup(modifiedProps);
+            let { buttonRoot } = setup(modifiedProps);
             expect(buttonRoot).toHaveClassName(
                 getBasicClass({ prefix: CLASSNAME, type: 'theme', value: DEFAULT_PROPS.theme }),
             );
@@ -580,19 +580,19 @@ describe(`<${Button.displayName}>`, (): void => {
         });
 
         it('should only have the "left-icon" CSS class when a left icon is passed in a \'button\' `variant`', (): void => {
-            const { buttonRoot }: ISetup = setup({ leftIcon: mdiPlus });
+            const { buttonRoot } = setup({ leftIcon: mdiPlus });
             expect(buttonRoot).toHaveClassName(`${CLASSNAME}--has-left-icon`);
             expect(buttonRoot).not.toHaveClassName(`${CLASSNAME}--has-right-icon`);
         });
 
         it('should only have the "right-icon" CSS class when a right icon is passed in a \'button\' `variant`', (): void => {
-            const { buttonRoot }: ISetup = setup({ rightIcon: mdiChevronDown });
+            const { buttonRoot } = setup({ rightIcon: mdiChevronDown });
             expect(buttonRoot).not.toHaveClassName(`${CLASSNAME}--has-left-icon`);
             expect(buttonRoot).toHaveClassName(`${CLASSNAME}--has-right-icon`);
         });
 
         it('should have both "left-icon" and "right-icon" CSS classes when both left and right icons are passed in a \'button\' `variant`', (): void => {
-            const { buttonRoot }: ISetup = setup({ leftIcon: mdiPlus, rightIcon: mdiChevronDown });
+            const { buttonRoot } = setup({ leftIcon: mdiPlus, rightIcon: mdiChevronDown });
             expect(buttonRoot).toHaveClassName(`${CLASSNAME}--has-left-icon`);
             expect(buttonRoot).toHaveClassName(`${CLASSNAME}--has-right-icon`);
         });

--- a/src/components/button/react/Button.tsx
+++ b/src/components/button/react/Button.tsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 
 import isEmpty from 'lodash/isEmpty';
 
-import { Icon, IconButton } from 'LumX';
-import { Color, Colors, ComplexPropDefault, Theme, Themes } from 'LumX/components';
+import { Color, ColorPalette, Icon, IconButton, Size, Theme } from 'LumX';
+import { ComplexPropDefault } from 'LumX/components';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, Omit, ValidateParameters, getRootClassName, validateComponent } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -17,30 +17,24 @@ import { ButtonRoot, ButtonRootProps } from './ButtonRoot';
 /**
  * The authorized values for the `emphasis` prop.
  */
-enum Emphasises {
+enum ButtonEmphasis {
     low = 'low',
     medium = 'medium',
     high = 'high',
 }
-type Emphasis = Emphasises;
 
 /**
  * The authorized values for the `size` prop.
  */
-enum Sizes {
-    s = 's',
-    m = 'm',
-}
-type Size = Sizes;
+type ButtonSize = Size.s | Size.m;
 
 /**
  * The authorized values for the `variant` prop.
  */
-enum Variants {
+enum ButtonVariant {
     button = 'button',
     icon = 'icon',
 }
-type Variant = Variants;
 
 /////////////////////////////
 
@@ -66,7 +60,7 @@ interface IButtonProps extends IGenericProps {
     /**
      * The emphasis.
      */
-    emphasis?: Emphasis;
+    emphasis?: ButtonEmphasis;
 
     /**
      * The icon that comes before the label.
@@ -81,7 +75,7 @@ interface IButtonProps extends IGenericProps {
     /**
      * The size.
      */
-    size?: Size;
+    size?: ButtonSize;
 
     /**
      * The theme.
@@ -91,7 +85,7 @@ interface IButtonProps extends IGenericProps {
     /**
      * The variant.
      */
-    variant?: Variant;
+    variant?: ButtonVariant;
 }
 type ButtonProps = IButtonProps & ButtonRootProps;
 
@@ -126,13 +120,13 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 const DEFAULT_PROPS: IDefaultPropsType = {
     buttonRef: undefined,
     color: {
-        default: Colors.dark,
-        [`emphasis-${Emphasises.high}`]: Colors.primary,
+        default: ColorPalette.dark,
+        [`emphasis-${ButtonEmphasis.high}`]: ColorPalette.primary,
     },
-    emphasis: Emphasises.high,
-    size: Sizes.m,
-    theme: Themes.light,
-    variant: Variants.button,
+    emphasis: ButtonEmphasis.high,
+    size: Size.m,
+    theme: Theme.light,
+    variant: ButtonVariant.button,
 };
 
 /////////////////////////////
@@ -153,7 +147,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  */
 function _postValidate({ childrenCount, props }: ValidateParameters): string | boolean | void {
     if (
-        props.variant === Variants.button &&
+        props.variant === ButtonVariant.button &&
         (!isEmpty(props.leftIcon) || !isEmpty(props.rightIcon)) &&
         childrenCount === 0
     ) {
@@ -178,7 +172,7 @@ function _postValidate({ childrenCount, props }: ValidateParameters): string | b
  */
 function _preValidate({ childrenCount, props }: ValidateParameters): string | boolean | void {
     if (!isEmpty(props.leftIcon) && !isEmpty(props.rightIcon)) {
-        if (props.variant === Variants.icon) {
+        if (props.variant === ButtonVariant.icon) {
             return `You cannot have 2 icons in a 'icon' \`variant\` of <${COMPONENT_NAME}>, You can only have one icon!`;
         }
 
@@ -203,7 +197,7 @@ function _preValidate({ childrenCount, props }: ValidateParameters): string | bo
  */
 function _validate(props: ButtonProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
-        maxChildren: props.variant === Variants.icon ? 0 : undefined,
+        maxChildren: props.variant === ButtonVariant.icon ? 0 : undefined,
         postValidate: _postValidate,
         preValidate: _preValidate,
         props,
@@ -243,7 +237,7 @@ const Button: React.FC<ButtonProps> = ({
         ...props,
     });
 
-    if (variant === Variants.button) {
+    if (variant === ButtonVariant.button) {
         if (!isEmpty(leftIcon)) {
             className += isEmpty(className) ? '' : ' ';
             className += `${CLASSNAME}--has-left-icon`;
@@ -269,7 +263,7 @@ const Button: React.FC<ButtonProps> = ({
                     emphasis,
                     prefix: CLASSNAME,
                     size,
-                    theme: emphasis === Emphasises.high ? theme : undefined,
+                    theme: emphasis === ButtonEmphasis.high ? theme : undefined,
                     variant,
                 }),
             )}
@@ -285,19 +279,4 @@ Button.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export {
-    CLASSNAME,
-    DEFAULT_PROPS,
-    Color,
-    Colors,
-    Emphasis,
-    Emphasises,
-    Button,
-    ButtonProps,
-    Size,
-    Sizes,
-    Theme,
-    Themes,
-    Variant,
-    Variants,
-};
+export { CLASSNAME, DEFAULT_PROPS, ButtonEmphasis, Button, ButtonProps, ButtonVariant };

--- a/src/components/button/react/Button.tsx
+++ b/src/components/button/react/Button.tsx
@@ -51,8 +51,7 @@ interface IButtonProps extends IGenericProps {
     /**
      * Button reference to handle focus, ...
      */
-    // tslint:disable-next-line: no-any
-    buttonRef?: React.RefObject<any>;
+    buttonRef?: React.RefObject<ButtonRoot>;
 
     /**
      * The label.

--- a/src/components/button/react/Button.tsx
+++ b/src/components/button/react/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -57,7 +57,7 @@ interface IButtonProps extends IGenericProps {
     /**
      * The label.
      */
-    children?: React.ReactNode;
+    children?: ReactNode;
 
     /**
      * The color.
@@ -202,7 +202,7 @@ function _preValidate({ childrenCount, props }: ValidateParameters): string | bo
  * @param     props The children and props of the component.
  * @return The processed children of the component.
  */
-function _validate(props: ButtonProps): React.ReactNode {
+function _validate(props: ButtonProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         maxChildren: props.variant === Variants.icon ? 0 : undefined,
         postValidate: _postValidate,
@@ -231,8 +231,8 @@ const Button: React.FC<ButtonProps> = ({
     theme = DEFAULT_PROPS.theme,
     variant = DEFAULT_PROPS.variant,
     ...props
-}: ButtonProps): React.ReactElement => {
-    const newChildren: React.ReactNode = _validate({
+}: ButtonProps): ReactElement => {
+    const newChildren: ReactNode = _validate({
         children,
         color,
         emphasis,

--- a/src/components/button/react/ButtonGroup.test.tsx
+++ b/src/components/button/react/ButtonGroup.test.tsx
@@ -71,7 +71,7 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
     // 1. Test render via snapshot (default state of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly a group button', (): void => {
-            const { group, wrapper }: ISetup = setup();
+            const { group, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(group).toExist();

--- a/src/components/button/react/ButtonGroup.test.tsx
+++ b/src/components/button/react/ButtonGroup.test.tsx
@@ -41,10 +41,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of
  *                       the component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: ButtonGroupProps = {
         children: (
             <Fragment>

--- a/src/components/button/react/ButtonGroup.test.tsx
+++ b/src/components/button/react/ButtonGroup.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -44,10 +44,10 @@ interface ISetup extends ICommonSetup {
 const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: ButtonGroupProps = {
         children: (
-            <Fragment>
+            <>
                 <Button>Label</Button>
                 <IconButton icon={mdiPlus} />
-            </Fragment>
+            </>
         ),
         ...propsOverrides,
     };
@@ -132,10 +132,10 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
             mockConsole('debug');
 
             let children: ReactNode = (
-                <Fragment>
+                <>
                     <Icon icon={mdiPlus} />
                     <Icon icon={mdiPlus} />
-                </Fragment>
+                </>
             );
 
             expect(
@@ -147,10 +147,10 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <span>Label</span>
                     <Icon icon={mdiPlus} />
-                </Fragment>
+                </>
             );
 
             expect(
@@ -162,10 +162,10 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <span>Label</span>
                     <span>Label 2</span>
-                </Fragment>
+                </>
             );
 
             expect(
@@ -177,10 +177,10 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <Button>Label</Button>
                     <Icon icon={mdiPlus} />
-                </Fragment>
+                </>
             );
 
             expect(
@@ -192,10 +192,10 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <Button>Label</Button>
                     <span>Label</span>>
-                </Fragment>
+                </>
             );
 
             expect(
@@ -207,10 +207,10 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <Icon icon={mdiPlus} />
                     <Button>Label</Button>
-                </Fragment>
+                </>
             );
 
             expect(
@@ -222,9 +222,9 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <span>Label</span>><Button>Label</Button>
-                </Fragment>
+                </>
             );
 
             expect(
@@ -236,11 +236,11 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
 
         it('should fail when more than 2 children are given', (): void => {
             const children: ReactNode = (
-                <Fragment>
+                <>
                     <Button>Label</Button>
                     <Button>Label 2</Button>
                     <Button>Label 3</Button>
-                </Fragment>
+                </>
             );
 
             expect(

--- a/src/components/button/react/ButtonGroup.test.tsx
+++ b/src/components/button/react/ButtonGroup.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement, ReactNode } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -55,7 +55,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<ButtonGroup {...props} />);
 
@@ -120,7 +120,7 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
         });
 
         it('should fail when less than 2 children are given', (): void => {
-            const children: React.ReactNode = <Button>Label</Button>;
+            const children: ReactNode = <Button>Label</Button>;
 
             expect(
                 (): void => {
@@ -134,7 +134,7 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
         }> is passed as children`, (): void => {
             mockConsole('debug');
 
-            let children: React.ReactNode = (
+            let children: ReactNode = (
                 <Fragment>
                     <Icon icon={mdiPlus} />
                     <Icon icon={mdiPlus} />
@@ -238,7 +238,7 @@ describe(`<${ButtonGroup.displayName}>`, (): void => {
         });
 
         it('should fail when more than 2 children are given', (): void => {
-            const children: React.ReactNode = (
+            const children: ReactNode = (
                 <Fragment>
                     <Button>Label</Button>
                     <Button>Label 2</Button>

--- a/src/components/button/react/ButtonGroup.tsx
+++ b/src/components/button/react/ButtonGroup.tsx
@@ -6,7 +6,7 @@ import { IconButton } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName, validateComponent } from 'LumX/react/utils';
 
-import { Button, Color, Colors, Size, Sizes, Theme, Themes } from './Button';
+import { Button } from './Button';
 
 /////////////////////////////
 /**
@@ -91,4 +91,4 @@ ButtonGroup.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Color, Colors, ButtonGroup, ButtonGroupProps, Size, Sizes, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, ButtonGroup, ButtonGroupProps };

--- a/src/components/button/react/ButtonGroup.tsx
+++ b/src/components/button/react/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -56,7 +56,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
  * @param props The children and props of the component.
  * @return    The processed children of the component.
  */
-function _validate(props: ButtonGroupProps): React.ReactNode {
+function _validate(props: ButtonGroupProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         allowedTypes: [IconButton, Button],
         maxChildren: 2,
@@ -78,8 +78,8 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({
     children,
     className = '',
     ...props
-}: ButtonGroupProps): React.ReactElement => {
-    const newChildren: React.ReactNode = _validate({ children });
+}: ButtonGroupProps): ReactElement => {
+    const newChildren: ReactNode = _validate({ children });
 
     return (
         <div className={classNames(className, CLASSNAME)} {...props}>

--- a/src/components/button/react/ButtonRoot.test.tsx
+++ b/src/components/button/react/ButtonRoot.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 
@@ -56,7 +56,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<ButtonRoot {...props} />);
 

--- a/src/components/button/react/ButtonRoot.test.tsx
+++ b/src/components/button/react/ButtonRoot.test.tsx
@@ -47,10 +47,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: ButtonRootProps = {
         children: 'Label',
         ...propsOverrides,

--- a/src/components/button/react/ButtonRoot.test.tsx
+++ b/src/components/button/react/ButtonRoot.test.tsx
@@ -73,7 +73,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly as a button', (): void => {
-            const { a, button, wrapper }: ISetup = setup();
+            const { a, button, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(a).not.toExist();
@@ -81,7 +81,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
         });
 
         it('should render correctly as a link', (): void => {
-            const { a, button, wrapper }: ISetup = setup({ href: TEST_URL });
+            const { a, button, wrapper } = setup({ href: TEST_URL });
             expect(wrapper).toMatchSnapshot();
 
             expect(a).toExist();
@@ -98,7 +98,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
                 disabled: 'true',
             };
 
-            const { button }: ISetup = setup(modifiedProps);
+            const { button } = setup(modifiedProps);
 
             expect(button).toBeDisabled();
 
@@ -106,7 +106,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
 
             modifiedProps.href = TEST_URL;
 
-            const { a }: ISetup = setup(modifiedProps);
+            const { a } = setup(modifiedProps);
 
             expect(a).toBeDisabled();
         });
@@ -117,7 +117,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
                 [testedProp]: TEST_URL,
             };
 
-            const { a }: ISetup = setup(modifiedProps);
+            const { a } = setup(modifiedProps);
 
             expect(a).toHaveProp(testedProp, modifiedProps[testedProp]);
         });
@@ -129,7 +129,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
                 href: TEST_URL,
             };
 
-            const { a }: ISetup = setup(modifiedProps);
+            const { a } = setup(modifiedProps);
 
             expect(a).toHaveProp(testedProp, modifiedProps[testedProp]);
         });
@@ -139,7 +139,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
                 className: 'component component--is-tested',
             };
 
-            const { button }: ISetup = setup(modifiedProps);
+            const { button } = setup(modifiedProps);
 
             expect(button).toHaveClassName(modifiedProps.className);
 
@@ -147,7 +147,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
 
             modifiedProps.href = TEST_URL;
 
-            const { a }: ISetup = setup(modifiedProps);
+            const { a } = setup(modifiedProps);
 
             expect(a).toHaveClassName(modifiedProps.className);
         });
@@ -158,7 +158,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
                 [testedProp]: 'is coming',
             };
 
-            const { button }: ISetup = setup(modifiedProps);
+            const { button } = setup(modifiedProps);
 
             expect(button).toHaveProp(testedProp, modifiedProps[testedProp]);
 
@@ -166,7 +166,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
 
             modifiedProps.href = TEST_URL;
 
-            const { a }: ISetup = setup(modifiedProps);
+            const { a } = setup(modifiedProps);
 
             expect(a).toHaveProp(testedProp, modifiedProps[testedProp]);
         });
@@ -179,7 +179,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
         const onClick: jest.Mock = jest.fn();
 
         it('should trigger `onClick` when the button is clicked', (): void => {
-            const { button }: ISetup = setup({ onClick });
+            const { button } = setup({ onClick });
 
             button.simulate('click');
             expect(onClick).toHaveBeenCalled();
@@ -188,7 +188,7 @@ describe(`<${ButtonRoot.displayName}>`, (): void => {
 
             onClick.mockClear();
 
-            const { a }: ISetup = setup({ href: TEST_URL, onClick });
+            const { a } = setup({ href: TEST_URL, onClick });
 
             a.simulate('click');
             expect(onClick).toHaveBeenCalled();

--- a/src/components/button/react/ButtonRoot.tsx
+++ b/src/components/button/react/ButtonRoot.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode, RefObject } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 
@@ -14,8 +14,7 @@ interface IProps extends IGenericProps {
     /**
      * Button reference to handle focus, ...
      */
-    // tslint:disable-next-line: no-any
-    buttonRef?: React.RefObject<any>;
+    buttonRef?: RefObject<HTMLElement>;
 
     /**
      * The `href` to reach if there is one.
@@ -94,14 +93,14 @@ const ButtonRoot: React.FC<ButtonRootProps> = ({
 
     if (isEmpty(href)) {
         return (
-            <button ref={buttonRef} className={className} {...props}>
+            <button ref={buttonRef as RefObject<HTMLButtonElement>} className={className} {...props}>
                 {newChildren}
             </button>
         );
     }
 
     return (
-        <a ref={buttonRef} className={className} href={href} target={target} {...props}>
+        <a ref={buttonRef as RefObject<HTMLAnchorElement>} className={className} href={href} target={target} {...props}>
             {newChildren}
         </a>
     );

--- a/src/components/button/react/ButtonRoot.tsx
+++ b/src/components/button/react/ButtonRoot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 
@@ -67,7 +67,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * @param props The children and props of the component.
  * @return The processed children of the component.
  */
-function _validate(props: ButtonRootProps): React.ReactNode {
+function _validate(props: ButtonRootProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         minChildren: 1,
         props,
@@ -89,8 +89,8 @@ const ButtonRoot: React.FC<ButtonRootProps> = ({
     href,
     target,
     ...props
-}: ButtonRootProps): React.ReactElement => {
-    const newChildren: React.ReactNode = _validate({ children, ...props });
+}: ButtonRootProps): ReactElement => {
+    const newChildren: ReactNode = _validate({ children, ...props });
 
     if (isEmpty(href)) {
         return (

--- a/src/components/button/react/DropdownButton.test.tsx
+++ b/src/components/button/react/DropdownButton.test.tsx
@@ -4,11 +4,11 @@ import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
 import { build, fake, oneOf } from 'test-data-bot';
 
-import { Button, ButtonGroup, ButtonVariants, Icon } from 'LumX';
+import { Button, ButtonEmphasis, ButtonGroup, ButtonVariant, Icon, Size, Theme } from 'LumX';
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
 import { mdiMenuDown, mdiPlus } from 'LumX/icons';
 
-import { CLASSNAME, DropdownButton, DropdownButtonProps, Emphasises, Sizes, Themes } from './DropdownButton';
+import { CLASSNAME, DropdownButton, DropdownButtonProps } from './DropdownButton';
 
 /////////////////////////////
 
@@ -183,44 +183,44 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
             const testedProp = 'variant' as string;
             const modifiedProps: ISetupProps = {
-                [testedProp]: ButtonVariants.button,
+                [testedProp]: ButtonVariant.button,
             };
 
             let { button } = setup(modifiedProps);
-            expect(button).toHaveProp(testedProp, ButtonVariants.button);
+            expect(button).toHaveProp(testedProp, ButtonVariant.button);
 
             /////////////////////////////
 
-            modifiedProps[testedProp] = ButtonVariants.button;
+            modifiedProps[testedProp] = ButtonVariant.button;
 
             ({ button } = setup(modifiedProps));
 
-            expect(button).toHaveProp(testedProp, ButtonVariants.button);
+            expect(button).toHaveProp(testedProp, ButtonVariant.button);
 
             /////////////////////////////
 
-            modifiedProps[testedProp] = ButtonVariants.icon;
+            modifiedProps[testedProp] = ButtonVariant.icon;
 
             ({ button } = setup({ ...modifiedProps, splitted: true }));
 
-            expect(button).toHaveProp(testedProp, ButtonVariants.button);
+            expect(button).toHaveProp(testedProp, ButtonVariant.button);
 
             /////////////////////////////
 
-            modifiedProps[testedProp] = ButtonVariants.button;
+            modifiedProps[testedProp] = ButtonVariant.button;
 
             ({ button } = setup(modifiedProps));
 
-            expect(button).toHaveProp(testedProp, ButtonVariants.button);
+            expect(button).toHaveProp(testedProp, ButtonVariant.button);
         });
 
         it(`should forward any <${Button.displayName}> prop (except \`variant\`)`, (): void => {
             const modifiedPropsBuilder: () => ISetupProps = build('props').fields({
                 // tslint:disable-next-line: no-any
                 color: fake((fakeData: any): string => fakeData.commerce.color()),
-                emphasis: oneOf(...Object.values(Emphasises)),
-                size: oneOf(...Object.values(Sizes)),
-                theme: oneOf(...Object.values(Themes)),
+                emphasis: oneOf(...Object.values(ButtonEmphasis)),
+                size: oneOf(...Object.values(Size)),
+                theme: oneOf(...Object.values(Theme)),
             });
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
@@ -420,7 +420,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
             // We know that a <DropdownButton> cannot receive a `variant`, but for the purpose of the test ignore it.
             // @ts-ignore
-            setup({ variant: ButtonVariants.icon });
+            setup({ variant: ButtonVariant.icon });
             expect(global.console.warn).toHaveBeenCalled();
 
             // @ts-ignore
@@ -428,7 +428,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
             // We know that a <DropdownButton> cannot receive a `variant`, but for the purpose of the test ignore it.
             // @ts-ignore
-            setup({ variant: ButtonVariants.button });
+            setup({ variant: ButtonVariant.button });
             expect(global.console.warn).toHaveBeenCalled();
         });
 

--- a/src/components/button/react/DropdownButton.test.tsx
+++ b/src/components/button/react/DropdownButton.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement, ReactNode } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -74,7 +74,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<DropdownButton {...props} />);
 
@@ -338,7 +338,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
         );
 
         it('should fail when more than 2 children are given', (): void => {
-            let children: React.ReactNode = (
+            let children: ReactNode = (
                 <Fragment>
                     <Icon icon={mdiPlus} />
                     <Icon icon={mdiPlus} />

--- a/src/components/button/react/DropdownButton.test.tsx
+++ b/src/components/button/react/DropdownButton.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -336,11 +336,11 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
         it('should fail when more than 2 children are given', (): void => {
             let children: ReactNode = (
-                <Fragment>
+                <>
                     <Icon icon={mdiPlus} />
                     <Icon icon={mdiPlus} />
                     <span>Label</span>
-                </Fragment>
+                </>
             );
 
             expect(
@@ -352,11 +352,11 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <Icon icon={mdiPlus} />
                     <Icon icon={mdiPlus} />
                     <span>Label</span>
-                </Fragment>
+                </>
             );
 
             expect(
@@ -368,11 +368,11 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <Icon icon={mdiPlus} />
                     <span>Label</span>
                     <span>Label 2</span>
-                </Fragment>
+                </>
             );
 
             expect(
@@ -384,11 +384,11 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
             /////////////////////////////
 
             children = (
-                <Fragment>
+                <>
                     <Icon icon={mdiPlus} />
                     <span>Label</span>
                     <span>Label 2</span>
-                </Fragment>
+                </>
             );
 
             expect(

--- a/src/components/button/react/DropdownButton.test.tsx
+++ b/src/components/button/react/DropdownButton.test.tsx
@@ -97,7 +97,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
     // 1. Test render via snapshot (default state of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly a non-splitted dropdown button', (): void => {
-            const { button, dropdown, group, iconButton, root, wrapper }: ISetup = setup();
+            const { button, dropdown, group, iconButton, root, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toHaveDisplayName(Button.displayName!);
@@ -114,7 +114,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
         });
 
         it('should render correctly a non-splitted dropdown button with a preceding icon', (): void => {
-            const { button, dropdown, group, iconButton, root, wrapper }: ISetup = setup({ icon: mdiPlus });
+            const { button, dropdown, group, iconButton, root, wrapper } = setup({ icon: mdiPlus });
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toHaveDisplayName(Button.displayName!);
@@ -133,7 +133,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
         });
 
         it('should render correctly a splitted dropdown button', (): void => {
-            const { button, dropdown, group, iconButton, root, wrapper }: ISetup = setup({ splitted: true });
+            const { button, dropdown, group, iconButton, root, wrapper } = setup({ splitted: true });
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toHaveDisplayName(ButtonGroup.displayName!);
@@ -150,7 +150,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
         });
 
         it('should render correctly a splitted dropdown button with a preceding icon', (): void => {
-            const { button, dropdown, group, iconButton, root, wrapper }: ISetup = setup({
+            const { button, dropdown, group, iconButton, root, wrapper } = setup({
                 icon: mdiPlus,
                 splitted: true,
             });
@@ -176,7 +176,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
         it('should use default props', (): void => {
-            const { root }: ISetup = setup();
+            const { root } = setup();
 
             expect(root).toHaveDisplayName(Button.displayName!);
         });
@@ -189,7 +189,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
                 [testedProp]: ButtonVariants.button,
             };
 
-            let { button }: ISetup = setup(modifiedProps);
+            let { button } = setup(modifiedProps);
             expect(button).toHaveProp(testedProp, ButtonVariants.button);
 
             /////////////////////////////
@@ -228,7 +228,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            let { button }: ISetup = setup(modifiedProps);
+            let { button } = setup(modifiedProps);
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {
@@ -253,7 +253,7 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
                 [testedProp]: 'is coming',
             };
 
-            let { button, iconButton }: ISetup = setup(modifiedProps);
+            let { button, iconButton } = setup(modifiedProps);
 
             expect(button).toHaveProp(testedProp, modifiedProps[testedProp]);
 
@@ -280,8 +280,8 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
         it('should both trigger `onClick` and toggle the dropdown when the button is clicked in non-splitted mode', (): void => {
             const setupReturn: ISetup = setup({ onClick }, false);
-            const { button, wrapper }: ISetup = setupReturn;
-            let { dropdown }: ISetup = setupReturn;
+            const { button, wrapper } = setupReturn;
+            let { dropdown } = setupReturn;
 
             expect(dropdown).not.toExist();
 
@@ -294,8 +294,8 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
         it('should only trigger `onClick` when the label button is clicked in splitted mode', (): void => {
             const setupReturn: ISetup = setup({ splitted: true, onClick }, false);
-            const { button, wrapper }: ISetup = setupReturn;
-            let { dropdown }: ISetup = setupReturn;
+            const { button, wrapper } = setupReturn;
+            let { dropdown } = setupReturn;
 
             expect(dropdown).not.toExist();
 
@@ -308,8 +308,8 @@ describe(`<${DropdownButton.displayName}>`, (): void => {
 
         it('should only toggle the dropdown when the dropdown (icon) button is clicked in splitted mode', (): void => {
             const setupReturn: ISetup = setup({ splitted: true, onClick }, false);
-            const { iconButton, wrapper }: ISetup = setupReturn;
-            let { dropdown }: ISetup = setupReturn;
+            const { iconButton, wrapper } = setupReturn;
+            let { dropdown } = setupReturn;
 
             expect(dropdown).not.toExist();
 

--- a/src/components/button/react/DropdownButton.test.tsx
+++ b/src/components/button/react/DropdownButton.test.tsx
@@ -64,10 +64,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of
  *                       the component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: DropdownButtonProps = {
         children: 'Label',
         dropdown: <span>Dropdown content</span>,

--- a/src/components/button/react/DropdownButton.tsx
+++ b/src/components/button/react/DropdownButton.tsx
@@ -10,28 +10,8 @@ import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, ValidateParameters, getRootClassName, validateComponent } from 'LumX/core/react/utils';
 import { mdiMenuDown } from 'LumX/icons';
 
-import {
-    Button,
-    ButtonProps,
-    Color,
-    Colors,
-    Emphasis,
-    Emphasises,
-    Size,
-    Sizes,
-    Theme,
-    Themes,
-    Variants as ButtonVariants,
-} from './Button';
+import { Button, ButtonProps, ButtonVariant } from './Button';
 import { ButtonGroup, ButtonGroupProps } from './ButtonGroup';
-
-/////////////////////////////
-
-enum Variants {
-    button = 'button',
-    icon = 'icon',
-}
-type Variant = Variants;
 
 /////////////////////////////
 
@@ -227,7 +207,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
     if (splitted) {
         rootElement = (
             <ButtonGroup className={extendedClassNames}>
-                <Button {...props} leftIcon={icon} variant={ButtonVariants.button}>
+                <Button {...props} leftIcon={icon} variant={ButtonVariant.button}>
                     {newChildren}
                 </Button>
 
@@ -241,7 +221,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
                 {...props}
                 leftIcon={icon}
                 rightIcon={mdiMenuDown}
-                variant={ButtonVariants.button}
+                variant={ButtonVariant.button}
                 onClick={openDropdown}
             >
                 {newChildren}
@@ -261,19 +241,4 @@ DropdownButton.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export {
-    CLASSNAME,
-    DEFAULT_PROPS,
-    Color,
-    Colors,
-    Emphasis,
-    Emphasises,
-    DropdownButton,
-    DropdownButtonProps,
-    Size,
-    Sizes,
-    Theme,
-    Themes,
-    Variant,
-    Variants,
-};
+export { CLASSNAME, DEFAULT_PROPS, DropdownButton, DropdownButtonProps };

--- a/src/components/button/react/DropdownButton.tsx
+++ b/src/components/button/react/DropdownButton.tsx
@@ -193,9 +193,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
     splitted = DEFAULT_PROPS.splitted,
     ...props
 }: DropdownButtonProps): ReactElement => {
-    const [isDropdownOpened, setIsDropdownOpened]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<
-        boolean
-    >(false);
+    const [isDropdownOpened, setIsDropdownOpened] = useState(false);
 
     const newChildren: ReactNode = _validate({
         children,

--- a/src/components/button/react/DropdownButton.tsx
+++ b/src/components/button/react/DropdownButton.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, ReactElement, ReactNode, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -42,7 +42,7 @@ interface IProps extends IGenericProps {
     /**
      * Contains the dropdown element to display when the icon is clicked.
      */
-    dropdown?: React.ReactNode;
+    dropdown?: ReactNode;
 
     /**
      * The left icon.
@@ -158,7 +158,7 @@ function _preValidate({ props }: ValidateParameters): string | boolean | void {
  * @param props The children and props of the component.
  * @return     The processed children of the component.
  */
-function _validate(props: DropdownButtonProps): React.ReactNode {
+function _validate(props: DropdownButtonProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         maxChildren: 2,
         postValidate: _postValidate,
@@ -192,12 +192,12 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
     rightIcon = '',
     splitted = DEFAULT_PROPS.splitted,
     ...props
-}: DropdownButtonProps): React.ReactElement => {
+}: DropdownButtonProps): ReactElement => {
     const [isDropdownOpened, setIsDropdownOpened]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<
         boolean
     >(false);
 
-    const newChildren: React.ReactNode = _validate({
+    const newChildren: ReactNode = _validate({
         children,
         dropdown,
         icon,
@@ -223,7 +223,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
         }
     };
 
-    let rootElement: React.ReactNode;
+    let rootElement: ReactElement;
     const extendedClassNames: string = classNames(className, CLASSNAME, { [`${CLASSNAME}--is-splitted`]: splitted });
 
     if (splitted) {

--- a/src/components/button/react/DropdownButton.tsx
+++ b/src/components/button/react/DropdownButton.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, ReactNode, useState } from 'react';
+import React, { ReactElement, ReactNode, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -250,11 +250,11 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
     }
 
     return (
-        <Fragment>
+        <>
             {rootElement}
 
             {isDropdownOpened ? <Dropdown>{dropdown}</Dropdown> : undefined}
-        </Fragment>
+        </>
     );
 };
 DropdownButton.displayName = COMPONENT_NAME;

--- a/src/components/button/react/IconButton.test.tsx
+++ b/src/components/button/react/IconButton.test.tsx
@@ -42,10 +42,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of
  *                       the component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: IconButtonProps = {
         icon: mdiPlus,
         ...propsOverrides,

--- a/src/components/button/react/IconButton.test.tsx
+++ b/src/components/button/react/IconButton.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -51,7 +51,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<IconButton {...props} />);
 

--- a/src/components/button/react/IconButton.test.tsx
+++ b/src/components/button/react/IconButton.test.tsx
@@ -4,11 +4,11 @@ import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
 import { build, fake, oneOf } from 'test-data-bot';
 
-import { Button, ButtonVariants } from 'LumX';
+import { Button, ButtonEmphasis, ButtonVariant, Size, Theme } from 'LumX';
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
 import { mdiChevronDown, mdiPlus } from 'LumX/icons';
 
-import { CLASSNAME, Emphasises, IconButton, IconButtonProps, Sizes, Themes } from './IconButton';
+import { CLASSNAME, IconButton, IconButtonProps } from './IconButton';
 
 /////////////////////////////
 
@@ -82,7 +82,7 @@ describe(`<${IconButton.displayName}>`, (): void => {
             const { button, props } = setup();
 
             expect(button).toHaveProp('leftIcon', props.icon);
-            expect(button).toHaveProp('variant', ButtonVariants.icon);
+            expect(button).toHaveProp('variant', ButtonVariant.icon);
         });
 
         it("should use 'icon' `variant` whatever the given `variant` prop is", (): void => {
@@ -91,32 +91,32 @@ describe(`<${IconButton.displayName}>`, (): void => {
             const modifiedProps: ISetupProps = {
                 // We known that <IconButton> could not have a `variant` prop.
                 // @ts-ignore
-                variant: ButtonVariants.icon,
+                variant: ButtonVariant.icon,
             };
 
             let { button } = setup(modifiedProps);
 
-            expect(button).toHaveProp('variant', ButtonVariants.icon);
+            expect(button).toHaveProp('variant', ButtonVariant.icon);
 
             /////////////////////////////
 
             // We known that <IconButton> could not have a `variant` prop.
             // @ts-ignore
-            modifiedProps.variant = ButtonVariants.button;
+            modifiedProps.variant = ButtonVariant.button;
 
             ({ button } = setup(modifiedProps));
 
-            expect(button).toHaveProp('variant', ButtonVariants.icon);
+            expect(button).toHaveProp('variant', ButtonVariant.icon);
         });
 
         it(`should forward any <${Button.displayName}> prop (except \`variant\`)`, (): void => {
             const modifiedPropsBuilder: () => ISetupProps = build('props').fields({
                 // tslint:disable-next-line: no-any
                 color: fake((fakeData: any): string => fakeData.commerce.color()),
-                emphasis: oneOf(...Object.values(Emphasises)),
+                emphasis: oneOf(...Object.values(ButtonEmphasis)),
                 icon: oneOf(mdiPlus, mdiChevronDown),
-                size: oneOf(...Object.values(Sizes)),
-                theme: oneOf(...Object.values(Themes)),
+                size: oneOf(...Object.values(Size)),
+                theme: oneOf(...Object.values(Theme)),
             });
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
@@ -197,7 +197,7 @@ describe(`<${IconButton.displayName}>`, (): void => {
 
             // We know that a <IconButton> cannot receive a `variant`, but for the purpose of the test ignore it.
             // @ts-ignore
-            setup({ variant: ButtonVariants.icon });
+            setup({ variant: ButtonVariant.icon });
             expect(global.console.warn).toHaveBeenCalled();
 
             // @ts-ignore
@@ -205,7 +205,7 @@ describe(`<${IconButton.displayName}>`, (): void => {
 
             // We know that a <IconButton> cannot receive a `variant`, but for the purpose of the test ignore it.
             // @ts-ignore
-            setup({ variant: ButtonVariants.button });
+            setup({ variant: ButtonVariant.button });
             expect(global.console.warn).toHaveBeenCalled();
         });
     });

--- a/src/components/button/react/IconButton.test.tsx
+++ b/src/components/button/react/IconButton.test.tsx
@@ -67,7 +67,7 @@ describe(`<${IconButton.displayName}>`, (): void => {
     // 1. Test render via snapshot (default state of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly an icon button', (): void => {
-            const { button, wrapper }: ISetup = setup();
+            const { button, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(button).toExist();
@@ -82,7 +82,7 @@ describe(`<${IconButton.displayName}>`, (): void => {
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
         it('should use default props', (): void => {
-            const { button, props }: ISetup = setup();
+            const { button, props } = setup();
 
             expect(button).toHaveProp('leftIcon', props.icon);
             expect(button).toHaveProp('variant', ButtonVariants.icon);
@@ -97,7 +97,7 @@ describe(`<${IconButton.displayName}>`, (): void => {
                 variant: ButtonVariants.icon,
             };
 
-            let { button }: ISetup = setup(modifiedProps);
+            let { button } = setup(modifiedProps);
 
             expect(button).toHaveProp('variant', ButtonVariants.icon);
 
@@ -124,7 +124,7 @@ describe(`<${IconButton.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { button }: ISetup = setup(modifiedProps);
+            const { button } = setup(modifiedProps);
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {

--- a/src/components/button/react/IconButton.tsx
+++ b/src/components/button/react/IconButton.tsx
@@ -7,14 +7,7 @@ import isEmpty from 'lodash/isEmpty';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { ValidateParameters, getRootClassName, validateComponent } from 'LumX/core/react/utils';
 
-import { Button, ButtonProps, Color, Colors, Emphasis, Emphasises, Size, Sizes, Theme, Themes } from './Button';
-
-/////////////////////////////
-
-enum Variants {
-    icon = 'icon',
-}
-type Variant = Variants;
+import { Button, ButtonProps, ButtonVariant } from './Button';
 
 /////////////////////////////
 
@@ -160,25 +153,12 @@ const IconButton: React.FC<IconButtonProps> = ({
 }: IconButtonProps): ReactElement => {
     _validate({ children, icon, leftIcon, rightIcon, ...props });
 
-    return <Button className={classNames(className, CLASSNAME)} {...props} leftIcon={icon} variant={Variants.icon} />;
+    return (
+        <Button className={classNames(className, CLASSNAME)} {...props} leftIcon={icon} variant={ButtonVariant.icon} />
+    );
 };
 IconButton.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export {
-    CLASSNAME,
-    DEFAULT_PROPS,
-    Color,
-    Colors,
-    Emphasis,
-    Emphasises,
-    IconButton,
-    IconButtonProps,
-    Size,
-    Sizes,
-    Theme,
-    Themes,
-    Variant,
-    Variants,
-};
+export { CLASSNAME, DEFAULT_PROPS, IconButton, IconButtonProps };

--- a/src/components/button/react/IconButton.tsx
+++ b/src/components/button/react/IconButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -127,7 +127,7 @@ function _preValidate({ props }: ValidateParameters): string | boolean | void {
  * @param props The children and props of the component.
  * @return The processed children of the component.
  */
-function _validate(props: IconButtonProps): React.ReactNode {
+function _validate(props: IconButtonProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         maxChildren: 0,
         postValidate: _postValidate,
@@ -157,7 +157,7 @@ const IconButton: React.FC<IconButtonProps> = ({
     // @ts-ignore
     rightIcon = '',
     ...props
-}: IconButtonProps): React.ReactElement => {
+}: IconButtonProps): ReactElement => {
     _validate({ children, icon, leftIcon, rightIcon, ...props });
 
     return <Button className={classNames(className, CLASSNAME)} {...props} leftIcon={icon} variant={Variants.icon} />;

--- a/src/components/checkbox/react/Checkbox.test.tsx
+++ b/src/components/checkbox/react/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import { build } from 'test-data-bot';
@@ -49,7 +49,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     // noinspection RequiredAttributes
     const wrapper: Wrapper = renderer(<Checkbox {...props} />);

--- a/src/components/checkbox/react/Checkbox.test.tsx
+++ b/src/components/checkbox/react/Checkbox.test.tsx
@@ -40,10 +40,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: CheckboxProps = {
         children: <CheckboxLabel>Default Test label</CheckboxLabel>,
         ...propsOverrides,

--- a/src/components/checkbox/react/Checkbox.test.tsx
+++ b/src/components/checkbox/react/Checkbox.test.tsx
@@ -64,7 +64,7 @@ describe(`<${Checkbox.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { wrapper }: ISetup = setup();
+            const { wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(wrapper).toExist();
@@ -86,7 +86,7 @@ describe(`<${Checkbox.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { wrapper }: ISetup = setup({ ...modifiedProps });
+            const { wrapper } = setup({ ...modifiedProps });
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {
@@ -109,7 +109,7 @@ describe(`<${Checkbox.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { wrapper }: ISetup = setup({ ...modifiedProps });
+            const { wrapper } = setup({ ...modifiedProps });
 
             expect(wrapper).toMatchSnapshot();
         });
@@ -128,7 +128,7 @@ describe(`<${Checkbox.displayName}>`, (): void => {
         );
 
         it('should trigger `onChange` when checkbox is clicked', (): void => {
-            const { wrapper }: ISetup = setup({ checked: false, onChange }, false);
+            const { wrapper } = setup({ checked: false, onChange }, false);
             const checkbox = wrapper.find('input');
 
             checkbox.simulate('change', { target: { checked: false } });

--- a/src/components/checkbox/react/Checkbox.tsx
+++ b/src/components/checkbox/react/Checkbox.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 
 import { mdiCheck } from '@mdi/js';
 
-import { Icon, Theme, Themes } from 'LumX';
+import { Icon, Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
 import { CheckboxHelper } from './CheckboxHelper';
@@ -66,7 +66,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
     checked: false,
     disabled: false,
     onChange: noop,
-    theme: Themes.light,
+    theme: Theme.light,
 };
 /////////////////////////////
 
@@ -141,4 +141,4 @@ Checkbox.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Checkbox, CheckboxProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, Checkbox, CheckboxProps };

--- a/src/components/checkbox/react/Checkbox.tsx
+++ b/src/components/checkbox/react/Checkbox.tsx
@@ -85,7 +85,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
     ...props
 }: CheckboxProps): ReactElement => {
     const checkboxId: string = uniqueId(`${CLASSNAME.toLowerCase()}-`);
-    const handleChange: () => void = (): void => {
+    const handleChange = (): void => {
         onChange!({ checked: !checked });
     };
 

--- a/src/components/checkbox/react/Checkbox.tsx
+++ b/src/components/checkbox/react/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement } from 'react';
+import React, { Children, ReactElement, cloneElement } from 'react';
 
 import noop from 'lodash/noop';
 
@@ -83,7 +83,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
     onChange = DEFAULT_PROPS.onChange,
     theme = DEFAULT_PROPS.theme,
     ...props
-}: CheckboxProps): React.ReactElement => {
+}: CheckboxProps): ReactElement => {
     const checkboxId: string = uniqueId(`${CLASSNAME.toLowerCase()}-`);
     const handleChange: () => void = (): void => {
         onChange!({ checked: !checked });

--- a/src/components/checkbox/react/CheckboxHelper.test.tsx
+++ b/src/components/checkbox/react/CheckboxHelper.test.tsx
@@ -36,10 +36,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: CheckboxHelperProps = {
         ...propsOverrides,
     };

--- a/src/components/checkbox/react/CheckboxHelper.test.tsx
+++ b/src/components/checkbox/react/CheckboxHelper.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import { build } from 'test-data-bot';
@@ -44,7 +44,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     // noinspection RequiredAttributes
     const wrapper: Wrapper = renderer(<CheckboxHelper {...props} />);

--- a/src/components/checkbox/react/CheckboxHelper.test.tsx
+++ b/src/components/checkbox/react/CheckboxHelper.test.tsx
@@ -59,7 +59,7 @@ describe(`<${CheckboxHelper.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { wrapper }: ISetup = setup();
+            const { wrapper } = setup();
 
             expect(wrapper).toMatchSnapshot();
             expect(wrapper).toExist();
@@ -78,7 +78,7 @@ describe(`<${CheckboxHelper.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { wrapper }: ISetup = setup({ ...modifiedProps });
+            const { wrapper } = setup({ ...modifiedProps });
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/src/components/checkbox/react/CheckboxHelper.tsx
+++ b/src/components/checkbox/react/CheckboxHelper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -55,7 +55,7 @@ const CheckboxHelper: React.FC<CheckboxHelperProps> = ({
     children,
     className = '',
     ...props
-}: CheckboxHelperProps): React.ReactElement => {
+}: CheckboxHelperProps): ReactElement => {
     return (
         <span className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
             {children}

--- a/src/components/checkbox/react/CheckboxLabel.test.tsx
+++ b/src/components/checkbox/react/CheckboxLabel.test.tsx
@@ -36,10 +36,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: CheckboxLabelProps = {
         checkboxId: 'test-checkbox-id',
         ...propsOverrides,

--- a/src/components/checkbox/react/CheckboxLabel.test.tsx
+++ b/src/components/checkbox/react/CheckboxLabel.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import { build } from 'test-data-bot';
@@ -45,7 +45,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     // noinspection RequiredAttributes
     const wrapper: Wrapper = renderer(<CheckboxLabel {...props} />);

--- a/src/components/checkbox/react/CheckboxLabel.test.tsx
+++ b/src/components/checkbox/react/CheckboxLabel.test.tsx
@@ -60,7 +60,7 @@ describe(`<${CheckboxLabel.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { wrapper }: ISetup = setup();
+            const { wrapper } = setup();
 
             expect(wrapper).toMatchSnapshot();
             expect(wrapper).toExist();
@@ -79,7 +79,7 @@ describe(`<${CheckboxLabel.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { wrapper }: ISetup = setup({ ...modifiedProps });
+            const { wrapper } = setup({ ...modifiedProps });
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/src/components/checkbox/react/CheckboxLabel.tsx
+++ b/src/components/checkbox/react/CheckboxLabel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactChild } from 'react';
+import React, { ReactChild, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -61,7 +61,7 @@ const CheckboxLabel: React.FC<CheckboxLabelProps> = ({
     children = DEFAULT_PROPS.children,
     className = '',
     ...props
-}: CheckboxLabelProps): React.ReactElement => {
+}: CheckboxLabelProps): ReactElement => {
     return (
         <label
             className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}

--- a/src/components/chip/react/Chip.tsx
+++ b/src/components/chip/react/Chip.tsx
@@ -113,7 +113,7 @@ const Chip: React.FC<IChipProps> = ({
      *
      * @param evt The click event on the before element that triggers this method.
      */
-    const handleOnBeforeClick: (evt: SyntheticEvent) => void = (evt: SyntheticEvent): void => {
+    const handleOnBeforeClick = (evt: SyntheticEvent): void => {
         if (!evt) {
             return;
         }
@@ -130,7 +130,7 @@ const Chip: React.FC<IChipProps> = ({
      *
      * @param evt The click event on the after element that triggers this method.
      */
-    const handleOnAfterClick: (evt: SyntheticEvent) => void = (evt: SyntheticEvent): void => {
+    const handleOnAfterClick = (evt: SyntheticEvent): void => {
         if (!evt) {
             return;
         }

--- a/src/components/chip/react/Chip.tsx
+++ b/src/components/chip/react/Chip.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from 'react';
+import React, { ReactElement, ReactNode, SyntheticEvent } from 'react';
 
 import classNames from 'classnames';
 
@@ -26,9 +26,9 @@ type Size = Sizes;
  */
 interface IChipProps extends IGenericProps {
     /** A component to be rendered after the main label area. */
-    after?: HTMLElement | React.ReactNode;
+    after?: HTMLElement | ReactNode;
     /** A component to be rendered before the main label area. */
-    before?: HTMLElement | React.ReactNode;
+    before?: HTMLElement | ReactNode;
     /** The component color variant. */
     color?: Color;
     /** Indicates if the chip is currently in an active state or not. */
@@ -103,7 +103,7 @@ const Chip: React.FC<IChipProps> = ({
     size = DEFAULT_PROPS.size,
     theme = DEFAULT_PROPS.theme,
     ...props
-}: ChipProps): React.ReactElement => {
+}: ChipProps): ReactElement => {
     const hasAfterClick: boolean = isFunction(onAfterClick);
     const hasBeforeClick: boolean = isFunction(onBeforeClick);
     const hasOnClick: boolean = isFunction(onClick);

--- a/src/components/chip/react/Chip.tsx
+++ b/src/components/chip/react/Chip.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import isFunction from 'lodash/isFunction';
 
-import { Color, Colors, Theme, Themes } from 'LumX/components';
+import { Color, ColorPalette, Size, Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
@@ -15,11 +15,7 @@ import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
 /**
  * Authorized size values.
  */
-enum Sizes {
-    s = 's',
-    m = 'm',
-}
-type Size = Sizes;
+type ChipSize = Size.s | Size.m;
 
 /**
  * Defines the props of the component.
@@ -36,7 +32,7 @@ interface IChipProps extends IGenericProps {
     /** Indicates if the chip is currently disabled or not. */
     isDisabled?: boolean;
     /** The size of the chip. */
-    size?: Size;
+    size?: ChipSize;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
     /** A function to be executed when the after element is clicked. */
@@ -75,10 +71,10 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 const DEFAULT_PROPS: IDefaultPropsType = {
     after: null,
     before: null,
-    color: Colors.dark,
+    color: ColorPalette.dark,
     isDisabled: false,
     isSelected: false,
-    size: Sizes.m,
+    size: Size.m,
     theme: undefined,
 };
 /////////////////////////////
@@ -196,4 +192,4 @@ Chip.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Chip, ChipProps, Size, Sizes, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, Chip, ChipProps };

--- a/src/components/divider/react/Divider.test.tsx
+++ b/src/components/divider/react/Divider.test.tsx
@@ -5,7 +5,8 @@ import { mount, shallow } from 'enzyme';
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
 import { getBasicClass } from 'LumX/core/utils';
 
-import { CLASSNAME, DEFAULT_PROPS, Divider, DividerProps, Themes } from './Divider';
+import { Theme } from 'LumX';
+import { CLASSNAME, DEFAULT_PROPS, Divider, DividerProps } from './Divider';
 
 /////////////////////////////
 
@@ -85,7 +86,7 @@ describe(`<${Divider.displayName}>`, (): void => {
         it('should use the given `theme`', (): void => {
             const testedProp = 'theme';
             const modifiedProps: ISetupProps = {
-                [testedProp]: Themes.dark,
+                [testedProp]: Theme.dark,
             };
 
             const { hr } = setup(modifiedProps);

--- a/src/components/divider/react/Divider.test.tsx
+++ b/src/components/divider/react/Divider.test.tsx
@@ -61,7 +61,7 @@ describe(`<${Divider.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { hr, wrapper }: ISetup = setup();
+            const { hr, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(hr).toExist();
@@ -74,7 +74,7 @@ describe(`<${Divider.displayName}>`, (): void => {
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
         it('should use default props', (): void => {
-            const { hr }: ISetup = setup();
+            const { hr } = setup();
 
             Object.keys(DEFAULT_PROPS).forEach(
                 (prop: string): void => {
@@ -91,7 +91,7 @@ describe(`<${Divider.displayName}>`, (): void => {
                 [testedProp]: Themes.dark,
             };
 
-            const { hr }: ISetup = setup(modifiedProps);
+            const { hr } = setup(modifiedProps);
 
             expect(hr).toHaveClassName(
                 getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] }),

--- a/src/components/divider/react/Divider.test.tsx
+++ b/src/components/divider/react/Divider.test.tsx
@@ -36,10 +36,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: DividerProps = {
         children: 'Label',
         ...propsOverrides,

--- a/src/components/divider/react/Divider.test.tsx
+++ b/src/components/divider/react/Divider.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 
@@ -45,7 +45,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<Divider {...props} />);
 

--- a/src/components/divider/react/Divider.tsx
+++ b/src/components/divider/react/Divider.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Theme, Themes } from 'LumX/components';
+import { Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { handleBasicClasses } from 'LumX/core/utils';
 import { IGenericProps, getRootClassName } from 'LumX/react/utils';
@@ -47,7 +47,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
-    theme: Themes.light,
+    theme: Theme.light,
 };
 
 /////////////////////////////
@@ -69,4 +69,4 @@ Divider.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Divider, DividerProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, Divider, DividerProps };

--- a/src/components/divider/react/Divider.tsx
+++ b/src/components/divider/react/Divider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -62,7 +62,7 @@ const Divider: React.FC<DividerProps> = ({
     className = '',
     theme = DEFAULT_PROPS.theme,
     ...props
-}: DividerProps): React.ReactElement => {
+}: DividerProps): ReactElement => {
     return <hr className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))} {...props} />;
 };
 Divider.displayName = COMPONENT_NAME;

--- a/src/components/dropdown/react/Dropdown.test.tsx
+++ b/src/components/dropdown/react/Dropdown.test.tsx
@@ -61,7 +61,7 @@ describe(`<${Dropdown.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { dropdown, wrapper }: ISetup = setup();
+            const { dropdown, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(dropdown).toExist();
@@ -74,7 +74,7 @@ describe(`<${Dropdown.displayName}>`, (): void => {
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
         it('should use default props', (): void => {
-            const { dropdown }: ISetup = setup();
+            const { dropdown } = setup();
 
             Object.keys(DEFAULT_PROPS).forEach(
                 (prop: string): void => {

--- a/src/components/dropdown/react/Dropdown.test.tsx
+++ b/src/components/dropdown/react/Dropdown.test.tsx
@@ -36,10 +36,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: DropdownProps = {
         children: 'This is the content of the dropdown',
         ...propsOverrides,

--- a/src/components/dropdown/react/Dropdown.test.tsx
+++ b/src/components/dropdown/react/Dropdown.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 
@@ -45,7 +45,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<Dropdown {...props} />);
 

--- a/src/components/dropdown/react/Dropdown.tsx
+++ b/src/components/dropdown/react/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -49,11 +49,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
  *
  * @return The component.
  */
-const Dropdown: React.FC<DropdownProps> = ({
-    children,
-    className = '',
-    ...props
-}: DropdownProps): React.ReactElement => (
+const Dropdown: React.FC<DropdownProps> = ({ children, className = '', ...props }: DropdownProps): ReactElement => (
     <div className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
         {children}
     </div>

--- a/src/components/icon/react/Icon.test.tsx
+++ b/src/components/icon/react/Icon.test.tsx
@@ -3,11 +3,12 @@ import React, { ReactElement } from 'react';
 import { mount, shallow } from 'enzyme';
 import { build, fake, oneOf } from 'test-data-bot';
 
+import { Size } from 'LumX';
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
 import { getBasicClass } from 'LumX/core/utils';
 import { mdiCheck, mdiPlus } from 'LumX/icons';
 
-import { CLASSNAME, Icon, IconProps, Sizes } from './Icon';
+import { CLASSNAME, Icon, IconProps } from './Icon';
 
 /////////////////////////////
 
@@ -102,7 +103,7 @@ describe(`<${Icon.displayName}>`, (): void => {
                 // tslint:disable-next-line: no-any
                 color: fake((fakeData: any) => fakeData.commerce.color()),
                 icon: oneOf(mdiPlus, mdiCheck),
-                size: oneOf(...Object.values(Sizes)),
+                size: oneOf(...Object.values(Size)),
             });
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();

--- a/src/components/icon/react/Icon.test.tsx
+++ b/src/components/icon/react/Icon.test.tsx
@@ -48,10 +48,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: IconProps = {
         icon: 'mdiPlus',
         ...propsOverrides,

--- a/src/components/icon/react/Icon.test.tsx
+++ b/src/components/icon/react/Icon.test.tsx
@@ -75,7 +75,7 @@ describe(`<${Icon.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { i, path, svg, wrapper }: ISetup = setup();
+            const { i, path, svg, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(i).toExist();
@@ -91,7 +91,7 @@ describe(`<${Icon.displayName}>`, (): void => {
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
         it("shouldn't use any default props", (): void => {
-            const { i }: ISetup = setup();
+            const { i } = setup();
 
             ['color', 'size'].forEach(
                 (prop: string): void => {
@@ -110,7 +110,7 @@ describe(`<${Icon.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { i, path }: ISetup = setup({ ...modifiedProps });
+            const { i, path } = setup({ ...modifiedProps });
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {

--- a/src/components/icon/react/Icon.test.tsx
+++ b/src/components/icon/react/Icon.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import { build, fake, oneOf } from 'test-data-bot';
@@ -57,7 +57,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<Icon {...props} />);
 

--- a/src/components/icon/react/Icon.tsx
+++ b/src/components/icon/react/Icon.tsx
@@ -23,8 +23,7 @@ interface IProps extends IGenericProps {
     /**
      * Icon reference
      */
-    // tslint:disable-next-line: no-any
-    iconRef?: React.RefObject<any>;
+    iconRef?: React.RefObject<HTMLElement>;
 
     /**
      * The icon color.

--- a/src/components/icon/react/Icon.tsx
+++ b/src/components/icon/react/Icon.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import isEmpty from 'lodash/isEmpty';
 
-import { Color, Colors, Size, Sizes } from 'LumX/components';
+import { Color, Size } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, ValidateParameters, getRootClassName, validateComponent } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -139,4 +139,4 @@ Icon.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Icon, IconProps, Color, Colors, Size, Sizes };
+export { CLASSNAME, DEFAULT_PROPS, Icon, IconProps };

--- a/src/components/icon/react/Icon.tsx
+++ b/src/components/icon/react/Icon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -93,7 +93,7 @@ function _preValidate({ props }: ValidateParameters): void {
  * @param       props The props of the component.
  * @return The processed children of the component.
  */
-function _validate(props: IconProps): React.ReactNode {
+function _validate(props: IconProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         preValidate: _preValidate,
         props,
@@ -114,7 +114,7 @@ const Icon: React.FC<IconProps> = ({
     iconRef = DEFAULT_PROPS.iconRef,
     size,
     ...props
-}: IconProps): React.ReactElement => {
+}: IconProps): ReactElement => {
     _validate({ color, icon, size, ...props });
 
     return (

--- a/src/components/image-block/react/ImageBlock.tsx
+++ b/src/components/image-block/react/ImageBlock.tsx
@@ -4,8 +4,7 @@ import classNames from 'classnames';
 
 import isObject from 'lodash/isObject';
 
-import { Chip, ChipSizes, Thumbnail, ThumbnailAspectRatio, ThumbnailAspectRatios } from 'LumX';
-import { Alignment, Alignments, Theme, Themes } from 'LumX/components';
+import { Alignment, Chip, Size, Theme, Thumbnail, ThumbnailAspectRatio } from 'LumX';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
@@ -16,11 +15,10 @@ import { handleBasicClasses } from 'LumX/core/utils';
 /**
  * Authorized variants.
  */
-enum CaptionPositions {
+enum ImageBlockCaptionPosition {
     below = 'below',
     over = 'over',
 }
-type CaptionPosition = CaptionPositions;
 
 /**
  * Defines the props of the component.
@@ -31,7 +29,7 @@ interface IImageBlockProps extends IGenericProps {
     /** The aspect ratio the image will get. */
     aspectRatio?: ThumbnailAspectRatio;
     /** Caption position. */
-    captionPosition?: CaptionPosition;
+    captionPosition?: ImageBlockCaptionPosition;
     /** The style to apply to the caption section. */
     captionStyle?: CSSProperties;
     /** The image description. Can be either a string, or sanitized html. */
@@ -80,14 +78,14 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
-    align: Alignments.left,
-    aspectRatio: ThumbnailAspectRatios.original,
-    captionPosition: CaptionPositions.below,
+    align: Alignment.left,
+    aspectRatio: ThumbnailAspectRatio.original,
+    captionPosition: ImageBlockCaptionPosition.below,
     captionStyle: {},
     description: undefined,
     fillHeight: false,
     tags: undefined,
-    theme: Themes.light,
+    theme: Theme.light,
     title: undefined,
 };
 
@@ -127,8 +125,8 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
                 }),
                 {
                     [`${CLASSNAME}--fill-height`]: fillHeight,
-                    [`${CLASSNAME}--format-crop`]: aspectRatio && aspectRatio !== 'original',
-                    [`${CLASSNAME}--format-original`]: !aspectRatio || aspectRatio === 'original',
+                    [`${CLASSNAME}--format-crop`]: aspectRatio && aspectRatio !== ThumbnailAspectRatio.original,
+                    [`${CLASSNAME}--format-original`]: !aspectRatio || aspectRatio === ThumbnailAspectRatio.original,
                 },
             )}
             {...restProps}
@@ -161,7 +159,7 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
                             {tags.map(
                                 (tag: string, index: number): JSX.Element => (
                                     <div key={index} className={`${CLASSNAME}__tag`}>
-                                        <Chip size={ChipSizes.s} theme={theme}>
+                                        <Chip size={Size.s} theme={theme}>
                                             {tag}
                                         </Chip>
                                     </div>
@@ -178,4 +176,4 @@ ImageBlock.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, CaptionPositions, ImageBlock, ImageBlockProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, ImageBlockCaptionPosition, ImageBlock, ImageBlockProps };

--- a/src/components/image-block/react/ImageBlock.tsx
+++ b/src/components/image-block/react/ImageBlock.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -111,7 +111,7 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
     theme = DEFAULT_PROPS.theme,
     title = DEFAULT_PROPS.title,
     ...props
-}: ImageBlockProps): React.ReactElement => {
+}: ImageBlockProps): ReactElement => {
     const { onClick = null, ...restProps }: IDefaultPropsType = props;
 
     return (

--- a/src/components/image-block/react/ImageBlock.tsx
+++ b/src/components/image-block/react/ImageBlock.tsx
@@ -112,7 +112,7 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
     title = DEFAULT_PROPS.title,
     ...props
 }: ImageBlockProps): ReactElement => {
-    const { onClick = null, ...restProps }: IDefaultPropsType = props;
+    const { onClick = null, ...restProps } = props;
 
     return (
         <div

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,12 +1,11 @@
 /**
  * Authorized alignments.
  */
-const enum Alignments {
+enum Alignment {
     center = 'center',
     left = 'left',
     right = 'right',
 }
-type Alignment = Alignments;
 
 /**
  * Defines the type of a complex default prop (which depends on the value of another prop).
@@ -17,7 +16,7 @@ interface IComplexPropDefault<T> {
 }
 type ComplexPropDefault<T> = IComplexPropDefault<T>;
 
-enum Colors {
+enum ColorPalette {
     primary = 'primary',
     blue = 'blue',
     dark = 'dark',
@@ -25,15 +24,14 @@ enum Colors {
     yellow = 'yellow',
     red = 'red',
 }
-type Color = Colors | string;
+type Color = ColorPalette | string;
 
-enum Themes {
+enum Theme {
     light = 'light',
     dark = 'dark',
 }
-type Theme = Themes;
 
-enum Sizes {
+enum Size {
     xxs = 'xxs',
     xs = 'xs',
     s = 's',
@@ -42,26 +40,12 @@ enum Sizes {
     xl = 'xl',
     xxl = 'xxl',
 }
-type Size = Sizes;
 
-const enum Orientations {
+enum Orientation {
     horizontal = 'horizontal',
     vertical = 'vertical',
 }
-type Orientation = Orientations;
 
 /////////////////////////////
 
-export {
-    Alignment,
-    Alignments,
-    ComplexPropDefault,
-    Color,
-    Colors,
-    Theme,
-    Themes,
-    Size,
-    Sizes,
-    Orientations,
-    Orientation,
-};
+export { Alignment, ComplexPropDefault, Color, ColorPalette, Theme, Size, Orientation };

--- a/src/components/lightbox/react/Lightbox.tsx
+++ b/src/components/lightbox/react/Lightbox.tsx
@@ -5,9 +5,7 @@ import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
 import { createPortal } from 'react-dom';
 
-import { Button } from 'LumX';
-import { Theme, Themes } from 'LumX/components';
-import { Emphasises, Variants } from 'LumX/components/button/react/Button';
+import { Button, ButtonEmphasis, ButtonVariant, Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -75,7 +73,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
     onClose: noop,
     onOpen: noop,
     role: 'dialog',
-    theme: Themes.light,
+    theme: Theme.light,
 };
 /////////////////////////////
 
@@ -193,11 +191,11 @@ const Lightbox: React.FC<LightboxProps> = ({
                                 buttonRef={buttonRef}
                                 className={`${CLASSNAME}__close`}
                                 color="light"
-                                emphasis={Emphasises.low}
+                                emphasis={ButtonEmphasis.low}
                                 leftIcon={mdiClose}
                                 theme={theme}
                                 type="button"
-                                variant={Variants.icon}
+                                variant={ButtonVariant.icon}
                                 onClick={handleClose}
                             />
                             <div
@@ -219,4 +217,4 @@ Lightbox.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Lightbox, LightboxProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, Lightbox, LightboxProps };

--- a/src/components/lightbox/react/Lightbox.tsx
+++ b/src/components/lightbox/react/Lightbox.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import classNames from 'classnames';
@@ -164,7 +164,7 @@ const Lightbox: React.FC<LightboxProps> = ({
     };
 
     return (
-        <Fragment>
+        <>
             {isTrapActive &&
                 createPortal(
                     <FocusTrap
@@ -212,7 +212,7 @@ const Lightbox: React.FC<LightboxProps> = ({
                     </FocusTrap>,
                     document.body,
                 )}
-        </Fragment>
+        </>
     );
 };
 Lightbox.displayName = COMPONENT_NAME;

--- a/src/components/lightbox/react/Lightbox.tsx
+++ b/src/components/lightbox/react/Lightbox.tsx
@@ -99,9 +99,7 @@ const Lightbox: React.FC<LightboxProps> = ({
     const buttonRef: React.RefObject<any> = useRef(null);
     // tslint:disable-next-line: no-any
     const childrenRef: React.RefObject<any> = useRef(null);
-    const [isTrapActive, setTrapActive]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(
-        false,
-    );
+    const [isTrapActive, setTrapActive] = useState(false);
     const modalElement: Element | null = document.querySelector(`.${CLASSNAME}`);
 
     useEffect(() => {

--- a/src/components/lightbox/react/Lightbox.tsx
+++ b/src/components/lightbox/react/Lightbox.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import React, { Fragment, ReactElement, RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import classNames from 'classnames';
@@ -94,7 +94,7 @@ const Lightbox: React.FC<LightboxProps> = ({
     parentElement,
     role = DEFAULT_PROPS.role,
     theme = DEFAULT_PROPS.theme,
-}: LightboxProps): React.ReactElement => {
+}: LightboxProps): ReactElement => {
     // tslint:disable-next-line: no-any
     const buttonRef: React.RefObject<any> = useRef(null);
     // tslint:disable-next-line: no-any

--- a/src/components/lightbox/react/Lightbox.tsx
+++ b/src/components/lightbox/react/Lightbox.tsx
@@ -119,7 +119,7 @@ const Lightbox: React.FC<LightboxProps> = ({
     /**
      * Callback on activation of focus trap.
      */
-    const handleFocusActivation: () => void = (): void => {
+    const handleFocusActivation = (): void => {
         if (childrenRef && childrenRef.current && childrenRef.current.firstChild) {
             // Set focus inside lightbox.
             childrenRef.current.firstChild.focus();
@@ -133,7 +133,7 @@ const Lightbox: React.FC<LightboxProps> = ({
     /**
      * Callback on deactivation of focus trap.
      */
-    const handleFocusDeactivation: () => void = (): void => {
+    const handleFocusDeactivation = (): void => {
         if (parentElement && parentElement.current) {
             // Set focus back on parent element.
             parentElement.current.focus();
@@ -149,22 +149,17 @@ const Lightbox: React.FC<LightboxProps> = ({
      *
      * @param evt Click event.
      */
-    const handleClose: (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => void = useCallback(
-        (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-            setTrapActive(false);
-            evt.stopPropagation();
-        },
-        [],
-    );
+    const handleClose = useCallback((evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+        setTrapActive(false);
+        evt.stopPropagation();
+    }, []);
 
     /**
      * Prevent click bubbling to parent.
      *
      * @param evt Click event.
      */
-    const preventClick: (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => void = (
-        evt: React.MouseEvent<HTMLDivElement, MouseEvent>,
-    ): void => {
+    const preventClick = (evt: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
         evt.stopPropagation();
     };
 

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -119,7 +119,7 @@ const List: React.FC<ListProps> = ({
      * Reset the active element
      * @param fromBlur Is request from blur event
      */
-    const resetActiveIndex: (fromBlur: boolean) => void = (fromBlur: boolean): void => {
+    const resetActiveIndex = (fromBlur: boolean): void => {
         if (!isClickable || preventResetOnBlurOrFocus.current) {
             if (fromBlur) {
                 preventResetOnBlurOrFocus.current = false;

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -6,12 +6,9 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
-import { ListItem, ListItemProps } from 'LumX/components/list/react/ListItem';
+import { ListItem, ListItemProps, ListSubheader, Theme } from 'LumX';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
-
-import { Theme, Themes } from 'LumX/components';
-import { ListSubheader } from 'LumX/components/list/react/ListSubheader';
 
 /////////////////////////////
 
@@ -59,7 +56,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     isClickable: false,
-    theme: Themes.light,
+    theme: Theme.light,
 };
 /////////////////////////////
 
@@ -220,4 +217,4 @@ List.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, List, ListProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, List, ListProps };

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, cloneElement, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -75,7 +75,7 @@ const List: React.FC<ListProps> = ({
     onListItemSelected,
     theme = DEFAULT_PROPS.theme,
     ...props
-}: ListProps): React.ReactElement => {
+}: ListProps): ReactElement => {
     // tslint:disable-next-line: typedef
     const [activeItemIndex, setActiveItemIndex] = useState(-1);
     // tslint:disable-next-line: typedef

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, cloneElement, useEffect, useRef, useState } from 'react';
+import React, { ReactElement, RefObject, cloneElement, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -6,7 +6,7 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
-import { ListItem } from 'LumX/components/list/react/ListItem';
+import { ListItem, ListItemProps } from 'LumX/components/list/react/ListItem';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
 
@@ -76,21 +76,17 @@ const List: React.FC<ListProps> = ({
     theme = DEFAULT_PROPS.theme,
     ...props
 }: ListProps): ReactElement => {
-    // tslint:disable-next-line: typedef
     const [activeItemIndex, setActiveItemIndex] = useState(-1);
-    // tslint:disable-next-line: typedef
     const preventResetOnBlurOrFocus = useRef(false);
-    // tslint:disable-next-line: typedef no-any
-    const listElementRef: any = useRef();
+    const listElementRef = useRef() as RefObject<HTMLUListElement>;
 
     /**
      * Override the mouse down event - forward the event if needed
      * @param  evt       Mouse event
-     * @param      idx       Index of the target in the list
-     * @param      itemProps Base props
+     * @param  idx       Index of the target in the list
+     * @param  itemProps Base props
      */
-    // tslint:disable-next-line: typedef
-    const mouseDownHandler = (evt, idx, itemProps) => {
+    const mouseDownHandler = (evt: React.MouseEvent, idx: number, itemProps: ListItemProps): void => {
         setActiveItemIndex(idx);
         if (itemProps.onMouseDown) {
             itemProps.onMouseDown(evt);
@@ -98,20 +94,16 @@ const List: React.FC<ListProps> = ({
     };
 
     /**
-     * Handle the blur event on the list -> we should reset the selection
-     * @param  evt Focus event
+     * Handle the blur event on the list -> we should reset the selection.
      */
-    // tslint:disable-next-line: typedef no-unused
-    const onListBlured = (evt: React.FocusEvent<HTMLUListElement>) => {
+    const onListBlured = (): void => {
         resetActiveIndex(true);
     };
 
     /**
      * Handle the focus event on the list -> we should reset the selection
-     * @param  evt Focus input event
      */
-    // tslint:disable-next-line: typedef no-unused
-    const onListFocused = (evt: React.FocusEvent<HTMLUListElement>) => {
+    const onListFocused = (): void => {
         resetActiveIndex(false);
     };
 
@@ -134,8 +126,7 @@ const List: React.FC<ListProps> = ({
      * Handle keyboard interactions
      * @param  evt Keybord input event
      */
-    // tslint:disable-next-line: typedef
-    const onKeyInteraction = (evt: React.KeyboardEvent<HTMLUListElement>) => {
+    const onKeyInteraction = (evt: React.KeyboardEvent<HTMLUListElement>): void => {
         if (!isClickable) {
             return;
         }
@@ -162,9 +153,8 @@ const List: React.FC<ListProps> = ({
      * Returns the index of the list item to activate. By default we search for the next
      * available element.
      * @param  previous Flag which indicates if we should search for the previous list item
-     * @return            Index of the element to activate.
+     * @return Index of the element to activate.
      */
-    // tslint:disable-next-line: typedef
     const selectItemOnKeyDown = (previous: boolean): number => {
         const lookupTable: Array<ListItem | ListSubheader> = children
             .slice(activeItemIndex + 1)
@@ -195,7 +185,7 @@ const List: React.FC<ListProps> = ({
 
     // Let's place the focus on the list so we can navigate with the keyboard.
     useEffect(() => {
-        if (isClickable) {
+        if (isClickable && listElementRef && listElementRef.current) {
             listElementRef.current.focus();
         }
     }, []);
@@ -212,13 +202,11 @@ const List: React.FC<ListProps> = ({
             {...props}
         >
             {children.map((elm: ListItem | ListSubheader, idx: number) => {
-                // tslint:disable-next-line: no-any
-                const elemProps: any = {
+                const elemProps: ListItemProps = {
                     key: `listEntry-${idx}`,
                 };
                 if (isClickable && elm.type.name === 'ListItem') {
-                    // tslint:disable-next-line: no-string-literal, typedef
-                    elemProps.onMouseDown = (evt) => mouseDownHandler(evt, idx, elm.props);
+                    elemProps.onMouseDown = (evt: React.MouseEvent): void => mouseDownHandler(evt, idx, elm.props);
                     elemProps.isActive = idx === activeItemIndex;
                     elemProps.isClickable = isClickable;
                 }

--- a/src/components/list/react/ListDivider.tsx
+++ b/src/components/list/react/ListDivider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -49,10 +49,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
  *
  * @return The component.
  */
-const ListDivider: React.FC<ListDividerProps> = ({
-    className = '',
-    ...props
-}: ListDividerProps): React.ReactElement => {
+const ListDivider: React.FC<ListDividerProps> = ({ className = '', ...props }: ListDividerProps): ReactElement => {
     return <li className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props} />;
 };
 ListDivider.displayName = COMPONENT_NAME;

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
-import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
+import { Callback, IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
 
 import { Theme, Themes } from 'LumX/components';
@@ -41,8 +41,7 @@ interface IListItemProps extends IGenericProps {
     /* theme */
     theme?: Theme;
     /* Callback used to retrieved the selected entry*/
-    // tslint:disable-next-line: typedef
-    onItemSelected?;
+    onItemSelected?(): void;
 }
 type ListItemProps = IListItemProps;
 
@@ -99,7 +98,7 @@ const ListItem: React.FC<ListItemProps> = ({
     before,
     ...props
 }: ListItemProps): ReactElement => {
-    const element: React.MutableRefObject<HTMLLIElement | null> = useRef(null);
+    const element = useRef<HTMLLIElement | null>(null);
 
     useEffect(() => {
         if (element && element.current && isActive) {
@@ -112,8 +111,7 @@ const ListItem: React.FC<ListItemProps> = ({
      *
      * @param evt Focus event
      */
-    // tslint:disable-next-line: typedef
-    const preventParentFocus = (evt: React.FocusEvent<HTMLLIElement>): void => {
+    const preventParentFocus = (evt: React.FocusEvent): void => {
         evt.preventDefault();
         evt.stopPropagation();
     };
@@ -122,12 +120,11 @@ const ListItem: React.FC<ListItemProps> = ({
      * Currying the on entre press behavior.
      * @return Returns either undefined or a callback
      */
-    // tslint:disable-next-line: typedef
-    const onKeyDown = () => {
+    const onKeyDown = (): Callback | undefined => {
         if (isClickable && onItemSelected) {
             return onEnterPressed(onItemSelected);
         }
-        return;
+        return undefined;
     };
 
     return (

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -4,21 +4,19 @@ import classNames from 'classnames';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
+import { Theme } from 'LumX';
 import { Callback, IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
-
-import { Theme, Themes } from 'LumX/components';
 
 /**
  *  Authorized size values.
  */
-const enum Sizes {
+enum ListItemSize {
     tiny = 'tiny',
     regular = 'regular',
     big = 'big',
     huge = 'huge',
 }
-type Size = Sizes;
 
 /////////////////////////////
 
@@ -31,7 +29,7 @@ interface IListItemProps extends IGenericProps {
     /* Whether the list item can be clicked */
     isClickable?: boolean;
     /* Component size*/
-    size?: Size;
+    size?: ListItemSize;
     /* before element */
     before?: ReactElement;
     /* after element */
@@ -75,8 +73,8 @@ const DEFAULT_PROPS: IDefaultPropsType = {
     isActive: false,
     isClickable: false,
     isSelected: false,
-    size: Sizes.regular,
-    theme: Themes.light,
+    size: ListItemSize.regular,
+    theme: Theme.light,
 };
 /////////////////////////////
 
@@ -150,4 +148,4 @@ ListItem.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, ListItem, ListItemProps, Sizes, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, ListItem, ListItemProps, ListItemSize };

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -98,7 +98,7 @@ const ListItem: React.FC<ListItemProps> = ({
     onItemSelected,
     before,
     ...props
-}: ListItemProps): React.ReactElement => {
+}: ListItemProps): ReactElement => {
     const element: React.MutableRefObject<HTMLLIElement | null> = useRef(null);
 
     useEffect(() => {

--- a/src/components/list/react/ListSubheader.tsx
+++ b/src/components/list/react/ListSubheader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -57,7 +57,7 @@ const ListSubheader: React.FC<ListSubheaderProps> = ({
     children,
     className = '',
     ...props
-}: ListSubheaderProps): React.ReactElement => {
+}: ListSubheaderProps): ReactElement => {
     return (
         <li className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
             {children}

--- a/src/components/list/react/ListSubheader.tsx
+++ b/src/components/list/react/ListSubheader.tsx
@@ -52,7 +52,6 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
  *
  * @return The component.
  */
-// tslint:disable: no-unused
 const ListSubheader: React.FC<ListSubheaderProps> = ({
     children,
     className = '',

--- a/src/components/list/react/ListSubheader.tsx
+++ b/src/components/list/react/ListSubheader.tsx
@@ -8,8 +8,6 @@ import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 
 import { handleBasicClasses } from 'LumX/core/utils';
 
-import { Theme, Themes } from 'LumX/components';
-
 /////////////////////////////
 
 /**
@@ -67,4 +65,4 @@ ListSubheader.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, ListSubheader, ListSubheaderProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, ListSubheader, ListSubheaderProps };

--- a/src/components/popover/react/Popover.tsx
+++ b/src/components/popover/react/Popover.tsx
@@ -136,17 +136,15 @@ const unwrap = (inputValue: boolean | string | (() => boolean) | undefined): boo
 
 /**
  * Get the popover offset base on its placement.
- * @param          placement       The prefered placement
- * @param      popperPlacement The actual platform
+ * @param   placement       The prefered placement
+ * @param   popperPlacement The actual platform
  * @param   popperOffset    An offset to be applied on the popper
- * @return                       The css position.
+ * @return  The css position.
  */
 function computeOffsets(
     placement: string,
-    // tslint:disable-next-line: no-shadowed-variable
-    popperPlacement: Placements | undefined,
-    // tslint:disable-next-line: no-shadowed-variable
-    popperOffset: PopperOffsets | undefined = { vertical: 0, horizontal: 0 },
+    popperPlacement?: Placements,
+    popperOffset: PopperOffsets = { vertical: 0, horizontal: 0 },
 ): Position {
     const computedOffs: Position = {
         left: popperOffset.horizontal || 0,
@@ -181,7 +179,6 @@ function computeOffsets(
  * @param matchAnchorWidth    Should the popper match the anchor width
  * @return                       The size of the popper holder
  */
-// tslint:disable: no-shadowed-variable
 function computeSize(
     fillHeight: boolean | undefined,
     fillwidth: boolean | undefined,
@@ -265,8 +262,7 @@ const Popover: React.FC<PopoverProps> = ({
         }
     }
 
-    // tslint:disable-next-line: no-any
-    const modifiers: any | undefined = {
+    const modifiers = {
         arrow: {
             // eslint-disable-next-line id-blacklist
             element: `.lumx-tooltip__arrow`,

--- a/src/components/popover/react/Popover.tsx
+++ b/src/components/popover/react/Popover.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef, useState } from 'react';
+import React, { ReactElement, ReactNode, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -238,7 +238,7 @@ const Popover: React.FC<PopoverProps> = ({
     showPopper,
     tooltipShowHideDelay = DEFAULT_PROPS.tooltipShowHideDelay,
     useTooltipMode = DEFAULT_PROPS.useTooltipMode,
-}: PopoverProps): React.ReactElement => {
+}: PopoverProps): ReactElement => {
     const [autoShowPopper, setAutoShowPopper]: [boolean, (autoShowPopper: boolean) => void] = useState(Boolean(false));
 
     const autoShowDelayer: React.MutableRefObject<number> = useRef(0);
@@ -280,7 +280,7 @@ const Popover: React.FC<PopoverProps> = ({
     return (
         <Manager>
             <Reference>
-                {({ ref }: ReferenceChildrenProps): ReactNode => (
+                {({ ref }: ReferenceChildrenProps): ReactElement => (
                     <div
                         ref={(elm: HTMLDivElement | null): void => {
                             anchorRef = elm;
@@ -296,7 +296,7 @@ const Popover: React.FC<PopoverProps> = ({
             </Reference>
             {(unwrap(showPopper) || (unwrap(useTooltipMode) && autoShowPopper)) && (
                 <Popper placement={popperPlacement as Placements} modifiers={modifiers}>
-                    {({ ref, style, arrowProps, ...others }: PopperChildrenProps): ReactNode => {
+                    {({ ref, style, arrowProps, ...others }: PopperChildrenProps): ReactElement => {
                         const computedOffsets: Position = popperPlacement
                             ? computeOffsets(others.placement, popperPlacement as Placements, popperOffset)
                             : {};

--- a/src/components/popover/react/Popover.tsx
+++ b/src/components/popover/react/Popover.tsx
@@ -239,7 +239,7 @@ const Popover: React.FC<PopoverProps> = ({
     tooltipShowHideDelay = DEFAULT_PROPS.tooltipShowHideDelay,
     useTooltipMode = DEFAULT_PROPS.useTooltipMode,
 }: PopoverProps): ReactElement => {
-    const [autoShowPopper, setAutoShowPopper]: [boolean, (autoShowPopper: boolean) => void] = useState(Boolean(false));
+    const [autoShowPopper, setAutoShowPopper] = useState(false);
 
     const autoShowDelayer: React.MutableRefObject<number> = useRef(0);
 

--- a/src/components/popover/react/Popover.tsx
+++ b/src/components/popover/react/Popover.tsx
@@ -130,9 +130,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * Helper method that returns a simple boolean value from different source format.
  * @param inputValue The input to extract the boolean value from
  */
-const unwrap: (inputValue: boolean | string | (() => boolean) | undefined) => boolean = (
-    inputValue: boolean | string | (() => boolean) | undefined,
-): boolean => {
+const unwrap = (inputValue: boolean | string | (() => boolean) | undefined): boolean => {
     return typeof inputValue === 'function' ? inputValue() : Boolean(inputValue);
 };
 

--- a/src/components/popover/react/Popover.tsx
+++ b/src/components/popover/react/Popover.tsx
@@ -18,7 +18,7 @@ const SAFE_ZONE = 8;
 // Reference to the anchor element
 let anchorRef: HTMLDivElement | null;
 
-const enum Placements {
+enum PopperPlacement {
     AUTO = 'auto',
     AUTO_END = 'auto-end',
     AUTO_START = 'auto-start',
@@ -39,7 +39,6 @@ const enum Placements {
     LEFT_END = 'left-end',
     LEFT_START = 'left-start',
 }
-type PopperPositions = Placements;
 
 interface IPopperOffsets {
     vertical?: number;
@@ -76,7 +75,7 @@ interface IPopoverProps extends IGenericProps {
     /* Should the popper be displayed ? */
     showPopper?: boolean | (() => boolean);
     /* The prefered popper location against the anchor */
-    popperPlacement?: PopperPositions | string;
+    popperPlacement?: PopperPlacement | string;
     /* Use the popover as a tooltip engine => auto show/hide the popper when hovering the anchor */
     useTooltipMode?: boolean | (() => boolean);
     /* Customize the delay when showing / hiding the popper */
@@ -143,7 +142,7 @@ const unwrap = (inputValue: boolean | string | (() => boolean) | undefined): boo
  */
 function computeOffsets(
     placement: string,
-    popperPlacement?: Placements,
+    popperPlacement?: PopperPlacement,
     popperOffset: PopperOffsets = { vertical: 0, horizontal: 0 },
 ): Position {
     const computedOffs: Position = {
@@ -289,10 +288,10 @@ const Popover: React.FC<PopoverProps> = ({
                 )}
             </Reference>
             {(unwrap(showPopper) || (unwrap(useTooltipMode) && autoShowPopper)) && (
-                <Popper placement={popperPlacement as Placements} modifiers={modifiers}>
+                <Popper placement={popperPlacement as PopperPlacement} modifiers={modifiers}>
                     {({ ref, style, arrowProps, ...others }: PopperChildrenProps): ReactElement => {
                         const computedOffsets: Position = popperPlacement
-                            ? computeOffsets(others.placement, popperPlacement as Placements, popperOffset)
+                            ? computeOffsets(others.placement, popperPlacement as PopperPlacement, popperOffset)
                             : {};
                         const computedSizes: Size = computeSize(
                             fillHeight,
@@ -332,14 +331,4 @@ Popover.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export {
-    CLASSNAME,
-    DEFAULT_PROPS,
-    Popover,
-    PopoverProps,
-    PopperPositions,
-    Placements,
-    IPopperOffsets,
-    PopperOffsets,
-    SHOW_HIDE_DELAY,
-};
+export { CLASSNAME, DEFAULT_PROPS, Popover, PopoverProps, PopperPlacement, PopperOffsets };

--- a/src/components/progress-tracker/react/ProgressTracker.tsx
+++ b/src/components/progress-tracker/react/ProgressTracker.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Theme, Themes } from 'LumX';
+import { Theme } from 'LumX';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
@@ -49,7 +49,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     activeStep: 0,
-    theme: Themes.light,
+    theme: Theme.light,
 };
 
 /////////////////////////////

--- a/src/components/progress-tracker/react/ProgressTracker.tsx
+++ b/src/components/progress-tracker/react/ProgressTracker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -68,7 +68,7 @@ const ProgressTracker: React.FC<ProgressTrackerProps> = ({
     className = '',
     theme = DEFAULT_PROPS.theme,
     ...props
-}: ProgressTrackerProps): React.ReactElement => {
+}: ProgressTrackerProps): ReactElement => {
     const backgroundPosition: number = 100 / (children.length * 2);
     const trackPosition: number = ((100 / (children.length - 1)) * activeStep) / 100;
 

--- a/src/components/progress-tracker/react/ProgressTrackerStep.tsx
+++ b/src/components/progress-tracker/react/ProgressTrackerStep.tsx
@@ -103,7 +103,7 @@ const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
      *
      * @return The correct svg path.
      */
-    const getIcon: () => string = (): string => {
+    const getIcon = (): string => {
         if (isComplete) {
             return mdiCheckCircle;
         }

--- a/src/components/progress-tracker/react/ProgressTrackerStep.tsx
+++ b/src/components/progress-tracker/react/ProgressTrackerStep.tsx
@@ -4,16 +4,10 @@ import classNames from 'classnames';
 
 import isFunction from 'lodash/isFunction';
 
-import { Theme, Themes } from 'LumX';
-
-import { Sizes } from 'LumX/components';
-
+import { Icon, Size, Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
-
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
-
-import { Icon } from 'LumX/components/icon/react/Icon';
 
 import { mdiAlertCircle, mdiCheckCircle, mdiRadioboxBlank, mdiRadioboxMarked } from 'LumX/icons';
 
@@ -75,7 +69,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
     isActive: false,
     isComplete: false,
     label: null,
-    theme: Themes.light,
+    theme: Theme.light,
 };
 /////////////////////////////
 
@@ -133,7 +127,7 @@ const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
             onKeyDown={onEnterPressed(onClick)}
             {...restProps}
         >
-            <Icon className={`${CLASSNAME}__state`} icon={getIcon()} size={Sizes.s} />
+            <Icon className={`${CLASSNAME}__state`} icon={getIcon()} size={Size.s} />
 
             <span className={`${CLASSNAME}__label`}>{label}</span>
 

--- a/src/components/progress-tracker/react/ProgressTrackerStep.tsx
+++ b/src/components/progress-tracker/react/ProgressTrackerStep.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -93,7 +93,7 @@ const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
     label = DEFAULT_PROPS.label,
     theme = DEFAULT_PROPS.theme,
     ...props
-}: ProgressTrackerStepProps): React.ReactElement => {
+}: ProgressTrackerStepProps): ReactElement => {
     const { onClick = null, ...restProps }: IProgressTrackerStepProps = props;
 
     const isClickable: boolean = isFunction(onClick);

--- a/src/components/progress/react/Progress.tsx
+++ b/src/components/progress/react/Progress.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -75,16 +75,16 @@ const Progress: React.FC<ProgressProps> = ({
         >
             <div className={classNames(`${CLASSNAME}-${variant}`)}>
                 {variant === Variants.circular && (
-                    <Fragment>
+                    <>
                         <div className="lumx-progress-circular__double-bounce1" />
                         <div className="lumx-progress-circular__double-bounce2" />
-                    </Fragment>
+                    </>
                 )}
                 {variant === Variants.linear && (
-                    <Fragment>
+                    <>
                         <div className="lumx-progress-linear__line1" />
                         <div className="lumx-progress-linear__line2" />
-                    </Fragment>
+                    </>
                 )}
             </div>
         </div>

--- a/src/components/progress/react/Progress.tsx
+++ b/src/components/progress/react/Progress.tsx
@@ -10,11 +10,10 @@ import { handleBasicClasses } from 'LumX/core/utils';
 /**
  * Authorized variants.
  */
-const enum Variants {
+enum ProgressVariant {
     linear = 'linear',
     circular = 'circular',
 }
-type Variant = Variants;
 
 /////////////////////////////
 
@@ -23,7 +22,7 @@ type Variant = Variants;
  */
 interface IProgressProps extends IGenericProps {
     /* Type of progress */
-    variant?: Variant;
+    variant?: ProgressVariant;
 }
 type ProgressProps = IProgressProps;
 
@@ -54,7 +53,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
-    variant: Variants.circular,
+    variant: ProgressVariant.circular,
 };
 /////////////////////////////
 
@@ -74,13 +73,13 @@ const Progress: React.FC<ProgressProps> = ({
             {...props}
         >
             <div className={classNames(`${CLASSNAME}-${variant}`)}>
-                {variant === Variants.circular && (
+                {variant === ProgressVariant.circular && (
                     <>
                         <div className="lumx-progress-circular__double-bounce1" />
                         <div className="lumx-progress-circular__double-bounce2" />
                     </>
                 )}
-                {variant === Variants.linear && (
+                {variant === ProgressVariant.linear && (
                     <>
                         <div className="lumx-progress-linear__line1" />
                         <div className="lumx-progress-linear__line2" />
@@ -94,4 +93,4 @@ Progress.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Progress, ProgressProps, Variants };
+export { CLASSNAME, DEFAULT_PROPS, Progress, ProgressProps, ProgressVariant };

--- a/src/components/progress/react/Progress.tsx
+++ b/src/components/progress/react/Progress.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -67,7 +67,7 @@ const Progress: React.FC<ProgressProps> = ({
     className = '',
     variant = DEFAULT_PROPS.variant,
     ...props
-}: ProgressProps): React.ReactElement => {
+}: ProgressProps): ReactElement => {
     return (
         <div
             className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }), `${CLASSNAME}--${variant}`)}

--- a/src/components/slideshow/react/Slideshow.tsx
+++ b/src/components/slideshow/react/Slideshow.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, ReactElement, ReactNode, useCallback, useEffect, 
 
 import classNames from 'classnames';
 
-import { Theme, Themes } from 'LumX/components';
+import { Theme } from 'LumX';
 import { AUTOPLAY_DEFAULT_INTERVAL, FULL_WIDTH_PERCENT } from 'LumX/components/slideshow/constants';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { useInterval } from 'LumX/core/react/hooks';
@@ -67,7 +67,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
     groupBy: 1,
     hasControls: false,
     interval: AUTOPLAY_DEFAULT_INTERVAL,
-    theme: Themes.light,
+    theme: Theme.light,
 };
 
 /////////////////////////////
@@ -244,4 +244,4 @@ Slideshow.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Slideshow, SlideshowProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, Slideshow, SlideshowProps };

--- a/src/components/slideshow/react/Slideshow.tsx
+++ b/src/components/slideshow/react/Slideshow.tsx
@@ -1,14 +1,4 @@
-import React, {
-    CSSProperties,
-    Dispatch,
-    ReactElement,
-    ReactNode,
-    SetStateAction,
-    useCallback,
-    useEffect,
-    useRef,
-    useState,
-} from 'react';
+import React, { CSSProperties, ReactElement, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -121,8 +111,8 @@ const Slideshow: React.FC<SlideshowProps> = ({
     }
 
     const newChildren: ReactNode = _validate({ activeIndex, autoPlay, children, groupBy, interval, ...props });
-    const [currentIndex, setCurrentIndex]: [number, Dispatch<SetStateAction<number>>] = useState(activeIndex);
-    const [isAutoPlaying, setIsAutoPlaying]: [boolean, Dispatch<SetStateAction<boolean>>] = useState(Boolean(autoPlay));
+    const [currentIndex, setCurrentIndex] = useState(activeIndex);
+    const [isAutoPlaying, setIsAutoPlaying] = useState(Boolean(autoPlay));
     const parentRef: React.MutableRefObject<null> = useRef(null);
 
     /**

--- a/src/components/slideshow/react/Slideshow.tsx
+++ b/src/components/slideshow/react/Slideshow.tsx
@@ -152,7 +152,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * Handle click on a bullet to go to a specific slide.
      */
-    const handleControlGotToSlide: (index: number) => void = useCallback(
+    const handleControlGotToSlide = useCallback(
         (index: number) => {
             stopAutoPlay();
 
@@ -166,7 +166,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * Handle click or keyboard event to go to next slide.
      */
-    const handleControlNextSlide: () => void = (): void => {
+    const handleControlNextSlide = (): void => {
         stopAutoPlay();
         goToNextSlide();
     };
@@ -174,7 +174,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * Handle click or keyboard event to go to previous slide.
      */
-    const handleControlPreviousSlide: () => void = (): void => {
+    const handleControlPreviousSlide = (): void => {
         stopAutoPlay();
         goToPreviousSlide();
     };
@@ -182,7 +182,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * Change current index to display next slide.
      */
-    const goToNextSlide: () => void = useCallback(() => {
+    const goToNextSlide = useCallback(() => {
         if (currentIndex === slidesCount - 1) {
             setCurrentIndex(() => 0);
         } else if (currentIndex < slidesCount - 1) {
@@ -193,7 +193,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * Change current index to display previous slide.
      */
-    const goToPreviousSlide: () => void = useCallback(() => {
+    const goToPreviousSlide = useCallback(() => {
         if (currentIndex === 0) {
             setCurrentIndex(() => slidesCount - 1);
         } else if (currentIndex > 0) {
@@ -204,7 +204,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * Stop slideshow auto rotating.
      */
-    const stopAutoPlay: () => void = (): void => {
+    const stopAutoPlay = (): void => {
         setIsAutoPlaying(false);
     };
 

--- a/src/components/slideshow/react/Slideshow.tsx
+++ b/src/components/slideshow/react/Slideshow.tsx
@@ -1,4 +1,14 @@
-import React, { CSSProperties, Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+    CSSProperties,
+    Dispatch,
+    ReactElement,
+    ReactNode,
+    SetStateAction,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 
 import classNames from 'classnames';
 
@@ -83,7 +93,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * @param props The children and props of the component.
  * @return    The processed children of the component.
  */
-function _validate(props: SlideshowProps): React.ReactNode {
+function _validate(props: SlideshowProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         props,
     });
@@ -105,12 +115,12 @@ const Slideshow: React.FC<SlideshowProps> = ({
     interval = DEFAULT_PROPS.interval,
     theme = DEFAULT_PROPS.theme,
     ...props
-}: SlideshowProps): React.ReactElement | null => {
+}: SlideshowProps): ReactElement | null => {
     if (typeof activeIndex === 'undefined' || typeof groupBy === 'undefined' || typeof interval === 'undefined') {
         return null;
     }
 
-    const newChildren: React.ReactNode = _validate({ activeIndex, autoPlay, children, groupBy, interval, ...props });
+    const newChildren: ReactNode = _validate({ activeIndex, autoPlay, children, groupBy, interval, ...props });
     const [currentIndex, setCurrentIndex]: [number, Dispatch<SetStateAction<number>>] = useState(activeIndex);
     const [isAutoPlaying, setIsAutoPlaying]: [boolean, Dispatch<SetStateAction<boolean>>] = useState(Boolean(autoPlay));
     const parentRef: React.MutableRefObject<null> = useRef(null);

--- a/src/components/slideshow/react/SlideshowControls.tsx
+++ b/src/components/slideshow/react/SlideshowControls.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useCallback, useEffect, useState } from 'react';
+import React, { ReactElement, RefObject, useCallback, useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -102,7 +102,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /** Theme */
     theme = DEFAULT_PROPS.theme,
     ...props
-}: SlideshowControlsProps): React.ReactElement | null => {
+}: SlideshowControlsProps): ReactElement | null => {
     if (typeof activeIndex === 'undefined' || typeof slidesCount === 'undefined') {
         return null;
     }

--- a/src/components/slideshow/react/SlideshowControls.tsx
+++ b/src/components/slideshow/react/SlideshowControls.tsx
@@ -2,10 +2,7 @@ import React, { ReactElement, RefObject, useCallback, useEffect, useState } from
 
 import classNames from 'classnames';
 
-import { Button } from 'LumX';
-import { Theme, Themes } from 'LumX/components';
-import { Emphasises } from 'LumX/components/button/react/Button';
-import { Variants } from 'LumX/components/button/react/DropdownButton';
+import { Button, ButtonEmphasis, ButtonVariant, Theme } from 'LumX';
 import {
     EDGE_FROM_ACTIVE_INDEX,
     PAGINATION_ITEMS_MAX,
@@ -76,7 +73,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
     onNextClick: noop,
     onPaginationClick: noop,
     onPreviousClick: noop,
-    theme: Themes.light,
+    theme: Theme.light,
 };
 
 /////////////////////////////
@@ -299,9 +296,9 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
             <Button
                 leftIcon={mdiChevronLeft}
                 className={`${CLASSNAME}__navigation`}
-                color={theme === Themes.dark ? 'light' : 'dark'}
-                emphasis={Emphasises.low}
-                variant={Variants.icon}
+                color={theme === Theme.dark ? 'light' : 'dark'}
+                emphasis={ButtonEmphasis.low}
+                variant={ButtonVariant.icon}
                 onClick={handlePreviousClick}
                 tabIndex={-1}
             />
@@ -313,9 +310,9 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
             <Button
                 leftIcon={mdiChevronRight}
                 className={`${CLASSNAME}__navigation`}
-                color={theme === Themes.dark ? 'light' : 'dark'}
-                emphasis={Emphasises.low}
-                variant={Variants.icon}
+                color={theme === Theme.dark ? 'light' : 'dark'}
+                emphasis={ButtonEmphasis.low}
+                variant={ButtonVariant.icon}
                 onClick={handleNextClick}
                 tabIndex={-1}
             />

--- a/src/components/slideshow/react/SlideshowControls.tsx
+++ b/src/components/slideshow/react/SlideshowControls.tsx
@@ -112,7 +112,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
      *
      * @param evt Keyboard event.
      */
-    const handleKeyPressed: (evt: KeyboardEvent) => void = (evt: KeyboardEvent): void => {
+    const handleKeyPressed = (evt: KeyboardEvent): void => {
         if (evt.keyCode === LEFT_KEY_CODE) {
             handlePreviousClick();
         } else if (evt.keyCode === RIGHT_KEY_CODE) {
@@ -129,7 +129,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
      * @param index Index used to determinate position in slides.
      * @return Min and max for pagination position.
      */
-    const initVisibleRange: (index: number) => PaginationRange = (index: number): PaginationRange => {
+    const initVisibleRange = (index: number): PaginationRange => {
         const deltaItems: number = PAGINATION_ITEMS_MAX - 1;
         let min: number = index - EDGE_FROM_ACTIVE_INDEX;
         let max: number = index + EDGE_FROM_ACTIVE_INDEX;
@@ -150,7 +150,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
      *
      * @param index Index used to determinate position in slides.
      */
-    const updateVisibleRange: (index: number) => void = (index: number): void => {
+    const updateVisibleRange = (index: number): void => {
         if (index === visibleRange.maxRange && index < lastSlide) {
             setVisibleRange(() => ({ minRange: visibleRange.minRange + 1, maxRange: visibleRange.maxRange + 1 }));
         } else if (index === visibleRange.minRange && index > 0) {
@@ -166,7 +166,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
      * @param lastIndex Index of last item.
      * @return Array of nabiagtion items.
      */
-    const buildItemsArray: (lastIndex: number) => JSX.Element[] = (lastIndex: number): JSX.Element[] => {
+    const buildItemsArray = (lastIndex: number): JSX.Element[] => {
         const items: JSX.Element[] = [];
 
         for (let i = 0; i <= lastIndex; i++) {
@@ -194,7 +194,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
      *
      * @param index Index of the slide to go to.
      */
-    const handleItemClick: (index: number) => void = useCallback(
+    const handleItemClick = useCallback(
         (index: number) => {
             if (isFunction(onPaginationClick)) {
                 onPaginationClick(index);
@@ -206,7 +206,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Handle click to go to next slide.
      */
-    const handleNextClick: () => void = useCallback(() => {
+    const handleNextClick = useCallback(() => {
         if (isFunction(onNextClick)) {
             onNextClick();
         }
@@ -215,7 +215,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /**
      * Handle click to go to previous slide.
      */
-    const handlePreviousClick: () => void = useCallback(() => {
+    const handlePreviousClick = useCallback(() => {
         if (isFunction(onPreviousClick)) {
             onPreviousClick();
         }
@@ -227,7 +227,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
      * @param index Index of navigation item.
      * @return Whether navigation item is visble or not.
      */
-    const isPaginationItemOutVisibleRange: (index: number) => boolean = (index: number): boolean => {
+    const isPaginationItemOutVisibleRange = (index: number): boolean => {
         return index < visibleRange.minRange || index > visibleRange.maxRange;
     };
 
@@ -237,7 +237,7 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
      * @param  index The index of the pagination item to check.
      * @return Whether the pagination item is on edge or not.
      */
-    const isPaginationItemOnEdge: (index: number) => boolean = (index: number): boolean => {
+    const isPaginationItemOnEdge = (index: number): boolean => {
         return (
             index !== 0 && index !== lastSlide && (index === visibleRange.minRange || index === visibleRange.maxRange)
         );

--- a/src/components/slideshow/react/SlideshowItem.tsx
+++ b/src/components/slideshow/react/SlideshowItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -35,7 +35,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * @param props The children and props of the component.
  * @return    The processed children of the component.
  */
-function _validate(props: IGenericProps): React.ReactNode {
+function _validate(props: IGenericProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         maxChildren: 1,
         minChildren: 1,
@@ -54,8 +54,8 @@ const SlideshowItem: React.FC<IGenericProps> = ({
     className = '',
     children,
     ...props
-}: IGenericProps): React.ReactElement => {
-    const newChildren: React.ReactNode = _validate({ children, ...props });
+}: IGenericProps): ReactElement => {
+    const newChildren: ReactNode = _validate({ children, ...props });
 
     return (
         <div

--- a/src/components/switch/react/Switch.test.tsx
+++ b/src/components/switch/react/Switch.test.tsx
@@ -9,7 +9,8 @@ import without from 'lodash/without';
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
 import { getBasicClass } from 'LumX/core/utils';
 
-import { CLASSNAME, DEFAULT_PROPS, Positions, Switch, SwitchProps, Themes } from './Switch';
+import { Theme } from 'LumX';
+import { CLASSNAME, DEFAULT_PROPS, Switch, SwitchPosition, SwitchProps } from './Switch';
 
 /////////////////////////////
 
@@ -169,8 +170,8 @@ describe(`<${Switch.displayName}>`, (): void => {
         it('should use the given props', (): void => {
             const modifiedPropsBuilder: () => ISetupProps = build('props').fields({
                 checked: true,
-                position: oneOf(...without(Object.values(Positions), DEFAULT_PROPS.position)),
-                theme: oneOf(...without(Object.values(Themes), DEFAULT_PROPS.theme)),
+                position: oneOf(...without(Object.values(SwitchPosition), DEFAULT_PROPS.position)),
+                theme: oneOf(...without(Object.values(Theme), DEFAULT_PROPS.theme)),
             });
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();

--- a/src/components/switch/react/Switch.test.tsx
+++ b/src/components/switch/react/Switch.test.tsx
@@ -168,7 +168,6 @@ describe(`<${Switch.displayName}>`, (): void => {
 
         it('should use the given props', (): void => {
             const modifiedPropsBuilder: () => ISetupProps = build('props').fields({
-                // tslint:disable-next-line: no-any
                 checked: true,
                 position: oneOf(...without(Object.values(Positions), DEFAULT_PROPS.position)),
                 theme: oneOf(...without(Object.values(Themes), DEFAULT_PROPS.theme)),

--- a/src/components/switch/react/Switch.test.tsx
+++ b/src/components/switch/react/Switch.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -224,10 +224,10 @@ describe(`<${Switch.displayName}>`, (): void => {
     describe('Conditions', (): void => {
         it('should fail when more than one child is given', (): void => {
             const children: ReactNode = (
-                <Fragment>
+                <>
                     Label
                     <span>Label 2</span>
-                </Fragment>
+                </>
             );
 
             expect(

--- a/src/components/switch/react/Switch.test.tsx
+++ b/src/components/switch/react/Switch.test.tsx
@@ -97,7 +97,7 @@ describe(`<${Switch.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly without any label', (): void => {
-            const { root, inputWrapper, input, content, wrapper }: ISetup = setup();
+            const { root, inputWrapper, input, content, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toExist();
@@ -111,7 +111,7 @@ describe(`<${Switch.displayName}>`, (): void => {
 
         it('should render correctly with only a `label`', (): void => {
             const props: ISetupProps = { children: 'Label' };
-            const { root, inputWrapper, input, content, helper, label, wrapper }: ISetup = setup(props);
+            const { root, inputWrapper, input, content, helper, label, wrapper } = setup(props);
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toExist();
@@ -129,7 +129,7 @@ describe(`<${Switch.displayName}>`, (): void => {
 
         it('should render correctly with a `label` and a `helper`', (): void => {
             const props: ISetupProps = { children: 'Label', helper: 'Helper' };
-            const { root, inputWrapper, input, content, helper, label, wrapper }: ISetup = setup(props);
+            const { root, inputWrapper, input, content, helper, label, wrapper } = setup(props);
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toExist();
@@ -152,7 +152,7 @@ describe(`<${Switch.displayName}>`, (): void => {
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
         it('should use default props', (): void => {
-            const { root }: ISetup = setup();
+            const { root } = setup();
 
             Object.keys(DEFAULT_PROPS).forEach(
                 (prop: string): void => {
@@ -179,7 +179,7 @@ describe(`<${Switch.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { root }: ISetup = setup({ ...modifiedProps });
+            const { root } = setup({ ...modifiedProps });
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {
@@ -216,7 +216,7 @@ describe(`<${Switch.displayName}>`, (): void => {
         );
 
         it('should trigger `onToggle` when toggled', (): void => {
-            const { input }: ISetup = setup({ onToggle }, false);
+            const { input } = setup({ onToggle }, false);
 
             input.simulate('click');
             expect(onToggle).toHaveBeenCalled();
@@ -255,7 +255,7 @@ describe(`<${Switch.displayName}>`, (): void => {
 
         it('should not display the `helper` if no `label` is given', (): void => {
             const props: ISetupProps = { helper: 'Helper' };
-            const { content, wrapper }: ISetup = setup(props);
+            const { content, wrapper } = setup(props);
             expect(wrapper).toMatchSnapshot();
 
             expect(content).not.toExist();

--- a/src/components/switch/react/Switch.test.tsx
+++ b/src/components/switch/react/Switch.test.tsx
@@ -65,10 +65,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: SwitchProps = {
         ...propsOverrides,
     };

--- a/src/components/switch/react/Switch.test.tsx
+++ b/src/components/switch/react/Switch.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement, ReactNode } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import mockConsole from 'jest-mock-console';
@@ -73,7 +73,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<Switch {...props} />);
 
@@ -227,7 +227,7 @@ describe(`<${Switch.displayName}>`, (): void => {
     // 4. Test conditions (i.e. things that display or not in the UI based on props).
     describe('Conditions', (): void => {
         it('should fail when more than one child is given', (): void => {
-            const children: React.ReactNode = (
+            const children: ReactNode = (
                 <Fragment>
                     Label
                     <span>Label 2</span>
@@ -244,7 +244,7 @@ describe(`<${Switch.displayName}>`, (): void => {
         it('should fail when anything else than a text or a <span> is given', (): void => {
             mockConsole('debug');
 
-            const children: React.ReactNode = <div>Label</div>;
+            const children: ReactNode = <div>Label</div>;
 
             expect(
                 (): void => {

--- a/src/components/switch/react/Switch.tsx
+++ b/src/components/switch/react/Switch.tsx
@@ -6,18 +6,17 @@ import uuid from 'uuid/v4';
 import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
 
-import { Theme, Themes } from 'LumX/components';
+import { Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName, validateComponent } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
 
 /////////////////////////////
 
-enum Positions {
+enum SwitchPosition {
     left = 'left',
     right = 'right',
 }
-type Position = Positions;
 
 /////////////////////////////
 
@@ -38,7 +37,7 @@ interface ISwitchProps extends IGenericProps {
     /**
      * The position of the toggle regarding the label.
      */
-    position?: Position;
+    position?: SwitchPosition;
 
     /**
      * The theme.
@@ -81,8 +80,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     checked: false,
-    position: Positions.left,
-    theme: Themes.light,
+    position: SwitchPosition.left,
+    theme: Theme.light,
 };
 
 /////////////////////////////
@@ -186,4 +185,4 @@ Switch.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Position, Positions, Switch, SwitchProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, Switch, SwitchProps, SwitchPosition };

--- a/src/components/switch/react/Switch.tsx
+++ b/src/components/switch/react/Switch.tsx
@@ -132,7 +132,7 @@ const Switch: React.FC<SwitchProps> = ({
     /**
      * Toggle the state of the <Switch> inner checkbox.
      */
-    const toggleIsChecked: (evt: React.MouseEvent<HTMLElement>) => void = (): void => {
+    const toggleIsChecked = (): void => {
         setIsChecked(!isChecked);
 
         if (isFunction(onToggle)) {

--- a/src/components/switch/react/Switch.tsx
+++ b/src/components/switch/react/Switch.tsx
@@ -128,7 +128,7 @@ const Switch: React.FC<SwitchProps> = ({
 
     const newChildren: ReactNode = _validate({ children, checked, helper, position, theme, ...props });
 
-    const [isChecked, setIsChecked]: [boolean, (isChecked: boolean) => void] = useState(Boolean(checked));
+    const [isChecked, setIsChecked] = useState(Boolean(checked));
     /**
      * Toggle the state of the <Switch> inner checkbox.
      */

--- a/src/components/switch/react/Switch.tsx
+++ b/src/components/switch/react/Switch.tsx
@@ -1,4 +1,4 @@
-import React, { Children, useState } from 'react';
+import React, { Children, ReactElement, ReactNode, useState } from 'react';
 
 import classNames from 'classnames';
 import uuid from 'uuid/v4';
@@ -98,7 +98,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * @param props The children and props of the component.
  * @return    The processed children of the component.
  */
-function _validate(props: SwitchProps): React.ReactNode {
+function _validate(props: SwitchProps): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         allowedTypes: ['text', <span />],
         maxChildren: 1,
@@ -123,10 +123,10 @@ const Switch: React.FC<SwitchProps> = ({
     position = DEFAULT_PROPS.position,
     theme = DEFAULT_PROPS.theme,
     ...props
-}: SwitchProps): React.ReactElement => {
+}: SwitchProps): ReactElement => {
     const switchId: string = uuid();
 
-    const newChildren: React.ReactNode = _validate({ children, checked, helper, position, theme, ...props });
+    const newChildren: ReactNode = _validate({ children, checked, helper, position, theme, ...props });
 
     const [isChecked, setIsChecked]: [boolean, (isChecked: boolean) => void] = useState(Boolean(checked));
     /**

--- a/src/components/table/react/Table.tsx
+++ b/src/components/table/react/Table.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Theme, Themes } from 'LumX/components';
+import { Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -52,7 +52,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     hasDividers: false,
-    theme: Themes.light,
+    theme: Theme.light,
 };
 
 /////////////////////////////
@@ -80,4 +80,4 @@ Table.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Table, TableProps, Theme };
+export { CLASSNAME, DEFAULT_PROPS, Table, TableProps };

--- a/src/components/table/react/Table.tsx
+++ b/src/components/table/react/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -68,7 +68,7 @@ const Table: React.FC<TableProps> = ({
     hasDividers,
     theme = DEFAULT_PROPS.theme,
     ...props
-}: TableProps): React.ReactElement => (
+}: TableProps): ReactElement => (
     <table className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, hasDividers, theme }))} {...props}>
         {children}
     </table>

--- a/src/components/table/react/TableBody.tsx
+++ b/src/components/table/react/TableBody.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -49,11 +49,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
  *
  * @return The component.
  */
-const TableBody: React.FC<TableBodyProps> = ({
-    children,
-    className = '',
-    ...props
-}: TableBodyProps): React.ReactElement => (
+const TableBody: React.FC<TableBodyProps> = ({ children, className = '', ...props }: TableBodyProps): ReactElement => (
     <tbody className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
         {children}
     </tbody>

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useCallback } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 
 import classNames from 'classnames';
 
@@ -140,7 +140,7 @@ const TableCell: React.FC<TableCellProps> = ({
     }, [onHeaderClick]);
 
     return (
-        <Fragment>
+        <>
             {variant === Variants.head && (
                 <th
                     className={classNames(
@@ -182,7 +182,7 @@ const TableCell: React.FC<TableCellProps> = ({
                     <div className={`${CLASSNAME}-content`}>{children}</div>
                 </td>
             )}
-        </Fragment>
+        </>
     );
 };
 TableCell.displayName = COMPONENT_NAME;

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback } from 'react';
+import React, { Fragment, ReactElement, useCallback } from 'react';
 
 import classNames from 'classnames';
 
@@ -129,7 +129,7 @@ const TableCell: React.FC<TableCellProps> = ({
     sortOrder,
     variant = DEFAULT_PROPS.variant,
     ...props
-}: TableCellProps): React.ReactElement => {
+}: TableCellProps): ReactElement => {
     /**
      * Handle click on the ordered thead.
      */

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -2,13 +2,11 @@ import React, { ReactElement, useCallback } from 'react';
 
 import classNames from 'classnames';
 
+import { Icon, Size } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
 
-import { Icon } from 'LumX/components/icon/react/Icon';
-
-import { IconSizes } from 'LumX';
 import { mdiArrowDown, mdiArrowUp } from 'LumX/icons';
 
 import isFunction from 'lodash/isFunction';
@@ -18,29 +16,26 @@ import isFunction from 'lodash/isFunction';
 /**
  * The authorized values for the `sortOrder` prop.
  */
-enum Orders {
+enum ThOrder {
     asc = 'asc',
     desc = 'desc',
 }
-type Order = Orders;
 
 /**
  * The authorized values for the `scope` prop.
  */
-enum Scopes {
+enum ThScope {
     col = 'col',
     row = 'row',
 }
-type Scope = Scopes;
 
 /**
  * The authorized variants.
  */
-enum Variants {
+enum TableCellVariant {
     body = 'body',
     head = 'head',
 }
-type Variant = Variants;
 
 /////////////////////////////
 
@@ -61,17 +56,17 @@ interface ITableCellProps extends IGenericProps {
     /**
      * The scope of the thead.
      */
-    scope?: Scope;
+    scope?: ThScope;
 
     /**
      * The initial sort order (sortable thead only).
      */
-    sortOrder?: Order;
+    sortOrder?: ThOrder;
 
     /**
      * The variant of the cell.
      */
-    variant?: Variant;
+    variant?: TableCellVariant;
 
     /**
      * The function to call when we click on an order button.
@@ -86,7 +81,7 @@ type TableCellProps = ITableCellProps;
  * Define the types of the default props.
  */
 interface IDefaultPropsType extends Partial<TableCellProps> {
-    variant: Variant;
+    variant: TableCellVariant;
 }
 
 /////////////////////////////
@@ -110,7 +105,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
     onHeaderClick: undefined,
-    variant: Variants.body,
+    variant: TableCellVariant.body,
 };
 
 /////////////////////////////
@@ -141,7 +136,7 @@ const TableCell: React.FC<TableCellProps> = ({
 
     return (
         <>
-            {variant === Variants.head && (
+            {variant === TableCellVariant.head && (
                 <th
                     className={classNames(
                         handleBasicClasses({ prefix: CLASSNAME, isSortable }),
@@ -157,16 +152,14 @@ const TableCell: React.FC<TableCellProps> = ({
                     {...props}
                 >
                     <div className={`${CLASSNAME}-wrapper`}>
-                        {icon && !isSortable && (
-                            <Icon className={`${CLASSNAME}-icon`} icon={icon} size={IconSizes.xxs} />
+                        {icon && !isSortable && <Icon className={`${CLASSNAME}-icon`} icon={icon} size={Size.xxs} />}
+
+                        {isSortable && sortOrder === ThOrder.asc && (
+                            <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowUp} size={Size.xxs} />
                         )}
 
-                        {isSortable && sortOrder === Orders.asc && (
-                            <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowUp} size={IconSizes.xxs} />
-                        )}
-
-                        {isSortable && sortOrder === Orders.desc && (
-                            <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowDown} size={IconSizes.xxs} />
+                        {isSortable && sortOrder === ThOrder.desc && (
+                            <Icon className={`${CLASSNAME}-icon`} icon={mdiArrowDown} size={Size.xxs} />
                         )}
 
                         <div className={`${CLASSNAME}-content`}>{children}</div>
@@ -174,7 +167,7 @@ const TableCell: React.FC<TableCellProps> = ({
                 </th>
             )}
 
-            {variant === Variants.body && (
+            {variant === TableCellVariant.body && (
                 <td
                     className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }), `${CLASSNAME}--body`)}
                     {...props}
@@ -189,4 +182,4 @@ TableCell.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Order, Orders, Scope, Scopes, TableCell, TableCellProps, Variant, Variants };
+export { CLASSNAME, DEFAULT_PROPS, TableCell, TableCellProps, TableCellVariant, ThOrder, ThScope };

--- a/src/components/table/react/TableCell.tsx
+++ b/src/components/table/react/TableCell.tsx
@@ -133,7 +133,7 @@ const TableCell: React.FC<TableCellProps> = ({
     /**
      * Handle click on the ordered thead.
      */
-    const handleOnHeaderClick: () => void = useCallback(() => {
+    const handleOnHeaderClick = useCallback(() => {
         if (isFunction(onHeaderClick)) {
             onHeaderClick();
         }

--- a/src/components/table/react/TableHeader.tsx
+++ b/src/components/table/react/TableHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -53,7 +53,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
     children,
     className = '',
     ...props
-}: TableHeaderProps): React.ReactElement => (
+}: TableHeaderProps): ReactElement => (
     <thead className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
         {children}
     </thead>

--- a/src/components/table/react/TableRow.tsx
+++ b/src/components/table/react/TableRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -49,11 +49,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {};
  *
  * @return The component.
  */
-const TableRow: React.FC<TableRowProps> = ({
-    children,
-    className = '',
-    ...props
-}: TableRowProps): React.ReactElement => (
+const TableRow: React.FC<TableRowProps> = ({ children, className = '', ...props }: TableRowProps): ReactElement => (
     <tr className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
         {children}
     </tr>

--- a/src/components/tabs/react/Tab.test.tsx
+++ b/src/components/tabs/react/Tab.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import { build } from 'test-data-bot';
@@ -46,7 +46,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     // noinspection RequiredAttributes
     const wrapper: Wrapper = renderer(<Tab {...props} />);

--- a/src/components/tabs/react/Tab.test.tsx
+++ b/src/components/tabs/react/Tab.test.tsx
@@ -61,7 +61,7 @@ describe(`<${Tab.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { wrapper }: ISetup = setup();
+            const { wrapper } = setup();
 
             expect(wrapper).toMatchSnapshot();
             expect(wrapper).toExist();
@@ -82,7 +82,7 @@ describe(`<${Tab.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { wrapper }: ISetup = setup({ ...modifiedProps });
+            const { wrapper } = setup({ ...modifiedProps });
             expect(wrapper).toMatchSnapshot();
         });
 
@@ -94,7 +94,7 @@ describe(`<${Tab.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { wrapper }: ISetup = setup({ ...modifiedProps });
+            const { wrapper } = setup({ ...modifiedProps });
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {
@@ -119,21 +119,21 @@ describe(`<${Tab.displayName}>`, (): void => {
         );
 
         it('should trigger `onTabClick` when clicked', (): void => {
-            const { wrapper }: ISetup = setup({ index: 7, onTabClick }, false);
+            const { wrapper } = setup({ index: 7, onTabClick }, false);
 
             wrapper.simulate('click');
             expect(onTabClick).toHaveBeenCalledWith({ event: jasmine.any(Object), index: 7 });
         });
 
         it('should trigger `onTabClick` when pressing `enter` key', (): void => {
-            const { wrapper }: ISetup = setup({ index: 9, onTabClick }, false);
+            const { wrapper } = setup({ index: 9, onTabClick }, false);
 
             wrapper.simulate('keypress', { keyCode: 13 });
             expect(onTabClick).toHaveBeenCalledWith({ event: jasmine.any(Object), index: 9 });
         });
 
         it('should not trigger `onTabClick` when pressing any other key', (): void => {
-            const { wrapper }: ISetup = setup({ index: 10, onTabClick }, false);
+            const { wrapper } = setup({ index: 10, onTabClick }, false);
 
             wrapper.simulate('keypress', { keyCode: 12 });
             expect(onTabClick).not.toHaveBeenCalled();

--- a/src/components/tabs/react/Tab.test.tsx
+++ b/src/components/tabs/react/Tab.test.tsx
@@ -38,10 +38,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const props: TabProps = {
         ...propsOverrides,
     };

--- a/src/components/tabs/react/Tab.tsx
+++ b/src/components/tabs/react/Tab.tsx
@@ -1,4 +1,11 @@
-import React, { AnchorHTMLAttributes, KeyboardEvent, KeyboardEventHandler, MouseEvent, MouseEventHandler } from 'react';
+import React, {
+    AnchorHTMLAttributes,
+    KeyboardEvent,
+    KeyboardEventHandler,
+    MouseEvent,
+    MouseEventHandler,
+    ReactElement,
+} from 'react';
 
 import noop from 'lodash/noop';
 
@@ -82,7 +89,7 @@ const Tab: React.FC<TabProps> = ({
     label = DEFAULT_PROPS.label,
     onTabClick = DEFAULT_PROPS.onTabClick,
     ...props
-}: TabProps): React.ReactElement => {
+}: TabProps): ReactElement => {
     const tabIndex: AnchorHTMLAttributes<HTMLAnchorElement>['tabIndex'] = isDisabled ? -1 : 0;
 
     const handleTabClick: MouseEventHandler = (event: MouseEvent<HTMLElement>): void => {

--- a/src/components/tabs/react/Tab.tsx
+++ b/src/components/tabs/react/Tab.tsx
@@ -11,13 +11,11 @@ import noop from 'lodash/noop';
 
 import classNames from 'classnames';
 
+import { Icon, IconProps, Size } from 'LumX';
 import { CSS_PREFIX, ENTER_KEY_CODE } from 'LumX/core/constants';
-import { COMPONENT_PREFIX } from 'LumX/react/constants';
-
 import { handleBasicClasses } from 'LumX/core/utils';
+import { COMPONENT_PREFIX } from 'LumX/react/constants';
 import { IGenericProps } from 'LumX/react/utils';
-
-import { Icon, IconProps, Sizes } from 'LumX/components/icon/react/Icon';
 
 /////////////////////////////
 
@@ -114,7 +112,7 @@ const Tab: React.FC<TabProps> = ({
             onKeyPress={handleKeyPress}
             {...props}
         >
-            {icon && <Icon icon={icon} size={Sizes.xs} />}
+            {icon && <Icon icon={icon} size={Size.xs} />}
             {label && <span>{label}</span>}
         </a>
     );

--- a/src/components/tabs/react/Tabs.test.tsx
+++ b/src/components/tabs/react/Tabs.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import noop from 'lodash/noop';
 
@@ -51,7 +51,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     // noinspection RequiredAttributes
     const wrapper: Wrapper = renderer(<Tabs {...props} />);

--- a/src/components/tabs/react/Tabs.test.tsx
+++ b/src/components/tabs/react/Tabs.test.tsx
@@ -8,8 +8,8 @@ import { build, oneOf } from 'test-data-bot';
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
 import { getBasicClass } from 'LumX/core/utils';
 
-import { Tab } from 'LumX/components/tabs/react/Tab';
-import { CLASSNAME, Layouts, Positions, Tabs, TabsProps } from './Tabs';
+import { Tab } from 'LumX';
+import { CLASSNAME, Tabs, TabsLayout, TabsPosition, TabsProps } from './Tabs';
 
 /////////////////////////////
 
@@ -84,8 +84,8 @@ describe(`<${Tabs.displayName}>`, (): void => {
         it('should use the given props', (): void => {
             const modifiedPropsBuilder: () => ISetupProps = build('props').fields!({
                 // tslint:disable-next-line: no-any
-                layout: Layouts.clustered,
-                position: oneOf(Positions.center, Positions.right),
+                layout: TabsLayout.clustered,
+                position: oneOf(TabsPosition.center, TabsPosition.right),
             });
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();

--- a/src/components/tabs/react/Tabs.test.tsx
+++ b/src/components/tabs/react/Tabs.test.tsx
@@ -40,10 +40,7 @@ interface ISetup extends ICommonSetup {
  * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
  *                       component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
-    { ...propsOverrides }: ISetupProps = {},
-    shallowRendering: boolean = true,
-): ISetup => {
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
     const tabs: Tabs[] = [<Tab>Tab 0</Tab>, <Tab>Tab 1</Tab>];
     const props: TabsProps = {
         children: tabs,

--- a/src/components/tabs/react/Tabs.test.tsx
+++ b/src/components/tabs/react/Tabs.test.tsx
@@ -66,7 +66,7 @@ describe(`<${Tabs.displayName}>`, (): void => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', (): void => {
         it('should render correctly', (): void => {
-            const { wrapper }: ISetup = setup();
+            const { wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(wrapper).toExist();
@@ -93,7 +93,7 @@ describe(`<${Tabs.displayName}>`, (): void => {
 
             const modifiedProps: ISetupProps = modifiedPropsBuilder();
 
-            const { wrapper }: ISetup = setup({ ...modifiedProps });
+            const { wrapper } = setup({ ...modifiedProps });
 
             Object.keys(modifiedProps).forEach(
                 (prop: string): void => {
@@ -118,7 +118,7 @@ describe(`<${Tabs.displayName}>`, (): void => {
         );
 
         it('should trigger `onTabClick` when a child tab is clicked', (): void => {
-            const { wrapper }: ISetup = setup({ onTabClick }, false);
+            const { wrapper } = setup({ onTabClick }, false);
             const firstTab: Tab = wrapper.find('Tab[index=1]');
 
             firstTab.simulate('click');

--- a/src/components/tabs/react/Tabs.tsx
+++ b/src/components/tabs/react/Tabs.tsx
@@ -2,29 +2,23 @@ import React, { Children, ReactElement, cloneElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Theme, Themes } from 'LumX/components';
-
+import { Tab, Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
-
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
 
-import { Tab } from 'LumX/components/tabs/react/Tab';
-
 /////////////////////////////
 
-const enum Layouts {
+enum TabsLayout {
     clustered = 'clustered',
     fixed = 'fixed',
 }
-type Layout = Layouts;
 
-const enum Positions {
+enum TabsPosition {
     center = 'center',
     left = 'left',
     right = 'right',
 }
-type Position = Positions;
 
 /////////////////////////////
 
@@ -37,11 +31,11 @@ interface ITabsProps extends IGenericProps {
     /* Component tabs */
     children: Tab[];
     /* Tabs Layout */
-    layout?: Layout;
+    layout?: TabsLayout;
     /* Function to trigger on tab click */
     onTabClick: CallableFunction;
     /* Tabs Position */
-    position?: Position;
+    position?: TabsPosition;
     /* Component theme */
     theme?: Theme;
 }
@@ -76,9 +70,9 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 const DEFAULT_PROPS: IDefaultPropsType = {
     activeTab: 0,
     children: [],
-    layout: Layouts.fixed,
-    position: Positions.left,
-    theme: Themes.light,
+    layout: TabsLayout.fixed,
+    position: TabsPosition.left,
+    theme: Theme.light,
 };
 
 /////////////////////////////
@@ -117,4 +111,4 @@ Tabs.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Layouts, Positions, Tabs, TabsProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, Tabs, TabsProps, TabsLayout, TabsPosition };

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -99,9 +99,7 @@ const TextField: React.FC<TextFieldProps> = ({
      *
      * @param event Event of HTML Element
      */
-    const handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void = (
-        event: React.ChangeEvent<HTMLInputElement>,
-    ): void => setHasValue(Boolean(event.target.value));
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => setHasValue(Boolean(event.target.value));
 
     return (
         <div

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -91,8 +91,8 @@ const TextField: React.FC<TextFieldProps> = ({
     theme = Themes.light,
     ...props
 }: TextFieldProps): ReactElement => {
-    const [hasFocus, setHasFocus]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);
-    const [hasValue, setHasValue]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);
+    const [hasFocus, setHasFocus] = useState(false);
+    const [hasValue, setHasValue] = useState(false);
 
     /**
      * Handle change event on input.

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import classNames from 'classnames';
 import uuid from 'uuid/v4';
@@ -90,7 +90,7 @@ const TextField: React.FC<TextFieldProps> = ({
     placeholder,
     theme = Themes.light,
     ...props
-}: TextFieldProps): React.ReactElement => {
+}: TextFieldProps): ReactElement => {
     const [hasFocus, setHasFocus]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);
     const [hasValue, setHasValue]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);
 

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useState } from 'react';
 import classNames from 'classnames';
 import uuid from 'uuid/v4';
 
-import { Icon, Sizes, Theme, Themes } from 'LumX';
+import { Icon, Size, Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -88,7 +88,7 @@ const TextField: React.FC<TextFieldProps> = ({
     isValid,
     label,
     placeholder,
-    theme = Themes.light,
+    theme = Theme.light,
     ...props
 }: TextFieldProps): ReactElement => {
     const [hasFocus, setHasFocus] = useState(false);
@@ -131,9 +131,9 @@ const TextField: React.FC<TextFieldProps> = ({
                 {icon && (
                     <Icon
                         className={`${CLASSNAME}__input-icon`}
-                        color={theme === Themes.dark ? 'light' : undefined}
+                        color={theme === Theme.dark ? 'light' : undefined}
                         icon={icon}
-                        size={Sizes.xs}
+                        size={Size.xs}
                     />
                 )}
 
@@ -155,9 +155,9 @@ const TextField: React.FC<TextFieldProps> = ({
                 {(isValid || hasError) && (
                     <Icon
                         className={`${CLASSNAME}__input-validity`}
-                        color={theme === Themes.dark ? 'light' : undefined}
+                        color={theme === Theme.dark ? 'light' : undefined}
                         icon={isValid ? mdiCheckCircle : mdiAlertCircle}
-                        size={Sizes.xs}
+                        size={Size.xs}
                     />
                 )}
             </div>
@@ -168,4 +168,4 @@ TextField.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, TextField, TextFieldProps, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, TextField, TextFieldProps };

--- a/src/components/thumbnail/react/Thumbnail.tsx
+++ b/src/components/thumbnail/react/Thumbnail.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -118,7 +118,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     variant = DEFAULT_PROPS.variant,
     image,
     ...props
-}: ThumbnailProps): React.ReactElement => {
+}: ThumbnailProps): ReactElement => {
     const style: CSSProperties = {
         backgroundImage: `url(${image})`,
     };

--- a/src/components/thumbnail/react/Thumbnail.tsx
+++ b/src/components/thumbnail/react/Thumbnail.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Alignment, Alignments, Theme, Themes } from 'LumX/components';
+import { Alignment, Size, Theme } from 'LumX';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
@@ -14,34 +14,24 @@ import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
 /**
  * All available aspect ratios.
  */
-const enum AspectRatios {
+const enum ThumbnailAspectRatio {
     original = 'original',
     horizontal = 'horizontal',
     vertical = 'vertical',
 }
-type AspectRatio = AspectRatios;
 
 /**
  *  Authorized size values.
  */
-enum Sizes {
-    xxs = 'xxs',
-    xs = 'xs',
-    s = 's',
-    m = 'm',
-    l = 'l',
-    xl = 'xl',
-}
-type Size = Sizes;
+type ThumbnailSize = Size.xxs | Size.xs | Size.s | Size.m | Size.l | Size.xl;
 
 /**
  * Authorized variants.
  */
-enum Variants {
+enum ThumbnailVariant {
     squared = 'squared',
     rounded = 'rounded',
 }
-type Variant = Variants;
 
 /////////////////////////////
 
@@ -52,17 +42,17 @@ interface IThumbnailProps extends IGenericProps {
     /* The thumbnail alignment. */
     align?: Alignment;
     /* The image aspect ratio. */
-    aspectRatio?: AspectRatio;
+    aspectRatio?: ThumbnailAspectRatio;
     /* Whether the image has to fill its container's height. */
     fillHeight?: boolean;
     /* Avatar image. */
     image: string;
     /* Size. */
-    size?: Size;
+    size?: ThumbnailSize;
     /* Theme. */
     theme?: Theme;
     /* Variant. */
-    variant?: Variant;
+    variant?: ThumbnailVariant;
 }
 type ThumbnailProps = IThumbnailProps;
 
@@ -93,12 +83,12 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
-    align: Alignments.left,
-    aspectRatio: AspectRatios.original,
+    align: Alignment.left,
+    aspectRatio: ThumbnailAspectRatio.original,
     fillHeight: false,
     size: undefined,
-    theme: Themes.light,
-    variant: Variants.squared,
+    theme: Theme.light,
+    variant: ThumbnailVariant.squared,
 };
 /////////////////////////////
 
@@ -139,7 +129,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             onKeyDown={onEnterPressed(onClick)}
             {...restProps}
         >
-            {aspectRatio === AspectRatios.original ? (
+            {aspectRatio === ThumbnailAspectRatio.original ? (
                 <img className="lumx-thumbnail__image" src={image} alt={alt} />
             ) : (
                 <div className="lumx-thumbnail__background" style={style} />
@@ -151,15 +141,4 @@ Thumbnail.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export {
-    CLASSNAME,
-    DEFAULT_PROPS,
-    AspectRatio,
-    AspectRatios,
-    Sizes,
-    Thumbnail,
-    ThumbnailProps,
-    Theme,
-    Themes,
-    Variants,
-};
+export { CLASSNAME, DEFAULT_PROPS, Thumbnail, ThumbnailProps, ThumbnailAspectRatio, ThumbnailSize, ThumbnailVariant };

--- a/src/components/thumbnail/react/Thumbnail.tsx
+++ b/src/components/thumbnail/react/Thumbnail.tsx
@@ -123,7 +123,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
         backgroundImage: `url(${image})`,
     };
 
-    const { alt = 'Thumbnail', onClick = null, ...restProps }: IDefaultPropsType = props;
+    const { alt = 'Thumbnail', onClick = null, ...restProps } = props;
 
     return (
         <div

--- a/src/components/tooltip/react/Tooltip.tsx
+++ b/src/components/tooltip/react/Tooltip.tsx
@@ -210,7 +210,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     ...props
 }: TooltipProps): ReactElement => {
     const [timer, setTimer] = useState(0);
-    const tooltipRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
+    const tooltipRef: React.RefObject<HTMLDivElement> = useRef(null);
     const [isOpen, setIsOpen] = useState(false);
 
     /**

--- a/src/components/tooltip/react/Tooltip.tsx
+++ b/src/components/tooltip/react/Tooltip.tsx
@@ -94,7 +94,7 @@ const useTooltipPosition: (
     // tslint:disable-next-line: no-any
     dependencies: any[] = [placement, anchorRef, tooltipRef],
 ): Position => {
-    const [position, setPosition]: [Position, React.Dispatch<React.SetStateAction<Position>>] = useState<Position>({
+    const [position, setPosition] = useState<Position>({
         x: 0,
         y: 0,
     });
@@ -104,7 +104,7 @@ const useTooltipPosition: (
             return;
         }
 
-        const { top, left, width, height }: ClientRect | DOMRect = anchorRef.current!.getBoundingClientRect();
+        const { top, left, width, height } = anchorRef.current!.getBoundingClientRect();
         const {
             width: widthTooltip,
             height: heightTooltip,
@@ -156,7 +156,7 @@ const useArrowPosition: (
     // tslint:disable-next-line: no-any
     dependencies: any[] = [placement, tooltipRef],
 ): Position => {
-    const [position, setPosition]: [Position, React.Dispatch<React.SetStateAction<Position>>] = useState<Position>({
+    const [position, setPosition] = useState<Position>({
         x: 0,
         y: 0,
     });
@@ -209,9 +209,9 @@ const Tooltip: React.FC<TooltipProps> = ({
     placement = DEFAULT_PROPS.placement,
     ...props
 }: TooltipProps): ReactElement => {
-    const [timer, setTimer]: [number, React.Dispatch<React.SetStateAction<number>>] = useState<number>(0);
+    const [timer, setTimer] = useState(0);
     const tooltipRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
-    const [isOpen, setIsOpen]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);
+    const [isOpen, setIsOpen] = useState(false);
 
     /**
      * Handle mouse over anchor element.

--- a/src/components/tooltip/react/Tooltip.tsx
+++ b/src/components/tooltip/react/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, RefObject, useEffect, useRef, useState } from 'react';
+import React, { CSSProperties, ReactElement, RefObject, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import classNames from 'classnames';
@@ -208,7 +208,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     delay = DEFAULT_PROPS.delay,
     placement = DEFAULT_PROPS.placement,
     ...props
-}: TooltipProps): React.ReactElement => {
+}: TooltipProps): ReactElement => {
     const [timer, setTimer]: [number, React.Dispatch<React.SetStateAction<number>>] = useState<number>(0);
     const tooltipRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
     const [isOpen, setIsOpen]: [boolean, React.Dispatch<React.SetStateAction<boolean>>] = useState<boolean>(false);

--- a/src/components/tooltip/react/Tooltip.tsx
+++ b/src/components/tooltip/react/Tooltip.tsx
@@ -216,7 +216,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     /**
      * Handle mouse over anchor element.
      */
-    const handleMouseEnter: () => void = (): void => {
+    const handleMouseEnter = (): void => {
         if (timer) {
             clearTimeout(timer);
             setTimer(0);
@@ -228,7 +228,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     /**
      * Handle mouse out anchor element.
      */
-    const handleMouseLeave: () => void = (): void => {
+    const handleMouseLeave = (): void => {
         const id: number = setTimeout(() => {
             setIsOpen(false);
         }, delay);

--- a/src/components/user-block/react/UserBlock.tsx
+++ b/src/components/user-block/react/UserBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -30,9 +30,9 @@ interface IUserBlockProps extends IGenericProps {
     /* Avatar image. */
     avatar?: string;
     /* Simple Action block. */
-    simpleAction?: React.ReactNode;
+    simpleAction?: ReactNode;
     /* Multiple Actions block. */
-    multipleActions?: React.ReactNode;
+    multipleActions?: ReactNode;
     /* Additionnal fields used to describe the use. */
     fields?: string[];
     /* User name. */
@@ -103,7 +103,7 @@ const UserBlock: React.FC<IUserBlockProps> = ({
     simpleAction,
     multipleActions,
     size = DEFAULT_PROPS.size,
-}: IUserBlockProps): React.ReactElement => {
+}: IUserBlockProps): ReactElement => {
     let componentSize: Sizes | undefined = size;
 
     // Special case - When using vertical orientation force the size to be Sizes.l.
@@ -113,7 +113,7 @@ const UserBlock: React.FC<IUserBlockProps> = ({
 
     const shouldDisplayActions: boolean = orientation === Orientations.vertical;
 
-    const nameBlock: React.ReactNode = name && (
+    const nameBlock: ReactNode = name && (
         <span
             className={`${CLASSNAME}__name`}
             onMouseEnter={onMouseEnter}
@@ -125,7 +125,7 @@ const UserBlock: React.FC<IUserBlockProps> = ({
         </span>
     );
 
-    const fieldsBlock: React.ReactNode = fields && componentSize !== Sizes.s && (
+    const fieldsBlock: ReactNode = fields && componentSize !== Sizes.s && (
         <div className={`${CLASSNAME}__fields`}>
             {fields.map((aField: string, idx: number) => (
                 <span key={`ubf${idx}`} className={`${CLASSNAME}__field`}>

--- a/src/components/user-block/react/UserBlock.tsx
+++ b/src/components/user-block/react/UserBlock.tsx
@@ -2,11 +2,9 @@ import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Orientation, Orientations, Theme, Themes } from 'LumX/components';
+import { Avatar, Orientation, Size, Theme } from 'LumX';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
-
-import { Avatar } from 'LumX/components/avatar/react/Avatar';
 
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -14,12 +12,7 @@ import { handleBasicClasses } from 'LumX/core/utils';
 /**
  * Authorized size values.
  */
-enum Sizes {
-    s = 's',
-    m = 'm',
-    l = 'l',
-}
-type Size = Sizes;
+type UserBlockSize = Size.s | Size.m | Size.l;
 
 /////////////////////////////
 
@@ -40,7 +33,7 @@ interface IUserBlockProps extends IGenericProps {
     /* Orientation. */
     orientation?: Orientation;
     /* Size. */
-    size?: Size;
+    size?: UserBlockSize;
     /* Theme. */
     theme?: Theme;
     /* Callback for the click event. */
@@ -79,9 +72,9 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
-    orientation: Orientations.horizontal,
-    size: Sizes.m,
-    theme: Themes.light,
+    orientation: Orientation.horizontal,
+    size: Size.m,
+    theme: Theme.light,
 };
 /////////////////////////////
 
@@ -104,14 +97,14 @@ const UserBlock: React.FC<IUserBlockProps> = ({
     multipleActions,
     size = DEFAULT_PROPS.size,
 }: IUserBlockProps): ReactElement => {
-    let componentSize: Sizes | undefined = size;
+    let componentSize = size;
 
     // Special case - When using vertical orientation force the size to be Sizes.l.
-    if (orientation === Orientations.vertical) {
-        componentSize = Sizes.l;
+    if (orientation === Orientation.vertical) {
+        componentSize = Size.l;
     }
 
-    const shouldDisplayActions: boolean = orientation === Orientations.vertical;
+    const shouldDisplayActions: boolean = orientation === Orientation.vertical;
 
     const nameBlock: ReactNode = name && (
         <span
@@ -125,7 +118,7 @@ const UserBlock: React.FC<IUserBlockProps> = ({
         </span>
     );
 
-    const fieldsBlock: ReactNode = fields && componentSize !== Sizes.s && (
+    const fieldsBlock: ReactNode = fields && componentSize !== Size.s && (
         <div className={`${CLASSNAME}__fields`}>
             {fields.map((aField: string, idx: number) => (
                 <span key={`ubf${idx}`} className={`${CLASSNAME}__field`}>
@@ -172,4 +165,4 @@ UserBlock.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, UserBlock, UserBlockProps, Sizes, Theme, Themes };
+export { CLASSNAME, DEFAULT_PROPS, UserBlock, UserBlockProps, UserBlockSize };

--- a/src/core/react/hooks/useInterval.tsx
+++ b/src/core/react/hooks/useInterval.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import isFunction from 'lodash/isFunction';
+import { Callback } from '../utils';
 
 /////////////////////////////
 
@@ -11,14 +12,14 @@ import isFunction from 'lodash/isFunction';
  * @param callback Function called by setInterval.
  * @param     delay    Delay for setInterval.
  */
-function useInterval(callback: () => void, delay: number | null): void {
-    const savedCallback: React.MutableRefObject<(() => void) | undefined> = useRef();
+function useInterval(callback: Callback, delay: number | null): void {
+    const savedCallback: React.MutableRefObject<Callback | void> = useRef();
 
     useEffect(() => {
         savedCallback.current = callback;
     });
 
-    useEffect((): void | (() => void) => {
+    useEffect((): Callback | void => {
         function tick(): void {
             if (isFunction(savedCallback.current)) {
                 savedCallback.current();

--- a/src/core/react/utils.ts
+++ b/src/core/react/utils.ts
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, ReactNode } from 'react';
 
 import get from 'lodash/get';
 import isBoolean from 'lodash/isBoolean';
@@ -47,12 +47,12 @@ interface IGenericProps {
  * Defines a generic component type.
  */
 // tslint:disable-next-line: no-any
-type ComponentType = React.ReactNode | React.FC<any> | React.PureComponent<any, any> | React.Component<any, any>;
+type ComponentType = ReactNode | React.FC<any> | React.PureComponent<any, any> | React.Component<any, any>;
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 interface IChildrenManipulationParameters {
-    child: React.ReactNode;
-    children: React.ReactNode;
+    child: ReactNode;
+    children: ReactNode;
     childrenCount: number;
     index: number;
     props: IGenericProps;
@@ -64,7 +64,7 @@ type ChildValidateParameters = IChildrenManipulationParameters;
  * Defines the parameters of the pre/post validate callback of the `validateComponent` function below.
  */
 interface IValidateParameters {
-    children: React.ReactNode;
+    children: ReactNode;
     childrenCount: number;
     props: IGenericProps;
 }
@@ -130,7 +130,7 @@ function getTypeName(type: string | ComponentType): string | ComponentType {
  * @param type The type we want to check if the ReactElement is of.
  * @return     If the ReactElement is of the given type or not.
  */
-function isElementOfType(el: React.ReactNode, type: string | ComponentType): boolean {
+function isElementOfType(el: ReactNode, type: string | ComponentType): boolean {
     const typeName: string | ComponentType = getTypeName(type);
 
     if (!isString(typeName) || isEmpty(typeName)) {
@@ -162,7 +162,7 @@ function isElementOfType(el: React.ReactNode, type: string | ComponentType): boo
  * @param el The ReactElement to check if it's a text.
  * @return   If the ReactElement is a text or not.
  */
-function isElementText(el: React.ReactNode): boolean {
+function isElementText(el: ReactNode): boolean {
     return isString(el);
 }
 
@@ -172,12 +172,12 @@ function isElementText(el: React.ReactNode): boolean {
  * @param children The children to unwrap (there should be only 1 child of React.Fragment type).
  * @return The unwrapped children (or the origin children if it wasn't a fragment).
  */
-function unwrapFragment(children: React.ReactNode): React.ReactNode {
-    let newChildren: React.ReactNode = children;
+function unwrapFragment(children: ReactNode): ReactNode {
+    let newChildren: ReactNode = children;
 
     const childrenCount: number = Children.count(children);
     if (childrenCount === 1) {
-        const firstChild: React.ReactNode = Children.toArray(children)[0];
+        const firstChild: ReactNode = Children.toArray(children)[0];
 
         if (get(firstChild, 'type') === React.Fragment) {
             newChildren = get(firstChild, 'props.children', []);
@@ -239,11 +239,11 @@ function validateComponent(
         props: IGenericProps;
         postValidate?(params: ValidateParameters): string | boolean | void;
         preValidate?(params: ValidateParameters): string | boolean | void;
-        transformChild?(params: ChildTransformParameters): React.ReactNode;
+        transformChild?(params: ChildTransformParameters): ReactNode;
         validateChild?(params: ChildValidateParameters): string | boolean | void;
     },
-): React.ReactNode | undefined {
-    let newChildren: React.ReactNode = !isEmpty(props.children) ? unwrapFragment(props.children) : undefined;
+): ReactNode | undefined {
+    let newChildren: ReactNode = !isEmpty(props.children) ? unwrapFragment(props.children) : undefined;
     const childrenCount: number = Children.count(newChildren);
 
     const preValidation: string | boolean | void = preValidate({ children: newChildren, childrenCount, props });
@@ -285,17 +285,17 @@ function validateComponent(
         const childrenFunctionName: string = isFunction(transformChild) ? 'map' : 'forEach';
 
         if (!isFunction(transformChild)) {
-            transformChild = ({ child }: ChildTransformParameters): React.ReactNode => child;
+            transformChild = ({ child }: ChildTransformParameters): ReactNode => child;
         }
         validateChild = validateChild || noop;
 
         let index = -1;
-        const transformedChildren: React.ReactNode = Children[childrenFunctionName](
+        const transformedChildren: ReactNode = Children[childrenFunctionName](
             newChildren,
-            (child: React.ReactNode): React.ReactNode => {
+            (child: ReactNode): ReactNode => {
                 index++;
 
-                const newChild: React.ReactNode = transformChild!({
+                const newChild: ReactNode = transformChild!({
                     child,
                     children: newChildren,
                     childrenCount,

--- a/src/core/react/utils.ts
+++ b/src/core/react/utils.ts
@@ -369,6 +369,11 @@ function validateComponent(
     return newChildren;
 }
 
+/**
+ * Callback function type alias (use for readability)
+ */
+type Callback = () => void;
+
 /////////////////////////////
 
 export {
@@ -384,4 +389,5 @@ export {
     isElementText,
     unwrapFragment,
     validateComponent,
+    Callback,
 };

--- a/src/core/utils.d.ts
+++ b/src/core/utils.d.ts
@@ -1,4 +1,4 @@
-import { Color, Size, Theme } from 'LumX/components';
+import { Color, Size, Theme } from 'LumX';
 import { Callback } from './react/utils';
 
 /////////////////////////////

--- a/src/core/utils.d.ts
+++ b/src/core/utils.d.ts
@@ -1,4 +1,5 @@
 import { Color, Size, Theme } from 'LumX/components';
+import { Callback } from './react/utils';
 
 /////////////////////////////
 
@@ -41,7 +42,7 @@ declare function handleBasicClasses({ prefix, ...props }: { prefix: string; [pro
  * @param cb Callback function.
  * @return Function to remove listeners.
  */
-declare function detectSwipe(el: Element, cb: (swipeDirection: SwipeDirection) => void): () => void;
+declare function detectSwipe(el: Element, cb: (swipeDirection: SwipeDirection) => void): Callback;
 
 declare type SwipeDirection = 'none' | 'up' | 'down' | 'left' | 'right';
 
@@ -51,7 +52,7 @@ declare type SwipeDirection = 'none' | 'up' | 'down' | 'left' | 'right';
  * @param  cb The callback to call on enter/return press.
  * @return The decorated function.
  */
-declare function onEnterPressed(cb: () => void): () => void;
+declare function onEnterPressed(cb: Callback): Callback;
 
 /////////////////////////////
 

--- a/src/react.index.ts
+++ b/src/react.index.ts
@@ -2,263 +2,80 @@ import 'focus-visible';
 
 import './core/react';
 
-export { Color, Colors, Size, Sizes, Theme, Themes } from './components';
+export { Alignment, Orientation, Color, ColorPalette, Size, Theme } from './components';
+
+export { Avatar, AvatarProps } from './components/avatar/react/Avatar';
+
+export { Button, ButtonProps, ButtonEmphasis, ButtonVariant } from './components/button/react/Button';
+
+export { ButtonGroup, ButtonGroupProps } from './components/button/react/ButtonGroup';
+
+export { Checkbox, CheckboxProps } from './components/checkbox/react/Checkbox';
+
+export { CheckboxHelper } from './components/checkbox/react/CheckboxHelper';
+export { CheckboxLabel } from './components/checkbox/react/CheckboxLabel';
+
+export { Chip, ChipProps } from './components/chip/react/Chip';
+
+export { Divider, DividerProps } from './components/divider/react/Divider';
+
+export { Dropdown, DropdownProps } from './components/dropdown/react/Dropdown';
+
+export { DropdownButton, DropdownButtonProps } from './components/button/react/DropdownButton';
+
+export { Icon, IconProps } from './components/icon/react/Icon';
+
+export { IconButton, IconButtonProps } from './components/button/react/IconButton';
+
+export { ImageBlock, ImageBlockProps, ImageBlockCaptionPosition } from './components/image-block/react/ImageBlock';
+
+export { Lightbox, LightboxProps } from './components/lightbox/react/Lightbox';
+
+export { List, ListProps } from './components/list/react/List';
+
+export { ListDivider, ListDividerProps } from './components/list/react/ListDivider';
+
+export { ListItem, ListItemProps, ListItemSize } from './components/list/react/ListItem';
+
+export { ListSubheader, ListSubheaderProps } from './components/list/react/ListSubheader';
+
+export { Popover, PopoverProps, PopperPlacement, PopperOffsets } from './components/popover/react/Popover';
+
+export { Progress, ProgressProps, ProgressVariant } from './components/progress/react/Progress';
+
+export { ProgressTracker, ProgressTrackerProps } from './components/progress-tracker/react/ProgressTracker';
+
+export { ProgressTrackerStep, ProgressTrackerStepProps } from './components/progress-tracker/react/ProgressTrackerStep';
+
+export { Slideshow, SlideshowProps } from './components/slideshow/react/Slideshow';
+
+export { SlideshowItem } from './components/slideshow/react/SlideshowItem';
+
+export { Switch, SwitchProps, SwitchPosition } from './components/switch/react/Switch';
+
+export { Table, TableProps } from './components/table/react/Table';
+
+export { TableBody, TableBodyProps } from './components/table/react/TableBody';
+
+export { TableCell, TableCellProps, TableCellVariant, ThOrder, ThScope } from './components/table/react/TableCell';
+
+export { TableHeader, TableHeaderProps } from './components/table/react/TableHeader';
+
+export { TableRow, TableRowProps } from './components/table/react/TableRow';
+
+export { Tabs, TabsProps, TabsLayout, TabsPosition } from './components/tabs/react/Tabs';
+
+export { Tab, TabProps } from './components/tabs/react/Tab';
+
+export { TextField, TextFieldProps } from './components/text-field/react/TextField';
 
 export {
-    CLASSNAME as AvatarClassName,
-    Avatar,
-    AvatarProps,
-    Sizes as AvatarSize,
-    Theme as AvatarTheme,
-    Themes as AvatarThemes,
-} from './components/avatar/react/Avatar';
-
-export {
-    CLASSNAME as ButtonClassName,
-    Button,
-    ButtonProps,
-    Color as ButtonColor,
-    Colors as ButtonColors,
-    Emphasis as ButtonEmphasis,
-    Emphasises as ButtonEmphasises,
-    Size as ButtonSize,
-    Sizes as ButtonSizes,
-    Theme as ButtonTheme,
-    Themes as ButtonThemes,
-    Variant as ButtonVariant,
-    Variants as ButtonVariants,
-} from './components/button/react/Button';
-
-export {
-    CLASSNAME as ButtonGroupClassName,
-    ButtonGroup,
-    ButtonGroupProps,
-    Color as ButtonGroupColor,
-    Colors as ButtonGroupColors,
-    Size as ButtonGroupSize,
-    Sizes as ButtonGroupSizes,
-    Theme as ButtonGroupTheme,
-    Themes as ButtonGroupThemes,
-} from './components/button/react/ButtonGroup';
-
-export {
-    CLASSNAME as CheckboxClassName,
-    Checkbox,
-    CheckboxProps,
-    Theme as CheckboxTheme,
-    Themes as CheckboxThemes,
-} from './components/checkbox/react/Checkbox';
-
-export {
-    CLASSNAME as ChipClassName,
-    Chip,
-    ChipProps,
-    Size as ChipSize,
-    Sizes as ChipSizes,
-    Theme as ChipTheme,
-    Themes as ChipThemes,
-} from './components/chip/react/Chip';
-
-export {
-    CLASSNAME as DividerClassName,
-    Divider,
-    DividerProps,
-    Theme as DividerTheme,
-    Themes as DividerThemes,
-} from './components/divider/react/Divider';
-
-export { CLASSNAME as DropdownClassName, Dropdown, DropdownProps } from './components/dropdown/react/Dropdown';
-
-export {
-    CLASSNAME as DropdownButtonClassName,
-    Color as DropdownButtonColor,
-    Colors as DropdownButtonColors,
-    Emphasis as DropdownButtonEmphasis,
-    Emphasises as DropdownButtonEmphasises,
-    DropdownButton,
-    DropdownButtonProps,
-    Size as DropdownButtonSize,
-    Sizes as DropdownButtonSizes,
-    Theme as DropdownButtonTheme,
-    Themes as DropdownButtonThemes,
-} from './components/button/react/DropdownButton';
-
-export {
-    CLASSNAME as IconClassName,
-    Color as IconColor,
-    Colors as IconColors,
-    Icon,
-    IconProps,
-    Size as IconSize,
-    Sizes as IconSizes,
-} from './components/icon/react/Icon';
-
-export {
-    CLASSNAME as IconButtonClassName,
-    Color as IconButtonColor,
-    Colors as IconButtonColors,
-    Emphasis as IconButtonEmphasis,
-    Emphasises as IconButtonEmphasises,
-    IconButton,
-    IconButtonProps,
-    Size as IconButtonSize,
-    Sizes as IconButtonSizes,
-    Theme as IconButtonTheme,
-    Themes as IconButtonThemes,
-    Variant as IconButtonVariant,
-    Variants as IconButtonVariants,
-} from './components/button/react/IconButton';
-
-export {
-    CLASSNAME as ImageBlockClassName,
-    CaptionPositions as ImageBlockCaptionPositions,
-    ImageBlock,
-    ImageBlockProps,
-    Theme as ImageBlockTheme,
-    Themes as ImageBlockThemes,
-} from './components/image-block/react/ImageBlock';
-
-export {
-    CLASSNAME as LightboxClassName,
-    Lightbox,
-    LightboxProps,
-    Theme as LightboxTheme,
-    Themes as LightboxThemes,
-} from './components/lightbox/react/Lightbox';
-
-export {
-    CLASSNAME as ListClassName,
-    List,
-    ListProps,
-    Theme as ListTheme,
-    Themes as ListThemes,
-} from './components/list/react/List';
-
-export { CLASSNAME as ListDividerClassName, ListDivider, ListDividerProps } from './components/list/react/ListDivider';
-
-export {
-    CLASSNAME as ListItemClassName,
-    ListItem,
-    ListItemProps,
-    Sizes as ListItemSizes,
-    Theme as ListItemTheme,
-    Themes as ListItemThemes,
-} from './components/list/react/ListItem';
-
-export {
-    CLASSNAME as ListSubheaderClassName,
-    ListSubheader,
-    ListSubheaderProps,
-    Theme as ListSubheaderTheme,
-    Themes as ListSubheaderThemes,
-} from './components/list/react/ListSubheader';
-
-export {
-    CLASSNAME as PopoverClassName,
-    Popover,
-    PopoverProps,
-    Placements,
-    PopperPositions,
-    IPopperOffsets,
-    PopperOffsets,
-} from './components/popover/react/Popover';
-
-export {
-    CLASSNAME as ProgressClassName,
-    Progress,
-    ProgressProps,
-    Variants,
-} from './components/progress/react/Progress';
-
-export {
-    CLASSNAME as ProgressTrackerClassName,
-    ProgressTracker,
-    ProgressTrackerProps,
-} from './components/progress-tracker/react/ProgressTracker';
-
-export {
-    CLASSNAME as ProgressTrackerStepClassName,
-    ProgressTrackerStep,
-    ProgressTrackerStepProps,
-} from './components/progress-tracker/react/ProgressTrackerStep';
-
-export {
-    CLASSNAME as SlideshowClassName,
-    Slideshow,
-    SlideshowProps,
-    Theme as SlideshowTheme,
-    Themes as SlideshowThemes,
-} from './components/slideshow/react/Slideshow';
-
-export { CLASSNAME as SlideshowItemClassName, SlideshowItem } from './components/slideshow/react/SlideshowItem';
-
-export {
-    CLASSNAME as SwitchClassName,
-    Position as SwitchPosition,
-    Positions as SwitchPositions,
-    Switch,
-    SwitchProps,
-    Theme as SwitchTheme,
-    Themes as SwitchThemes,
-} from './components/switch/react/Switch';
-
-export { CLASSNAME as TableClassName, Table, TableProps, Theme as TableTheme } from './components/table/react/Table';
-
-export { CLASSNAME as TableBodyClassName, TableBody, TableBodyProps } from './components/table/react/TableBody';
-
-export {
-    CLASSNAME as TableCellClassName,
-    TableCell,
-    TableCellProps,
-    Orders as ThOrder,
-    Scopes as ThScope,
-    Variants as TableCellVariant,
-} from './components/table/react/TableCell';
-
-export { CLASSNAME as TableHeaderClassName, TableHeader, TableHeaderProps } from './components/table/react/TableHeader';
-
-export { CLASSNAME as TableRowClassName, TableRow, TableRowProps } from './components/table/react/TableRow';
-
-export {
-    CLASSNAME as TabsClassName,
-    Tabs,
-    TabsProps,
-    Theme as TabsTheme,
-    Themes as TabsThemes,
-} from './components/tabs/react/Tabs';
-
-export {
-    CLASSNAME as TextFieldClassName,
-    TextField,
-    TextFieldProps,
-    Theme as TextFieldTheme,
-    Themes as TextFieldThemes,
-} from './components/text-field/react/TextField';
-
-export {
-    AspectRatios as ThumbnailAspectRatios,
-    AspectRatio as ThumbnailAspectRatio,
-    CLASSNAME as ThumbnailClassName,
-    Sizes as ThumbnailSizes,
     Thumbnail,
     ThumbnailProps,
-    Theme as ThumbnailTheme,
-    Themes as ThumbnailThemes,
-    Variants as ThumbnailVariants,
+    ThumbnailVariant,
+    ThumbnailAspectRatio,
 } from './components/thumbnail/react/Thumbnail';
 
-export {
-    CLASSNAME as TooltipClassName,
-    Tooltip,
-    TooltipPlacement,
-    TooltipProps,
-} from './components/tooltip/react/Tooltip';
+export { Tooltip, TooltipProps, TooltipPlacement } from './components/tooltip/react/Tooltip';
 
-export {
-    CLASSNAME as UserBlockClassName,
-    UserBlock,
-    UserBlockProps,
-    Sizes as UserBlockSize,
-    Theme as UserBlockTheme,
-    Themes as UserBlockThemes,
-} from './components/user-block/react/UserBlock';
+export { UserBlock, UserBlockProps } from './components/user-block/react/UserBlock';

--- a/yo-generators/generator-lumx-component/generators/component/templates/ClassComponent.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/component/templates/ClassComponent.tsx.ejs
@@ -77,9 +77,9 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
         <%_ if (validateComponent) { -%>
         const newChildren: ReactNode = this.validate({ ...this.props });
 
-        const { className, ...props }: <%= componentName %>Props = this.props;
+        const { className, ...props } = this.props;
         <%_ } else { -%>
-        const { children, className, ...props }: <%= componentName %>Props = this.props;
+        const { children, className, ...props } = this.props;
         <%_ } -%>
 
         return (

--- a/yo-generators/generator-lumx-component/generators/component/templates/ClassComponent.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/component/templates/ClassComponent.tsx.ejs
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -73,9 +73,9 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
 
     public state: IState = {};
 
-    public render(): React.ReactNode {
+    public render(): ReactElement {
         <%_ if (validateComponent) { -%>
-        const newChildren: React.ReactNode = this.validate({ ...this.props });
+        const newChildren: ReactNode = this.validate({ ...this.props });
 
         const { className, ...props }: <%= componentName %>Props = this.props;
         <%_ } else { -%>
@@ -130,7 +130,7 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
      * @param  params The parameters received from the `validateComponent` function.
      * @return The transformed child (or the original one if there is no transformation to do).
      */
-    private transformChild({ child, children, childrenCount, index }: ChildTransformParameters): React.ReactNode {
+    private transformChild({ child, children, childrenCount, index }: ChildTransformParameters): ReactNode {
         // Do your transformation here. Here is an example:
         if (typeof child === 'string') {
             return <span>{child}</span>;
@@ -164,7 +164,7 @@ class <%= componentName %> extends React.<%= componentType %>Component<<%= compo
      * @param  props The children and props of the component.
      * @return The processed children of the component.
      */
-    private validate(props: <%= componentName %>Props): React.ReactNode {
+    private validate(props: <%= componentName %>Props): ReactNode {
         return validateComponent(COMPONENT_NAME, {
             <%_ if (checkChildrenTypes) { -%>
             allowedTypes: [

--- a/yo-generators/generator-lumx-component/generators/component/templates/FunctionalComponent.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/component/templates/FunctionalComponent.tsx.ejs
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -112,7 +112,7 @@ function _transformChild({
     childrenCount,
     index,
     props,
-}: ChildTransformParameters): React.ReactNode {
+}: ChildTransformParameters): ReactNode {
     // Do your transformation here. Here is an example:
     if (typeof child === 'string') {
         return <span>{child}</span>;
@@ -152,7 +152,7 @@ function _validateChild({
  * @param  props The children and props of the component.
  * @return The processed children of the component.
  */
-function _validate(props: <%= componentName %>Props): React.ReactNode {
+function _validate(props: <%= componentName %>Props): ReactNode {
     return validateComponent(COMPONENT_NAME, {
         <%_ if (checkChildrenTypes) { -%>
         allowedTypes: [
@@ -191,9 +191,9 @@ function _validate(props: <%= componentName %>Props): React.ReactNode {
  *
  * @return The component.
  */
-const <%= componentName %>: React.FC<<%= componentName %>Props> = ({ children, className = '', ...props }: <%= componentName %>Props): React.ReactElement => {
+const <%= componentName %>: React.FC<<%= componentName %>Props> = ({ children, className = '', ...props }: <%= componentName %>Props): ReactElement => {
     <%_ if (validateComponent) { -%>
-    const newChildren: React.ReactNode = _validate({ children, ...props });
+    const newChildren: ReactNode = _validate({ children, ...props });
 
     <%_ } -%>
     return (

--- a/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { <%= componentName %>, <%= componentName %>Theme, <%= componentName %>Themes } from 'LumX';
+import { <%= componentName %>, Theme } from 'LumX';
 
 /////////////////////////////
 
@@ -8,7 +8,7 @@ interface IProps {
     /**
      * The theme to use to display this demo.
      */
-    theme: <%= componentName %>Theme;
+    theme: Theme;
 }
 
 /////////////////////////////

--- a/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import { <%= componentName %>, <%= componentName %>Theme, <%= componentName %>Themes } from 'LumX';
 
@@ -18,7 +18,7 @@ interface IProps {
  *
  * @return The demo component.
  */
-const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement => (
+const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
     <Fragment>
         <<%= componentName %> theme={theme}>Default <%= componentName %></<%= componentName %>>
     </Fragment>

--- a/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/demo/templates/default.tsx.ejs
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 import { <%= componentName %>, <%= componentName %>Theme, <%= componentName %>Themes } from 'LumX';
 
@@ -19,9 +19,9 @@ interface IProps {
  * @return The demo component.
  */
 const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => (
-    <Fragment>
+    <>
         <<%= componentName %> theme={theme}>Default <%= componentName %></<%= componentName %>>
-    </Fragment>
+    </>
 );
 
 /////////////////////////////

--- a/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
@@ -1,4 +1,4 @@
-import React<% if (validateComponent && checkChildrenNumber) {%>, { Fragment }<% } %> from 'react';
+import React<% if (validateComponent && checkChildrenNumber) {%>, { Fragment, ReactNode, ReactElement }<% } %> from 'react';
 
 import { mount, shallow } from 'enzyme';
 <%_ if (validateComponent && checkChildrenTypes) { -%>
@@ -49,7 +49,7 @@ const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
         ...propsOverrides,
     };
 
-    const renderer: (el: React.ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<<%= componentName %> {...props} />);
 
@@ -133,7 +133,7 @@ describe(`<${<%= componentName %>.displayName}>`, (): void => {
         });
 
         it('should fail when more than 2 children are given', (): void => {
-            const children: React.ReactNode = (
+            const children: ReactNode = (
                 <Fragment>
                     <span>Label</span>
                     <span>Label 2</span>
@@ -154,7 +154,7 @@ describe(`<${<%= componentName %>.displayName}>`, (): void => {
         it('should fail when anything else than text, <span> or <p> is given as child', (): void => {
             mockConsole('debug');
 
-            const children: React.ReactNode = <div>Label</div>;
+            const children: ReactNode = <div>Label</div>;
 
             expect(
                 (): void => {

--- a/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
@@ -35,10 +35,9 @@ interface ISetup extends ICommonSetup {
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  *
- * @param  {ISetupProps} props  The props to use to override the default props of the component.
- * @param  {boolean}     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return {ISetup}      An object with the props, the component wrapper and some shortcut to some element inside of the
- *                       component.
+ * @param  props  The props to use to override the default props of the component.
+ * @param  [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return An object with the props, the component wrapper and some shortcut to some element inside of the component.
  */
 const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
     { ...propsOverrides }: ISetupProps = {},
@@ -67,7 +66,7 @@ describe(`<${<%= componentName %>.displayName}>`, (): void => {
         // Here is an example of a basic rendering check, with snapshot.
 
         it('should render correctly', (): void => {
-            const { root, wrapper }: ISetup = setup();
+            const { root, wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toExist();
@@ -82,7 +81,7 @@ describe(`<${<%= componentName %>.displayName}>`, (): void => {
         // Here are some examples of basic props check.
 
         it('should use default props', (): void => {
-            const { root }: ISetup = setup();
+            const { root } = setup();
 
             Object.keys(DEFAULT_PROPS).forEach(
                 (prop: string): void => {
@@ -109,7 +108,7 @@ describe(`<${<%= componentName %>.displayName}>`, (): void => {
         );
 
         it('should trigger `onClick` when clicked', (): void => {
-            const { root }: ISetup = setup({ onClick }, false);
+            const { root } = setup({ onClick }, false);
 
             root.simulate('click');
 

--- a/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
@@ -39,7 +39,7 @@ interface ISetup extends ICommonSetup {
  * @param  [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
  * @return An object with the props, the component wrapper and some shortcut to some element inside of the component.
  */
-const setup: (props?: ISetupProps, shallowRendering?: boolean) => ISetup = (
+const setup = (
     { ...propsOverrides }: ISetupProps = {},
     shallowRendering: boolean = true,
 ): ISetup => {

--- a/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
+++ b/yo-generators/generator-lumx-component/generators/tests/templates/Component.test.tsx.ejs
@@ -1,4 +1,4 @@
-import React<% if (validateComponent && checkChildrenNumber) {%>, { Fragment, ReactNode, ReactElement }<% } %> from 'react';
+import React<% if (validateComponent && checkChildrenNumber) {%>, { ReactNode, ReactElement }<% } %> from 'react';
 
 import { mount, shallow } from 'enzyme';
 <%_ if (validateComponent && checkChildrenTypes) { -%>
@@ -133,11 +133,11 @@ describe(`<${<%= componentName %>.displayName}>`, (): void => {
 
         it('should fail when more than 2 children are given', (): void => {
             const children: ReactNode = (
-                <Fragment>
+                <>
                     <span>Label</span>
                     <span>Label 2</span>
                     <span>Label 3</span>
-                </Fragment>
+                </>
             );
 
             expect(


### PR DESCRIPTION
- Use ReactElement instead of React.ReactElement
- Use ReactNode instead of React.ReactNode
- Use ReactElement over ReactNode to be more specific when possible.
- Remove array/object destructuring typedefs when redundant
- Remove lambda typedefs when redundant
- Remove `// tslint:disable...` comments when trivially uneccessary
- Add `Callback` in place of `() => void` for readability when relevant
- Replace `<Fragment>` with `<>`
- Generalize use for core enums (ex: `Themes`, `Sizes`) instead of redefining new enums for each component
- Remove redundant import/export (ex: re-exporting a type that was just imported)
- Use type union to subset the `Size` enum instead of redefining new size enums for each components
ex: `type UserBlockSize = Size.s | Size.m | Size.l;`