### PR TITLE
fix(react): removed const enum so they can be imported as object

### DIFF
--- a/src/components/expansion-panel/react/ExpansionPanel.tsx
+++ b/src/components/expansion-panel/react/ExpansionPanel.tsx
@@ -11,7 +11,7 @@ import { get, isEmpty, isFunction } from 'lodash';
 
 /////////////////////////////
 
-const enum ExpansionPanelVariant {
+enum ExpansionPanelVariant {
     boxed = 'boxed',
     trimmed = 'trimmed',
 }

--- a/src/components/select/react/Select.tsx
+++ b/src/components/select/react/Select.tsx
@@ -17,7 +17,7 @@ import { handleBasicClasses } from 'LumX/core/utils';
 /**
  * The authorized variants.
  */
-const enum SelectVariant {
+enum SelectVariant {
     input = 'input',
     chip = 'chip',
 }

--- a/src/components/thumbnail/react/Thumbnail.tsx
+++ b/src/components/thumbnail/react/Thumbnail.tsx
@@ -14,7 +14,7 @@ import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
 /**
  * All available aspect ratios.
  */
-const enum ThumbnailAspectRatio {
+enum ThumbnailAspectRatio {
     original = 'original',
     horizontal = 'horizontal',
     vertical = 'vertical',

--- a/src/react.index.ts
+++ b/src/react.index.ts
@@ -28,6 +28,13 @@ export { Icon, IconProps } from './components/icon/react/Icon';
 
 export { IconButton, IconButtonProps } from './components/button/react/IconButton';
 
+export {
+    Thumbnail,
+    ThumbnailProps,
+    ThumbnailVariant,
+    ThumbnailAspectRatio,
+} from './components/thumbnail/react/Thumbnail';
+
 export { ImageBlock, ImageBlockProps, ImageBlockCaptionPosition } from './components/image-block/react/ImageBlock';
 
 export { Lightbox, LightboxProps } from './components/lightbox/react/Lightbox';
@@ -79,13 +86,6 @@ export { Tabs, TabsProps, TabsLayout, TabsPosition } from './components/tabs/rea
 export { Tab, TabProps } from './components/tabs/react/Tab';
 
 export { TextField, TextFieldProps } from './components/text-field/react/TextField';
-
-export {
-    Thumbnail,
-    ThumbnailProps,
-    ThumbnailVariant,
-    ThumbnailAspectRatio,
-} from './components/thumbnail/react/Thumbnail';
 
 export { Tooltip, TooltipProps, TooltipPlacement } from './components/tooltip/react/Tooltip';
 

--- a/tslint.json
+++ b/tslint.json
@@ -151,7 +151,7 @@
         "no-unnecessary-else": true,
         "no-unused": true,
         "no-var-before-return": [true, "allow-destructuring"],
-        "prefer-const-enum": true
+        "prefer-const-enum": false
     },
     "rulesDirectory": ["tslint-consistent-codestyle", "tslint-plugin-prettier"]
 }


### PR DESCRIPTION
# Problem
Some `enum` where declared as `const enum` which would compile await and thus could not be imported in demos or even in lumsites.
Ex: The `ThumbnailAspectRatio` enum could not be used in react demos

# Fix
Remove `const`. If the error persist on your machine, delete the `.awcache` directory and rebuild

**:warning: Warning**: non-const enum **have** to be defined before their use. Here I moved the `Thumbnail` import/export before the `ImageBlock` in the `react.index.ts` because the `ThumbnailAspectRatio` enum is used by the `ImageBlock`