### PR TITLE
feat(autocomplete simple): react component for autocomplete - simple variation

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Text field enhancements (`chips`, `onFocus`, `onBlur`, `textfieldRef`, `inputRef` props) [#199](https://github.com/lumapps/design-system/pull/199)
+-   Autocomplete component [#191](https://github.com/lumapps/design-system/pull/191)
 
 ### Changed
 

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -47,6 +47,8 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
 
     const [showSuggestions, setShowSuggestions] = React.useState(false);
     const [filterValue, setFilterValue] = React.useState('');
+    const inputRef = React.useRef(null);
+
     const filteredCities = CITIES.filter(city => city.text.replace(' ', '').toLowerCase().includes(filterValue.replace(' ', '').toLowerCase()));
     const closeAutocomplete = () => setShowSuggestions(false);
 
@@ -62,17 +64,14 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
 
     const {
         activeItemIndex,
-        onKeyboardNavigation,
-        setActiveItemIndex,
-        resetActiveIndex
     } = List.useKeyboardListNavigation(
         filteredCities,
         setSelectedCity,
+        inputRef,
     );
 
     const onFocus = (evt) => {
-        resetActiveIndex();
-        return setShowSuggestions(filterValue.length > 0);
+        setShowSuggestions(filterValue.length > 0);
     }
 
     return (
@@ -82,8 +81,8 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
             onClose={closeAutocomplete}
             value={filterValue}
             onChange={onChange}
-            onKeyDown={onKeyboardNavigation}
             onFocus={onFocus}
+            inputRef={inputRef}
         >
             <List isClickable>
                 { filteredCities.length > 0 ? filteredCities.map((city, index) => (

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -89,16 +89,19 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
         }
     };
 
+    const onFocus = (evt) => setShowSuggestions(filterValue.length > 0);
+    const onBlur = (evt) => setShowSuggestions(false);
+
     return (
         <Autocomplete
             theme={theme}
-            showSuggestions={showSuggestions}
-            closeOnClick
-            closeOnEscape
+            isOpen={showSuggestions}
             onClose={closeAutocomplete}
             value={filterValue}
             onChange={onChange}
             onKeyDown={onKeyDown}
+            onFocus={onFocus}
+            onBlur={onBlur}
         >
             <List isClickable>
                 { filteredCities.length > 0 ? filteredCities.map((city, index) => (

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -1,5 +1,6 @@
 ```javascript import
-import { Autocomplete } from 'LumX';
+import { Autocomplete, List, ListItem, ListItemSize, Size, TextField, Chip, ListDivider, Icon, ListSubheader } from 'LumX';
+import { useBooleanState } from 'LumX/core/react/hooks';
 ```
 
 # Autocomplete
@@ -7,11 +8,50 @@ import { Autocomplete } from 'LumX';
 ## Default
 
 ```javascript jsx withThemeSwitcher
-(theme) => (
-    <>
-        <Autocomplete theme={theme}/>
-    </>
-);
+(theme) => {
+    const CHOICES = [
+        {
+            text: 'Los Angeles',
+            id: 'losangeles'
+        },
+        {
+            text: 'San Francisco',
+            id: 'sanfrancisco'
+        },
+        {
+            text: 'Lyon',
+            id: 'lyon'
+        },
+        {
+            text: 'Montevideo',
+            id: 'montevideo'
+        }
+    ];
+
+    const [showSuggestions, setShowSuggestions] = React.useState(true);
+    const ddRef = React.useRef(null);
+    const closeAutocomplete = () => setShowSuggestions(false);
+    const onItemSelectedHandler = (choice) => console.log(choice);
+
+    return (
+        <Autocomplete theme={theme} showSuggestions={showSuggestions} closeOnClick closeOnEscape onClose={closeAutocomplete}>
+            <List isClickable>
+                { CHOICES.map((choice, index) => (
+                        <ListItem
+                            size={ListItemSize.tiny}
+                            isClickable
+                            key={choice.id}
+                            onItemSelected={() => onItemSelectedHandler(choice)}
+                            size={ListItemSize.tiny}
+                        >
+                            <div>{choice.text}</div>
+                        </ListItem>
+                    ))
+                }
+            </List>
+        </Autocomplete>
+    );
+};
 ```
 
 ### Properties

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -46,15 +46,13 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
     ];
 
     const [showSuggestions, setShowSuggestions] = React.useState(false);
-    const [activeIndex, setActiveIndex] = React.useState(-1);
     const [filterValue, setFilterValue] = React.useState('');
-
+    const filteredCities = CITIES.filter(city => city.text.replace(' ', '').toLowerCase().includes(filterValue.replace(' ', '').toLowerCase()));
     const closeAutocomplete = () => setShowSuggestions(false);
 
     const setSelectedCity = (city) => {
         setFilterValue(city.text);
         setShowSuggestions(false);
-        setActiveIndex(-1);
     }
 
     const onChange = (value) => {
@@ -62,40 +60,19 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
         setShowSuggestions(value.length > 0);
     };
 
-    const filteredCities = CITIES.filter(city => city.text.replace(' ', '').toLowerCase().includes(filterValue.replace(' ', '').toLowerCase()));
-
-    const calculateActiveIndex = (keyPressed) => {
-        if (keyPressed === DOWN_KEY_CODE) {
-            return activeIndex + 1 < filteredCities.length ? activeIndex + 1 : 0;
-        } else if (keyPressed === UP_KEY_CODE) {
-            return activeIndex - 1 >= 0 ? activeIndex - 1 : filteredCities.length - 1;
-        }
-    }
-
-    const onKeyDown = (evt) => {
-        if (evt.keyCode === DOWN_KEY_CODE || evt.keyCode === UP_KEY_CODE) {
-            evt.nativeEvent.preventDefault();
-            evt.nativeEvent.stopPropagation();
-
-            const nextActiveIndex = calculateActiveIndex(evt.keyCode);
-            setActiveIndex(nextActiveIndex);
-        } else if (evt.keyCode === ENTER_KEY_CODE) {
-            evt.currentTarget.blur();
-
-            const selectedCity = filteredCities[activeIndex];
-            if (selectedCity) {
-                setSelectedCity(selectedCity);
-            }
-        }
-    };
+    const {
+        activeItemIndex,
+        onKeyboardNavigation,
+        setActiveItemIndex,
+        resetActiveIndex
+    } = List.useKeyboardListNavigation(
+        filteredCities,
+        setSelectedCity,
+    );
 
     const onFocus = (evt) => {
-        setActiveIndex(-1);
+        resetActiveIndex();
         return setShowSuggestions(filterValue.length > 0);
-    }
-    const onBlur = (evt) => {
-        setActiveIndex(-1);
-        return setShowSuggestions(false);
     }
 
     return (
@@ -105,9 +82,8 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
             onClose={closeAutocomplete}
             value={filterValue}
             onChange={onChange}
-            onKeyDown={onKeyDown}
+            onKeyDown={onKeyboardNavigation}
             onFocus={onFocus}
-            onBlur={onBlur}
         >
             <List isClickable>
                 { filteredCities.length > 0 ? filteredCities.map((city, index) => (
@@ -115,7 +91,7 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
                             size={ListItemSize.tiny}
                             isClickable
                             key={city.id}
-                            isHighlighted={index === activeIndex}
+                            isHighlighted={index === activeItemIndex}
                             onItemSelected={() => setSelectedCity(city)}
                         >
                             <div>{city.text}</div>

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -29,12 +29,17 @@ import { useBooleanState } from 'LumX/core/react/hooks';
     ];
 
     const [showSuggestions, setShowSuggestions] = React.useState(true);
+    const [filterValue, setFilterValue] = React.useState('');
     const ddRef = React.useRef(null);
     const closeAutocomplete = () => setShowSuggestions(false);
     const onItemSelectedHandler = (choice) => console.log(choice);
+    const onChange = (value) => {
+        setFilterValue(value);
+        console.log(value);
+    };
 
     return (
-        <Autocomplete theme={theme} showSuggestions={showSuggestions} closeOnClick closeOnEscape onClose={closeAutocomplete}>
+        <Autocomplete theme={theme} showSuggestions={showSuggestions} closeOnClick closeOnEscape onClose={closeAutocomplete} value={filterValue} onChange={onChange}>
             <List isClickable>
                 { CHOICES.map((choice, index) => (
                         <ListItem

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -1,6 +1,7 @@
 ```javascript import
 import { Autocomplete, List, ListItem, ListItemSize, Size, TextField, Chip, ListDivider, Icon, ListSubheader } from 'LumX';
 import { useBooleanState } from 'LumX/core/react/hooks';
+import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/core/constants';
 ```
 
 # Autocomplete
@@ -9,7 +10,7 @@ import { useBooleanState } from 'LumX/core/react/hooks';
 
 ```javascript jsx withThemeSwitcher
 (theme) => {
-    const CHOICES = [
+    const CITIES = [
         {
             text: 'Los Angeles',
             id: 'losangeles'
@@ -17,6 +18,22 @@ import { useBooleanState } from 'LumX/core/react/hooks';
         {
             text: 'San Francisco',
             id: 'sanfrancisco'
+        },
+        {
+            text: 'Paris',
+            id: 'paris'
+        },
+        {
+            text: 'Montpellier',
+            id: 'montpellier'
+        },
+        {
+            text: 'Bordeaux',
+            id: 'bordeaux'
+        },
+        {
+            text: 'Toulouse',
+            id: 'toulouse'
         },
         {
             text: 'Lyon',
@@ -28,30 +45,68 @@ import { useBooleanState } from 'LumX/core/react/hooks';
         }
     ];
 
-    const [showSuggestions, setShowSuggestions] = React.useState(true);
+    const [showSuggestions, setShowSuggestions] = React.useState(false);
+    const [activeIndex, setActiveIndex] = React.useState(-1);
     const [filterValue, setFilterValue] = React.useState('');
-    const ddRef = React.useRef(null);
+
+    const setSelectedCity = (city) => {
+        setFilterValue(city.text);
+        setShowSuggestions(false);
+        setActiveIndex(-1);
+    }
+
     const closeAutocomplete = () => setShowSuggestions(false);
-    const onItemSelectedHandler = (choice) => console.log(choice);
+
     const onChange = (value) => {
         setFilterValue(value);
-        console.log(value);
+        setShowSuggestions(value.length > 0);
+    };
+
+    const filterCity = city => city.text.replace(' ', '').toLowerCase().includes(filterValue.replace(' ', '').toLowerCase());
+    const filteredCities = CITIES.filter(filterCity);
+
+    const calculateActiveIndex = (keyPressed) => {
+        if (keyPressed === DOWN_KEY_CODE) {
+            return activeIndex + 1 < filteredCities.length ? activeIndex + 1 : 0;
+        } else if (keyPressed === UP_KEY_CODE) {
+            return activeIndex - 1 >= 0 ? activeIndex - 1 : filteredCities.length - 1;
+        }
+    }
+
+    const onKeyDown = (evt) => {
+        if (evt.keyCode === DOWN_KEY_CODE || evt.keyCode === UP_KEY_CODE) {
+            evt.nativeEvent.preventDefault();
+            evt.nativeEvent.stopPropagation();
+            
+            const nextActiveIndex = calculateActiveIndex(evt.keyCode);
+            setActiveIndex(nextActiveIndex);
+        } else if (evt.keyCode === ENTER_KEY_CODE) {
+            evt.currentTarget.blur();
+            const selectedCity = filteredCities[activeIndex];
+            setSelectedCity(selectedCity);
+        }
     };
 
     return (
-        <Autocomplete theme={theme} showSuggestions={showSuggestions} closeOnClick closeOnEscape onClose={closeAutocomplete} value={filterValue} onChange={onChange}>
+        <Autocomplete theme={theme} showSuggestions={showSuggestions} closeOnClick closeOnEscape onClose={closeAutocomplete} value={filterValue} onChange={onChange} onKeyDown={onKeyDown}>
             <List isClickable>
-                { CHOICES.map((choice, index) => (
+                { filteredCities.length > 0 ? filteredCities.map((city, index) => (
                         <ListItem
                             size={ListItemSize.tiny}
                             isClickable
-                            key={choice.id}
-                            onItemSelected={() => onItemSelectedHandler(choice)}
+                            key={city.id}
+                            isHighlighted={index === activeIndex}
+                            onItemSelected={() => setSelectedCity(city)}
+                        >
+                            <div>{city.text}</div>
+                        </ListItem>
+                    )) : (
+                        <ListItem
                             size={ListItemSize.tiny}
                         >
-                            <div>{choice.text}</div>
+                            <div>No results</div>
                         </ListItem>
-                    ))
+                    )
                 }
             </List>
         </Autocomplete>

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -89,8 +89,14 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
         }
     };
 
-    const onFocus = (evt) => setShowSuggestions(filterValue.length > 0);
-    const onBlur = (evt) => setShowSuggestions(false);
+    const onFocus = (evt) => {
+        setActiveIndex(-1);
+        return setShowSuggestions(filterValue.length > 0);
+    }
+    const onBlur = (evt) => {
+        setActiveIndex(-1);
+        return setShowSuggestions(false);
+    }
 
     return (
         <Autocomplete

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -1,0 +1,19 @@
+```javascript import
+import { Autocomplete } from 'LumX';
+```
+
+# Autocomplete
+
+## Default
+
+```javascript jsx withThemeSwitcher
+(theme) => (
+    <>
+        <Autocomplete theme={theme}/>
+    </>
+);
+```
+
+### Properties
+
+<PropTable component="Autocomplete" />

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -49,21 +49,20 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
     const [activeIndex, setActiveIndex] = React.useState(-1);
     const [filterValue, setFilterValue] = React.useState('');
 
+    const closeAutocomplete = () => setShowSuggestions(false);
+
     const setSelectedCity = (city) => {
         setFilterValue(city.text);
         setShowSuggestions(false);
         setActiveIndex(-1);
     }
 
-    const closeAutocomplete = () => setShowSuggestions(false);
-
     const onChange = (value) => {
         setFilterValue(value);
         setShowSuggestions(value.length > 0);
     };
 
-    const filterCity = city => city.text.replace(' ', '').toLowerCase().includes(filterValue.replace(' ', '').toLowerCase());
-    const filteredCities = CITIES.filter(filterCity);
+    const filteredCities = CITIES.filter(city => city.text.replace(' ', '').toLowerCase().includes(filterValue.replace(' ', '').toLowerCase()));
 
     const calculateActiveIndex = (keyPressed) => {
         if (keyPressed === DOWN_KEY_CODE) {
@@ -77,18 +76,30 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
         if (evt.keyCode === DOWN_KEY_CODE || evt.keyCode === UP_KEY_CODE) {
             evt.nativeEvent.preventDefault();
             evt.nativeEvent.stopPropagation();
-            
+
             const nextActiveIndex = calculateActiveIndex(evt.keyCode);
             setActiveIndex(nextActiveIndex);
         } else if (evt.keyCode === ENTER_KEY_CODE) {
             evt.currentTarget.blur();
+
             const selectedCity = filteredCities[activeIndex];
-            setSelectedCity(selectedCity);
+            if (selectedCity) {
+                setSelectedCity(selectedCity);
+            }
         }
     };
 
     return (
-        <Autocomplete theme={theme} showSuggestions={showSuggestions} closeOnClick closeOnEscape onClose={closeAutocomplete} value={filterValue} onChange={onChange} onKeyDown={onKeyDown}>
+        <Autocomplete
+            theme={theme}
+            showSuggestions={showSuggestions}
+            closeOnClick
+            closeOnEscape
+            onClose={closeAutocomplete}
+            value={filterValue}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+        >
             <List isClickable>
                 { filteredCities.length > 0 ? filteredCities.map((city, index) => (
                         <ListItem

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -74,18 +74,21 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
         setShowSuggestions(filterValue.length > 0);
     }
 
+    const hasSuggestions = filteredCities.length > 0;
+
     return (
         <Autocomplete
             theme={theme}
-            isOpen={showSuggestions}
+            isOpen={showSuggestions && hasSuggestions}
             onClose={closeAutocomplete}
             value={filterValue}
             onChange={onChange}
             onFocus={onFocus}
             inputRef={inputRef}
         >
-            <List isClickable>
-                { filteredCities.length > 0 ? filteredCities.map((city, index) => (
+            { hasSuggestions && (
+                <List isClickable>
+                    {filteredCities.map((city, index) => (
                         <ListItem
                             size={ListItemSize.tiny}
                             isClickable
@@ -95,15 +98,9 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
                         >
                             <div>{city.text}</div>
                         </ListItem>
-                    )) : (
-                        <ListItem
-                            size={ListItemSize.tiny}
-                        >
-                            <div>No results</div>
-                        </ListItem>
-                    )
-                }
-            </List>
+                    ))}
+                </List>
+            )}
         </Autocomplete>
     );
 };

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -87,7 +87,7 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
             inputRef={inputRef}
         >
             { hasSuggestions && (
-                <List isClickable>
+                <List>
                     {filteredCities.map((city, index) => (
                         <ListItem
                             size={ListItemSize.tiny}

--- a/demo/react/layout/MainNav.tsx
+++ b/demo/react/layout/MainNav.tsx
@@ -45,6 +45,7 @@ const ITEMS: Item[] = [
             {
                 label: 'Components',
                 children: [
+                    'Autocomplete',
                     'Avatar',
                     'Button',
                     'Checkbox',

--- a/src/components/autocomplete/react/Autocomplete.test.tsx
+++ b/src/components/autocomplete/react/Autocomplete.test.tsx
@@ -17,23 +17,12 @@ type ISetupProps = Partial<AutocompleteProps>;
  * Defines what the `setup` function will return.
  */
 interface ISetup extends ICommonSetup {
-    /**
-     * The <div> element that holds the dropdown content.
-     */
-    dropdown: Wrapper;
-
     props: ISetupProps;
 
     /**
-     * [Enter the description of this wrapper].
-     * [You should also probably change the name of the wrapper to something more meaningful].
+     * The <div> element that holds the popover content.
      */
     wrapper: Wrapper;
-
-    /**
-     * The <input> element.
-     */
-    textField: Wrapper;
 }
 
 /////////////////////////////
@@ -51,12 +40,8 @@ const setup = (props: ISetupProps = {}, shallowRendering: boolean = true): ISetu
     // @ts-ignore
     const wrapper: Wrapper = renderer(<Autocomplete {...props} />);
 
-    const input = wrapper.find('input');
-
     return {
-        dropdown: wrapper.find('div').first(),
         props,
-        textField: input,
         wrapper,
     };
 };

--- a/src/components/autocomplete/react/Autocomplete.test.tsx
+++ b/src/components/autocomplete/react/Autocomplete.test.tsx
@@ -1,0 +1,120 @@
+import React, { ReactElement } from 'react';
+
+import { mount, shallow } from 'enzyme';
+
+import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
+import { getBasicClass } from 'LumX/core/utils';
+
+import { Autocomplete, AutocompleteProps, CLASSNAME, DEFAULT_PROPS } from './Autocomplete';
+
+/////////////////////////////
+
+/**
+ * Define the overriding properties waited by the `setup` function.
+ */
+type ISetupProps = Partial<AutocompleteProps>;
+
+/**
+ * Defines what the `setup` function will return.
+ */
+interface ISetup extends ICommonSetup {
+    props: ISetupProps;
+
+    /**
+     * [Enter the description of this wrapper].
+     * [You should also probably change the name of the wrapper to something more meaningful].
+     */
+    wrapper: Wrapper;
+}
+
+/////////////////////////////
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ *
+ * @param  props  The props to use to override the default props of the component.
+ * @param  [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return An object with the props, the component wrapper and some shortcut to some element inside of the component.
+ */
+const setup = (props: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+
+    // @ts-ignore
+    const wrapper: Wrapper = renderer(<Autocomplete {...props} />);
+
+    return {
+        props,
+        wrapper,
+    };
+};
+
+describe(`<${Autocomplete.displayName}>`, (): void => {
+    // 1. Test render via snapshot (default states of component).
+    describe('Snapshots and structure', (): void => {
+        // Here is an example of a basic rendering check, with snapshot.
+
+        it('should render correctly', (): void => {
+            const { wrapper } = setup();
+            expect(wrapper).toMatchSnapshot();
+
+            expect(wrapper).toExist();
+            expect(wrapper).toHaveClassName(CLASSNAME);
+        });
+    });
+
+    /////////////////////////////
+
+    // 2. Test defaultProps value and important props custom values.
+    describe('Props', (): void => {
+        // Here are some examples of basic props check.
+
+        it('should use default props', (): void => {
+            const { wrapper } = setup();
+
+            Object.keys(DEFAULT_PROPS).forEach((prop: string): void => {
+                expect(wrapper).toHaveClassName(
+                    getBasicClass({ prefix: CLASSNAME, type: prop, value: DEFAULT_PROPS[prop] }),
+                );
+            });
+        });
+    });
+
+    /////////////////////////////
+
+    // 3. Test events.
+    describe('Events', (): void => {
+        // Here is an example how to check a `onClick` event.
+
+        const onClick: jest.Mock = jest.fn();
+
+        beforeEach((): void => {
+            onClick.mockClear();
+        });
+
+        it('should trigger `onClick` when clicked', (): void => {
+            const { wrapper } = setup({ onClick }, false);
+
+            wrapper.simulate('click');
+
+            expect(onClick).toHaveBeenCalled();
+        });
+    });
+    /////////////////////////////
+
+    // 4. Test conditions (i.e. things that display or not in the UI based on props).
+    describe('Conditions', (): void => {
+        // Nothing to do here.
+    });
+
+    /////////////////////////////
+
+    // 5. Test state.
+    describe('State', (): void => {
+        // Nothing to do here.
+    });
+
+    /////////////////////////////
+
+    // Common tests suite.
+    commonTestsSuite(setup, { className: 'wrapper', prop: 'wrapper' }, { className: CLASSNAME });
+});

--- a/src/components/autocomplete/react/Autocomplete.test.tsx
+++ b/src/components/autocomplete/react/Autocomplete.test.tsx
@@ -3,9 +3,8 @@ import React, { ReactElement } from 'react';
 import { mount, shallow } from 'enzyme';
 
 import { ICommonSetup, Wrapper, commonTestsSuite } from 'LumX/core/testing/utils.test';
-import { getBasicClass } from 'LumX/core/utils';
 
-import { Autocomplete, AutocompleteProps, CLASSNAME, DEFAULT_PROPS } from './Autocomplete';
+import { Autocomplete, AutocompleteProps, CLASSNAME } from './Autocomplete';
 
 /////////////////////////////
 
@@ -18,6 +17,11 @@ type ISetupProps = Partial<AutocompleteProps>;
  * Defines what the `setup` function will return.
  */
 interface ISetup extends ICommonSetup {
+    /**
+     * The <div> element that holds the dropdown content.
+     */
+    dropdown: Wrapper;
+
     props: ISetupProps;
 
     /**
@@ -25,6 +29,11 @@ interface ISetup extends ICommonSetup {
      * [You should also probably change the name of the wrapper to something more meaningful].
      */
     wrapper: Wrapper;
+
+    /**
+     * The <input> element.
+     */
+    textField: Wrapper;
 }
 
 /////////////////////////////
@@ -42,8 +51,12 @@ const setup = (props: ISetupProps = {}, shallowRendering: boolean = true): ISetu
     // @ts-ignore
     const wrapper: Wrapper = renderer(<Autocomplete {...props} />);
 
+    const input = wrapper.find('input');
+
     return {
+        dropdown: wrapper.find('div').first(),
         props,
+        textField: input,
         wrapper,
     };
 };
@@ -58,6 +71,7 @@ describe(`<${Autocomplete.displayName}>`, (): void => {
             expect(wrapper).toMatchSnapshot();
 
             expect(wrapper).toExist();
+
             expect(wrapper).toHaveClassName(CLASSNAME);
         });
     });
@@ -66,16 +80,10 @@ describe(`<${Autocomplete.displayName}>`, (): void => {
 
     // 2. Test defaultProps value and important props custom values.
     describe('Props', (): void => {
-        // Here are some examples of basic props check.
-
         it('should use default props', (): void => {
-            const { wrapper } = setup();
+            const { wrapper }: ISetup = setup();
 
-            Object.keys(DEFAULT_PROPS).forEach((prop: string): void => {
-                expect(wrapper).toHaveClassName(
-                    getBasicClass({ prefix: CLASSNAME, type: prop, value: DEFAULT_PROPS[prop] }),
-                );
-            });
+            expect(wrapper).toHaveClassName(CLASSNAME);
         });
     });
 
@@ -83,21 +91,7 @@ describe(`<${Autocomplete.displayName}>`, (): void => {
 
     // 3. Test events.
     describe('Events', (): void => {
-        // Here is an example how to check a `onClick` event.
-
-        const onClick: jest.Mock = jest.fn();
-
-        beforeEach((): void => {
-            onClick.mockClear();
-        });
-
-        it('should trigger `onClick` when clicked', (): void => {
-            const { wrapper } = setup({ onClick }, false);
-
-            wrapper.simulate('click');
-
-            expect(onClick).toHaveBeenCalled();
-        });
+        // Nothing to do here.
     });
     /////////////////////////////
 

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -59,13 +59,13 @@ interface IAutocompleteProps extends IGenericProps {
      * Text field focus change handler.
      * @see {@link TextFieldProps#onFocus}
      */
-    onFocus(event: React.FocusEvent): void;
+    onFocus?(event: React.FocusEvent): void;
 
     /**
      * Text field blur change handler.
      * @see {@link TextFieldProps#onBlur}
      */
-    onBlur(event: React.FocusEvent): void;
+    onBlur?(event: React.FocusEvent): void;
 }
 type AutocompleteProps = IAutocompleteProps;
 

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -1,0 +1,68 @@
+import React, { ReactElement } from 'react';
+
+import classNames from 'classnames';
+
+import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
+import { handleBasicClasses } from 'LumX/core/utils';
+import { IGenericProps, getRootClassName } from 'LumX/react/utils';
+
+/////////////////////////////
+
+/**
+ * Defines the props of the component.
+ */
+interface IAutocompleteProps extends IGenericProps {}
+type AutocompleteProps = IAutocompleteProps;
+
+/////////////////////////////
+
+/////////////////////////////
+//                         //
+//    Public attributes    //
+//                         //
+/////////////////////////////
+
+/**
+ * The display name of the component.
+ */
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Autocomplete`;
+
+/**
+ * The default class name and classes prefix for this component.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
+
+/**
+ * The default value of props.
+ */
+const DEFAULT_PROPS: Partial<AutocompleteProps> = {};
+
+/////////////////////////////
+
+/**
+ * [Enter the description of the component here].
+ *
+ * @return The component.
+ */
+const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): ReactElement => {
+    const { children, className, ...forwardedProps } = props;
+
+    return (
+        <div
+            className={classNames(
+                className,
+                handleBasicClasses({
+                    prefix: CLASSNAME,
+                }),
+            )}
+            {...forwardedProps}
+        >
+            {children}
+        </div>
+    );
+};
+Autocomplete.displayName = COMPONENT_NAME;
+
+/////////////////////////////
+
+export { CLASSNAME, DEFAULT_PROPS, Autocomplete, AutocompleteProps };

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -14,7 +14,10 @@ import { IGenericProps, getRootClassName } from 'LumX/react/utils';
  * Defines the props of the component.
  */
 interface IAutocompleteProps extends IGenericProps {
-    /** Children of the Autocomplete. */
+    /**
+     * Children of the Autocomplete. This should be a list of the different
+     * suggestions that
+     */
     children: React.ReactNode;
 
     /**
@@ -27,17 +30,17 @@ interface IAutocompleteProps extends IGenericProps {
      * Whether the suggestions from the autocomplete should be displayed or not.
      * Useful to control when the suggestions are displayed from outside the component
      */
-    showSuggestions: boolean;
+    isOpen: boolean;
 
     /**
      * Whether a click anywhere out of the Autocomplete would close it
-     * @see {@link TextFieldProps#closeOnClick}
+     * @see {@link DropdownProps#closeOnClick}
      */
     closeOnClick?: boolean;
 
     /**
      * Whether an escape key press would close the Autocomplete.
-     * @see {@link TextFieldProps#closeOnEscape}
+     * @see {@link DropdownProps#closeOnEscape}
      */
     closeOnEscape?: boolean;
 
@@ -78,13 +81,14 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
 const DEFAULT_PROPS: Partial<AutocompleteProps> = {
     closeOnClick: true,
     closeOnEscape: true,
-    showSuggestions: undefined,
+    isOpen: undefined,
 };
 
 /////////////////////////////
 
 /**
- * [Enter the description of the component here].
+ * This component allows to make the connection between a Text Field and a Dropdown,
+ * displaying a list of suggestions from the text entered on the text field.
  *
  * @return The component.
  */
@@ -95,12 +99,12 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         value,
         onChange,
         onKeyDown,
-        showSuggestions,
+        isOpen,
         closeOnClick,
         closeOnEscape,
         ...forwardedProps
     } = props;
-    const textfieldRef = useRef(null);
+    const textFieldRef = useRef(null);
 
     return (
         <div
@@ -115,13 +119,13 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
             <TextField
                 value={value}
                 onChange={onChange}
-                textFieldRef={textfieldRef}
+                textFieldRef={textFieldRef}
                 onKeyDown={onKeyDown}
                 {...forwardedProps}
             />
             <Dropdown
-                anchorRef={textfieldRef}
-                showDropdown={showSuggestions}
+                anchorRef={textFieldRef}
+                showDropdown={isOpen}
                 closeOnClick={closeOnClick}
                 closeOnEscape={closeOnEscape}
                 {...forwardedProps}

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -73,6 +73,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         children,
         value,
         onChange,
+        onKeyDown,
         showSuggestions,
         closeOnClick,
         closeOnEscape,
@@ -90,7 +91,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
             )}
             {...forwardedProps}
         >
-            <TextField value={value} onChange={onChange} textFieldRef={textfieldRef} />
+            <TextField value={value} onChange={onChange} textFieldRef={textfieldRef} onKeyDown={onKeyDown} />
             <Dropdown
                 anchorRef={textfieldRef}
                 showDropdown={showSuggestions}

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useRef } from 'react';
+import React, { ReactElement, RefObject, useRef } from 'react';
 
 import classNames from 'classnames';
 
@@ -14,6 +14,9 @@ import { IGenericProps, getRootClassName } from 'LumX/react/utils';
  * Defines the props of the component.
  */
 interface IAutocompleteProps extends IGenericProps {
+    /** A ref that will be passed to the input or textarea element. */
+    inputRef?: RefObject<HTMLInputElement>;
+
     /**
      * Vertical and/or horizontal offsets that will be applied to the Dropdown position.
      * @see {@link DropdownProps#offset}
@@ -132,11 +135,6 @@ interface IAutocompleteProps extends IGenericProps {
     onChange(value: string): void;
 
     /**
-     * Text field on key down handler.
-     */
-    onKeyDown(value: string): void;
-
-    /**
      * Text field focus change handler.
      * @see {@link TextFieldProps#onFocus}
      */
@@ -193,7 +191,6 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         onBlur,
         onChange,
         onFocus,
-        onKeyDown,
         isOpen,
         closeOnClick,
         closeOnEscape,
@@ -209,10 +206,12 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         onClose,
         offset,
         placement,
+        inputRef = useRef(null),
         fitToAnchorWidth,
         onInfiniteScroll,
         ...forwardedProps
     } = props;
+
     const textFieldRef = useRef(null);
 
     return (
@@ -229,7 +228,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 value={value}
                 onChange={onChange}
                 textFieldRef={textFieldRef}
-                onKeyDown={onKeyDown}
+                inputRef={inputRef}
                 onBlur={onBlur}
                 onFocus={onFocus}
                 hasError={hasError}
@@ -243,7 +242,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 type={type}
             />
             <Dropdown
-                anchorRef={textFieldRef}
+                anchorRef={textFieldRef as React.RefObject<HTMLElement>}
                 showDropdown={isOpen}
                 closeOnClick={closeOnClick}
                 closeOnEscape={closeOnEscape}

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -54,6 +54,18 @@ interface IAutocompleteProps extends IGenericProps {
      * Text field on key down handler.
      */
     onKeyDown(value: string): void;
+
+    /**
+     * Text field focus change handler.
+     * @see {@link TextFieldProps#onFocus}
+     */
+    onFocus(event: React.FocusEvent): void;
+
+    /**
+     * Text field blur change handler.
+     * @see {@link TextFieldProps#onBlur}
+     */
+    onBlur(event: React.FocusEvent): void;
 }
 type AutocompleteProps = IAutocompleteProps;
 
@@ -97,7 +109,9 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         className,
         children,
         value,
+        onBlur,
         onChange,
+        onFocus,
         onKeyDown,
         isOpen,
         closeOnClick,
@@ -121,6 +135,8 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 onChange={onChange}
                 textFieldRef={textFieldRef}
                 onKeyDown={onKeyDown}
+                onBlur={onBlur}
+                onFocus={onFocus}
                 {...forwardedProps}
             />
             <Dropdown

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Dropdown, TextField } from 'LumX';
+import { Dropdown, Offset, Placement, TextField, TextFieldType, Theme } from 'LumX';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -14,6 +14,75 @@ import { IGenericProps, getRootClassName } from 'LumX/react/utils';
  * Defines the props of the component.
  */
 interface IAutocompleteProps extends IGenericProps {
+    /**
+     * Vertical and/or horizontal offsets that will be applied to the Dropdown position.
+     * @see {@link DropdownProps#offset}
+     */
+    offset?: Offset;
+
+    /**
+     * The preferred Dropdown location against the anchor element.
+     * @see {@link DropdownProps#placement}
+     */
+    placement?: Placement;
+
+    /**
+     * Whether the dropdown should fit to the anchor width
+     * @see {@link DropdownProps#hasError}
+     */
+    fitToAnchorWidth?: boolean;
+
+    /**
+     * Whether the text field is displayed with error style or not.
+     * @see {@link TextFieldProps#hasError}
+     */
+    hasError?: boolean;
+
+    /**
+     * Text field helper message.
+     * @see {@link TextFieldProps#helper}
+     */
+    helper?: string;
+
+    /**
+     * Text field icon (SVG path)
+     * @see {@link TextFieldProps#icon}
+     */
+    icon?: string;
+
+    /**
+     * Whether the text field is disabled or not.
+     * @see {@link TextFieldProps#isDisabled}
+     */
+    isDisabled?: boolean;
+
+    /**
+     * Whether the text field is displayed with valid style or not.
+     * @see {@link TextFieldProps#isValid}
+     */
+    isValid?: boolean;
+
+    /**
+     * Text field label displayed in a label tag.
+     * @see {@link TextFieldProps#label}
+     */
+    label?: string;
+
+    /**
+     * Text field placeholder message.
+     * @see {@link TextFieldProps#placeholder}
+     */
+    placeholder?: string;
+
+    /** Theme. */
+    theme?: Theme;
+
+    /**
+     * Text field type (input or textarea).
+     * @see {@link TextFieldProps#type}
+     */
+    type?: TextFieldType;
+
     /**
      * Children of the Autocomplete. This should be a list of the different
      * suggestions that
@@ -43,6 +112,18 @@ interface IAutocompleteProps extends IGenericProps {
      * @see {@link DropdownProps#closeOnEscape}
      */
     closeOnEscape?: boolean;
+
+    /**
+     * The function to be called when the user clicks away or Escape is pressed
+     * @see {@link DropdownProps#onClose}
+     */
+    onClose?: VoidFunction;
+
+    /**
+     * The callback function called when the bottom of the dropdown is reached.
+     * @see {@link DropdownProps#onInfinite}
+     */
+    onInfinite?: VoidFunction;
 
     /**
      * Text field value change handler.
@@ -116,6 +197,20 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         isOpen,
         closeOnClick,
         closeOnEscape,
+        hasError,
+        helper,
+        icon,
+        isDisabled,
+        isValid,
+        label,
+        placeholder,
+        theme,
+        type,
+        onClose,
+        offset,
+        placement,
+        fitToAnchorWidth,
+        onInfiniteScroll,
         ...forwardedProps
     } = props;
     const textFieldRef = useRef(null);
@@ -137,14 +232,26 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 onKeyDown={onKeyDown}
                 onBlur={onBlur}
                 onFocus={onFocus}
-                {...forwardedProps}
+                hasError={hasError}
+                helper={helper}
+                icon={icon}
+                isDisabled={isDisabled}
+                isValid={isValid}
+                label={label}
+                placeholder={placeholder}
+                theme={theme}
+                type={type}
             />
             <Dropdown
                 anchorRef={textFieldRef}
                 showDropdown={isOpen}
                 closeOnClick={closeOnClick}
                 closeOnEscape={closeOnEscape}
-                {...forwardedProps}
+                onClose={onClose}
+                offset={offset}
+                placement={placement}
+                fitToAnchorWidth={fitToAnchorWidth}
+                onInfiniteScroll={onInfiniteScroll}
             >
                 {children}
             </Dropdown>

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -1,6 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useRef } from 'react';
 
 import classNames from 'classnames';
+
+import { Dropdown, TextField } from 'LumX';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { handleBasicClasses } from 'LumX/core/utils';
@@ -11,7 +13,28 @@ import { IGenericProps, getRootClassName } from 'LumX/react/utils';
 /**
  * Defines the props of the component.
  */
-interface IAutocompleteProps extends IGenericProps {}
+interface IAutocompleteProps extends IGenericProps {
+    /** Children of the Autocomplete. */
+    children: React.ReactNode;
+
+    /**
+     * Text field value.
+     * @see {@link TextFieldProps#onChange}
+     */
+    value: string;
+
+    /**
+     * Whether the suggestions from the autocomplete should be displayed or not.
+     * Useful to control the when the suggestions are displayed from outside the component
+     */
+    showSuggestions: boolean;
+
+    /**
+     * Text field value change handler.
+     * @see {@link TextFieldProps#onChange}
+     */
+    onChange(value: string): void;
+}
 type AutocompleteProps = IAutocompleteProps;
 
 /////////////////////////////
@@ -45,7 +68,17 @@ const DEFAULT_PROPS: Partial<AutocompleteProps> = {};
  * @return The component.
  */
 const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): ReactElement => {
-    const { children, className, ...forwardedProps } = props;
+    const {
+        className,
+        children,
+        value,
+        onChange,
+        showSuggestions,
+        closeOnClick,
+        closeOnEscape,
+        ...forwardedProps
+    } = props;
+    const textfieldRef = useRef(null);
 
     return (
         <div
@@ -57,7 +90,15 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
             )}
             {...forwardedProps}
         >
-            {children}
+            <TextField value={value} onChange={onChange} textFieldRef={textfieldRef} />
+            <Dropdown
+                anchorRef={textfieldRef}
+                showDropdown={showSuggestions}
+                closeOnClick={closeOnClick}
+                closeOnEscape={closeOnEscape}
+            >
+                {children}
+            </Dropdown>
         </div>
     );
 };

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -96,6 +96,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 showDropdown={showSuggestions}
                 closeOnClick={closeOnClick}
                 closeOnEscape={closeOnEscape}
+                {...forwardedProps}
             >
                 {children}
             </Dropdown>

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -25,15 +25,32 @@ interface IAutocompleteProps extends IGenericProps {
 
     /**
      * Whether the suggestions from the autocomplete should be displayed or not.
-     * Useful to control the when the suggestions are displayed from outside the component
+     * Useful to control when the suggestions are displayed from outside the component
      */
     showSuggestions: boolean;
+
+    /**
+     * Whether a click anywhere out of the Autocomplete would close it
+     * @see {@link TextFieldProps#closeOnClick}
+     */
+    closeOnClick?: boolean;
+
+    /**
+     * Whether an escape key press would close the Autocomplete.
+     * @see {@link TextFieldProps#closeOnEscape}
+     */
+    closeOnEscape?: boolean;
 
     /**
      * Text field value change handler.
      * @see {@link TextFieldProps#onChange}
      */
     onChange(value: string): void;
+
+    /**
+     * Text field on key down handler.
+     */
+    onKeyDown(value: string): void;
 }
 type AutocompleteProps = IAutocompleteProps;
 
@@ -58,7 +75,11 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: Partial<AutocompleteProps> = {};
+const DEFAULT_PROPS: Partial<AutocompleteProps> = {
+    closeOnClick: true,
+    closeOnEscape: true,
+    showSuggestions: undefined,
+};
 
 /////////////////////////////
 
@@ -91,7 +112,13 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
             )}
             {...forwardedProps}
         >
-            <TextField value={value} onChange={onChange} textFieldRef={textfieldRef} onKeyDown={onKeyDown} />
+            <TextField
+                value={value}
+                onChange={onChange}
+                textFieldRef={textfieldRef}
+                onKeyDown={onKeyDown}
+                {...forwardedProps}
+            />
             <Dropdown
                 anchorRef={textfieldRef}
                 showDropdown={showSuggestions}

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -81,12 +81,6 @@ interface IAutocompleteProps extends IGenericProps {
     theme?: Theme;
 
     /**
-     * Text field type (input or textarea).
-     * @see {@link TextFieldProps#type}
-     */
-    type?: TextFieldType;
-
-    /**
      * Children of the Autocomplete. This should be a list of the different
      * suggestions that
      */
@@ -202,7 +196,6 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         label,
         placeholder,
         theme,
-        type,
         onClose,
         offset,
         placement,
@@ -239,7 +232,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 label={label}
                 placeholder={placeholder}
                 theme={theme}
-                type={type}
+                type={TextFieldType.input}
             />
             <Dropdown
                 anchorRef={textFieldRef as React.RefObject<HTMLElement>}

--- a/src/components/autocomplete/react/__snapshots__/Autocomplete.test.tsx.snap
+++ b/src/components/autocomplete/react/__snapshots__/Autocomplete.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
+<div
+  className="lumx-autocomplete"
+>
+  <TextField
+    textFieldRef={
+      Object {
+        "current": null,
+      }
+    }
+  />
+  <Dropdown
+    anchorRef={
+      Object {
+        "current": null,
+      }
+    }
+  />
+</div>
+`;

--- a/src/components/autocomplete/react/__snapshots__/Autocomplete.test.tsx.snap
+++ b/src/components/autocomplete/react/__snapshots__/Autocomplete.test.tsx.snap
@@ -5,6 +5,11 @@ exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
   className="lumx-autocomplete"
 >
   <TextField
+    inputRef={
+      Object {
+        "current": null,
+      }
+    }
     textFieldRef={
       Object {
         "current": null,

--- a/src/components/autocomplete/react/__snapshots__/Autocomplete.test.tsx.snap
+++ b/src/components/autocomplete/react/__snapshots__/Autocomplete.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
         "current": null,
       }
     }
+    type="input"
   />
   <Dropdown
     anchorRef={

--- a/src/components/list/react/List.tsx
+++ b/src/components/list/react/List.tsx
@@ -11,6 +11,8 @@ import { ListItem, ListItemProps, Theme } from 'LumX';
 import { IGenericProps, getRootClassName, isComponent } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
 
+import { useKeyboardListNavigation, useKeyboardListNavigationType } from 'LumX/core/react/hooks';
+
 /////////////////////////////
 /**
  * Defines the props of the component.
@@ -65,12 +67,16 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 };
 /////////////////////////////
 
+interface IList {
+    useKeyboardListNavigation: useKeyboardListNavigationType;
+}
+
 /**
  * List component - Use vertical layout to display elements
  *
  * @return The component.
  */
-const List: React.FC<ListProps> = ({
+const List: React.FC<ListProps> & IList = ({
     className = '',
     isClickable = DEFAULT_PROPS.isClickable,
     onListItemSelected,
@@ -221,7 +227,9 @@ const List: React.FC<ListProps> = ({
         </ul>
     );
 };
+
 List.displayName = COMPONENT_NAME;
+List.useKeyboardListNavigation = useKeyboardListNavigation;
 
 /////////////////////////////
 

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -146,13 +146,19 @@ const ListItem: React.FC<ListItemProps> = ({
             ref={element}
             className={classNames(
                 className,
-                handleBasicClasses({ prefix: CLASSNAME, theme, selected: isSelected, clickable: isClickable, size }),
+                handleBasicClasses({
+                    clickable: isClickable,
+                    highlighted: isHighlighted,
+                    prefix: CLASSNAME,
+                    selected: isSelected,
+                    size,
+                    theme,
+                }),
             )}
             tabIndex={isClickable ? 0 : -1}
             onFocusCapture={preventParentFocus}
             onClick={onItemSelected}
             onKeyDown={onKeyDown()}
-            data-focus-visible-added={isHighlighted || undefined}
             {...props}
         >
             {before && <div className={`${CLASSNAME}__before`}>{before}</div>}

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -97,6 +97,7 @@ const ListItem: React.FC<ListItemProps> = ({
     after,
     children,
     className = '',
+    isHighlighted,
     isSelected = DEFAULT_PROPS.isSelected,
     isClickable = DEFAULT_PROPS.isSelected,
     isActive = DEFAULT_PROPS.isActive,
@@ -147,6 +148,7 @@ const ListItem: React.FC<ListItemProps> = ({
             onFocusCapture={preventParentFocus}
             onClick={onItemSelected}
             onKeyDown={onKeyDown()}
+            data-focus-visible-added={isHighlighted || undefined}
             {...props}
         >
             {before && <div className={`${CLASSNAME}__before`}>{before}</div>}

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -36,6 +36,9 @@ interface IListItemProps extends IGenericProps {
     /** Whether the list item is active. */
     isActive?: boolean;
 
+    /** Whether the list item should be highlighted. */
+    isHighlighted?: boolean;
+
     /** Whether the list item can be clicked. */
     isClickable?: boolean;
 
@@ -82,6 +85,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 const DEFAULT_PROPS: IDefaultPropsType = {
     isActive: false,
     isClickable: false,
+    isHighlighted: false,
     isSelected: false,
     size: ListItemSize.regular,
     theme: Theme.light,

--- a/src/components/list/style/lumapps/_index.scss
+++ b/src/components/list/style/lumapps/_index.scss
@@ -41,6 +41,10 @@
     &--is-selected {
         @include lumx-list-item-selected;
     }
+
+    &--is-highlighted {
+        @include lumx-list-item-highlighted;
+    }
 }
 
 /* Subheader

--- a/src/components/list/style/lumapps/_mixins.scss
+++ b/src/components/list/style/lumapps/_mixins.scss
@@ -36,6 +36,16 @@
     }
 }
 
+@mixin lumx-list-item-highlighted() {
+    cursor: pointer;
+
+    @include lumx-state(state-hover, emphasis-low, dark);
+
+    &:active {
+        @include lumx-state(state-active, emphasis-low, dark);
+    }
+}
+
 @mixin lumx-list-item-selected() {
     @include lumx-state-as-selected('state-default', 'dark');
 

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -229,10 +229,10 @@ const renderInputNative = (props: IInputNativeProps): ReactElement => {
                 disabled={isDisabled}
                 placeholder={placeholder}
                 value={value}
-                rows={rows}
                 onFocus={onTextFieldFocus}
                 onBlur={onTextFieldBlur}
                 onChange={handleChange}
+                rows={rows}
                 ref={inputRef as RefObject<HTMLTextAreaElement>}
                 {...forwardedProps}
             />

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -392,6 +392,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
         </div>
     );
 };
+
 TextField.displayName = COMPONENT_NAME;
 
 /////////////////////////////

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -64,14 +64,14 @@ interface ITextFieldProps extends IGenericProps {
     /** A ref that will be passed to the input or text area element. */
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
 
-    /** A ref that will be passed to the wrapper element. */
-    textFieldRef?: RefObject<HTMLDivElement>;
-
     /** Text field value. */
     value: string;
 
     /** Text field type (input or textarea). */
     type?: TextFieldType;
+
+    /** A ref that will be passed to the wrapper element. */
+    textFieldRef?: RefObject<HTMLDivElement>;
 
     /** Text field value change handler. */
     onChange(value: string): void;
@@ -229,10 +229,10 @@ const renderInputNative = (props: IInputNativeProps): ReactElement => {
                 disabled={isDisabled}
                 placeholder={placeholder}
                 value={value}
+                rows={rows}
                 onFocus={onTextFieldFocus}
                 onBlur={onTextFieldBlur}
                 onChange={handleChange}
-                rows={rows}
                 ref={inputRef as RefObject<HTMLTextAreaElement>}
                 {...forwardedProps}
             />
@@ -392,7 +392,6 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
         </div>
     );
 };
-
 TextField.displayName = COMPONENT_NAME;
 
 /////////////////////////////

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -64,14 +64,14 @@ interface ITextFieldProps extends IGenericProps {
     /** A ref that will be passed to the input or text area element. */
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
 
+    /** A ref that will be passed to the wrapper element. */
+    textFieldRef?: RefObject<HTMLDivElement>;
+
     /** Text field value. */
     value: string;
 
     /** Text field type (input or textarea). */
     type?: TextFieldType;
-
-    /** A ref that will be passed to the wrapper element. */
-    textFieldRef?: RefObject<HTMLDivElement>;
 
     /** Text field value change handler. */
     onChange(value: string): void;

--- a/src/core/react/hooks/index.tsx
+++ b/src/core/react/hooks/index.tsx
@@ -4,6 +4,8 @@ export { useComputePosition, useComputePositionType } from './useComputePosition
 
 export { useInterval } from './useInterval';
 
+export { useKeyboardListNavigation, useKeyboardListNavigationType } from './useKeyboardListNavigation';
+
 export { useBooleanState } from './useBooleanState';
 
 export { useInfiniteScroll } from './useInfiniteScroll';

--- a/src/core/react/hooks/useKeyboardListNavigation.tsx
+++ b/src/core/react/hooks/useKeyboardListNavigation.tsx
@@ -1,0 +1,112 @@
+import React, { SetStateAction, useState } from 'react';
+
+import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/core/constants';
+
+/////////////////////////////
+
+type useKeyboardListNavigationType = (
+    /** the list of items that will be navigated using the keyboard */
+    items: object[],
+    /** callback to be executed when the ENTER key is pressed on an item */
+    onListItemSelected: (itemSelected: object) => {},
+    /** where should the navigation start from. it defaults to `-1`, so the first item navigated is the item on position `0` */
+    initialIndex: number,
+) => {
+    /** the current active index */
+    activeItemIndex: number;
+    /** callback to be used when a key is pressed. usually used with the native prop `onKeyDown` */
+    onKeyboardNavigation(evt: React.KeyboardEvent): void;
+    /** Resets the active index to the initial state */
+    resetActiveIndex(): void;
+    /** Sets the active index to a given value */
+    setActiveItemIndex(value: SetStateAction<number>): void;
+};
+
+/////////////////////////////
+
+const INITIAL_INDEX = -1;
+
+/////////////////////////////
+
+/**
+ * This custom hook provides the necessary set of functions and values to properly navigate
+ * a list using the keyboard.
+ * @param items - the list of items that will be navigated using the keyboard
+ * @param onListItemSelected - callback to be executed when the ENTER key is pressed on an item
+ * @param initialIndex - where should the navigation start from. it defaults to `-1`, so the first item navigated is the item on position `0`
+ */
+const useKeyboardListNavigation: useKeyboardListNavigationType = (
+    items: object[],
+    onListItemSelected?: (itemSelected: object) => {},
+    initialIndex: number = INITIAL_INDEX,
+): {
+    activeItemIndex: number;
+    onKeyboardNavigation(evt: React.KeyboardEvent): void;
+    resetActiveIndex(): void;
+    setActiveItemIndex(value: SetStateAction<number>): void;
+} => {
+    const [activeItemIndex, setActiveItemIndex] = useState(initialIndex);
+
+    /**
+     * This function calculates the next index in the list to be highlighted
+     * @param keyPressed - key code pressed
+     * @return next active index
+     */
+    const calculateActiveIndex = (keyPressed: number): number => {
+        switch (keyPressed) {
+            case DOWN_KEY_CODE:
+                return activeItemIndex + 1 < items.length ? activeItemIndex + 1 : 0;
+            case UP_KEY_CODE:
+                return activeItemIndex - 1 >= 0 ? activeItemIndex - 1 : items.length - 1;
+            default:
+                return initialIndex;
+        }
+    };
+
+    /**
+     * Resets the active index to the initial state
+     */
+    const resetActiveIndex = (): void => {
+        setActiveItemIndex(initialIndex);
+    };
+
+    /**
+     * Calculates the next active item index depending on the key pressed.
+     * If the key pressed was ENTER, the function executes the callback `onListItemSelected`
+     * and resets the active index, since an item was selected.
+     * @param evt - key pressed or key down event
+     */
+    const onKeyboardNavigation = (evt: React.KeyboardEvent): void => {
+        const { keyCode } = evt;
+
+        if (keyCode === DOWN_KEY_CODE || evt.keyCode === UP_KEY_CODE) {
+            setActiveItemIndex(calculateActiveIndex(keyCode));
+            evt.nativeEvent.preventDefault();
+            evt.nativeEvent.stopPropagation();
+        } else if (keyCode === TAB_KEY_CODE) {
+            evt.nativeEvent.preventDefault();
+            evt.nativeEvent.stopPropagation();
+        } else if (keyCode === ENTER_KEY_CODE && onListItemSelected) {
+            evt.nativeEvent.preventDefault();
+            evt.nativeEvent.stopPropagation();
+            (evt.currentTarget as HTMLElement).blur();
+
+            const selectedItem: object = items[activeItemIndex];
+
+            if (selectedItem) {
+                // tslint:disable-next-line: no-inferred-empty-object-type
+                onListItemSelected(selectedItem);
+                resetActiveIndex();
+            }
+        }
+    };
+
+    return {
+        activeItemIndex,
+        onKeyboardNavigation,
+        resetActiveIndex,
+        setActiveItemIndex,
+    };
+};
+
+export { useKeyboardListNavigation, useKeyboardListNavigationType };

--- a/src/core/react/hooks/useKeyboardListNavigation.tsx
+++ b/src/core/react/hooks/useKeyboardListNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { SetStateAction, useState } from 'react';
+import { RefObject, SetStateAction, useEffect, useState } from 'react';
 
 import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/core/constants';
 
@@ -9,13 +9,15 @@ type useKeyboardListNavigationType = (
     items: object[],
     /** callback to be executed when the ENTER key is pressed on an item */
     onListItemSelected: (itemSelected: object) => {},
+    /** A reference to the element that is controlling the navigation. */
+    ref: RefObject<HTMLElement>,
     /** where should the navigation start from. it defaults to `-1`, so the first item navigated is the item on position `0` */
     initialIndex: number,
 ) => {
     /** the current active index */
     activeItemIndex: number;
     /** callback to be used when a key is pressed. usually used with the native prop `onKeyDown` */
-    onKeyboardNavigation(evt: React.KeyboardEvent): void;
+    onKeyboardNavigation(evt: KeyboardEvent): void;
     /** Resets the active index to the initial state */
     resetActiveIndex(): void;
     /** Sets the active index to a given value */
@@ -37,15 +39,70 @@ const INITIAL_INDEX = -1;
  */
 const useKeyboardListNavigation: useKeyboardListNavigationType = (
     items: object[],
-    onListItemSelected?: (itemSelected: object) => {},
+    onListItemSelected: (itemSelected: object) => {},
+    ref: RefObject<HTMLElement>,
     initialIndex: number = INITIAL_INDEX,
 ): {
     activeItemIndex: number;
-    onKeyboardNavigation(evt: React.KeyboardEvent): void;
+    onKeyboardNavigation(evt: KeyboardEvent): void;
     resetActiveIndex(): void;
     setActiveItemIndex(value: SetStateAction<number>): void;
 } => {
     const [activeItemIndex, setActiveItemIndex] = useState(initialIndex);
+
+    /**
+     * Calculates the next active item index depending on the key pressed.
+     * If the key pressed was ENTER, the function executes the callback `onListItemSelected`
+     * and resets the active index, since an item was selected.
+     * @param evt - key pressed or key down event
+     */
+    const onKeyboardNavigation = (evt: KeyboardEvent): void => {
+        // tslint:disable-next-line: deprecation
+        const { keyCode } = evt;
+
+        if (keyCode === DOWN_KEY_CODE || keyCode === UP_KEY_CODE) {
+            setActiveItemIndex(calculateActiveIndex(keyCode));
+            evt.preventDefault();
+            evt.stopPropagation();
+        } else if (keyCode === TAB_KEY_CODE) {
+            evt.preventDefault();
+            evt.stopPropagation();
+        } else if (keyCode === ENTER_KEY_CODE && onListItemSelected) {
+            evt.preventDefault();
+            evt.stopPropagation();
+            (evt.currentTarget as HTMLElement).blur();
+
+            const selectedItem: object = items[activeItemIndex];
+
+            if (selectedItem) {
+                // tslint:disable-next-line: no-inferred-empty-object-type
+                onListItemSelected(selectedItem);
+                resetActiveIndex();
+            }
+        }
+    };
+
+    /**
+     * Resets the active index to the initial state
+     */
+    const resetActiveIndex = (): void => {
+        setActiveItemIndex(initialIndex);
+    };
+
+    useEffect(() => {
+        if (ref && ref.current) {
+            const textFieldRefCurrent = ref.current;
+            textFieldRefCurrent.addEventListener('focus', resetActiveIndex);
+            textFieldRefCurrent.addEventListener('keydown', onKeyboardNavigation);
+
+            return (): void => {
+                textFieldRefCurrent.removeEventListener('focus', resetActiveIndex);
+                textFieldRefCurrent.removeEventListener('keydown', onKeyboardNavigation);
+            };
+        }
+
+        return undefined;
+    });
 
     /**
      * This function calculates the next index in the list to be highlighted
@@ -60,44 +117,6 @@ const useKeyboardListNavigation: useKeyboardListNavigationType = (
                 return activeItemIndex - 1 >= 0 ? activeItemIndex - 1 : items.length - 1;
             default:
                 return initialIndex;
-        }
-    };
-
-    /**
-     * Resets the active index to the initial state
-     */
-    const resetActiveIndex = (): void => {
-        setActiveItemIndex(initialIndex);
-    };
-
-    /**
-     * Calculates the next active item index depending on the key pressed.
-     * If the key pressed was ENTER, the function executes the callback `onListItemSelected`
-     * and resets the active index, since an item was selected.
-     * @param evt - key pressed or key down event
-     */
-    const onKeyboardNavigation = (evt: React.KeyboardEvent): void => {
-        const { keyCode } = evt;
-
-        if (keyCode === DOWN_KEY_CODE || evt.keyCode === UP_KEY_CODE) {
-            setActiveItemIndex(calculateActiveIndex(keyCode));
-            evt.nativeEvent.preventDefault();
-            evt.nativeEvent.stopPropagation();
-        } else if (keyCode === TAB_KEY_CODE) {
-            evt.nativeEvent.preventDefault();
-            evt.nativeEvent.stopPropagation();
-        } else if (keyCode === ENTER_KEY_CODE && onListItemSelected) {
-            evt.nativeEvent.preventDefault();
-            evt.nativeEvent.stopPropagation();
-            (evt.currentTarget as HTMLElement).blur();
-
-            const selectedItem: object = items[activeItemIndex];
-
-            if (selectedItem) {
-                // tslint:disable-next-line: no-inferred-empty-object-type
-                onListItemSelected(selectedItem);
-                resetActiveIndex();
-            }
         }
     };
 

--- a/src/core/react/hooks/useKeyboardListNavigation.tsx
+++ b/src/core/react/hooks/useKeyboardListNavigation.tsx
@@ -1,6 +1,6 @@
 import { RefObject, SetStateAction, useEffect, useState } from 'react';
 
-import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/core/constants';
+import { DOWN_KEY_CODE, ENTER_KEY_CODE, UP_KEY_CODE } from 'LumX/core/constants';
 
 /////////////////////////////
 
@@ -62,9 +62,6 @@ const useKeyboardListNavigation: useKeyboardListNavigationType = (
 
         if (keyCode === DOWN_KEY_CODE || keyCode === UP_KEY_CODE) {
             setActiveItemIndex(calculateActiveIndex(keyCode));
-            evt.preventDefault();
-            evt.stopPropagation();
-        } else if (keyCode === TAB_KEY_CODE) {
             evt.preventDefault();
             evt.stopPropagation();
         } else if (keyCode === ENTER_KEY_CODE && onListItemSelected) {

--- a/src/react.index.ts
+++ b/src/react.index.ts
@@ -6,6 +6,8 @@ export * from './components';
 
 export { Avatar, AvatarProps } from './components/avatar/react/Avatar';
 
+export { Autocomplete } from './components/autocomplete/react/Autocomplete';
+
 export { Button, ButtonEmphasis, ButtonProps } from './components/button/react/Button';
 
 export { ButtonGroup, ButtonGroupProps } from './components/button/react/ButtonGroup';

--- a/src/react.index.ts
+++ b/src/react.index.ts
@@ -85,7 +85,7 @@ export { Tabs, TabsProps, TabsLayout, TabsPosition } from './components/tabs/rea
 
 export { Tab, TabProps } from './components/tabs/react/Tab';
 
-export { TextField, TextFieldProps } from './components/text-field/react/TextField';
+export { TextField, TextFieldProps, TextFieldType } from './components/text-field/react/TextField';
 
 export { Tooltip, TooltipProps, TooltipPlacement } from './components/tooltip/react/Tooltip';
 

--- a/src/react.index.ts
+++ b/src/react.index.ts
@@ -85,7 +85,7 @@ export { Tabs, TabsProps, TabsLayout, TabsPosition } from './components/tabs/rea
 
 export { Tab, TabProps } from './components/tabs/react/Tab';
 
-export { TextField, TextFieldProps, TextFieldType } from './components/text-field/react/TextField';
+export { TextField, TextFieldProps } from './components/text-field/react/TextField';
 
 export { Tooltip, TooltipProps, TooltipPlacement } from './components/tooltip/react/Tooltip';
 


### PR DESCRIPTION
Created the first version of the autocomplete component. it supports:
- Filter options based on a given input
- Control over the value, options, and when the suggestions are displayed or not
- Navigate between options using the keyboard
- Selecting one option either by clicking or pressing Enter

**Simple usage**
![QHePgrkFJV](https://user-images.githubusercontent.com/13719066/66750498-e49f7b80-ee8c-11e9-88b9-b9713495c5fc.gif)

**Keyboard navigation**
![BrMiLlz37o](https://user-images.githubusercontent.com/13719066/66751172-aacf7480-ee8e-11e9-9e14-4cefc2a4770d.gif)

**No results**
![BRTzGGX353](https://user-images.githubusercontent.com/13719066/66750548-0b5db200-ee8d-11e9-93ee-f10cd06d92e0.gif)

**Note**: this variation may need css changes since the `no results` label is a little bit more gray on the mockups.

**Leave and come back**
![96ohhIcDx4](https://user-images.githubusercontent.com/13719066/66816530-86c96d00-ef3a-11e9-9299-179f2e795b87.gif)

Side effects:
- ListItem: in order to allow the keyboard navigation, it was necessary to add some sort of mechanism to ListItem in order to, from the outside, control which ListItem is highlighted. To do that, we can create a new prop called `isHighlighted` and control the boolean from the outside
- TextField: added textFieldRef in order to forward the ref, since `Dropdown` needs that reference to display the popover. Also, TextField did not allow to override `onFocus` and `onBlur`, so now, when the `onFocus` and `onBlur` are executed inside the component, they will check whether there are functions passed in as props and they will be executed first. `inputRef` was also added since it is necessary to have a reference to the actual input, and not the wrapper as `textFieldRef` did.

