### PR TITLE
fix(config): fix failing imports due to multiple package.json files

### DIFF
--- a/src/core/angularjs/constants/theme_constant.js
+++ b/src/core/angularjs/constants/theme_constant.js
@@ -1,4 +1,4 @@
-import { MODULE_NAME, SERVICE_PREFIX } from 'LumX/angularjs/constants/common_constants';
+import { MODULE_NAME, SERVICE_PREFIX } from './common_constants';
 
 /////////////////////////////
 

--- a/src/core/angularjs/lumx.js
+++ b/src/core/angularjs/lumx.js
@@ -1,4 +1,4 @@
-import { MODULE_NAME } from 'LumX/angularjs/constants/common_constants';
+import { MODULE_NAME } from './constants/common_constants';
 
 angular.module(`${MODULE_NAME}.utils.depth`, []);
 angular.module(`${MODULE_NAME}.utils.enter-keypress`, []);

--- a/src/core/angularjs/utils/depth_service.js
+++ b/src/core/angularjs/utils/depth_service.js
@@ -1,4 +1,4 @@
-import { MODULE_NAME, SERVICE_PREFIX } from 'LumX/angularjs/constants/common_constants';
+import { MODULE_NAME, SERVICE_PREFIX } from '../constants/common_constants';
 
 /////////////////////////////
 

--- a/src/core/angularjs/utils/enter-keypress_directive.js
+++ b/src/core/angularjs/utils/enter-keypress_directive.js
@@ -1,5 +1,5 @@
-import { ENTER_KEY_CODE } from 'LumX/core/constants';
-import { COMPONENT_PREFIX, MODULE_NAME } from 'LumX/angularjs/constants/common_constants';
+import { ENTER_KEY_CODE } from '../../constants';
+import { COMPONENT_PREFIX, MODULE_NAME } from '../constants/common_constants';
 
 /////////////////////////////
 

--- a/src/core/angularjs/utils/event-scheduler_service.js
+++ b/src/core/angularjs/utils/event-scheduler_service.js
@@ -1,4 +1,4 @@
-import { MODULE_NAME, SERVICE_PREFIX } from 'LumX/angularjs/constants/common_constants';
+import { MODULE_NAME, SERVICE_PREFIX } from '../constants/common_constants';
 
 /////////////////////////////
 

--- a/src/core/angularjs/utils/focus-on-init_directive.js
+++ b/src/core/angularjs/utils/focus-on-init_directive.js
@@ -1,4 +1,4 @@
-import { COMPONENT_PREFIX, MODULE_NAME } from 'LumX/angularjs/constants/common_constants';
+import { COMPONENT_PREFIX, MODULE_NAME } from '../constants/common_constants';
 
 /////////////////////////////
 

--- a/src/core/angularjs/utils/focus-trap_service.js
+++ b/src/core/angularjs/utils/focus-trap_service.js
@@ -1,5 +1,5 @@
-import { TAB_KEY_CODE } from 'LumX/core/constants';
-import { MODULE_NAME, SERVICE_PREFIX } from 'LumX/angularjs/constants/common_constants';
+import { TAB_KEY_CODE } from '../../constants';
+import { MODULE_NAME, SERVICE_PREFIX } from '../constants/common_constants';
 
 /////////////////////////////
 

--- a/src/core/angularjs/utils/utils_service.js
+++ b/src/core/angularjs/utils/utils_service.js
@@ -1,4 +1,4 @@
-import { COMPONENT_PREFIX, MODULE_NAME, SERVICE_PREFIX } from 'LumX/angularjs/constants/common_constants';
+import { COMPONENT_PREFIX, MODULE_NAME, SERVICE_PREFIX } from '../constants/common_constants';
 
 /////////////////////////////
 


### PR DESCRIPTION
Webpack aliases are not tolerated by eslint inside `core` folder due to the presence of multiple `package.json` files (one for each package).