### PR TITLE
feat(doc): add asset block for React doc site

### DIFF
--- a/demo/react/layout/AssetBlock.tsx
+++ b/demo/react/layout/AssetBlock.tsx
@@ -1,0 +1,69 @@
+import { Button, Emphasis, Icon, Size } from 'LumX';
+import { mdiDownload, mdiFile } from 'LumX/icons';
+import React, { ReactElement } from 'react';
+
+interface IAssetBlock {
+    /**
+     * Asset download URL.
+     */
+    downloadURL: string;
+    /**
+     * Asset file name.
+     * If not provided, the file name will be extracted from the download URL (with varying result quality).
+     */
+    fileName?: string;
+    /**
+     * Asset thumbnail preview image URL.
+     * If not provided, a generic file icon will be displayed.
+     */
+    thumbnailURL?: string;
+}
+
+/**
+ * Extract file name (last path part) from URL.
+ * Else returns the unchanged URL.
+ * @param url The input URL
+ * @return The file name.
+ */
+function getFileName(url: string): string {
+    const match = url.match(/\/([^\/]+$)/);
+    if (match) {
+        const [, fileName] = match;
+        return fileName;
+    }
+    return url;
+}
+
+/**
+ * Component used to present an asset in the documentation site.
+ *
+ * @param props Components props.
+ * @return ReactElement
+ */
+const AssetBlock: React.FC<IAssetBlock> = (props: IAssetBlock): ReactElement => {
+    const { downloadURL, fileName, thumbnailURL } = props;
+
+    return (
+        <div className="asset-block">
+            <div className="asset-block__content">
+                {thumbnailURL ? (
+                    <img alt="File download thumbnail" className="asset-block__thumbnail" src={thumbnailURL} />
+                ) : (
+                    <Icon className="asset-block__thumbnail" icon={mdiFile} size={Size.xl} />
+                )}
+            </div>
+
+            <div className="asset-block__toolbar">
+                <div className="asset-block__filename">{fileName || getFileName(downloadURL)}</div>
+
+                <div className="asset-block__download-button">
+                    <Button emphasis={Emphasis.low} leftIcon={mdiDownload} href={downloadURL} target="_blank">
+                        Download
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export { AssetBlock };

--- a/demo/style/layout/_asset-block.scss
+++ b/demo/style/layout/_asset-block.scss
@@ -1,0 +1,31 @@
+/* ==========================================================================
+   Asset block
+   ========================================================================== */
+
+.asset-block {
+    border: 1px solid lumx-theme-color-variant(dark, L4);
+    border-radius: $lumx-theme-border-radius;
+
+    &__content {
+        padding: $lumx-spacing-unit * 3;
+        background-color: lumx-theme-color-variant(dark, L6);
+        text-align: center;
+    }
+
+    &__thumbnail {
+        display: inline-block !important;
+        max-width: 100%;
+    }
+
+    &__toolbar {
+        display: flex;
+        align-items: center;
+        padding: $lumx-spacing-unit $lumx-spacing-unit * 2 $lumx-spacing-unit $lumx-spacing-unit;
+        border-top: 1px solid lumx-theme-color-variant(dark, L4);
+    }
+
+    &__filename {
+        flex: 1;
+        padding-left: $lumx-spacing-unit * 2;
+    }
+}

--- a/demo/style/lumapps.scss
+++ b/demo/style/lumapps.scss
@@ -13,3 +13,4 @@ $mdi-font-path: '../../src/icons/node_modules/@mdi/font/fonts';
 @import './layout/app/app';
 @import './layout/main-nav/main-nav';
 @import './layout/main/main';
+@import './layout/asset-block';


### PR DESCRIPTION
Add an `AssetBlock` component for use in React demo site.
Zeplin mock-up: https://app.zeplin.io/project/5beed1207b5f913ebc61d14e/screen/5d8e26da4c9cce181197c1b8

Example of use:
```mdx
import { AssetBlock } from 'LumX/demo/react/layout/AssetBlock';

# Assets

<AssetBlock downloadURL="foo.com/bar"/>

<AssetBlock downloadURL="foo.com/bar/981981" fileName="Toto.pdf"/>

<AssetBlock 
  downloadURL="foo.com/bar" 
  fileName="Doodle-grandparent-day.jpg"
  thumbnailURL="https://www.google.com/logos/doodles/2019/grandparents-day-2019-uk-ie-5839152682631168-2x.jpg"
/>

```