### PR TITLE
fix(textarea styles): Text area height and style fixes

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ The `tags` prop of the `ImageBlock` must now be JSX and not an array.
 -   Minor SCSS style changes on the `Tooltip` component.
 -   Image Lazy Loading for Thumbnail Component [#190]
+-   Fixes to Text Area related to Input resizing and `valid` and `error` states in Material
 
 ### Removed
 

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -100,6 +100,26 @@ There are three options: _helper text_, _placeholder_ and _icon_.
 };
 ```
 
+### Valid Text Area
+
+```javascript jsx withThemeSwitcher disableGrid
+(theme) => {
+    const [value, setValue] = useState('');
+
+    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" isValid />;
+};
+```
+
+### Error Text Area
+
+```javascript jsx withThemeSwitcher disableGrid
+(theme) => {
+    const [value, setValue] = useState('');
+
+    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" hasError />;
+};
+```
+
 ### Properties
 
 <PropTable component="TextField" />

--- a/demo/react/doc/product/components/text-field.mdx
+++ b/demo/react/doc/product/components/text-field.mdx
@@ -90,6 +90,16 @@ There are three options: _helper text_, _placeholder_ and _icon_.
 };
 ```
 
+### Text Area
+
+```javascript jsx withThemeSwitcher disableGrid
+(theme) => {
+    const [value, setValue] = useState('');
+
+    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" />;
+};
+```
+
 ### Properties
 
 <PropTable component="TextField" />

--- a/src/components/select/style/material/_index.scss
+++ b/src/components/select/style/material/_index.scss
@@ -37,13 +37,7 @@
     }
 
     &__input-native {
-        #{$self}--theme-light & {
-            @include lumx-text-field-material-input-native('dark');
-        }
-
-        #{$self}--theme-dark & {
-            @include lumx-text-field-material-input-native('light');
-        }
+        @include lumx-text-field-material-input-native();
     }
 
     &__input-chip {

--- a/src/components/select/style/material/_index.scss
+++ b/src/components/select/style/material/_index.scss
@@ -37,7 +37,7 @@
     }
 
     &__input-native {
-        @include lumx-text-field-material-input-native();
+        @include lumx-text-field-material-input-native('input');
     }
 
     &__input-chip {

--- a/src/components/text-field/angularjs/text-field_directive.js
+++ b/src/components/text-field/angularjs/text-field_directive.js
@@ -89,7 +89,6 @@ function TextFieldDirective() {
     'ngInject';
 
     function link(scope, el, attrs, ctrl) {
-        const _LINE_HEIGHT = 20;
         const _MIN_ROWS = 2;
 
         let input = el.find('input');
@@ -101,7 +100,7 @@ function TextFieldDirective() {
 
             input.on('input', (evt) => {
                 evt.target.rows = _MIN_ROWS;
-                const currentRows = evt.target.scrollHeight / _LINE_HEIGHT;
+                const currentRows = evt.target.scrollHeight / (evt.target.clientHeight / _MIN_ROWS);
                 evt.target.rows = currentRows;
             });
 

--- a/src/components/text-field/angularjs/text-field_directive.js
+++ b/src/components/text-field/angularjs/text-field_directive.js
@@ -89,12 +89,21 @@ function TextFieldDirective() {
     'ngInject';
 
     function link(scope, el, attrs, ctrl) {
+        const _LINE_HEIGHT = 20;
+        const _MIN_ROWS = 2;
+
         let input = el.find('input');
 
         if (input.length === 1) {
             el.addClass(`${CSS_PREFIX}-text-field--has-input`);
         } else {
             input = el.find('textarea');
+
+            input.on('input', (evt) => {
+                evt.target.rows = _MIN_ROWS;
+                const currentRows = evt.target.scrollHeight / _LINE_HEIGHT;
+                evt.target.rows = currentRows;
+            });
 
             el.addClass(`${CSS_PREFIX}-text-field--has-textarea`);
         }

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -53,7 +53,7 @@ interface ITextFieldProps extends IGenericProps {
     useCustomColors?: boolean;
 
     /** Minimum rows to be displayed in a text area. */
-    minimumRows: number;
+    minimumRows?: number;
 
     /** A ref that will be passed to the input or text area element. */
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -91,7 +91,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The line height for the Text Area. Please keep in mind that if that changes via css, the prop lineHeight needs to be changed
  */
 const LINE_HEIGHT = 20;
-const MIN_ROWS = 1;
+const MIN_ROWS = 2;
 
 /**
  * The default value of props.

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -52,8 +52,8 @@ interface ITextFieldProps extends IGenericProps {
     /** Whether custom colors are applied to this component. */
     useCustomColors?: boolean;
 
-    /** Line height of the input or text area element. */
-    lineHeight?: number;
+    /** Minimum rows to be displayed in a text area. */
+    minimumRows?: number;
 
     /** A ref that will be passed to the input or text area element. */
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
@@ -93,12 +93,23 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 const MIN_ROWS = 2;
 
 /**
+ * The default value of props.
+ */
+const DEFAULT_PROPS: Partial<TextFieldProps> = {
+    hasError: false,
+    isDisabled: false,
+    isValid: false,
+    minimumRows: MIN_ROWS,
+    theme: Theme.light,
+    type: TextFieldType.input,
+};
+/**
  * Hook that allows to calculate the number of rows needed for a text area.
  * @param minimumNumberOfRows Minimum number of rows that we want to display.
  * @return rows to be used and a callback to recalculate
  */
 const useComputeNumberOfRows = (
-    minimumNumberOfRows: number,
+    minimumNumberOfRows: number | undefined = MIN_ROWS,
 ): {
     /** number of rows to be used on the text area */
     rows: number;
@@ -137,19 +148,6 @@ const useComputeNumberOfRows = (
         rows,
     };
 };
-
-/**
- * The default value of props.
- */
-const DEFAULT_PROPS: Partial<TextFieldProps> = {
-    hasError: false,
-    isDisabled: false,
-    isValid: false,
-    minimumRows: MIN_ROWS,
-    theme: Theme.light,
-    type: TextFieldType.input,
-};
-
 /////////////////////////////
 
 interface IInputNativeProps {
@@ -247,6 +245,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
         value,
         ...forwardedProps
     } = props;
+
     const [isFocus, setFocus] = useState(false);
     const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(minimumRows);
 

--- a/src/components/text-field/react/TextField.tsx
+++ b/src/components/text-field/react/TextField.tsx
@@ -53,7 +53,7 @@ interface ITextFieldProps extends IGenericProps {
     useCustomColors?: boolean;
 
     /** Minimum rows to be displayed in a text area. */
-    minimumRows?: number;
+    minimumRows: number;
 
     /** A ref that will be passed to the input or text area element. */
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
@@ -105,11 +105,11 @@ const DEFAULT_PROPS: Partial<TextFieldProps> = {
 };
 /**
  * Hook that allows to calculate the number of rows needed for a text area.
- * @param minimumNumberOfRows Minimum number of rows that we want to display.
+ * @param minimumRows Minimum number of rows that we want to display.
  * @return rows to be used and a callback to recalculate
  */
 const useComputeNumberOfRows = (
-    minimumNumberOfRows: number | undefined = MIN_ROWS,
+    minimumRows: number,
 ): {
     /** number of rows to be used on the text area */
     rows: number;
@@ -119,7 +119,7 @@ const useComputeNumberOfRows = (
      */
     recomputeNumberOfRows(event: React.ChangeEvent): void;
 } => {
-    const [rows, setRows] = useState(minimumNumberOfRows);
+    const [rows, setRows] = useState(minimumRows);
 
     const recompute = (event: React.ChangeEvent): void => {
         /**
@@ -136,8 +136,8 @@ const useComputeNumberOfRows = (
          * 5. In case there is any other update on the component that changes the UI, we need to keep the number of rows
          * on the state in order to allow React to re-render. Therefore, we save them using `useState`
          */
-        (event.target as HTMLTextAreaElement).rows = minimumNumberOfRows;
-        const currentRows = event.target.scrollHeight / (event.target.clientHeight / minimumNumberOfRows);
+        (event.target as HTMLTextAreaElement).rows = minimumRows;
+        const currentRows = event.target.scrollHeight / (event.target.clientHeight / minimumRows);
         (event.target as HTMLTextAreaElement).rows = currentRows;
 
         setRows(currentRows);
@@ -237,7 +237,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
         label,
         onChange,
         placeholder,
-        minimumRows = DEFAULT_PROPS.minimumRows,
+        minimumRows = DEFAULT_PROPS.minimumRows as number,
         inputRef = React.useRef(null),
         theme = DEFAULT_PROPS.theme,
         type = DEFAULT_PROPS.type,

--- a/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`<TextField> Snapshots and structure should render textarea 1`] = `
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
+        rows={1}
       />
     </div>
   </div>

--- a/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
+++ b/src/components/text-field/react/__snapshots__/TextField.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`<TextField> Snapshots and structure should render textarea 1`] = `
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
-        rows={1}
+        rows={2}
       />
     </div>
   </div>

--- a/src/components/text-field/style/lumapps/_index.scss
+++ b/src/components/text-field/style/lumapps/_index.scss
@@ -84,8 +84,12 @@
         }
 
         textarea {
+            overflow: hidden;
+
+            /* Disallow resizing on browsers that do not support `resize` */
             min-width: 100%;
             max-width: 100%;
+            resize: none;
 
             #{$self}--theme-light & {
                 @include lumx-text-field-input-native('dark', 'textarea');

--- a/src/components/text-field/style/lumapps/_index.scss
+++ b/src/components/text-field/style/lumapps/_index.scss
@@ -60,7 +60,7 @@
     }
 
     &__input-native {
-        flex: 1;
+        width: 100%;
 
         input,
         textarea {
@@ -84,6 +84,9 @@
         }
 
         textarea {
+            min-width: 100%;
+            max-width: 100%;
+
             #{$self}--theme-light & {
                 @include lumx-text-field-input-native('dark', 'textarea');
             }

--- a/src/components/text-field/style/lumapps/_index.scss
+++ b/src/components/text-field/style/lumapps/_index.scss
@@ -60,7 +60,7 @@
     }
 
     &__input-native {
-        width: 100%;
+        flex: 1;
 
         input,
         textarea {
@@ -84,11 +84,6 @@
         }
 
         textarea {
-            overflow: hidden;
-
-            /* Disallow resizing on browsers that do not support `resize` */
-            min-width: 100%;
-            max-width: 100%;
             resize: none;
 
             #{$self}--theme-light & {

--- a/src/components/text-field/style/lumapps/_mixins.scss
+++ b/src/components/text-field/style/lumapps/_mixins.scss
@@ -34,10 +34,11 @@
 @mixin lumx-text-field-input-native($theme, $type: 'input') {
     @include lumx-typography('body1');
 
+    display: block;
     width: 100%;
     padding: 0;
-    margin: 0;
     border: none;
+    margin: 0;
     background-color: transparent;
     color: lumx-theme-color-variant($theme, 'N');
     outline: none;

--- a/src/components/text-field/style/material/_index.scss
+++ b/src/components/text-field/style/material/_index.scss
@@ -45,7 +45,11 @@
 
     &__input-native {
         input {
-            @include lumx-text-field-material-input-native();
+            @include lumx-text-field-material-input-native('input');
+        }
+
+        textarea {
+            @include lumx-text-field-material-input-native('textarea');
         }
     }
 }

--- a/src/components/text-field/style/material/_index.scss
+++ b/src/components/text-field/style/material/_index.scss
@@ -87,3 +87,90 @@
         @include lumx-text-field-material-label-focus('light');
     }
 }
+
+/* Text field validity
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-text-field--theme-light {
+    &.#{$lumx-base-prefix}-text-field--is-valid {
+        .#{$lumx-base-prefix}-text-field__input-wrapper {
+            @include lumx-text-field-material-input-wrapper-validity('valid', 'light');
+        }
+
+        .#{$lumx-base-prefix}-text-field__input-validity {
+            @include lumx-text-field-material-input-wrapper-validity('valid', 'light');
+        }
+
+        &.#{$lumx-base-prefix}-text-field--is-focus {
+            .#{$lumx-base-prefix}-text-field__input-wrapper {
+                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'light');
+            }
+
+            .#{$lumx-base-prefix}-text-field__input-validity {
+                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'light');
+            }
+        }
+    }
+
+    &.#{$lumx-base-prefix}-text-field--has-error {
+        .#{$lumx-base-prefix}-text-field__input-wrapper {
+            @include lumx-text-field-material-input-wrapper-validity('error', 'light');
+        }
+
+        .#{$lumx-base-prefix}-text-field__input-validity {
+            @include lumx-text-field-material-input-wrapper-validity('error', 'light');
+        }
+
+        &.#{$lumx-base-prefix}-text-field--is-focus {
+            .#{$lumx-base-prefix}-text-field__input-wrapper {
+                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'light');
+            }
+
+            .#{$lumx-base-prefix}-text-field__input-validity {
+                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'light');
+            }
+        }
+    }
+}
+
+.#{$lumx-base-prefix}-text-field--theme-dark {
+    &.#{$lumx-base-prefix}-text-field--is-valid {
+        .#{$lumx-base-prefix}-text-field__input-wrapper {
+            @include lumx-text-field-material-input-wrapper-validity('valid', 'dark');
+        }
+
+        .#{$lumx-base-prefix}-text-field__input-validity {
+            @include lumx-text-field-material-input-wrapper-validity('valid', 'dark');
+        }
+
+        &.#{$lumx-base-prefix}-text-field--is-focus {
+            .#{$lumx-base-prefix}-text-field__input-wrapper {
+                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'dark');
+            }
+
+            .#{$lumx-base-prefix}-text-field__input-validity {
+                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'dark');
+            }
+        }
+    }
+
+    &.#{$lumx-base-prefix}-text-field--has-error {
+        .#{$lumx-base-prefix}-text-field__input-wrapper {
+            @include lumx-text-field-material-input-wrapper-validity('error', 'dark');
+        }
+
+        .#{$lumx-base-prefix}-text-field__input-validity {
+            @include lumx-text-field-material-input-wrapper-validity('error', 'dark');
+        }
+
+        &.#{$lumx-base-prefix}-text-field--is-focus {
+            .#{$lumx-base-prefix}-text-field__input-wrapper {
+                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'dark');
+            }
+
+            .#{$lumx-base-prefix}-text-field__input-validity {
+                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'dark');
+            }
+        }
+    }
+}

--- a/src/components/text-field/style/material/_index.scss
+++ b/src/components/text-field/style/material/_index.scss
@@ -45,23 +45,7 @@
 
     &__input-native {
         input {
-            #{$self}--theme-light & {
-                @include lumx-text-field-material-input-native('dark', 'input');
-            }
-
-            #{$self}--theme-dark & {
-                @include lumx-text-field-material-input-native('light', 'input');
-            }
-        }
-
-        textarea {
-            #{$self}--theme-light & {
-                @include lumx-text-field-material-input-native('dark', 'textarea');
-            }
-
-            #{$self}--theme-dark & {
-                @include lumx-text-field-material-input-native('light', 'textarea');
-            }
+            @include lumx-text-field-material-input-native();
         }
     }
 }

--- a/src/components/text-field/style/material/_index.scss
+++ b/src/components/text-field/style/material/_index.scss
@@ -91,86 +91,22 @@
 /* Text field validity
    ========================================================================== */
 
-.#{$lumx-base-prefix}-text-field--theme-light {
-    &.#{$lumx-base-prefix}-text-field--is-valid {
-        .#{$lumx-base-prefix}-text-field__input-wrapper {
-            @include lumx-text-field-material-input-wrapper-validity('valid', 'light');
-        }
-
-        .#{$lumx-base-prefix}-text-field__input-validity {
-            @include lumx-text-field-material-input-wrapper-validity('valid', 'light');
-        }
-
-        &.#{$lumx-base-prefix}-text-field--is-focus {
-            .#{$lumx-base-prefix}-text-field__input-wrapper {
-                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'light');
-            }
-
-            .#{$lumx-base-prefix}-text-field__input-validity {
-                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'light');
-            }
-        }
+.#{$lumx-base-prefix}-text-field--theme-light.#{$lumx-base-prefix}-text-field--is-valid {
+    .#{$lumx-base-prefix}-text-field__label {
+        @include lumx-text-field-material-label-validity('valid');
     }
 
-    &.#{$lumx-base-prefix}-text-field--has-error {
-        .#{$lumx-base-prefix}-text-field__input-wrapper {
-            @include lumx-text-field-material-input-wrapper-validity('error', 'light');
-        }
-
-        .#{$lumx-base-prefix}-text-field__input-validity {
-            @include lumx-text-field-material-input-wrapper-validity('error', 'light');
-        }
-
-        &.#{$lumx-base-prefix}-text-field--is-focus {
-            .#{$lumx-base-prefix}-text-field__input-wrapper {
-                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'light');
-            }
-
-            .#{$lumx-base-prefix}-text-field__input-validity {
-                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'light');
-            }
-        }
+    .#{$lumx-base-prefix}-text-field__input-wrapper {
+        @include lumx-text-field-material-input-wrapper-validity('valid');
     }
 }
 
-.#{$lumx-base-prefix}-text-field--theme-dark {
-    &.#{$lumx-base-prefix}-text-field--is-valid {
-        .#{$lumx-base-prefix}-text-field__input-wrapper {
-            @include lumx-text-field-material-input-wrapper-validity('valid', 'dark');
-        }
-
-        .#{$lumx-base-prefix}-text-field__input-validity {
-            @include lumx-text-field-material-input-wrapper-validity('valid', 'dark');
-        }
-
-        &.#{$lumx-base-prefix}-text-field--is-focus {
-            .#{$lumx-base-prefix}-text-field__input-wrapper {
-                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'dark');
-            }
-
-            .#{$lumx-base-prefix}-text-field__input-validity {
-                @include lumx-text-field-material-input-wrapper-validity-focus('valid', 'dark');
-            }
-        }
+.#{$lumx-base-prefix}-text-field--theme-light.#{$lumx-base-prefix}-text-field--has-error {
+    .#{$lumx-base-prefix}-text-field__label {
+        @include lumx-text-field-material-label-validity('error');
     }
 
-    &.#{$lumx-base-prefix}-text-field--has-error {
-        .#{$lumx-base-prefix}-text-field__input-wrapper {
-            @include lumx-text-field-material-input-wrapper-validity('error', 'dark');
-        }
-
-        .#{$lumx-base-prefix}-text-field__input-validity {
-            @include lumx-text-field-material-input-wrapper-validity('error', 'dark');
-        }
-
-        &.#{$lumx-base-prefix}-text-field--is-focus {
-            .#{$lumx-base-prefix}-text-field__input-wrapper {
-                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'dark');
-            }
-
-            .#{$lumx-base-prefix}-text-field__input-validity {
-                @include lumx-text-field-material-input-wrapper-validity-focus('error', 'dark');
-            }
-        }
+    .#{$lumx-base-prefix}-text-field__input-wrapper {
+        @include lumx-text-field-material-input-wrapper-validity('error');
     }
 }

--- a/src/components/text-field/style/material/_mixins.scss
+++ b/src/components/text-field/style/material/_mixins.scss
@@ -11,6 +11,14 @@
     transition-property: color, transform;
 }
 
+@mixin lumx-text-field-material-label-validity($validity) {
+    @if $validity == 'valid' {
+        color: lumx-theme-color-variant('green', 'L2');
+    } @else if $validity == 'error' {
+        color: lumx-theme-color-variant('red', 'N');
+    }
+}
+
 @mixin lumx-text-field-material-label-focus($theme) {
     @if $theme == 'dark' {
         color: lumx-theme-color-variant('primary', 'N');
@@ -56,39 +64,17 @@
     }
 }
 
-@mixin lumx-text-field-material-input-wrapper-validity($validity, $theme) {
-    &::before {
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        height: 2px;
-        content: '';
-        pointer-events: none;
-
-        @if $validity == 'valid' {
-            background-color: lumx-theme-color-variant('green', 'N');
-        } @else if $validity == 'error' {
-            background-color: lumx-theme-color-variant('red', 'N');
-        }
-    }
-}
-
-@mixin lumx-text-field-material-input-wrapper-validity-focus($validity, $theme) {
+@mixin lumx-text-field-material-input-wrapper-validity($validity) {
     &::after {
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        height: 2px;
-        content: '';
-        pointer-events: none;
-        transform: scaleX(0);
-        transition: transform 200ms;
+        transform: scaleX(1);
+    }
 
-        @if $validity == 'valid' {
+    @if $validity == 'valid' {
+        &::after {
             background-color: lumx-theme-color-variant('green', 'N');
-        } @else if $validity == 'error' {
+        }
+    } @else if $validity == 'error' {
+        &::after {
             background-color: lumx-theme-color-variant('red', 'N');
         }
     }

--- a/src/components/text-field/style/material/_mixins.scss
+++ b/src/components/text-field/style/material/_mixins.scss
@@ -13,7 +13,7 @@
 
 @mixin lumx-text-field-material-label-validity($validity) {
     @if $validity == 'valid' {
-        color: lumx-theme-color-variant('green', 'L2');
+        color: lumx-theme-color-variant('green', 'N');
     } @else if $validity == 'error' {
         color: lumx-theme-color-variant('red', 'N');
     }

--- a/src/components/text-field/style/material/_mixins.scss
+++ b/src/components/text-field/style/material/_mixins.scss
@@ -86,7 +86,13 @@
     }
 }
 
-@mixin lumx-text-field-material-input-native() {
+@mixin lumx-text-field-material-input-native($type) {
     font-size: map-get($lumx-typography-font-size, 'body2') !important;
-    line-height: $lumx-text-field-height !important;
+    font-weight: map-get($lumx-typography-font-weight, 'body2') !important;
+
+    @if $type == 'input' {
+        line-height: $lumx-text-field-height !important;
+    } @else if $type == 'textarea' {
+        line-height: map-get($lumx-typography-line-height, 'body2') !important;
+    }
 }

--- a/src/components/text-field/style/material/_mixins.scss
+++ b/src/components/text-field/style/material/_mixins.scss
@@ -56,6 +56,44 @@
     }
 }
 
+@mixin lumx-text-field-material-input-wrapper-validity($validity, $theme) {
+    &::before {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        height: 2px;
+        content: '';
+        pointer-events: none;
+
+        @if $validity == 'valid' {
+            background-color: lumx-theme-color-variant('green', 'N');
+        } @else if $validity == 'error' {
+            background-color: lumx-theme-color-variant('red', 'N');
+        }
+    }
+}
+
+@mixin lumx-text-field-material-input-wrapper-validity-focus($validity, $theme) {
+    &::after {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        height: 2px;
+        content: '';
+        pointer-events: none;
+        transform: scaleX(0);
+        transition: transform 200ms;
+
+        @if $validity == 'valid' {
+            background-color: lumx-theme-color-variant('green', 'N');
+        } @else if $validity == 'error' {
+            background-color: lumx-theme-color-variant('red', 'N');
+        }
+    }
+}
+
 @mixin lumx-text-field-material-input-wrapper-focus() {
     &::after {
         transform: scaleX(1);

--- a/src/components/text-field/style/material/_mixins.scss
+++ b/src/components/text-field/style/material/_mixins.scss
@@ -86,10 +86,7 @@
     }
 }
 
-@mixin lumx-text-field-material-input-native($theme, $type: 'input') {
-    @include lumx-typography('body2');
-
-    @if $type == 'input' {
-        line-height: $lumx-text-field-height;
-    }
+@mixin lumx-text-field-material-input-native() {
+    font-size: map-get($lumx-typography-font-size, 'body2') !important;
+    line-height: $lumx-text-field-height !important;
 }


### PR DESCRIPTION
All around fixes to Text Area component:
- Remove resizing from browsers that [support it](https://caniuse.com/#feat=css-resize) by using `resize` attribute. For the ones that do not support it, we can make the width fixed.
- Allow automatic resizing for the height when the user is writing (with a little bit of magic)
![ZPC9shZ3pF](https://user-images.githubusercontent.com/13719066/67266593-dcf55d80-f4b0-11e9-8805-025eb74eab0d.gif)

- Add valid and error css to the Text Area component for Material CSS
![Screenshot 2019-10-22 at 09 42 45](https://user-images.githubusercontent.com/13719066/67266577-d1a23200-f4b0-11e9-8f87-7a6c01d28190.png)
![Screenshot 2019-10-22 at 09 43 25](https://user-images.githubusercontent.com/13719066/67266584-d830a980-f4b0-11e9-8e0c-698ced5c7a51.png)
