### PR TITLE
fix(demo): fix bug when using template string in React MDX demo block

### DIFF
--- a/demo/react/doc/product/components/popover.mdx
+++ b/demo/react/doc/product/components/popover.mdx
@@ -415,7 +415,7 @@ You can force the width of the popper to match the anchor width.
             {demoActions.map(
                 (demoAction, idx) => (
                     <IconButton
-                        key={'ubAction'+idx}
+                        key={`ubAction${idx}`}
                         emphasis={Emphasis.low}
                         color={theme === Theme.dark ? 'light' : undefined}
                         icon={demoAction}

--- a/demo/react/doc/product/components/progress-tracker.mdx
+++ b/demo/react/doc/product/components/progress-tracker.mdx
@@ -29,10 +29,11 @@ There are four states: _Current_, _Future_, _Completed_, and _Error_.
             <ProgressTracker activeStep={activeIndex} theme={theme}>
                 {stepProps.map((step, index) => (
                     <ProgressTrackerStep
+                        key={index}
                         isActive={activeIndex === index}
                         onClick={index < 3 ? () => setActiveIndex(index) : null}
-                        label={'Step ' + (index + 1)}
-                        helper={index == 2 ? 'Error message' : 'Helper text ' + (index + 1)}
+                        label={`Step ${index + 1}`}
+                        helper={index == 2 ? 'Error message' : `Helper text ${index + 1}`}
                         {...step}
                     />
                 ))}

--- a/demo/react/doc/product/components/thumbnail.mdx
+++ b/demo/react/doc/product/components/thumbnail.mdx
@@ -19,7 +19,7 @@ Thumbnails come in 7 sizes: _xxsmall_, _xsmall_, _small_, _medium_, _large_, _xl
         <Thumbnail image="https://picsum.photos/72" size={Size.m} theme={theme} />
         <Thumbnail image="https://picsum.photos/128" size={Size.l} theme={theme} />
         <Thumbnail image="https://picsum.photos/256" size={Size.xl} theme={theme} />
-        <div style={{ width: '300' + 'px' }}>
+        <div style={{ width: 300 }}>
             <Thumbnail image="https://picsum.photos/400" size={Size.unset} theme={theme} />
         </div>
     </>

--- a/webpack/react/mdx-demo-code-extractor/index.js
+++ b/webpack/react/mdx-demo-code-extractor/index.js
@@ -7,7 +7,10 @@ const { get, partition, flatMap } = require('lodash');
  * @return {string} The formatted sample code.
  */
 const getSourceCode = (importStatement, code) => {
-    return `${importStatement}\nconst App = ${code.trim()}`.trim().replace(/\n/g, '\\n');
+    return `${importStatement}\nconst App = ${code.trim()}`
+        .trim()
+        .replace(/\n/g, '\\n')
+        .replace(/'/g, "\\'");
 };
 
 /**
@@ -29,7 +32,7 @@ function createDemoBlock(importStatement, node) {
         position: node.position,
         value: `
         <div>
-            <DemoBlock withThemeSwitcher={${withThemeSwitcher}} disableGrid={${disableGrid}} sourceCode={\`${sourceCode}\`}>
+            <DemoBlock withThemeSwitcher={${withThemeSwitcher}} disableGrid={${disableGrid}} sourceCode={'${sourceCode}'}>
                 {${code.trim().replace(/;$/, '')}}
             </DemoBlock>
         </div>


### PR DESCRIPTION
# Problem
The use of template string in MDX demo would break the demo.

# Fix
Better escape the character when injecting the demo code in the DemoBlock (used for the "show code")