### PR TITLE
fix(react-list): cast children as array when unique child

### DIFF
--- a/demo/react/doc/product/components/list.mdx
+++ b/demo/react/doc/product/components/list.mdx
@@ -1,0 +1,3 @@
+```javascript import
+import { List } from 'LumX';
+```

--- a/demo/react/doc/product/components/select.mdx
+++ b/demo/react/doc/product/components/select.mdx
@@ -1,5 +1,5 @@
 ```javascript import
-import { Select, List, ListItem, ListItemSize, Size, TextField, Chip, ListDivider, Icon } from 'LumX';
+import { Select, List, ListItem, ListItemSize, Size, TextField, Chip, ListDivider, Icon, ListSubheader } from 'LumX';
 import { useBooleanState } from 'LumX/core/react/hooks';
 import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from '@mdi/js';
 ```
@@ -223,31 +223,29 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
             }}
         >
             <List isClickable={isOpen}>
-                <div>
+                <ListSubheader>
                     <TextField
+                        style={{ width: '100%', padding: 0 }}
                         value={filterValue}
-                        initialValue={filterValue}
                         onChange={setFilterValue}
                         icon={mdiMagnify}
                     />
-                    <ListDivider />
-                </div>
-                <div>
-                    {filteredChoices.length > 0
-                        ? filteredChoices.map((choice, index) => (
-                              <ListItem
-                                  size={ListItemSize.tiny}
-                                  isClickable
-                                  isSelected={values.includes(choice.label)}
-                                  key={index}
-                                  onItemSelected={() => onItemSelectedHandler(choice.label)}
-                                  before={<Icon size={Size.xs} icon={choice.icon} />}
-                              >
-                                  <div>{choice.label}</div>
-                              </ListItem>
-                          ))
-                        : [<ListItem key={0}>No data</ListItem>]}
-                </div>
+                </ListSubheader>
+                <ListDivider />
+                {filteredChoices.length > 0
+                    ? filteredChoices.map((choice, index) => (
+                            <ListItem
+                                size={ListItemSize.tiny}
+                                isClickable
+                                isSelected={values.includes(choice.label)}
+                                key={index}
+                                onItemSelected={() => onItemSelectedHandler(choice.label)}
+                                before={<Icon size={Size.xs} icon={choice.icon} />}
+                            >
+                                <div>{choice.label}</div>
+                            </ListItem>
+                        ))
+                    : [<ListItem key={0}>No data</ListItem>]}
             </List>
         </Select>
     );

--- a/src/components/expansion-panel/react/ExpansionPanel.tsx
+++ b/src/components/expansion-panel/react/ExpansionPanel.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
+import React, { Children, PropsWithChildren, ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -7,7 +7,7 @@ import { Button, ButtonEmphasis, ButtonVariant, ColorPalette, DragHandle, Theme 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { Callback, IGenericProps, getRootClassName, isComponent, partitionMulti } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
-import { castArray, get, isEmpty, isFunction } from 'lodash';
+import { get, isEmpty, isFunction } from 'lodash';
 
 /////////////////////////////
 
@@ -82,7 +82,7 @@ const ExpansionPanel: React.FC<ExpansionPanelProps> = (props: ExpansionPanelProp
         ...otherProps
     } = props;
 
-    const children: ReactNode[] = castArray(props.children);
+    const children: ReactNode[] = Children.toArray(props.children);
 
     // partition children by types
     const [[dragHandle], [header], [footer], content] = partitionMulti(children, [isDragHandle, isHeader, isFooter]);

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -156,13 +156,13 @@ const List: React.FC<ListProps> = ({
      * @return Index of the element to activate.
      */
     const selectItemOnKeyDown = (previous: boolean): number => {
-        const lookupTable: Array<ListItem | ListSubheader> = children
+        const lookupTable: ListChild[] = children
             .slice(activeItemIndex + 1)
             .concat(children.slice(0, activeItemIndex + 1));
 
         if (previous) {
             lookupTable.reverse();
-            const first: ListItem | ListSubheader = lookupTable.shift();
+            const first: ListChild = lookupTable.shift();
             lookupTable.push(first);
         }
 

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -16,7 +16,7 @@ import { handleBasicClasses } from 'LumX/core/utils';
  * Defines the props of the component.
  */
 interface IListProps extends IGenericProps {
-    children: ListItem[];
+    children: ListItem[] | ListItem;
     /* Whether the list items are clickable */
     isClickable?: boolean;
     /**
@@ -73,6 +73,7 @@ const List: React.FC<ListProps> = ({
     theme = DEFAULT_PROPS.theme,
     ...props
 }: ListProps): ReactElement => {
+    const childrenAsAnArray = Array.isArray(children) ? children : [children];
     const [activeItemIndex, setActiveItemIndex] = useState(-1);
     const preventResetOnBlurOrFocus = useRef(false);
     const listElementRef = useRef() as RefObject<HTMLUListElement>;
@@ -142,7 +143,7 @@ const List: React.FC<ListProps> = ({
         } else if (evt.keyCode === ENTER_KEY_CODE && onListItemSelected) {
             evt.nativeEvent.preventDefault();
             evt.nativeEvent.stopPropagation();
-            onListItemSelected(children[activeItemIndex]);
+            onListItemSelected(childrenAsAnArray[activeItemIndex]);
         }
     };
 
@@ -153,9 +154,9 @@ const List: React.FC<ListProps> = ({
      * @return Index of the element to activate.
      */
     const selectItemOnKeyDown = (previous: boolean): number => {
-        const lookupTable: Array<ListItem | ListSubheader> = children
+        const lookupTable: Array<ListItem | ListSubheader> = childrenAsAnArray
             .slice(activeItemIndex + 1)
-            .concat(children.slice(0, activeItemIndex + 1));
+            .concat(childrenAsAnArray.slice(0, activeItemIndex + 1));
 
         if (previous) {
             lookupTable.reverse();
@@ -167,7 +168,7 @@ const List: React.FC<ListProps> = ({
 
         for (const child of lookupTable) {
             nextIdx = previous ? nextIdx - 1 : nextIdx + 1;
-            if (nextIdx > children.length - 1) {
+            if (nextIdx > childrenAsAnArray.length - 1) {
                 nextIdx = 0;
             }
             if (nextIdx < 0) {
@@ -198,7 +199,7 @@ const List: React.FC<ListProps> = ({
             ref={listElementRef}
             {...props}
         >
-            {flattenArray(children).map((elm: ListItem | ListSubheader, idx: number) => {
+            {flattenArray(childrenAsAnArray).map((elm: ListItem | ListSubheader, idx: number) => {
                 const elemProps: ListItemProps = {
                     key: `listEntry-${idx}`,
                 };

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, RefObject, cloneElement, useEffect, useRef, useState } from 'react';
+import React, { Children, ReactElement, RefObject, cloneElement, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -7,7 +7,7 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
 import { ListItem, ListItemProps, ListSubheader, Theme } from 'LumX';
-import { IGenericProps, flattenArray, getRootClassName } from 'LumX/core/react/utils';
+import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
 
 /////////////////////////////
@@ -73,7 +73,7 @@ const List: React.FC<ListProps> = ({
     theme = DEFAULT_PROPS.theme,
     ...props
 }: ListProps): ReactElement => {
-    const childrenAsAnArray = Array.isArray(children) ? children : [children];
+    const childrenAsAnArray = Children.toArray(children);
     const [activeItemIndex, setActiveItemIndex] = useState(-1);
     const preventResetOnBlurOrFocus = useRef(false);
     const listElementRef = useRef() as RefObject<HTMLUListElement>;
@@ -199,7 +199,7 @@ const List: React.FC<ListProps> = ({
             ref={listElementRef}
             {...props}
         >
-            {flattenArray(childrenAsAnArray).map((elm: ListItem | ListSubheader, idx: number) => {
+            {childrenAsAnArray.map((elm: ListItem | ListSubheader, idx: number) => {
                 const elemProps: ListItemProps = {
                     key: `listEntry-${idx}`,
                 };

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -66,7 +66,6 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  * @return The component.
  */
 const List: React.FC<ListProps> = ({
-    children,
     className = '',
     isClickable = DEFAULT_PROPS.isClickable,
     onListItemSelected,
@@ -76,7 +75,7 @@ const List: React.FC<ListProps> = ({
     const isValidChild = (elm: ReactChild): boolean => {
         return isComponent(ListItem)(elm) || isComponent(ListDivider)(elm) || isComponent(ListSubheader)(elm);
     };
-    const childrenAsAnArray = Children.toArray(children).filter(isValidChild);
+    const children = Children.toArray(props.children).filter(isValidChild);
     const [activeItemIndex, setActiveItemIndex] = useState(-1);
     const preventResetOnBlurOrFocus = useRef(false);
     const listElementRef = useRef() as RefObject<HTMLUListElement>;
@@ -146,7 +145,7 @@ const List: React.FC<ListProps> = ({
         } else if (evt.keyCode === ENTER_KEY_CODE && onListItemSelected) {
             evt.nativeEvent.preventDefault();
             evt.nativeEvent.stopPropagation();
-            onListItemSelected(childrenAsAnArray[activeItemIndex]);
+            onListItemSelected(children[activeItemIndex]);
         }
     };
 
@@ -157,9 +156,9 @@ const List: React.FC<ListProps> = ({
      * @return Index of the element to activate.
      */
     const selectItemOnKeyDown = (previous: boolean): number => {
-        const lookupTable: Array<ListItem | ListSubheader> = childrenAsAnArray
+        const lookupTable: Array<ListItem | ListSubheader> = children
             .slice(activeItemIndex + 1)
-            .concat(childrenAsAnArray.slice(0, activeItemIndex + 1));
+            .concat(children.slice(0, activeItemIndex + 1));
 
         if (previous) {
             lookupTable.reverse();
@@ -171,7 +170,7 @@ const List: React.FC<ListProps> = ({
 
         for (const child of lookupTable) {
             nextIdx = previous ? nextIdx - 1 : nextIdx + 1;
-            if (nextIdx > childrenAsAnArray.length - 1) {
+            if (nextIdx > children.length - 1) {
                 nextIdx = 0;
             }
             if (nextIdx < 0) {
@@ -202,7 +201,7 @@ const List: React.FC<ListProps> = ({
             ref={listElementRef}
             {...props}
         >
-            {childrenAsAnArray.map((elm: ListItem | ListSubheader, idx: number) => {
+            {children.map((elm: ListChild, idx: number) => {
                 if (!elm) {
                     return undefined;
                 }

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -1,4 +1,4 @@
-import React, { Children, ReactChild, ReactElement, RefObject, cloneElement, useEffect, useRef, useState } from 'react';
+import React, { Children, ReactElement, RefObject, cloneElement, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -16,7 +16,8 @@ type ListChild = ListItem | ListDivider | ListSubheader;
  * Defines the props of the component.
  */
 interface IListProps extends IGenericProps {
-    children: ListChild[] | ListChild;
+    // tslint:disable-next-line: array-type
+    children: Array<ListChild> | ListChild;
     /* Whether the list items are clickable */
     isClickable?: boolean;
     /**
@@ -72,10 +73,7 @@ const List: React.FC<ListProps> = ({
     theme = DEFAULT_PROPS.theme,
     ...props
 }: ListProps): ReactElement => {
-    const isValidChild = (elm: ReactChild): boolean => {
-        return isComponent(ListItem)(elm) || isComponent(ListDivider)(elm) || isComponent(ListSubheader)(elm);
-    };
-    const children = Children.toArray(props.children).filter(isValidChild);
+    const children = Children.toArray(props.children);
     const [activeItemIndex, setActiveItemIndex] = useState(-1);
     const preventResetOnBlurOrFocus = useRef(false);
     const listElementRef = useRef() as RefObject<HTMLUListElement>;
@@ -202,21 +200,16 @@ const List: React.FC<ListProps> = ({
             {...props}
         >
             {children.map((elm: ListChild, idx: number) => {
-                if (!elm) {
-                    return undefined;
-                }
-
-                const elemProps: ListItemProps = {
-                    key: `listEntry-${idx}`,
-                };
-
-                if (isClickable && elm.type && elm.type.name === 'ListItem') {
+                if (isClickable && isComponent(ListItem)(elm)) {
+                    const elemProps: ListItemProps = {};
                     elemProps.onMouseDown = (evt: React.MouseEvent): void => mouseDownHandler(evt, idx, elm.props);
                     elemProps.isActive = idx === activeItemIndex;
                     elemProps.isClickable = isClickable;
+
+                    return cloneElement(elm, { ...elemProps });
                 }
 
-                return cloneElement(elm, { ...elemProps });
+                return elm;
             })}
         </ul>
     );

--- a/src/components/side-navigation/react/SideNavigation.tsx
+++ b/src/components/side-navigation/react/SideNavigation.tsx
@@ -1,10 +1,10 @@
+import React, { Children, ReactElement } from 'react';
+
 import { SideNavigationItem, Theme } from 'LumX';
 import { handleBasicClasses } from 'LumX/core/utils';
 import { COMPONENT_PREFIX } from 'LumX/react/constants';
 import { IGenericProps, getRootClassName, isComponent } from 'LumX/react/utils';
 import classNames from 'classnames';
-import { castArray } from 'lodash';
-import React, { ReactElement } from 'react';
 
 /**
  * Defines the props of the component.
@@ -39,7 +39,7 @@ const DEFAULT_PROPS: Partial<SideNavigationProps> = {};
 const SideNavigation: React.FC<ISideNavigationProps> = (props: ISideNavigationProps): ReactElement => {
     const { className, theme, children, ...otherProps } = props;
 
-    const content = castArray(children).filter(isComponent(SideNavigationItem));
+    const content = Children.toArray(children).filter(isComponent(SideNavigationItem));
     return (
         <ul
             className={classNames(

--- a/src/components/side-navigation/react/SideNavigationItem.tsx
+++ b/src/components/side-navigation/react/SideNavigationItem.tsx
@@ -1,3 +1,5 @@
+import React, { Children, ReactElement } from 'react';
+
 import { Icon, Size } from 'LumX';
 import { Emphasis } from 'LumX/components/index';
 import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
@@ -5,8 +7,7 @@ import { mdiChevronDown, mdiChevronUp } from 'LumX/icons';
 import { COMPONENT_PREFIX } from 'LumX/react/constants';
 import { Callback, IGenericProps, getRootClassName, isComponent } from 'LumX/react/utils';
 import classNames from 'classnames';
-import { castArray, isEmpty } from 'lodash';
-import React, { ReactElement } from 'react';
+import { isEmpty } from 'lodash';
 
 /**
  * Defines the props of the component.
@@ -75,7 +76,7 @@ const SideNavigationItem: React.FC<ISideNavigationItemProps> = (props: ISideNavi
         ...otherProps
     } = props;
 
-    const content = castArray(children).filter(isComponent(SideNavigationItem));
+    const content = Children.toArray(children).filter(isComponent(SideNavigationItem));
     return (
         <li
             className={classNames(


### PR DESCRIPTION
#### What was the problem ? 
When a List contained only one ListItem (not from a Array.map), the component was crashing.
#### What caused the problem ?
It was due to the fact that the List component only accept an array as children. 
#### What has been done to resolve the problem ? 
To avoid crashes, I cast the children as an array if it is not.