### PR TITLE
fix(dropdown): fix onClose unnecessary calls

### DIFF
--- a/src/components/dropdown/react/Dropdown.tsx
+++ b/src/components/dropdown/react/Dropdown.tsx
@@ -125,21 +125,19 @@ const Dropdown: React.FC<DropdownProps> = ({
         </div>
     );
 
-    const onEscapeHandler = onClose ? onEscapePressed(onClose) : undefined;
+    const onEscapeHandler = closeOnEscape && onClose && showDropdown && onEscapePressed(onClose);
 
     useEffect(() => {
-        if (!onEscapeHandler) {
+        if (!onEscapeHandler || !wrapperRef.current) {
             return undefined;
         }
         if (closeOnEscape && showDropdown && wrapperRef.current) {
             window.addEventListener('keydown', onEscapeHandler);
-        } else {
-            window.removeEventListener('keydown', onEscapeHandler);
         }
         return (): void => {
             window.removeEventListener('keydown', onEscapeHandler);
         };
-    }, [onEscapeHandler, closeOnEscape, onClose]);
+    }, [showDropdown, closeOnEscape, onClose]);
 
     // Any click away from the dropdown container will close it.
     useClickAway(

--- a/src/components/dropdown/react/Dropdown.tsx
+++ b/src/components/dropdown/react/Dropdown.tsx
@@ -125,31 +125,33 @@ const Dropdown: React.FC<DropdownProps> = ({
         </div>
     );
 
+    const onEscapeHandler = onClose ? onEscapePressed(onClose) : undefined;
+
     useEffect(() => {
-        if (!onClose) {
+        if (!onEscapeHandler) {
             return undefined;
         }
         if (closeOnEscape && showDropdown && wrapperRef.current) {
-            window.addEventListener('keydown', onEscapePressed(onClose));
+            window.addEventListener('keydown', onEscapeHandler);
         } else {
-            window.removeEventListener('keydown', onEscapePressed(onClose));
+            window.removeEventListener('keydown', onEscapeHandler);
         }
         return (): void => {
-            window.removeEventListener('keydown', onEscapePressed(onClose));
+            window.removeEventListener('keydown', onEscapeHandler);
         };
-    }, [showDropdown, closeOnEscape, onClose]);
+    }, [onEscapeHandler, closeOnEscape, onClose]);
 
     // Any click away from the dropdown container will close it.
     useClickAway(
         wrapperRef,
         () => {
-            if (!closeOnClick || !onClose) {
+            if (!closeOnClick || !onClose || !showDropdown) {
                 return;
             }
 
             onClose();
         },
-        [anchorRef!],
+        [anchorRef],
     );
 
     return (


### PR DESCRIPTION
**Bug**
Fix https://lumapps.atlassian.net/browse/LUM-5350

**Fix**
- Add a condition to prevent clickAway from calling onClose when the dropdown is already closed.
- Fix the eventListener removal on the Escape press handler.