### PR TITLE
feat(textfield-enhancements): Text field enhancements

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fix stroke-width property on react progress bar.
 -   Fixes to Text Area related to Input resizing and `valid` and `error` states in Material
+-   Text field enhancements (`before`, `after`, `onFocus`, `onBlur`, `textfieldRef`, `inputRef` props) [#199](https://github.com/lumapps/design-system/pull/199)
 
 ## [0.11.0][] - 2019-10-23
 

--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Text field enhancements (`chips`, `onFocus`, `onBlur`, `textfieldRef`, `inputRef` props) [#199](https://github.com/lumapps/design-system/pull/199)
+
 ### Changed
 
 -   Fix stroke-width property on react progress bar.
 -   Fixes to Text Area related to Input resizing and `valid` and `error` states in Material
--   Text field enhancements (`before`, `after`, `onFocus`, `onBlur`, `textfieldRef`, `inputRef` props) [#199](https://github.com/lumapps/design-system/pull/199)
 
 ## [0.11.0][] - 2019-10-23
 

--- a/demo/react/doc/product/components/chip.mdx
+++ b/demo/react/doc/product/components/chip.mdx
@@ -1,6 +1,6 @@
 ```javascript import
 import { useState } from 'react';
-import { Chip, Icon, Size } from 'LumX';
+import { Chip, ChipGroup, Icon, Size } from 'LumX';
 import { mdiEmail, mdiClose, mdiCloseCircle, mdiMenuDown, mdiFilterVariant } from 'LumX/icons';
 ```
 
@@ -140,6 +140,32 @@ Use small when space is a constraint, as in areas like text fields, selects, dro
 };
 ```
 
-# Properties 
+# Properties
 
 <PropTable component="Chip" />
+
+
+# Chip Group
+
+```javascript jsx withThemeSwitcher
+(theme) => {
+    return (
+        <ChipGroup>
+            <Chip theme={theme} size={Size.s}>
+                Default
+            </Chip>
+            <Chip theme={theme} size={Size.s} before={<Icon icon={mdiEmail} size={Size.xxs} />}>
+                Rich
+            </Chip>
+            <Chip theme={theme} size={Size.s} after={<Icon icon={mdiClose} size={Size.xxs} />}>
+                Dismissible
+            </Chip>
+        </ChipGroup>
+    );
+};
+```
+
+# Properties
+
+<PropTable component="ChipGroup" />
+

--- a/demo/react/doc/product/components/chip.mdx
+++ b/demo/react/doc/product/components/chip.mdx
@@ -169,3 +169,5 @@ Use small when space is a constraint, as in areas like text fields, selects, dro
 
 <PropTable component="ChipGroup" />
 
+<PropTable component="Chip" />
+

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -113,13 +113,13 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
             theme={theme}
             chips={
                 <ChipGroup>
-                    <Chip>
+                    <Chip size={Size.s}>
                         First
                     </Chip>
-                    <Chip>
+                    <Chip size={Size.s}>
                         Second
                     </Chip>
-                    <Chip>
+                    <Chip size={Size.s}>
                         Third
                     </Chip>
                 </ChipGroup>

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -91,6 +91,15 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
 ```
 
 ### Text Area
+### Clearable
+
+```javascript jsx withThemeSwitcher disableGrid
+(theme) => {
+    const [value, setValue] = useState('');
+
+    return <TextField isClearable value={value} onChange={setValue} theme={theme} />;
+};
+```
 
 ### With Buttons
 

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -90,7 +90,6 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
 };
 ```
 
-### Text Area
 ### Clearable
 
 ```javascript jsx withThemeSwitcher disableGrid
@@ -124,6 +123,8 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
 #### After button
 ```javascript jsx withThemeSwitcher disableGrid
 (theme) => {
+    const [value, setValue] = useState('');
+
     return (
         <TextField
             after={<IconButton emphasis={Emphasis.low} icon={mdiClose} />}
@@ -132,6 +133,36 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
             theme={theme}
         />
     );
+};
+```
+
+### Text Area
+
+```javascript jsx withThemeSwitcher disableGrid
+(theme) => {
+    const [value, setValue] = useState('');
+
+    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" />;
+};
+```
+
+### Valid
+
+```javascript jsx withThemeSwitcher disableGrid
+(theme) => {
+    const [value, setValue] = useState('Valid value');
+
+    return <TextField label="Textfield label" value={value} onChange={setValue} isValid theme={theme} type="textarea" />;
+};
+```
+
+### Invalid
+
+```javascript jsx withThemeSwitcher disableGrid
+(theme) => {
+    const [value, setValue] = useState('Invalid value');
+
+    return <TextField label="Textfield label" value={value} onChange={setValue} hasError theme={theme} type="textarea" />;
 };
 ```
 

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -114,13 +114,13 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
             chips={
                 <ChipGroup>
                     <Chip>
-                        Default
+                        First
                     </Chip>
                     <Chip>
-                        Rich
+                        Second
                     </Chip>
                     <Chip>
-                        Dismissible
+                        Third
                     </Chip>
                 </ChipGroup>
             }

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -1,7 +1,7 @@
 ```javascript import
 import { ReactElement, useState } from 'react';
-import { TextField, Theme } from 'LumX';
-import { mdiMagnify } from 'LumX/icons';
+import { TextField, Theme, IconButton, Emphasis, Size } from 'LumX';
+import { mdiMagnify, mdiClose } from 'LumX/icons';
 ```
 
 # Text field
@@ -50,7 +50,7 @@ There are three states: _disabled_, _valid_, and _invalid_.
 
 ## Options
 
-There are three options: _helper text_, _placeholder_ and _icon_.
+There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
 
 ### Helper text
 
@@ -92,31 +92,37 @@ There are three options: _helper text_, _placeholder_ and _icon_.
 
 ### Text Area
 
+### With Buttons
+
+#### Before button
+
 ```javascript jsx withThemeSwitcher disableGrid
 (theme) => {
     const [value, setValue] = useState('');
 
-    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" />;
+    return (
+        <TextField
+            value={value}
+            onChange={setValue}
+            theme={theme}
+            before={<IconButton emphasis={Emphasis.low} icon={mdiMagnify} />}
+        />
+    );
 };
 ```
 
-### Valid Text Area
 
+#### After button
 ```javascript jsx withThemeSwitcher disableGrid
 (theme) => {
-    const [value, setValue] = useState('');
-
-    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" isValid />;
-};
-```
-
-### Error Text Area
-
-```javascript jsx withThemeSwitcher disableGrid
-(theme) => {
-    const [value, setValue] = useState('');
-
-    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" hasError />;
+    return (
+        <TextField
+            after={<IconButton emphasis={Emphasis.low} icon={mdiClose} />}
+            value={value}
+            onChange={setValue}
+            theme={theme}
+        />
+    );
 };
 ```
 

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -1,6 +1,6 @@
 ```javascript import
 import { ReactElement, useState } from 'react';
-import { TextField, Theme, IconButton, Emphasis, Size } from 'LumX';
+import { Chip, ChipGroup, TextField, Theme, IconButton, Emphasis, Size } from 'LumX';
 import { mdiMagnify, mdiClose } from 'LumX/icons';
 ```
 
@@ -100,9 +100,7 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
 };
 ```
 
-### With Buttons
-
-#### Before button
+### With Chips
 
 ```javascript jsx withThemeSwitcher disableGrid
 (theme) => {
@@ -113,24 +111,19 @@ There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
             value={value}
             onChange={setValue}
             theme={theme}
-            before={<IconButton emphasis={Emphasis.low} icon={mdiMagnify} />}
-        />
-    );
-};
-```
-
-
-#### After button
-```javascript jsx withThemeSwitcher disableGrid
-(theme) => {
-    const [value, setValue] = useState('');
-
-    return (
-        <TextField
-            after={<IconButton emphasis={Emphasis.low} icon={mdiClose} />}
-            value={value}
-            onChange={setValue}
-            theme={theme}
+            chips={
+                <ChipGroup>
+                    <Chip>
+                        Default
+                    </Chip>
+                    <Chip>
+                        Rich
+                    </Chip>
+                    <Chip>
+                        Dismissible
+                    </Chip>
+                </ChipGroup>
+            }
         />
     );
 };

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -50,7 +50,7 @@ There are three states: _disabled_, _valid_, and _invalid_.
 
 ## Options
 
-There are four options: _helper text_, _placeholder_, _icon_ and _with buttons_.
+There are five options: _helper text_, _placeholder_, _icon_, _is clearable_ and _with chips_.
 
 ### Helper text
 

--- a/src/angularjs.index.js
+++ b/src/angularjs.index.js
@@ -7,6 +7,7 @@ import './components/button/angularjs/button_directive';
 import './components/button/angularjs/button-group_directive';
 import './components/checkbox/angularjs/checkbox_directive';
 import './components/chip/angularjs/chip_directive';
+import './components/chip/angularjs/chip-group_directive';
 import './components/comment-block/angularjs/comment-block_directive';
 import './components/dialog/angularjs/dialog_directive';
 import './components/dialog/angularjs/dialog_service';

--- a/src/components/button/style/lumapps/_mixins.scss
+++ b/src/components/button/style/lumapps/_mixins.scss
@@ -33,7 +33,7 @@
         }
     } @else if $variant == 'variant-icon' {
         width: map-get($lumx-sizes, $size);
-        border-radius: 50%;
+        border-radius: $lumx-button-variant-icon-border-radius;
     }
 }
 

--- a/src/components/button/style/lumapps/_variables.scss
+++ b/src/components/button/style/lumapps/_variables.scss
@@ -10,3 +10,5 @@ $lumx-button-icon-sizes: (
     'm': map-get($lumx-sizes, 'xs'),
     's': map-get($lumx-sizes, 'xxs')
 ) !default;
+
+$lumx-button-variant-icon-border-radius: $lumx-theme-border-radius !default;

--- a/src/components/button/style/material/_variables.scss
+++ b/src/components/button/style/material/_variables.scss
@@ -5,3 +5,5 @@ $lumx-button-text-sizes: (
 
 $lumx-button-text-weight: 500;
 $lumx-button-text-transform: uppercase;
+
+$lumx-button-variant-icon-border-radius: 50%;

--- a/src/components/chip/angularjs/chip-group_directive.js
+++ b/src/components/chip/angularjs/chip-group_directive.js
@@ -1,0 +1,82 @@
+import { CSS_PREFIX } from 'LumX/core/constants';
+import { COMPONENT_PREFIX, MODULE_NAME } from 'LumX/angularjs/constants/common_constants';
+
+/////////////////////////////
+
+function ChipGroupController() {
+    'ngInject';
+
+    // eslint-disable-next-line consistent-this
+    const lumx = this;
+
+    /////////////////////////////
+    //                         //
+    //    Private attributes   //
+    //                         //
+    /////////////////////////////
+
+    /**
+     * The default props.
+     *
+     * @type {Object}
+     * @constant
+     * @readonly
+     */
+    const _DEFAULT_PROPS = {
+        align: 'left',
+    };
+
+    /////////////////////////////
+    //                         //
+    //     Public functions    //
+    //                         //
+    /////////////////////////////
+
+    /**
+     * Get button classes.
+     *
+     * @return {Array} The list of button classes.
+     */
+    function getClasses() {
+        const classes = [];
+
+        if (angular.isDefined(lumx.align) && lumx.align) {
+            classes.push(`${CSS_PREFIX}-chip-group--align-${lumx.align}`);
+        } else {
+            classes.push(`${CSS_PREFIX}-chip-group--align-${_DEFAULT_PROPS.align}`);
+        }
+
+        return classes;
+    }
+
+    /////////////////////////////
+
+    lumx.getClasses = getClasses;
+}
+
+/////////////////////////////
+
+function ChipGroupDirective() {
+    'ngInject';
+
+    return {
+        bindToController: true,
+        controller: ChipGroupController,
+        controllerAs: 'lumx',
+        replace: true,
+        restrict: 'E',
+        scope: {
+            align: '@?lumxAlign',
+        },
+        template: `<div class="${CSS_PREFIX}-chip-group" ng-class="lumx.getClasses()" ng-transclude></div>`,
+        transclude: true,
+    };
+}
+
+/////////////////////////////
+
+angular.module(`${MODULE_NAME}.chip`).directive(`${COMPONENT_PREFIX}ChipGroup`, ChipGroupDirective);
+
+/////////////////////////////
+
+export { ChipGroupDirective };

--- a/src/components/chip/react/ChipGroup.test.tsx
+++ b/src/components/chip/react/ChipGroup.test.tsx
@@ -1,0 +1,38 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { ICommonSetup } from 'LumX/core/testing/utils.test';
+import { Chip } from './Chip';
+import { ChipGroup, ChipGroupProps } from './ChipGroup';
+
+interface ISetup extends ICommonSetup {}
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ *
+ * @param propOverrides An object that will extend the default properties.
+ * @return An object with some shortcuts to elements or data required in tests.
+ */
+const setup = (propOverrides: Partial<ChipGroupProps> = {}): ISetup => {
+    const props = {
+        children: [<Chip key="1">Chip 1</Chip>, <Chip key="2">Chip 2</Chip>, <Chip key="3">Chip 3</Chip>],
+        ...propOverrides,
+    };
+
+    const wrapper = shallow(<ChipGroup {...props} />);
+
+    return {
+        props,
+        wrapper,
+    };
+};
+
+describe('<ChipGroup />', () => {
+    // 1. Test render via snapshot (default state of component).
+    describe('Snapshot', () => {
+        it('should render correctly Chip Group component', () => {
+            const { wrapper } = setup();
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+});

--- a/src/components/chip/react/ChipGroup.tsx
+++ b/src/components/chip/react/ChipGroup.tsx
@@ -54,9 +54,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /////////////////////////////
 
 /**
- * Displays information or allow an action on a compact element.
- * This is the base component for all variations of the chips see https://material.io/design/components/chips.html.
- *
+ * Displays a list of Chips in a grouped fashion.
  * @return The Chip Group component.
  */
 const ChipGroup: React.FC<IChipGroupProps> = ({

--- a/src/components/chip/react/ChipGroup.tsx
+++ b/src/components/chip/react/ChipGroup.tsx
@@ -1,0 +1,85 @@
+import React, { ReactElement } from 'react';
+
+import classNames from 'classnames';
+
+import { CSS_PREFIX } from 'LumX/core/constants';
+import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
+
+import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
+
+/////////////////////////////
+
+/**
+ * Defines the props of the component.
+ */
+interface IChipGroupProps extends IGenericProps {
+    /** Children of the ChipGroup. This should be a list of Chips */
+    children: React.ReactNode;
+
+    /** Chip group alignment */
+    align?: string;
+}
+type ChipGroupProps = IChipGroupProps;
+
+/////////////////////////////
+
+/**
+ * Define the types of the default props.
+ */
+interface IDefaultPropsType extends Partial<ChipGroupProps> {}
+
+/////////////////////////////
+//                         //
+//    Public attributes    //
+//                         //
+/////////////////////////////
+
+/**
+ * The default value of props.
+ */
+const DEFAULT_PROPS: IDefaultPropsType = {
+    align: 'left',
+};
+
+/**
+ * The display name of the component.
+ */
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Chip`;
+
+/**
+ * The default class name and classes prefix for this component.
+ */
+const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
+
+/////////////////////////////
+
+/**
+ * Displays information or allow an action on a compact element.
+ * This is the base component for all variations of the chips see https://material.io/design/components/chips.html.
+ *
+ * @return The Chip Group component.
+ */
+const ChipGroup: React.FC<IChipGroupProps> = ({
+    className,
+    align = DEFAULT_PROPS.align,
+    children,
+    ...props
+}: ChipGroupProps): ReactElement => {
+    const chipGroupClassName = classNames(
+        `${CSS_PREFIX}-chip-group`,
+        `${CSS_PREFIX}-chip-group--align-${align}`,
+        className,
+    );
+
+    return (
+        <div className={chipGroupClassName} {...props}>
+            {children}
+        </div>
+    );
+};
+
+ChipGroup.displayName = COMPONENT_NAME;
+
+/////////////////////////////
+
+export { CLASSNAME, ChipGroup, ChipGroupProps };

--- a/src/components/chip/react/ChipGroup.tsx
+++ b/src/components/chip/react/ChipGroup.tsx
@@ -2,10 +2,10 @@ import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { CSS_PREFIX } from 'LumX/core/constants';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
+import { handleBasicClasses } from 'LumX/core/utils';
 
 /////////////////////////////
 
@@ -44,7 +44,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
 /**
  * The display name of the component.
  */
-const COMPONENT_NAME = `${COMPONENT_PREFIX}Chip`;
+const COMPONENT_NAME = `${COMPONENT_PREFIX}ChipGroup`;
 
 /**
  * The default class name and classes prefix for this component.
@@ -63,14 +63,13 @@ const ChipGroup: React.FC<IChipGroupProps> = ({
     children,
     ...props
 }: ChipGroupProps): ReactElement => {
-    const chipGroupClassName = classNames(
-        `${CSS_PREFIX}-chip-group`,
-        `${CSS_PREFIX}-chip-group--align-${align}`,
-        className,
-    );
+    const chipGroupClassName = handleBasicClasses({
+        align,
+        prefix: CLASSNAME,
+    });
 
     return (
-        <div className={chipGroupClassName} {...props}>
+        <div className={classNames(className, chipGroupClassName)} {...props}>
             {children}
         </div>
     );

--- a/src/components/chip/react/__snapshots__/ChipGroup.test.tsx.snap
+++ b/src/components/chip/react/__snapshots__/ChipGroup.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ChipGroup /> Snapshot should render correctly Chip Group component 1`] = `
+<div
+  className="lumx-chip-group lumx-chip-group--align-left"
+>
+  <Chip
+    key="1"
+  >
+    Chip 1
+  </Chip>
+  <Chip
+    key="2"
+  >
+    Chip 2
+  </Chip>
+  <Chip
+    key="3"
+  >
+    Chip 3
+  </Chip>
+</div>
+`;

--- a/src/components/chip/style/lumapps/_index.scss
+++ b/src/components/chip/style/lumapps/_index.scss
@@ -121,3 +121,28 @@
 .#{$lumx-base-prefix}-chip--is-disabled {
     @include lumx-state-disabled-input;
 }
+
+/* Chip group
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-chip-group {
+    display: flex;
+    flex-wrap: wrap;
+
+    .#{$lumx-base-prefix}-chip {
+        margin: $lumx-chip-group-spacing 0;
+    }
+
+    &--align-left .#{$lumx-base-prefix}-chip {
+        margin-right: $lumx-chip-group-spacing * 2;
+    }
+
+    &--align-center .#{$lumx-base-prefix}-chip {
+        margin-right: $lumx-chip-group-spacing;
+        margin-left: $lumx-chip-group-spacing;
+    }
+
+    &--align-right .#{$lumx-base-prefix}-chip {
+        margin-left: $lumx-chip-group-spacing * 2;
+    }
+}

--- a/src/components/chip/style/lumapps/_variables.scss
+++ b/src/components/chip/style/lumapps/_variables.scss
@@ -2,3 +2,5 @@ $lumx-chip-sizes: (
     'm': map-get($lumx-sizes, 'm'),
     's': map-get($lumx-sizes, 's')
 ) !default;
+
+$lumx-chip-group-spacing: 3px;

--- a/src/components/select/angularjs/select.html
+++ b/src/components/select/angularjs/select.html
@@ -22,7 +22,7 @@
     </span>
 
     <div
-        class="lumx-select__input-wrapper"
+        class="lumx-select__wrapper"
         id="{{ lumx.targetUuid }}"
         tabindex="0"
         ng-click="lumx.openDropdown()"
@@ -30,6 +30,24 @@
         ng-blur="lumx.disableKeyEvents()"
         ng-if="!lumx.variant || lumx.variant === 'input'"
     >
+        <div class="lumx-select__chips" ng-if="!lumx.isModelEmpty() && lumx.multiple">
+            <lumx-chip-group>
+                <lumx-chip
+                    lumx-on-click="lumx.select(selected, $event)"
+                    lumx-size="s"
+                    lumx-theme="{{ lumx.theme === 'dark' ? 'dark' : 'light' }}"
+                    ng-repeat="selected in lumx.viewValue"
+                    ng-disabled="lumx.isDisabled"
+                >
+                    <lumx-chip-label ng-bind-html="lumx.displaySelected(selected)"></lumx-chip-label>
+
+                    <lumx-chip-after>
+                        <lumx-icon lumx-path="{{ lumx.icons.mdiClose }}" lumx-size="xxs"></lumx-icon>
+                    </lumx-chip-after>
+                </lumx-chip>
+            </lumx-chip-group>
+        </div>
+
         <div
             class="lumx-select__input-native lumx-select__input-native--placeholder"
             ng-if="lumx.isModelEmpty() && lumx.placeholder"
@@ -41,40 +59,24 @@
             <span ng-bind-html="lumx.displaySelected()"></span>
         </div>
 
-        <div class="lumx-select__input-chips">
-            <div
-                class="lumx-select__input-chip"
-                ng-repeat="selected in lumx.viewValue"
-                ng-if="!lumx.isModelEmpty() && lumx.multiple"
-            >
-                <lumx-chip
-                    lumx-on-click="lumx.select(selected, $event)"
-                    lumx-size="s"
-                    lumx-theme="{{ lumx.theme === 'dark' ? 'dark' : 'light' }}"
-                    ng-disabled="lumx.isDisabled"
-                >
-                    <lumx-chip-label ng-bind-html="lumx.displaySelected(selected)"></lumx-chip-label>
-                    <lumx-chip-after
-                        ><lumx-icon lumx-path="{{ lumx.icons.mdiClose }}" lumx-size="xxs"></lumx-icon
-                    ></lumx-chip-after>
-                </lumx-chip>
-            </div>
-        </div>
-
         <div class="lumx-select__input-validity" ng-if="lumx.isValid || lumx.hasError">
             <lumx-icon
                 lumx-path="{{ lumx.isValid ? lumx.icons.mdiCheckCircle : lumx.icons.mdiAlertCircle }}"
-                lumx-size="xs"
+                lumx-size="xxs"
             ></lumx-icon>
         </div>
 
-        <div
+        <lumx-button
             class="lumx-select__input-clear"
+            lumx-emphasis="low"
+            lumx-size="s"
+            lumx-theme="{{ lumx.theme }}"
+            lumx-variant="icon"
             ng-if="lumx.isClearable && !lumx.multiple && !lumx.isModelEmpty()"
             ng-click="lumx.clearModel($event)"
         >
-            <lumx-icon lumx-path="{{ lumx.icons.mdiCloseCircle }}" lumx-size="xs"></lumx-icon>
-        </div>
+            <lumx-icon lumx-path="{{ lumx.icons.mdiCloseCircle }}"></lumx-icon>
+        </lumx-button>
 
         <div class="lumx-select__input-indicator">
             <lumx-icon lumx-path="{{ lumx.icons.mdiMenuDown }}" lumx-size="s"></lumx-icon>

--- a/src/components/select/angularjs/select.html
+++ b/src/components/select/angularjs/select.html
@@ -15,6 +15,7 @@
                 'lumx-select--has-error': lumx.hasError,
                 'lumx-select--has-placeholder': lumx.placeholder,
                 'lumx-select--is-focus': lumx.isFocus,
+                'lumx-select--has-input-clear': lumx.isClearable && !lumx.multiple && !lumx.isModelEmpty(),
                 'lumx-custom-colors': lumx.customColors }"
 >
     <span class="lumx-select__label" ng-if="::lumx.label && (!lumx.variant || lumx.variant === 'input')">

--- a/src/components/select/react/Select.tsx
+++ b/src/components/select/react/Select.tsx
@@ -7,7 +7,7 @@ import { mdiAlertCircle, mdiCheckCircle, mdiClose, mdiCloseCircle, mdiMenuDown }
 import { CSS_PREFIX } from 'LumX/core/constants';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
-import { Chip, Dropdown, Icon, Placement, Size, Theme } from 'LumX';
+import { Chip, ChipGroup, Dropdown, Icon, Placement, Size, Theme } from 'LumX';
 
 import { ENTER_KEY_CODE, SPACE_KEY_CODE } from 'LumX/core/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
@@ -280,6 +280,16 @@ const Select: React.FC<SelectProps> = ({
                             onKeyPress={handleKeyboardNav}
                             tabIndex={0}
                         >
+                            <div className={`${CLASSNAME}__chips`}>
+                                {!isEmpty && isMultiple && (
+                                    <ChipGroup>
+                                        {value.map((val: string, index: number) =>
+                                            selectedChipRender!(val, index, onClear, isDisabled),
+                                        )}
+                                    </ChipGroup>
+                                )}
+                            </div>
+
                             {isEmpty && placeholder && (
                                 <div
                                     className={classNames([
@@ -297,25 +307,15 @@ const Select: React.FC<SelectProps> = ({
                                 </div>
                             )}
 
-                            <div className={`${CLASSNAME}__input-chips`}>
-                                {!isEmpty &&
-                                    isMultiple &&
-                                    value.map((val: string, index: number) => (
-                                        <div key={index} className={`${CLASSNAME}__input-chip`}>
-                                            {selectedChipRender!(val, index, onClear, isDisabled)}
-                                        </div>
-                                    ))}
-                            </div>
-
                             {(isValid || hasError) && (
                                 <div className={`${CLASSNAME}__input-validity`}>
-                                    <Icon icon={isValid ? mdiCheckCircle : mdiAlertCircle} size={Size.xs} />
+                                    <Icon icon={isValid ? mdiCheckCircle : mdiAlertCircle} size={Size.xxs} />
                                 </div>
                             )}
 
                             {onClear && !isMultiple && !isEmpty && (
                                 <div className={`${CLASSNAME}__input-clear`} onClick={onClear}>
-                                    <Icon icon={mdiCloseCircle} size={Size.xs} />
+                                    <Icon icon={mdiCloseCircle} />
                                 </div>
                             )}
 

--- a/src/components/select/react/Select.tsx
+++ b/src/components/select/react/Select.tsx
@@ -275,7 +275,7 @@ const Select: React.FC<SelectProps> = ({
                         <div
                             ref={anchorRef as RefObject<HTMLDivElement>}
                             id={targetUuid}
-                            className={`${CLASSNAME}__input-wrapper`}
+                            className={`${CLASSNAME}__wrapper`}
                             onClick={onInputClick}
                             onKeyPress={handleKeyboardNav}
                             tabIndex={0}

--- a/src/components/select/react/Select.tsx
+++ b/src/components/select/react/Select.tsx
@@ -7,7 +7,7 @@ import { mdiAlertCircle, mdiCheckCircle, mdiClose, mdiCloseCircle, mdiMenuDown }
 import { CSS_PREFIX } from 'LumX/core/constants';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
-import { Chip, ChipGroup, Dropdown, Icon, Placement, Size, Theme } from 'LumX';
+import { Chip, ChipGroup, Dropdown, Emphasis, Icon, IconButton, Placement, Size, Theme } from 'LumX';
 
 import { ENTER_KEY_CODE, SPACE_KEY_CODE } from 'LumX/core/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
@@ -314,9 +314,14 @@ const Select: React.FC<SelectProps> = ({
                             )}
 
                             {onClear && !isMultiple && !isEmpty && (
-                                <div className={`${CLASSNAME}__input-clear`} onClick={onClear}>
-                                    <Icon icon={mdiCloseCircle} />
-                                </div>
+                                <IconButton
+                                    className={`${CLASSNAME}__input-clear`}
+                                    icon={mdiCloseCircle}
+                                    emphasis={Emphasis.low}
+                                    size={Size.s}
+                                    theme={theme}
+                                    onClick={onClear}
+                                />
                             )}
 
                             <div className={`${CLASSNAME}__input-indicator`}>

--- a/src/components/select/react/Select.tsx
+++ b/src/components/select/react/Select.tsx
@@ -254,6 +254,7 @@ const Select: React.FC<SelectProps> = ({
     const isEmpty = value.length === 0;
     const targetUuid = 'uuid';
     const anchorRef = useRef<HTMLElement>(null);
+    const hasInputClear = onClear && !isMultiple && !isEmpty;
 
     useFocusOnClose(anchorRef.current, isOpen);
     useHandleElementFocus(anchorRef.current, setIsFocus);
@@ -313,7 +314,7 @@ const Select: React.FC<SelectProps> = ({
                                 </div>
                             )}
 
-                            {onClear && !isMultiple && !isEmpty && (
+                            {hasInputClear && (
                                 <IconButton
                                     className={`${CLASSNAME}__input-clear`}
                                     icon={mdiCloseCircle}
@@ -364,6 +365,7 @@ const Select: React.FC<SelectProps> = ({
                 className,
                 handleBasicClasses({
                     hasError,
+                    hasInputClear,
                     hasLabel: Boolean(label),
                     hasMultiple: !isEmpty && isMultiple,
                     hasPlaceholder: Boolean(placeholder),

--- a/src/components/select/react/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/react/__snapshots__/Select.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Select> Snapshots and structure should render correctly 1`] = `
   className="lumx-select lumx-select--is-empty lumx-select--theme-light"
 >
   <div
-    className="lumx-select__input-wrapper"
+    className="lumx-select__wrapper"
     id="uuid"
     onKeyPress={[Function]}
     tabIndex={0}

--- a/src/components/select/react/__snapshots__/Select.test.tsx.snap
+++ b/src/components/select/react/__snapshots__/Select.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<Select> Snapshots and structure should render correctly 1`] = `
     tabIndex={0}
   >
     <div
-      className="lumx-select__input-chips"
+      className="lumx-select__chips"
     />
     <div
       className="lumx-select__input-indicator"

--- a/src/components/select/style/lumapps/_index.scss
+++ b/src/components/select/style/lumapps/_index.scss
@@ -15,30 +15,31 @@
         }
     }
 
-    &__input-wrapper {
+    &__wrapper {
+        flex-wrap: nowrap !important;
         cursor: pointer;
 
-        #{$self}--theme-light#{$self}--is-empty &,
-        #{$self}--theme-light#{$self}--has-unique & {
-            @include lumx-text-field-input-wrapper('dark', true, false);
+        #{$self}--theme-light & {
+            @include lumx-text-field-wrapper('dark');
         }
 
-        #{$self}--theme-dark#{$self}--is-empty &,
-        #{$self}--theme-dark#{$self}--has-unique & {
-            @include lumx-text-field-input-wrapper('light', true, false);
+        #{$self}--theme-dark & {
+            @include lumx-text-field-wrapper('dark');
         }
 
-        #{$self}--theme-light#{$self}--has-multiple & {
-            @include lumx-text-field-input-wrapper('dark', true, true);
+        #{$self}--has-label & {
+            @include lumx-text-field-wrapper-has-label;
         }
 
-        #{$self}--theme-dark#{$self}--has-multiple & {
-            @include lumx-text-field-input-wrapper('light', true, true);
+        #{$self}--multiple & {
+            @include lumx-text-field-wrapper-has-chips;
         }
     }
 
-    &--has-label &__input-wrapper {
-        margin-top: $lumx-spacing-unit;
+    &__chips {
+        @include lumx-text-field-chips;
+
+        flex: 1;
     }
 
     &__input-native {
@@ -61,26 +62,8 @@
         }
     }
 
-    &__input-chips {
-        display: flex;
-        flex: 1;
-        flex-wrap: wrap;
-    }
-
-    &__input-chip {
-        @include lumx-select-input-chip;
-    }
-
     &__input-clear {
-        flex-shrink: 0;
-
-        #{$self}--theme-light & {
-            @include lumx-select-input-clear('dark');
-        }
-
-        #{$self}--theme-dark & {
-            @include lumx-select-input-clear('light');
-        }
+        @include lumx-text-field-input-clear;
     }
 
     &__input-validity {
@@ -129,7 +112,7 @@
 
 // Disabled state
 .#{$lumx-base-prefix}-select--is-disabled {
-    .#{$lumx-base-prefix}-select__input-wrapper {
+    .#{$lumx-base-prefix}-select__wrapper {
         @include lumx-state-disabled-input;
     }
 
@@ -147,33 +130,31 @@
 }
 
 // Hover state
-.#{$lumx-base-prefix}-select--theme-light .#{$lumx-base-prefix}-select__input-wrapper:hover {
-    @include lumx-text-field-input-wrapper-state('state-hover', 'dark');
+.#{$lumx-base-prefix}-select--theme-light .#{$lumx-base-prefix}-select__wrapper:hover {
+    @include lumx-text-field-wrapper-state('state-hover', 'dark');
 }
 
-.#{$lumx-base-prefix}-select--theme-dark .#{$lumx-base-prefix}-select__input-wrapper:hover {
-    @include lumx-text-field-input-wrapper-state('state-hover', 'light');
+.#{$lumx-base-prefix}-select--theme-dark .#{$lumx-base-prefix}-select__wrapper:hover {
+    @include lumx-text-field-wrapper-state('state-hover', 'light');
 }
 
 // Focus state
-.#{$lumx-base-prefix}-select--theme-light.#{$lumx-base-prefix}-select--is-open
-.#{$lumx-base-prefix}-select__input-wrapper,
-.#{$lumx-base-prefix}-select--theme-light .#{$lumx-base-prefix}-select__input-wrapper:focus {
-    @include lumx-text-field-input-wrapper-state('state-focus', 'dark');
+.#{$lumx-base-prefix}-select--theme-light.#{$lumx-base-prefix}-select--is-open .#{$lumx-base-prefix}-select__wrapper,
+.#{$lumx-base-prefix}-select--theme-light .#{$lumx-base-prefix}-select__wrapper:focus {
+    @include lumx-text-field-wrapper-state('state-focus', 'dark');
 }
 
-.#{$lumx-base-prefix}-select--theme-dark.#{$lumx-base-prefix}-select--is-open
-.#{$lumx-base-prefix}-select__input-wrapper,
-.#{$lumx-base-prefix}-select--theme-dark .#{$lumx-base-prefix}-select__input-wrapper:focus {
-    @include lumx-text-field-input-wrapper-state('state-focus', 'light');
+.#{$lumx-base-prefix}-select--theme-dark.#{$lumx-base-prefix}-select--is-open .#{$lumx-base-prefix}-select__wrapper,
+.#{$lumx-base-prefix}-select--theme-dark .#{$lumx-base-prefix}-select__wrapper:focus {
+    @include lumx-text-field-wrapper-state('state-focus', 'light');
 }
 
 /* Select validity
    ========================================================================== */
 
 .#{$lumx-base-prefix}-select--theme-light.#{$lumx-base-prefix}-select--is-valid {
-    .#{$lumx-base-prefix}-select__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('valid', 'dark');
+    .#{$lumx-base-prefix}-select__wrapper {
+        @include lumx-text-field-wrapper-validity('valid', 'dark');
     }
 
     .#{$lumx-base-prefix}-select__input-validity {
@@ -182,8 +163,8 @@
 }
 
 .#{$lumx-base-prefix}-select--theme-light.#{$lumx-base-prefix}-select--has-error {
-    .#{$lumx-base-prefix}-select__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('error', 'dark');
+    .#{$lumx-base-prefix}-select__wrapper {
+        @include lumx-text-field-wrapper-validity('error', 'dark');
     }
 
     .#{$lumx-base-prefix}-select__input-validity {
@@ -192,8 +173,8 @@
 }
 
 .#{$lumx-base-prefix}-select--theme-dark.#{$lumx-base-prefix}-select--is-valid {
-    .#{$lumx-base-prefix}-select__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('valid', 'light');
+    .#{$lumx-base-prefix}-select__wrapper {
+        @include lumx-text-field-wrapper-validity('valid', 'light');
     }
 
     .#{$lumx-base-prefix}-select__input-validity {
@@ -202,8 +183,8 @@
 }
 
 .#{$lumx-base-prefix}-select--theme-dark.#{$lumx-base-prefix}-select--has-error {
-    .#{$lumx-base-prefix}-select__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('error', 'light');
+    .#{$lumx-base-prefix}-select__wrapper {
+        @include lumx-text-field-wrapper-validity('error', 'light');
     }
 
     .#{$lumx-base-prefix}-select__input-validity {

--- a/src/components/select/style/lumapps/_index.scss
+++ b/src/components/select/style/lumapps/_index.scss
@@ -80,6 +80,10 @@
         #{$self}--theme-dark & {
             @include lumx-select-input-indicator('light');
         }
+
+        #{$self}--has-input-clear & {
+            margin-left: $lumx-spacing-unit / 2;
+        }
     }
 
     &__filter {

--- a/src/components/select/style/lumapps/_index.scss
+++ b/src/components/select/style/lumapps/_index.scss
@@ -24,7 +24,7 @@
         }
 
         #{$self}--theme-dark & {
-            @include lumx-text-field-wrapper('dark');
+            @include lumx-text-field-wrapper('light');
         }
 
         #{$self}--has-label & {

--- a/src/components/select/style/lumapps/_mixins.scss
+++ b/src/components/select/style/lumapps/_mixins.scss
@@ -1,19 +1,5 @@
-@mixin lumx-select-input-chip() {
-    height: map-get($lumx-chip-sizes, 's');
-    margin: 3px;
-}
-
-@mixin lumx-select-input-clear($theme) {
-    margin-left: $lumx-spacing-unit;
-    color: lumx-theme-color-variant($theme, 'N');
-
-    &:hover {
-        opacity: 0.8;
-    }
-}
-
 @mixin lumx-select-input-indicator($theme) {
-    margin-left: $lumx-spacing-unit;
+    margin-left: $lumx-spacing-unit / 2;
     color: lumx-theme-color-variant($theme, 'N');
 }
 

--- a/src/components/select/style/lumapps/_mixins.scss
+++ b/src/components/select/style/lumapps/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin lumx-select-input-indicator($theme) {
-    margin-left: $lumx-spacing-unit / 2;
+    margin-left: $lumx-spacing-unit;
     color: lumx-theme-color-variant($theme, 'N');
 }
 

--- a/src/components/select/style/material/_index.scss
+++ b/src/components/select/style/material/_index.scss
@@ -24,15 +24,15 @@
         }
     }
 
-    &__input-wrapper {
+    &__wrapper {
         padding-left: 0 !important;
 
         #{$self}--theme-light & {
-            @include lumx-text-field-material-input-wrapper('dark');
+            @include lumx-text-field-material-wrapper('dark');
         }
 
         #{$self}--theme-dark & {
-            @include lumx-text-field-material-input-wrapper('light');
+            @include lumx-text-field-material-wrapper('light');
         }
     }
 
@@ -52,8 +52,8 @@
 // Focus state
 .#{$lumx-base-prefix}-select--is-focus,
 .#{$lumx-base-prefix}-select--is-open {
-    .#{$lumx-base-prefix}-select__input-wrapper {
-        @include lumx-text-field-material-input-wrapper-focus;
+    .#{$lumx-base-prefix}-select__wrapper {
+        @include lumx-text-field-material-wrapper-focus;
     }
 }
 

--- a/src/components/select/style/material/_index.scss
+++ b/src/components/select/style/material/_index.scss
@@ -70,3 +70,26 @@
         @include lumx-text-field-material-label-focus('light');
     }
 }
+
+/* Select validity
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-select--theme-light.#{$lumx-base-prefix}-select--is-valid {
+    .#{$lumx-base-prefix}-select__label {
+        @include lumx-text-field-material-label-validity('valid');
+    }
+
+    .#{$lumx-base-prefix}-select__wrapper {
+        @include lumx-text-field-material-wrapper-validity('valid');
+    }
+}
+
+.#{$lumx-base-prefix}-select--theme-light.#{$lumx-base-prefix}-select--has-error {
+    .#{$lumx-base-prefix}-select__label {
+        @include lumx-text-field-material-label-validity('error');
+    }
+
+    .#{$lumx-base-prefix}-select__wrapper {
+        @include lumx-text-field-material-wrapper-validity('error');
+    }
+}

--- a/src/components/text-field/angularjs/text-field.html
+++ b/src/components/text-field/angularjs/text-field.html
@@ -2,8 +2,10 @@
     class="lumx-text-field"
     ng-class="{ 'lumx-text-field--theme-light': !lumx.theme || lumx.theme === 'light',
                 'lumx-text-field--theme-dark': lumx.theme === 'dark',
-                'lumx-text-field--has-label': lumx.label,
+                'lumx-text-field--has-chips': lumx.hasChips,
                 'lumx-text-field--has-icon': lumx.icon,
+                'lumx-text-field--has-input-clear': lumx.isClearable && lumx.hasValue(),
+                'lumx-text-field--has-label': lumx.label,
                 'lumx-text-field--has-value': lumx.hasValue(),
                 'lumx-text-field--is-valid': lumx.isValid,
                 'lumx-text-field--has-error': lumx.hasError,
@@ -15,21 +17,38 @@
 
     <span class="lumx-text-field__helper" ng-if="::lumx.helper">{{ lumx.helper }}</span>
 
-    <div class="lumx-text-field__input-wrapper">
+    <div class="lumx-text-field__wrapper">
         <lumx-icon
             class="lumx-text-field__input-icon"
             lumx-path="{{ lumx.icon }}"
             lumx-size="xs"
-            ng-if="::lumx.icon"
+            ng-if="::lumx.icon && !lumx.hasChips"
         ></lumx-icon>
 
-        <div class="lumx-text-field__input-native" ng-transclude></div>
+        <div class="lumx-text-field__chips" ng-transclude="chips" ng-if="::lumx.hasChips"></div>
 
-        <lumx-icon
-            class="lumx-text-field__input-validity"
-            lumx-path="{{ lumx.isValid ? lumx.icons.mdiCheckCircle : lumx.icons.mdiAlertCircle }}"
-            lumx-size="xs"
-            ng-if="lumx.isValid || lumx.hasError"
-        ></lumx-icon>
+        <div class="lumx-text-field__input-wrapper">
+            <div class="lumx-text-field__input-native" ng-transclude ng-if="::!lumx.hasInput"></div>
+            <div class="lumx-text-field__input-native" ng-transclude="input" ng-if="::lumx.hasInput"></div>
+
+            <lumx-icon
+                class="lumx-text-field__input-validity"
+                lumx-path="{{ lumx.isValid ? lumx.icons.mdiCheckCircle : lumx.icons.mdiAlertCircle }}"
+                lumx-size="xxs"
+                ng-if="lumx.isValid || lumx.hasError"
+            ></lumx-icon>
+
+            <lumx-button
+                class="lumx-text-field__input-clear"
+                lumx-emphasis="low"
+                lumx-size="s"
+                lumx-theme="{{ lumx.theme }}"
+                lumx-variant="icon"
+                ng-if="lumx.isClearable && lumx.hasValue()"
+                ng-click="lumx.clearModel($event)"
+            >
+                <lumx-icon lumx-path="{{ lumx.icons.mdiCloseCircle }}"></lumx-icon>
+            </lumx-button>
+        </div>
     </div>
 </div>

--- a/src/components/text-field/angularjs/text-field_directive.js
+++ b/src/components/text-field/angularjs/text-field_directive.js
@@ -1,7 +1,7 @@
 import { CSS_PREFIX } from 'LumX/core/constants';
 import { COMPONENT_PREFIX, MODULE_NAME } from 'LumX/angularjs/constants/common_constants';
 
-import { mdiAlertCircle, mdiCheckCircle } from 'LumX/icons';
+import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from 'LumX/icons';
 
 import template from './text-field.html';
 
@@ -33,6 +33,20 @@ function TextFieldController(LumXUtilsService) {
     /////////////////////////////
 
     /**
+     * Whether the directive has chips slot filled or not.
+     *
+     * @type {boolean}
+     */
+    lumx.hasChips = false;
+
+    /**
+     * Whether the directive has input slot filled or not.
+     *
+     * @type {boolean}
+     */
+    lumx.hasInput = false;
+
+    /**
      * The text field icons.
      *
      * @type {Object}
@@ -40,6 +54,7 @@ function TextFieldController(LumXUtilsService) {
     lumx.icons = {
         mdiAlertCircle,
         mdiCheckCircle,
+        mdiCloseCircle,
     };
 
     /**
@@ -56,12 +71,26 @@ function TextFieldController(LumXUtilsService) {
     /////////////////////////////
 
     /**
+     * Clear the model on clear button click.
+     *
+     * @param {Event} [evt] The event that triggered the function.
+     */
+    function clearModel(evt) {
+        if (angular.isDefined(evt)) {
+            evt.stopPropagation();
+        }
+
+        _modelController.$setViewValue(undefined);
+        _modelController.$render();
+    }
+
+    /**
      * Define if the model controller has a value or not.
      *
      * @return {boolean} Wether the model controller has a value or not.
      */
     function hasValue() {
-        if (angular.isUndefined(_modelController.$viewValue)) {
+        if (angular.isUndefined(_modelController) || angular.isUndefined(_modelController.$viewValue)) {
             return false;
         }
 
@@ -79,70 +108,81 @@ function TextFieldController(LumXUtilsService) {
 
     /////////////////////////////
 
+    lumx.clearModel = clearModel;
     lumx.hasValue = hasValue;
     lumx.setModelController = setModelController;
 }
 
 /////////////////////////////
 
-function TextFieldDirective() {
+function TextFieldDirective($timeout) {
     'ngInject';
 
-    function link(scope, el, attrs, ctrl) {
-        const _MIN_ROWS = 2;
-
-        let input = el.find('input');
-
-        if (input.length === 1) {
-            el.addClass(`${CSS_PREFIX}-text-field--has-input`);
-        } else {
-            input = el.find('textarea');
-
-            input.on('input', (evt) => {
-                evt.target.rows = _MIN_ROWS;
-                const currentRows = evt.target.scrollHeight / (evt.target.clientHeight / _MIN_ROWS);
-                evt.target.rows = currentRows;
-            });
-
-            el.addClass(`${CSS_PREFIX}-text-field--has-textarea`);
+    function link(scope, el, attrs, ctrl, transclude) {
+        if (transclude.isSlotFilled('chips')) {
+            ctrl.hasChips = true;
         }
 
-        const modelController = input.data('$ngModelController');
-
-        ctrl.setModelController(modelController);
-
-        if (input.attr('id')) {
-            ctrl.inputId = input.attr('id');
-        } else {
-            input.attr('id', ctrl.inputId);
+        if (transclude.isSlotFilled('input')) {
+            ctrl.hasInput = true;
         }
 
-        input
-            .on('focus', function onFocus() {
-                el.addClass(`${CSS_PREFIX}-text-field--is-focus`);
-            })
-            .on('blur', function onBlur() {
-                el.removeClass(`${CSS_PREFIX}-text-field--is-focus`);
+        $timeout(() => {
+            const _MIN_ROWS = 2;
+
+            let input = el.find('input');
+
+            if (input.length === 1) {
+                el.addClass(`${CSS_PREFIX}-text-field--has-input`);
+            } else {
+                input = el.find('textarea');
+
+                input.on('input', (evt) => {
+                    evt.target.rows = _MIN_ROWS;
+                    const currentRows = evt.target.scrollHeight / (evt.target.clientHeight / _MIN_ROWS);
+                    evt.target.rows = currentRows;
+                });
+
+                el.addClass(`${CSS_PREFIX}-text-field--has-textarea`);
+            }
+
+            const modelController = input.data('$ngModelController');
+
+            ctrl.setModelController(modelController);
+
+            if (input.attr('id')) {
+                ctrl.inputId = input.attr('id');
+            } else {
+                input.attr('id', ctrl.inputId);
+            }
+
+            input
+                .on('focus', function onFocus() {
+                    el.addClass(`${CSS_PREFIX}-text-field--is-focus`);
+                })
+                .on('blur', function onBlur() {
+                    el.removeClass(`${CSS_PREFIX}-text-field--is-focus`);
+                });
+
+            modelController.$$attr.$observe('disabled', (isDisabled) => {
+                if (isDisabled) {
+                    el.addClass(`${CSS_PREFIX}-text-field--is-disabled`);
+                } else {
+                    el.removeClass(`${CSS_PREFIX}-text-field--is-disabled`);
+                }
             });
 
-        modelController.$$attr.$observe('disabled', (isDisabled) => {
-            if (isDisabled) {
-                el.addClass(`${CSS_PREFIX}-text-field--is-disabled`);
-            } else {
-                el.removeClass(`${CSS_PREFIX}-text-field--is-disabled`);
-            }
-        });
+            modelController.$$attr.$observe('placeholder', (placeholder) => {
+                if (placeholder.length > 0) {
+                    el.addClass(`${CSS_PREFIX}-text-field--has-placeholder`);
+                } else {
+                    el.removeClass(`${CSS_PREFIX}-text-field--has-placeholder`);
+                }
+            });
 
-        modelController.$$attr.$observe('placeholder', (placeholder) => {
-            if (placeholder.length > 0) {
-                el.addClass(`${CSS_PREFIX}-text-field--has-placeholder`);
-            } else {
-                el.removeClass(`${CSS_PREFIX}-text-field--has-placeholder`);
-            }
-        });
-
-        scope.$on('$destroy', () => {
-            input.off();
+            scope.$on('$destroy', () => {
+                input.off();
+            });
         });
     }
 
@@ -158,12 +198,16 @@ function TextFieldDirective() {
             hasError: '=?lumxHasError',
             helper: '@?lumxHelper',
             icon: '@?lumxIcon',
+            isClearable: '=?lumxIsClearable',
             isValid: '=?lumxIsValid',
             label: '@?lumxLabel',
             theme: '@?lumxTheme',
         },
         template,
-        transclude: true,
+        transclude: {
+            chips: `?${COMPONENT_PREFIX}TextFieldChips`,
+            input: `?${COMPONENT_PREFIX}TextFieldInput`,
+        },
     };
 }
 

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -76,9 +76,6 @@ interface ITextFieldProps extends IGenericProps {
     /** A ref that will be passed to the wrapper element. */
     textFieldRef?: RefObject<HTMLDivElement>;
 
-    /** A ref that will be passed to the input or text area element. */
-    inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
-
     /** Text field value change handler. */
     onChange(value: string): void;
 
@@ -176,7 +173,6 @@ interface IInputNativeProps {
     id?: string;
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
     isDisabled?: boolean;
-    inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
     placeholder?: string;
     type?: TextFieldType;
     value: string;
@@ -290,7 +286,6 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
         type = DEFAULT_PROPS.type,
         useCustomColors,
         textFieldRef,
-        inputRef,
         value,
         ...forwardedProps
     } = props;

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -9,7 +9,7 @@ import { CSS_PREFIX } from 'LumX/core/constants';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
-import { mdiAlertCircle, mdiCheckCircle, mdiClose } from 'LumX/icons';
+import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from 'LumX/icons';
 
 /////////////////////////////
 
@@ -288,6 +288,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
 
     const [isFocus, setFocus] = useState(false);
     const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(minimumRows);
+    const isNotEmpty = value && value.length > 0;
 
     /**
      * Function triggered when the Clear Button is clicked.
@@ -312,6 +313,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                     hasError: !isValid && hasError,
                     hasIcon: Boolean(icon),
                     hasInput: type === TextFieldType.input,
+                    hasInputClear: isClearable && isNotEmpty,
                     hasLabel: Boolean(label),
                     hasPlaceholder: Boolean(placeholder),
                     hasTextarea: type === TextFieldType.textarea,
@@ -347,36 +349,45 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                     />
                 )}
 
-                <div className={`${CLASSNAME}__input-native`}>
-                    {renderInputNative({
-                        id,
-                        inputRef,
-                        isDisabled,
-                        onBlur,
-                        onChange,
-                        onFocus,
-                        placeholder,
-                        recomputeNumberOfRows,
-                        rows,
-                        setFocus,
-                        type,
-                        value,
-                        ...forwardedProps,
-                    })}
+                <div className={`${CLASSNAME}__input-wrapper`}>
+                    <div className={`${CLASSNAME}__input-native`}>
+                        {renderInputNative({
+                            id,
+                            inputRef,
+                            isDisabled,
+                            onBlur,
+                            onChange,
+                            onFocus,
+                            placeholder,
+                            recomputeNumberOfRows,
+                            rows,
+                            setFocus,
+                            type,
+                            value,
+                            ...forwardedProps,
+                        })}
+                    </div>
+
+                    {(isValid || hasError) && (
+                        <Icon
+                            className={`${CLASSNAME}__input-validity`}
+                            color={theme === Theme.dark ? 'light' : undefined}
+                            icon={isValid ? mdiCheckCircle : mdiAlertCircle}
+                            size={Size.xxs}
+                        />
+                    )}
+
+                    {isClearable && isNotEmpty && (
+                        <IconButton
+                            className={`${CLASSNAME}__input-clear`}
+                            icon={mdiCloseCircle}
+                            emphasis={Emphasis.low}
+                            size={Size.s}
+                            theme={theme}
+                            onClick={onClear}
+                        />
+                    )}
                 </div>
-
-                {isClearable && (
-                    <IconButton icon={mdiClose} emphasis={Emphasis.low} size={Size.s} theme={theme} onClick={onClear} />
-                )}
-
-                {(isValid || hasError) && (
-                    <Icon
-                        className={`${CLASSNAME}__input-validity`}
-                        color={theme === Theme.dark ? 'light' : undefined}
-                        icon={isValid ? mdiCheckCircle : mdiAlertCircle}
-                        size={Size.xs}
-                    />
-                )}
             </div>
         </div>
     );

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -22,11 +22,8 @@ enum TextFieldType {
  * Defines the props of the component.
  */
 interface ITextFieldProps extends IGenericProps {
-    /** A component to be rendered after the main text input. */
-    after?: HTMLElement | ReactNode;
-
-    /** A component to be rendered before the main text input */
-    before?: HTMLElement | ReactNode;
+    /** A Chip Group to be rendered before the main text input */
+    chips?: HTMLElement | ReactNode;
 
     /** Whether the text field is displayed with error style or not. */
     hasError?: boolean;
@@ -265,8 +262,7 @@ const renderInputNative = (props: IInputNativeProps): ReactElement => {
  */
 const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElement => {
     const {
-        after,
-        before,
+        chips,
         className = '',
         hasError,
         helper,
@@ -312,6 +308,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
             className={classNames(
                 className,
                 handleBasicClasses({
+                    hasChips: Boolean(chips),
                     hasError: !isValid && hasError,
                     hasIcon: Boolean(icon),
                     hasInput: type === TextFieldType.input,
@@ -319,6 +316,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                     hasPlaceholder: Boolean(placeholder),
                     hasTextarea: type === TextFieldType.textarea,
                     hasValue: Boolean(value),
+                    isClearable,
                     isDisabled,
                     isFocus,
                     isValid,
@@ -338,7 +336,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
             {helper && <span className={`${CLASSNAME}__helper`}>{helper}</span>}
 
             <div className={`${CLASSNAME}__wrapper`}>
-                {before}
+                {chips && <div className={`${CLASSNAME}__chips`}>{chips}</div>}
 
                 {icon && (
                     <Icon
@@ -379,8 +377,6 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                         size={Size.xs}
                     />
                 )}
-
-                {after}
             </div>
         </div>
     );

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -4,12 +4,12 @@ import classNames from 'classnames';
 import get from 'lodash/get';
 import uuid from 'uuid/v4';
 
-import { Icon, Size, Theme } from 'LumX';
+import { Emphasis, Icon, IconButton, Size, Theme } from 'LumX';
 import { CSS_PREFIX } from 'LumX/core/constants';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
-import { mdiAlertCircle, mdiCheckCircle } from 'LumX/icons';
+import { mdiAlertCircle, mdiCheckCircle, mdiClose } from 'LumX/icons';
 
 /////////////////////////////
 
@@ -45,6 +45,9 @@ interface ITextFieldProps extends IGenericProps {
 
     /** Whether the text field is displayed with valid style or not. */
     isValid?: boolean;
+
+    /** Whether the text field shows a cross to clear its content or not. */
+    isClearable?: boolean;
 
     /** Text field label displayed in a label tag. */
     label?: string;
@@ -115,6 +118,7 @@ const MIN_ROWS = 2;
  */
 const DEFAULT_PROPS: Partial<TextFieldProps> = {
     hasError: false,
+    isClearable: false,
     isDisabled: false,
     isValid: false,
     minimumRows: MIN_ROWS,
@@ -273,6 +277,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
         icon,
         id = uuid(),
         isDisabled,
+        isClearable = DEFAULT_PROPS.isClearable,
         isValid,
         label,
         onChange,
@@ -292,6 +297,20 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
 
     const [isFocus, setFocus] = useState(false);
     const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(minimumRows);
+
+    /**
+     * Function triggered when the Clear Button is clicked.
+     * The idea is to execute the `onChange` callback with an empty string
+     * and remove focus from the clear button.
+     * @param evt On clear event.
+     */
+    const onClear = (evt: React.ChangeEvent): void => {
+        evt.nativeEvent.preventDefault();
+        evt.nativeEvent.stopPropagation();
+        (evt.currentTarget as HTMLElement).blur();
+
+        onChange('');
+    };
 
     return (
         <div
@@ -352,6 +371,10 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                         ...forwardedProps,
                     })}
                 </div>
+
+                {isClearable && (
+                    <IconButton icon={mdiClose} emphasis={Emphasis.low} size={Size.s} theme={theme} onClick={onClear} />
+                )}
 
                 {(isValid || hasError) && (
                     <Icon

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -337,7 +337,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
 
             {helper && <span className={`${CLASSNAME}__helper`}>{helper}</span>}
 
-            <div className={`${CLASSNAME}__input-wrapper`}>
+            <div className={`${CLASSNAME}__wrapper`}>
                 {before}
 
                 {icon && (

--- a/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<TextField> Snapshots and structure should render defaults 1`] = `
   className="lumx-text-field lumx-text-field--has-input lumx-text-field--theme-light"
 >
   <div
-    className="lumx-text-field__input-wrapper"
+    className="lumx-text-field__wrapper"
   >
     <div
       className="lumx-text-field__input-native"
@@ -27,7 +27,7 @@ exports[`<TextField> Snapshots and structure should render textarea 1`] = `
   className="lumx-text-field lumx-text-field--has-textarea lumx-text-field--theme-light"
 >
   <div
-    className="lumx-text-field__input-wrapper"
+    className="lumx-text-field__wrapper"
   >
     <div
       className="lumx-text-field__input-native"

--- a/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
@@ -8,15 +8,19 @@ exports[`<TextField> Snapshots and structure should render defaults 1`] = `
     className="lumx-text-field__wrapper"
   >
     <div
-      className="lumx-text-field__input-native"
+      className="lumx-text-field__input-wrapper"
     >
-      <input
-        id="fixedId"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="text"
-      />
+      <div
+        className="lumx-text-field__input-native"
+      >
+        <input
+          id="fixedId"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="text"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -30,15 +34,19 @@ exports[`<TextField> Snapshots and structure should render textarea 1`] = `
     className="lumx-text-field__wrapper"
   >
     <div
-      className="lumx-text-field__input-native"
+      className="lumx-text-field__input-wrapper"
     >
-      <textarea
-        id="fixedId"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        rows={2}
-      />
+      <div
+        className="lumx-text-field__input-native"
+      >
+        <textarea
+          id="fixedId"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          rows={2}
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/text-field/style/lumapps/_index.scss
+++ b/src/components/text-field/style/lumapps/_index.scss
@@ -25,26 +25,34 @@
         }
     }
 
-    &__input-wrapper {
+    &__wrapper {
         #{$self}--has-input#{$self}--theme-light & {
-            @include lumx-text-field-input-wrapper('dark', false, false, 'input');
+            @include lumx-text-field-wrapper('dark', 'input');
         }
 
         #{$self}--has-input#{$self}--theme-dark & {
-            @include lumx-text-field-input-wrapper('light', false, false, 'input');
+            @include lumx-text-field-wrapper('light', 'input');
         }
 
         #{$self}--has-textarea#{$self}--theme-light & {
-            @include lumx-text-field-input-wrapper('dark', false, false, 'textarea');
+            @include lumx-text-field-wrapper('dark', 'textarea');
         }
 
         #{$self}--has-textarea#{$self}--theme-dark & {
-            @include lumx-text-field-input-wrapper('light', false, false, 'textarea');
+            @include lumx-text-field-wrapper('light', 'textarea');
+        }
+
+        #{$self}--has-input-clear & {
+            @include lumx-text-field-wrapper-has-input-clear;
+        }
+
+        #{$self}--has-chips & {
+            @include lumx-text-field-wrapper-has-chips;
         }
     }
 
-    &--has-label &__input-wrapper {
-        margin-top: $lumx-spacing-unit;
+    &--has-label &__wrapper {
+        @include lumx-text-field-wrapper-has-label;
     }
 
     &__input-icon {
@@ -57,6 +65,10 @@
         #{$self}--theme-dark & {
             @include lumx-text-field-input-icon('light');
         }
+    }
+
+    &__input-wrapper {
+        @include lumx-text-field-input-wrapper;
     }
 
     &__input-native {
@@ -96,8 +108,12 @@
         }
     }
 
-    &__input-validity {
-        flex-shrink: 0;
+    &__input-clear {
+        @include lumx-text-field-input-clear;
+    }
+
+    &__chips {
+        @include lumx-text-field-chips;
     }
 }
 
@@ -106,7 +122,7 @@
 
 // Disabled state
 .#{$lumx-base-prefix}-text-field--is-disabled {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
+    .#{$lumx-base-prefix}-text-field__wrapper {
         @include lumx-state-disabled-input;
     }
 
@@ -127,27 +143,27 @@
 
 // Hover state
 .#{$lumx-base-prefix}-text-field--theme-light {
-    .#{$lumx-base-prefix}-text-field__input-wrapper:hover {
-        @include lumx-text-field-input-wrapper-state('state-hover', 'dark');
+    .#{$lumx-base-prefix}-text-field__wrapper:hover {
+        @include lumx-text-field-wrapper-state('state-hover', 'dark');
     }
 }
 
 .#{$lumx-base-prefix}-text-field--theme-dark {
-    .#{$lumx-base-prefix}-text-field__input-wrapper:hover {
-        @include lumx-text-field-input-wrapper-state('state-hover', 'light');
+    .#{$lumx-base-prefix}-text-field__wrapper:hover {
+        @include lumx-text-field-wrapper-state('state-hover', 'light');
     }
 }
 
 // Focus state
 .#{$lumx-base-prefix}-text-field--theme-light.#{$lumx-base-prefix}-text-field--is-focus {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-input-wrapper-state('state-focus', 'dark');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-wrapper-state('state-focus', 'dark');
     }
 }
 
 .#{$lumx-base-prefix}-text-field--theme-dark.#{$lumx-base-prefix}-text-field--is-focus {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-input-wrapper-state('state-focus', 'light');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-wrapper-state('state-focus', 'light');
     }
 }
 
@@ -155,8 +171,8 @@
    ========================================================================== */
 
 .#{$lumx-base-prefix}-text-field--theme-light.#{$lumx-base-prefix}-text-field--is-valid {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('valid', 'dark');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-wrapper-validity('valid', 'dark');
     }
 
     .#{$lumx-base-prefix}-text-field__input-validity {
@@ -165,8 +181,8 @@
 }
 
 .#{$lumx-base-prefix}-text-field--theme-light.#{$lumx-base-prefix}-text-field--has-error {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('error', 'dark');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-wrapper-validity('error', 'dark');
     }
 
     .#{$lumx-base-prefix}-text-field__input-validity {
@@ -175,8 +191,8 @@
 }
 
 .#{$lumx-base-prefix}-text-field--theme-dark.#{$lumx-base-prefix}-text-field--is-valid {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('valid', 'light');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-wrapper-validity('valid', 'light');
     }
 
     .#{$lumx-base-prefix}-text-field__input-validity {
@@ -185,8 +201,8 @@
 }
 
 .#{$lumx-base-prefix}-text-field--theme-dark.#{$lumx-base-prefix}-text-field--has-error {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-input-wrapper-validity('error', 'light');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-wrapper-validity('error', 'light');
     }
 
     .#{$lumx-base-prefix}-text-field__input-validity {

--- a/src/components/text-field/style/lumapps/_mixins.scss
+++ b/src/components/text-field/style/lumapps/_mixins.scss
@@ -1,6 +1,7 @@
-@mixin lumx-text-field-input-wrapper($theme, $has-indicator: false, $is-multiple: false, $type: 'input') {
+@mixin lumx-text-field-wrapper($theme, $type: 'input') {
     position: relative;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     background-color: lumx-theme-color-variant($theme, 'L6');
     border-radius: $lumx-theme-border-radius;
@@ -10,20 +11,30 @@
     transition-property: background-color, box-shadow;
 
     @if $type == 'input' {
-        @if $is-multiple {
-            min-height: $lumx-text-field-height;
-            padding: 3px;
-        } @else {
-            height: $lumx-text-field-height;
-            padding: 0 $lumx-text-field-horizontal-padding;
-        }
+        height: $lumx-text-field-height;
+        padding: 0 $lumx-text-field-horizontal-padding;
     } @else {
         padding: $lumx-text-field-vertical-padding $lumx-text-field-horizontal-padding;
     }
+}
 
-    @if $has-indicator {
-        padding-right: $lumx-spacing-unit * 1.5;
-    }
+@mixin lumx-text-field-wrapper-has-label() {
+    margin-top: $lumx-spacing-unit;
+}
+
+@mixin lumx-text-field-wrapper-has-input-clear() {
+    padding-right: $lumx-spacing-unit !important;
+}
+
+@mixin lumx-text-field-wrapper-has-chips() {
+    height: auto !important;
+    min-height: $lumx-text-field-height;
+}
+
+@mixin lumx-text-field-input-wrapper() {
+    display: flex;
+    flex: 1;
+    align-items: center;
 }
 
 @mixin lumx-text-field-input-icon($theme) {
@@ -36,6 +47,7 @@
 
     display: block;
     width: 100%;
+    min-width: $lumx-text-field-min-width;
     padding: 0;
     border: none;
     margin: 0;
@@ -50,6 +62,7 @@
 }
 
 @mixin lumx-text-field-input-validity($validity, $theme) {
+    flex-shrink: 0;
     margin-left: $lumx-spacing-unit;
 
     @if $theme == 'dark' {
@@ -63,11 +76,19 @@
     }
 }
 
+@mixin lumx-text-field-input-clear() {
+    margin-left: $lumx-spacing-unit / 2;
+}
+
+@mixin lumx-text-field-chips() {
+    margin: $lumx-chip-group-spacing 0;
+}
+
 @mixin lumx-text-field-placeholder($theme) {
     color: lumx-theme-color-variant($theme, 'L2');
 }
 
-@mixin lumx-text-field-input-wrapper-state($state, $theme) {
+@mixin lumx-text-field-wrapper-state($state, $theme) {
     @if $state == 'state-hover' {
         background-color: lumx-theme-color-variant($theme, 'L5');
     } @else if $state == 'state-focus' {
@@ -81,7 +102,7 @@
     }
 }
 
-@mixin lumx-text-field-input-wrapper-validity($validity, $theme) {
+@mixin lumx-text-field-wrapper-validity($validity, $theme) {
     @if $theme == 'dark' {
         @if $validity == 'valid' {
             box-shadow: inset 0 0 0 2px lumx-theme-color-variant('green', 'N');

--- a/src/components/text-field/style/lumapps/_variables.scss
+++ b/src/components/text-field/style/lumapps/_variables.scss
@@ -1,4 +1,5 @@
 $lumx-text-field-height: map-get($lumx-sizes, 'm') !default;
-$lumx-text-field-horizontal-padding: $lumx-spacing-unit * 2 !default;
+$lumx-text-field-horizontal-padding: $lumx-spacing-unit * 1.5 !default;
 $lumx-text-field-vertical-padding: $lumx-spacing-unit * 1.5 !default;
 $lumx-text-field-transition-duration: 100ms;
+$lumx-text-field-min-width: 150px;

--- a/src/components/text-field/style/material/_index.scss
+++ b/src/components/text-field/style/material/_index.scss
@@ -24,7 +24,8 @@
 
         #{$self}--has-placeholder &,
         #{$self}--has-value &,
-        #{$self}--is-focus & {
+        #{$self}--is-focus &,
+        #{$self}--has-chips & {
             transform: scale(0.75) translateY(0);
         }
     }
@@ -33,13 +34,17 @@
         display: none !important;
     }
 
-    &__input-wrapper {
+    &__wrapper {
         #{$self}--theme-light & {
-            @include lumx-text-field-material-input-wrapper('dark');
+            @include lumx-text-field-material-wrapper('dark');
         }
 
         #{$self}--theme-dark & {
-            @include lumx-text-field-material-input-wrapper('light');
+            @include lumx-text-field-material-wrapper('light');
+        }
+
+        #{$self}--has-input-clear & {
+            padding-right: 0 !important;
         }
     }
 
@@ -59,8 +64,8 @@
 
 // Focus state
 .#{$lumx-base-prefix}-text-field--is-focus {
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-material-input-wrapper-focus;
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-material-wrapper-focus;
     }
 }
 

--- a/src/components/text-field/style/material/_index.scss
+++ b/src/components/text-field/style/material/_index.scss
@@ -89,8 +89,8 @@
         @include lumx-text-field-material-label-validity('valid');
     }
 
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-material-input-wrapper-validity('valid');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-material-wrapper-validity('valid');
     }
 }
 
@@ -99,7 +99,7 @@
         @include lumx-text-field-material-label-validity('error');
     }
 
-    .#{$lumx-base-prefix}-text-field__input-wrapper {
-        @include lumx-text-field-material-input-wrapper-validity('error');
+    .#{$lumx-base-prefix}-text-field__wrapper {
+        @include lumx-text-field-material-wrapper-validity('error');
     }
 }

--- a/src/components/text-field/style/material/_mixins.scss
+++ b/src/components/text-field/style/material/_mixins.scss
@@ -27,7 +27,7 @@
     }
 }
 
-@mixin lumx-text-field-material-input-wrapper($theme) {
+@mixin lumx-text-field-material-wrapper($theme) {
     position: relative;
     margin-top: 0;
     background-color: transparent !important;
@@ -80,7 +80,7 @@
     }
 }
 
-@mixin lumx-text-field-material-input-wrapper-focus() {
+@mixin lumx-text-field-material-wrapper-focus() {
     &::after {
         transform: scaleX(1);
     }

--- a/src/components/text-field/style/material/_mixins.scss
+++ b/src/components/text-field/style/material/_mixins.scss
@@ -64,7 +64,7 @@
     }
 }
 
-@mixin lumx-text-field-material-input-wrapper-validity($validity) {
+@mixin lumx-text-field-material-wrapper-validity($validity) {
     &::after {
         transform: scaleX(1);
     }

--- a/src/core/custom-colors.js
+++ b/src/core/custom-colors.js
@@ -330,8 +330,8 @@ function _getSelectCSSRules(colorPalette, theme) {
         selectRules = [
             {
                 selector: `
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light.${CSS_PREFIX}-select--is-open .${CSS_PREFIX}-select__input-wrapper,
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light .${CSS_PREFIX}-select__input-wrapper:focus
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light.${CSS_PREFIX}-select--is-open:not(.${CSS_PREFIX}-select--has-error):not(.${CSS_PREFIX}-select--is-valid) .${CSS_PREFIX}-select__wrapper,
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light:not(.${CSS_PREFIX}-select--has-error):not(.${CSS_PREFIX}-select--is-valid) .${CSS_PREFIX}-select__wrapper:focus
                 `,
                 rule: `box-shadow: inset 0 0 0 2px ${colorPalette.primary.L2}`,
             },
@@ -340,14 +340,14 @@ function _getSelectCSSRules(colorPalette, theme) {
         selectRules = [
             {
                 selector: `
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light.${CSS_PREFIX}-select--is-focus .${CSS_PREFIX}-select__label,
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light.${CSS_PREFIX}-select--is-open .${CSS_PREFIX}-select__label
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light.${CSS_PREFIX}-select--is-focus:not(.${CSS_PREFIX}-select--has-error):not(.${CSS_PREFIX}-select--is-valid) .${CSS_PREFIX}-select__label,
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light.${CSS_PREFIX}-select--is-open:not(.${CSS_PREFIX}-select--has-error):not(.${CSS_PREFIX}-select--is-valid) .${CSS_PREFIX}-select__label
                 `,
                 rule: `color: ${colorPalette.primary.N}`,
             },
             {
                 selector: `
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light .${CSS_PREFIX}-select__input-wrapper::after
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-select--theme-light:not(.${CSS_PREFIX}-select--has-error):not(.${CSS_PREFIX}-select--is-valid) .${CSS_PREFIX}-select__wrapper::after
                 `,
                 rule: `background-color: ${colorPalette.primary.N}`,
             },
@@ -554,7 +554,7 @@ function _getTextFieldCSSRules(colorPalette, theme) {
         textFieldRules = [
             {
                 selector: `
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-text-field--theme-light.${CSS_PREFIX}-text-field--is-focus .${CSS_PREFIX}-text-field__input-wrapper
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-text-field--theme-light.${CSS_PREFIX}-text-field--is-focus:not(.${CSS_PREFIX}-text-field--has-error):not(.${CSS_PREFIX}-text-field--is-valid) .${CSS_PREFIX}-text-field__wrapper
                 `,
                 rule: `box-shadow: inset 0 0 0 2px ${colorPalette.primary.L2}`,
             },
@@ -563,13 +563,13 @@ function _getTextFieldCSSRules(colorPalette, theme) {
         textFieldRules = [
             {
                 selector: `
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-text-field--theme-light.${CSS_PREFIX}-text-field--is-focus .${CSS_PREFIX}-text-field__label
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-text-field--theme-light.${CSS_PREFIX}-text-field--is-focus:not(.${CSS_PREFIX}-text-field--has-error):not(.${CSS_PREFIX}-text-field--is-valid) .${CSS_PREFIX}-text-field__label
                 `,
                 rule: `color: ${colorPalette.primary.N}`,
             },
             {
                 selector: `
-                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-text-field--theme-light .${CSS_PREFIX}-text-field__input-wrapper::after
+                    .${CSS_PREFIX}-custom-colors.${CSS_PREFIX}-text-field--theme-light:not(.${CSS_PREFIX}-text-field--has-error):not(.${CSS_PREFIX}-text-field--is-valid) .${CSS_PREFIX}-text-field__wrapper::after
                 `,
                 rule: `background-color: ${colorPalette.primary.N}`,
             },

--- a/src/react.index.ts
+++ b/src/react.index.ts
@@ -14,6 +14,8 @@ export { Checkbox, CheckboxProps } from './components/checkbox/react/Checkbox';
 
 export { Chip, ChipProps } from './components/chip/react/Chip';
 
+export { ChipGroup, ChipGroupProps } from './components/chip/react/ChipGroup';
+
 export { Divider, DividerProps } from './components/divider/react/Divider';
 
 export { Dropdown, DropdownProps } from './components/dropdown/react/Dropdown';


### PR DESCRIPTION
Due to the upcoming feature `Autocomplete and Autocomplete multiple` there are some changes that we need on the Text Field:
- In order to have the possibility to show a list of chips before the Text Field, we add the props `chips` to the Text Field and show them before the native input.

![Screenshot 2019-10-25 at 10 32 56](https://user-images.githubusercontent.com/13719066/67556094-d6feb700-f712-11e9-8848-0ae61c4739a4.png)

- In order to have the ability to listen to the `focus` and `blur` events on the text field itself, it was necessary to add the props `onFocus` and `onBlur` and pass them on the native input, where they were overwritten. If these functions are passed on, they will be executed.

- Furthermore, in order to use this component in conjunction  with the Dropdown, we need to provide a `ref` to the Dropdown so it knows where to open. On the other hand, if we want to manually trigger the focus on the text field, we need a reference to the input itself (input or text area, depends on the type of Text Field used). In order to tackle that, two different props are created, one of them associated with the Text field wrapper, and another one associated with to the native input. 

- Also, a prop called `isClearable` was added in order to allow erasing the content on the text field.
![ECmxFl0MH2](https://user-images.githubusercontent.com/13719066/67406531-7bb7b200-f5b6-11e9-9a9a-1be70cac9360.gif)

- Moreover, a component called ChipGroup was created in order to support a list of chips presented in a grouped fashion, which we will use in the future for the `AutocompleteMultiple` component
