### PR TITLE
feat(demo-react): manual prop table section (instead of the automatic one)

### DIFF
--- a/demo/react/doc/product/components/chip.mdx
+++ b/demo/react/doc/product/components/chip.mdx
@@ -149,3 +149,7 @@ Use small when space is a constraint, as in areas like text fields, selects, dro
     </Chip>
 </>
 ```
+
+# Properties 
+
+<PropTable component="Chip" />

--- a/demo/react/doc/product/components/dropdown.mdx
+++ b/demo/react/doc/product/components/dropdown.mdx
@@ -172,3 +172,7 @@ You can control the dropdown opening from outside easily.
     );
 }
 ```
+
+# Properties
+
+<PropTable component="Dropdown" />

--- a/demo/react/doc/product/components/expansion-panel.mdx
+++ b/demo/react/doc/product/components/expansion-panel.mdx
@@ -15,3 +15,7 @@ import { mdiEmail } from 'LumX/icons';
     </ExpansionPanel>
 </>
 ```
+
+# Properties
+
+<PropTable component="ExpansionPanel" />

--- a/demo/react/doc/product/components/popover.mdx
+++ b/demo/react/doc/product/components/popover.mdx
@@ -467,3 +467,8 @@ You can force the width of the popper to match the anchor width.
     );
 };
 ```
+
+
+# Properties
+
+<PropTable component="Popover" />

--- a/demo/react/doc/product/components/select.mdx
+++ b/demo/react/doc/product/components/select.mdx
@@ -474,3 +474,7 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
     );
 }
 ```
+
+# Properties
+
+<PropTable component="Select" />

--- a/demo/react/doc/product/components/side-navigation.mdx
+++ b/demo/react/doc/product/components/side-navigation.mdx
@@ -88,12 +88,12 @@ Side navigation items have three emphasises: _low_, _medium_, and _high_. Defaul
 );
 ```
 
+### Properties
 
-# Properties
+#### SideNavigation
 
-## SideNavigation
 <PropTable component="SideNavigation" />
 
-## SideNavigationItem
-<PropTable component="SideNavigationItem" />
+#### SideNavigationItem
 
+<PropTable component="SideNavigationItem" />

--- a/demo/react/doc/product/components/side-navigation.mdx
+++ b/demo/react/doc/product/components/side-navigation.mdx
@@ -87,3 +87,13 @@ Side navigation items have three emphasises: _low_, _medium_, and _high_. Defaul
     </>
 );
 ```
+
+
+# Properties
+
+## SideNavigation
+<PropTable component="SideNavigation" />
+
+## SideNavigationItem
+<PropTable component="SideNavigationItem" />
+

--- a/demo/react/layout/PropTable.tsx
+++ b/demo/react/layout/PropTable.tsx
@@ -1,39 +1,47 @@
 import { Table, TableBody, TableCell, TableCellVariant, TableHeader, TableRow } from 'LumX';
 import React, { ReactElement } from 'react';
 
+// @ts-ignore
+import { propsByComponent } from 'props-loader!';
+
 import orderBy from 'lodash/orderBy';
 
-const PropTable: React.FC<IPropTableProps> = ({ propertyList }: IPropTableProps): ReactElement => {
-    const renderTypeTableRow = ({ type, defaultValue }: IProperty): ReactElement => {
-        let formattedType = <>{type}</>;
-        const splitType = type.split(defaultValue);
+const renderTypeTableRow = ({ type, defaultValue }: IProperty): ReactElement => {
+    let formattedType = <>{type}</>;
+    const splitType = type.split(defaultValue);
 
-        if (splitType.length > 1) {
-            formattedType = (
-                <>
-                    {splitType[0]}
-                    <strong>{defaultValue}</strong>
-                    {splitType[1]}
-                </>
-            );
-        } else if (splitType.length === 1 && defaultValue) {
-            formattedType = (
-                <>
-                    {type}
-                    {' (default: '}
-                    <strong>{defaultValue}</strong>
-                    {')'}
-                </>
-            );
-        }
-
-        return (
-            <TableCell>
-                <code>{formattedType}</code>
-            </TableCell>
+    if (splitType.length > 1) {
+        formattedType = (
+            <>
+                {splitType[0]}
+                <strong>{defaultValue}</strong>
+                {splitType[1]}
+            </>
         );
-    };
+    } else if (splitType.length === 1 && defaultValue) {
+        formattedType = (
+            <>
+                {type}
+                {' (default: '}
+                <strong>{defaultValue}</strong>
+                {')'}
+            </>
+        );
+    }
 
+    return (
+        <TableCell>
+            <code>{formattedType}</code>
+        </TableCell>
+    );
+};
+
+const PropTable: React.FC<IPropTableProps> = ({ component }: IPropTableProps): ReactElement => {
+    const propertyList: IProperty[] = propsByComponent[component];
+
+    if (!propertyList) {
+        return <span>Could not load property table for {component}.</span>;
+    }
     return (
         <Table hasDividers>
             <TableHeader>
@@ -74,7 +82,7 @@ interface IProperty {
 }
 
 interface IPropTableProps {
-    propertyList: IProperty[];
+    component: string;
 }
 
 export { PropTable, IProperty };

--- a/demo/style/layout/main/_main.scss
+++ b/demo/style/layout/main/_main.scss
@@ -41,15 +41,18 @@
         }
 
         & > h2,
-        & > h3 {
+        & > h3,
+        & > h4 {
             margin-top: $lumx-spacing-unit * 2;
         }
 
         & > h1,
         & > h2,
         & > h3,
+        & > h4,
         & > p,
-        & > div {
+        & > div,
+        table {
             margin-bottom: $lumx-spacing-unit * 2;
 
             &:last-child {

--- a/webpack/react/mdx-demo-code-extractor/index.js
+++ b/webpack/react/mdx-demo-code-extractor/index.js
@@ -46,36 +46,8 @@ const isPreJSXDemo = (node) =>
     node.type === 'element' && node.tagName === 'pre' && get(node, ['children', 0, 'properties', 'jsx']);
 const ADDITIONAL_IMPORT = `
 import { DemoBlock } from 'LumX/demo/react/layout/DemoBlock';
-import { propsByComponent } from 'props-loader!';
 import { PropTable } from 'LumX/demo/react/layout/PropTable';
 `;
-
-/**
- * Create prop table section for each imported component.
- *
- * @param  {Array}  lumxImports list of LumX imported elements.
- * @return {Object} The JSX node for the prop table section.
- */
-function createPropSection(lumxImports) {
-    return {
-        type: 'jsx',
-        value: `
-            <h2>Properties</h2>
-            ${lumxImports
-                .map(
-                    (component) => `
-                {('${component}' in propsByComponent) && (
-                    <>
-                        <h3>${component}</h3>
-                        <PropTable propertyList={propsByComponent['${component}']} />
-                    </>
-                )}
-            `,
-                )
-                .join('')}
-        `,
-    };
-}
 
 /**
  * Recursively browse a node to replace '\n' in text node by '</br>' elements.
@@ -127,18 +99,11 @@ function replaceNewLineWithBreakLine(node) {
 module.exports = () => {
     return (tree) => {
         const [importNodes, others] = partition(tree.children, isImport);
-        const lumxImports = [];
 
         // Accumulate import statements.
         let importStatement = '';
         importNodes.forEach((node) => {
             const importCode = isJSXImport(node) ? node.value : get(node, ['children', 0, 'children', 0, 'value']);
-
-            const matches = importCode.match(/import { (.*) } from 'LumX'/);
-            if (matches) {
-                lumxImports.push(...matches[1].split(/,\s*/).filter(Boolean));
-            }
-
             importStatement += importCode;
         });
 
@@ -163,9 +128,5 @@ module.exports = () => {
                 return node;
             }),
         ];
-
-        if (lumxImports.length > 0) {
-            tree.children.push(createPropSection(lumxImports));
-        }
     };
 };


### PR DESCRIPTION
This PR removes the automatic insertion of the component properties tables in favor of manually inserting the prop table on the demo.