### PR TITLE
feat(post-block): add light and dark theme variant for post-block meta and text

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ The `checked` props of the `Checkbox` component has been renamed `value`.
 -   _[BREAKING]_ The `onChange` callback of the `Checkbox` component now has a boolean value argument instead of the `{ checked: boolean }` object
 -   TypeScript and JSDoc cleanup for `List` component
+-   Adding dark and light theme variant for text and meta blocks for `PostBlock` component.
 
 ### Removed
 

--- a/demo/react/doc/product/components/post-block.mdx
+++ b/demo/react/doc/product/components/post-block.mdx
@@ -1,7 +1,7 @@
 ```javascript import
 import { mdiComment, mdiHeart } from 'LumX/icons';
 
-import { Button, Chip, Emphasis, Grid, Orientation, PostBlock, Size, Theme, UserBlock } from 'LumX';
+import { Button, Chip, ColorPalette, Emphasis, Grid, Orientation, PostBlock, Size, Theme, UserBlock } from 'LumX';
 ```
 
 # Post Block
@@ -13,10 +13,18 @@ import { Button, Chip, Emphasis, Grid, Orientation, PostBlock, Size, Theme, User
     <PostBlock
         actions={
             <Grid>
-                <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiComment}>
+                <Button
+                    color={theme === Theme.dark ? ColorPalette.light : undefined}
+                    emphasis={Emphasis.low}
+                    size={Size.s}
+                    leftIcon={mdiComment}>
                     <span>16</span>
                 </Button>
-                <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                <Button
+                    color={theme === Theme.dark ? ColorPalette.light : undefined}
+                    emphasis={Emphasis.low}
+                    size={Size.s}
+                    leftIcon={mdiHeart}>
                     <span>8</span>
                 </Button>
             </Grid>
@@ -49,6 +57,7 @@ import { Button, Chip, Emphasis, Grid, Orientation, PostBlock, Size, Theme, User
         }
         meta="1 day ago in community's name"
         text={{__html: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rhoncus libero aliquet pharetra luctus. Fusce nisl turpis, posuere ac tellus at, euismod vulputate libero..."}}
+        theme={theme}
         thumbnail="https://picsum.photos/800/600/?random"
         title="Annual Bonus Payments"
     />

--- a/src/components/post-block/style/lumapps/_index.scss
+++ b/src/components/post-block/style/lumapps/_index.scss
@@ -54,13 +54,28 @@
 
         display: block;
         margin-bottom: $lumx-spacing-unit;
-        color: lumx-theme-color-variant('dark', 'L2');
+
+        #{$self}--theme-light & {
+            color: lumx-link('dark', 'L2');
+        }
+
+        #{$self}--theme-dark & {
+            @include lumx-link('light', 'L2');
+        }
     }
 
     &__text {
         @include lumx-typography('body1');
 
         margin-bottom: $lumx-spacing-unit;
+
+        #{$self}--theme-light & {
+            @include lumx-link('dark');
+        }
+
+        #{$self}--theme-dark & {
+            @include lumx-link('light');
+        }
     }
 
     &__toolbar {

--- a/src/components/post-block/style/lumapps/_index.scss
+++ b/src/components/post-block/style/lumapps/_index.scss
@@ -56,11 +56,11 @@
         margin-bottom: $lumx-spacing-unit;
 
         #{$self}--theme-light & {
-            color: lumx-link('dark', 'L2');
+            color: lumx-theme-color-variant('dark', 'L2');
         }
 
         #{$self}--theme-dark & {
-            @include lumx-link('light', 'L2');
+            color: lumx-theme-color-variant('light', 'L2');
         }
     }
 
@@ -70,11 +70,11 @@
         margin-bottom: $lumx-spacing-unit;
 
         #{$self}--theme-light & {
-            @include lumx-link('dark');
+            color: lumx-theme-color-variant('dark', 'N');
         }
 
         #{$self}--theme-dark & {
-            @include lumx-link('light');
+            color: lumx-theme-color-variant('light', 'N');
         }
     }
 


### PR DESCRIPTION
Add the missing theme variant for the "meta" and "text" block in the react PostBlock.