### PR TITLE
feat(icon): add color variant parameter

### DIFF
--- a/src/components/icon/angularjs/icon_directive.js
+++ b/src/components/icon/angularjs/icon_directive.js
@@ -35,6 +35,16 @@ function IconDirective() {
             }).addClass(`${CSS_PREFIX}-icon--color-${color}`);
         });
 
+        attrs.$observe('lumxColorVariant', (colorVariant) => {
+            if (!colorVariant) {
+                return;
+            }
+
+            el.removeClass((index, className) => {
+                return (className.match(/(?:\S|-)*icon--color-variant-\S+/g) || []).join(' ');
+            }).addClass(`${CSS_PREFIX}-icon--color-variant-${colorVariant}`);
+        });
+
         attrs.$observe('lumxSize', (size) => {
             if (!size) {
                 return;

--- a/src/components/icon/react/Icon.test.tsx
+++ b/src/components/icon/react/Icon.test.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react';
 import { mount, shallow } from 'enzyme';
 import { build, fake, oneOf } from 'test-data-bot';
 
-import { Size } from 'LumX';
+import { ColorPalette, ColorVariant, Size } from 'LumX';
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
 import { getBasicClass } from 'LumX/core/utils';
 import { mdiCheck, mdiPlus } from 'LumX/icons';
@@ -81,6 +81,11 @@ describe(`<${Icon.displayName}>`, (): void => {
 
             expect(svg).toExist();
             expect(path).toExist();
+        });
+
+        it('should render color & color variant', (): void => {
+            const { wrapper } = setup({ color: ColorPalette.primary, colorVariant: ColorVariant.D1 });
+            expect(wrapper).toMatchSnapshot();
         });
     });
 

--- a/src/components/icon/react/Icon.tsx
+++ b/src/components/icon/react/Icon.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import isEmpty from 'lodash/isEmpty';
 
-import { Color, Size } from 'LumX';
+import { Color, ColorVariant, Size } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, ValidateParameters, getRootClassName, validateComponent } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -29,6 +29,11 @@ interface IProps extends IGenericProps {
      * The icon color.
      */
     color?: Color;
+
+    /**
+     * The icon color variant.
+     */
+    colorVariant?: ColorVariant;
 
     /**
      * The icon size.
@@ -109,6 +114,7 @@ function _validate(props: IconProps): ReactNode {
 const Icon: React.FC<IconProps> = ({
     className,
     color,
+    colorVariant,
     icon,
     iconRef = DEFAULT_PROPS.iconRef,
     size,
@@ -119,7 +125,7 @@ const Icon: React.FC<IconProps> = ({
     return (
         <i
             ref={iconRef}
-            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, size }))}
+            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant, size }))}
             {...props}
         >
             <svg

--- a/src/components/icon/react/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/icon/react/__snapshots__/Icon.test.tsx.snap
@@ -2,6 +2,30 @@
 
 exports[`<Icon> Conditions should fail when no \`icon\` is given 1`] = `"<Icon> must have an \`icon\` prop!"`;
 
+exports[`<Icon> Snapshots and structure should render color & color variant 1`] = `
+<i
+  className="lumx-icon lumx-icon--color-primary lumx-icon--color-variant-D1"
+>
+  <svg
+    aria-hidden="true"
+    height="1em"
+    preserveAspectRatio="xMidYMid meet"
+    style={
+      Object {
+        "verticalAlign": "-0.125em",
+      }
+    }
+    viewBox="0 0 24 24"
+    width="1em"
+  >
+    <path
+      d="mdiPlus"
+      fill="currentColor"
+    />
+  </svg>
+</i>
+`;
+
 exports[`<Icon> Snapshots and structure should render correctly 1`] = `
 <i
   className="lumx-icon"

--- a/src/components/icon/style/lumapps/_index.scss
+++ b/src/components/icon/style/lumapps/_index.scss
@@ -17,17 +17,23 @@
 /* Icon sizes
    ========================================================================== */
 
-@each $key, $size in $lumx-sizes {
-    .#{$lumx-base-prefix}-icon--size-#{$key} {
-        @include lumx-icon-size($key);
+@each $size-key, $size in $lumx-sizes {
+    .#{$lumx-base-prefix}-icon--size-#{$size-key} {
+        @include lumx-icon-size($size-key);
     }
 }
 
 /* Button colors
    ========================================================================== */
 
-@each $key, $color in $lumx-theme-color-palette {
-    .#{$lumx-base-prefix}-icon--color-#{$key} {
-        @include lumx-icon-color($key);
+@each $color-key, $color in $lumx-theme-color-palette {
+    .#{$lumx-base-prefix}-icon--color-#{$color-key} {
+        @include lumx-icon-color($color-key, N);
+    }
+
+    @each $color-variant in $lumx-theme-color-variants {
+        .#{$lumx-base-prefix}-icon--color-#{$color-key}.#{$lumx-base-prefix}-icon--color-variant-#{$color-variant} {
+            @include lumx-icon-color($color-key, $color-variant);
+        }
     }
 }

--- a/src/components/icon/style/lumapps/_mixins.scss
+++ b/src/components/icon/style/lumapps/_mixins.scss
@@ -2,6 +2,6 @@
     font-size: map-get($lumx-sizes, $size);
 }
 
-@mixin lumx-icon-color($color) {
-    color: lumx-theme-color-variant($color, N);
+@mixin lumx-icon-color($color, $color-variant) {
+    color: lumx-theme-color-variant($color, $color-variant);
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,8 +20,12 @@ interface IComplexPropDefault<T> {
 }
 type ComplexPropDefault<T> = IComplexPropDefault<T>;
 
+/**
+ * See SCSS variable $lumx-theme-color-palette
+ */
 enum ColorPalette {
     primary = 'primary',
+    secondary = 'secondary',
     blue = 'blue',
     dark = 'dark',
     green = 'green',
@@ -30,6 +34,21 @@ enum ColorPalette {
     light = 'light',
 }
 type Color = ColorPalette | string;
+
+/**
+ * See SCSS variable $lumx-theme-color-variants
+ */
+enum ColorVariant {
+    D1 = 'D1',
+    D2 = 'D2',
+    L1 = 'L1',
+    L2 = 'L2',
+    L3 = 'L3',
+    L4 = 'L4',
+    L5 = 'L5',
+    L6 = 'L6',
+    N = 'N',
+}
 
 enum Theme {
     light = 'light',
@@ -62,4 +81,4 @@ enum Emphasis {
 
 /////////////////////////////
 
-export { Alignment, ComplexPropDefault, Color, ColorPalette, Theme, Size, Orientation, Emphasis };
+export { Alignment, ComplexPropDefault, Color, ColorPalette, ColorVariant, Theme, Size, Orientation, Emphasis };


### PR DESCRIPTION
Add color variant parameter

To do in React version :
Add color-variant prop (no default value = if no prop, no class)
Associated class: lumx-icon--color-variant-{colorVariant} (N, L2, L5...)