### PR TITLE
chore: uniformize React component sizes

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Deprecated `ListItemSize` (use `Size` instead).
+
 ## [0.12.0][] - 2019-10-30
 
 ### Added

--- a/demo/react/components/expansion-panel/complex.tsx
+++ b/demo/react/components/expansion-panel/complex.tsx
@@ -9,7 +9,6 @@ import {
     Icon,
     List,
     ListItem,
-    ListItemSize,
     ListSubheader,
     Size,
     Theme,
@@ -40,24 +39,24 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): ReactElement => {
 
                 <List>
                     <ListSubheader>Lorem ipsum</ListSubheader>
-                    <ListItem size={ListItemSize.tiny} before={sendIcon}>
+                    <ListItem size={Size.tiny} before={sendIcon}>
                         Lorem ipsum
                     </ListItem>
-                    <ListItem size={ListItemSize.tiny} before={sendIcon}>
+                    <ListItem size={Size.tiny} before={sendIcon}>
                         Lorem ipsum
                     </ListItem>
                     <ListSubheader>Lorem ipsum</ListSubheader>
-                    <ListItem size={ListItemSize.tiny} before={sendIcon}>
+                    <ListItem size={Size.tiny} before={sendIcon}>
                         Lorem ipsum
                     </ListItem>
-                    <ListItem size={ListItemSize.tiny} before={sendIcon}>
+                    <ListItem size={Size.tiny} before={sendIcon}>
                         Lorem ipsum
                     </ListItem>
                     <Divider />
-                    <ListItem size={ListItemSize.tiny} before={sendIcon}>
+                    <ListItem size={Size.tiny} before={sendIcon}>
                         Lorem ipsum
                     </ListItem>
-                    <ListItem size={ListItemSize.tiny} before={sendIcon}>
+                    <ListItem size={Size.tiny} before={sendIcon}>
                         Lorem ipsum
                     </ListItem>
                 </List>

--- a/demo/react/components/select/multiSelectionWithSearch.tsx
+++ b/demo/react/components/select/multiSelectionWithSearch.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 
-import { Chip, Icon, List, ListDivider, ListItem, ListItemSize, Select, Size, TextField, Theme } from 'LumX';
+import { Chip, Icon, List, ListDivider, ListItem, Select, Size, TextField, Theme } from 'LumX';
 
 import { mdiClose, mdiMagnify } from '@mdi/js';
 import { useBooleanState } from 'LumX/core/react/hooks';
@@ -131,7 +131,7 @@ const DemoComponent: React.FC<IProps> = ({ theme }: IProps): React.ReactElement 
                         ? filteredChoices.map((choice: IChoice, index: number) => (
                               // tslint:disable-next-line: jsx-no-lambda
                               <ListItem
-                                  size={ListItemSize.tiny}
+                                  size={Size.tiny}
                                   isClickable
                                   isSelected={values.includes(choice.label)}
                                   key={index}

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -1,5 +1,5 @@
 ```javascript import
-import { Autocomplete, List, ListItem, ListItemSize, Size, TextField, Chip, ListDivider, Icon, ListSubheader } from 'LumX';
+import { Autocomplete, List, ListItem, Size, TextField, Chip, ListDivider, Icon, ListSubheader } from 'LumX';
 import { useBooleanState } from 'LumX/core/react/hooks';
 import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/core/constants';
 ```
@@ -90,7 +90,7 @@ import { DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from 'LumX/c
                 <List>
                     {filteredCities.map((city, index) => (
                         <ListItem
-                            size={ListItemSize.tiny}
+                            size={Size.tiny}
                             isClickable
                             key={city.id}
                             isHighlighted={index === activeItemIndex}

--- a/demo/react/doc/product/components/dropdown.mdx
+++ b/demo/react/doc/product/components/dropdown.mdx
@@ -1,5 +1,5 @@
 ```javascript import
-import { Dropdown, List, ListItem, ListItemSize, Chip, Button, ListSubheader, Placement } from 'LumX';
+import { Dropdown, List, ListItem, Size, Chip, Button, ListSubheader, Placement } from 'LumX';
 ```
 
 # Dropdown
@@ -63,31 +63,31 @@ By default, dropdowns open right next to the trigger.
                 <List isClickable>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('losangeles', closeSimpleMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Los Angeles
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('monterrey', closeSimpleMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Monterrey
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('georgetown', closeSimpleMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Georgetown
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('cali', closeSimpleMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Cali
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('trondheim', closeSimpleMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Trondheim
                     </ListItem>
@@ -110,44 +110,44 @@ By default, dropdowns open right next to the trigger.
                     <ListSubheader>Contribution</ListSubheader>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('pages', closeComplexMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Pages
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('news', closeComplexMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         News Articles with a longer name
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('jobs', closeComplexMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Job Offers
                     </ListItem>
                     <ListSubheader>Directories</ListSubheader>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('projects', closeComplexMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Projects
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('useful', closeComplexMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Useful links
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('support', closeComplexMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Support links
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('engineering', closeComplexMenu)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Engineering
                     </ListItem>
@@ -193,31 +193,31 @@ Dropdowns can be controlled from external events.
                 <List isClickable>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('losangeles', closeDropdown)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Los Angeles
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('monterrey', closeDropdown)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Monterrey
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('georgetown', closeDropdown)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Georgetown
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('cali', closeDropdown)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Cali
                     </ListItem>
                     <ListItem
                         onItemSelected={() => onItemSelectedHandler('trondheim', closeDropdown)}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     >
                         Trondheim
                     </ListItem>

--- a/demo/react/doc/product/components/list.mdx
+++ b/demo/react/doc/product/components/list.mdx
@@ -7,7 +7,6 @@ import {
     IconButton,
     List,
     ListItem,
-    ListItemSize,
     ListSubheader,
     Size,
     Thumbnail,
@@ -28,20 +27,20 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
     <>
         <List>
             <ListSubheader>text only</ListSubheader>
-            <ListItem size={ListItemSize.tiny}>Single-line item</ListItem>
-            <ListItem size={ListItemSize.tiny}>Single-line item</ListItem>
-            <ListItem size={ListItemSize.tiny}>Single-line item</ListItem>
+            <ListItem size={Size.tiny}>Single-line item</ListItem>
+            <ListItem size={Size.tiny}>Single-line item</ListItem>
+            <ListItem size={Size.tiny}>Single-line item</ListItem>
             <ListSubheader>rich</ListSubheader>
-            <ListItem size={ListItemSize.tiny} before={<Icon icon={mdiSend} size={Size.xs} />}>
+            <ListItem size={Size.tiny} before={<Icon icon={mdiSend} size={Size.xs} />}>
                 Single-line item
             </ListItem>
             <ListItem
-                size={ListItemSize.tiny}
+                size={Size.tiny}
                 before={<Thumbnail variant={ThumbnailVariant.rounded} image="https://picsum.photos/48" size={Size.s} />}
             >
                 Single-line item
             </ListItem>
-            <ListItem size={ListItemSize.tiny} before={<Avatar image="http://i.pravatar.cc/48" size={Size.s} />}>
+            <ListItem size={Size.tiny} before={<Avatar image="http://i.pravatar.cc/48" size={Size.s} />}>
                 Single-line item
             </ListItem>
         </List>
@@ -83,7 +82,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
     <>
         <List>
             <ListSubheader>text only</ListSubheader>
-            <ListItem size={ListItemSize.big}>
+            <ListItem size={Size.big}>
                 <div>
                     <span>Two-line item</span>
                 </div>
@@ -92,7 +91,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
                 </div>
             </ListItem>
             <ListSubheader>rich</ListSubheader>
-            <ListItem size={ListItemSize.big} before={<Icon icon={mdiSend} size={Size.xs} />}>
+            <ListItem size={Size.big} before={<Icon icon={mdiSend} size={Size.xs} />}>
                 <div>
                     <span>Two-line item</span>
                 </div>
@@ -101,7 +100,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
                 </div>
             </ListItem>
             <ListItem
-                size={ListItemSize.big}
+                size={Size.big}
                 before={<Thumbnail variant={ThumbnailVariant.rounded} image="https://picsum.photos/72" size={Size.m} />}
                 after={<IconButton emphasis={ButtonEmphasis.low} icon={mdiDotsHorizontal} />}
             >
@@ -113,7 +112,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
                 </div>
             </ListItem>
             <ListItem
-                size={ListItemSize.big}
+                size={Size.big}
                 before={<Avatar image="http://i.pravatar.cc/72" size={Size.m} />}
                 after={<Button emphasis={ButtonEmphasis.low}>Button</Button>}
             >
@@ -136,7 +135,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
     <>
         <List>
             <ListSubheader>text only</ListSubheader>
-            <ListItem size={ListItemSize.huge}>
+            <ListItem size={Size.huge}>
                 <div>
                     <span>Multi-line item</span>
                 </div>
@@ -148,7 +147,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
                 </div>
             </ListItem>
             <ListSubheader>rich</ListSubheader>
-            <ListItem size={ListItemSize.huge} before={<Icon icon={mdiSend} size={Size.xs} />}>
+            <ListItem size={Size.huge} before={<Icon icon={mdiSend} size={Size.xs} />}>
                 <div>
                     <span>Multi-line item</span>
                 </div>
@@ -160,7 +159,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
                 </div>
             </ListItem>
             <ListItem
-                size={ListItemSize.huge}
+                size={Size.huge}
                 before={<Thumbnail variant={ThumbnailVariant.rounded} image="https://picsum.photos/72" size={Size.m} />}
                 after={<IconButton emphasis={ButtonEmphasis.low} icon={mdiDotsHorizontal} />}
             >
@@ -175,7 +174,7 @@ import { mdiDotsHorizontal, mdiSend } from 'LumX/icons';
                 </div>
             </ListItem>
             <ListItem
-                size={ListItemSize.huge}
+                size={Size.huge}
                 before={<Avatar image="http://i.pravatar.cc/72" size={Size.m} />}
                 after={<Button emphasis={ButtonEmphasis.low}>Button</Button>}
             >

--- a/demo/react/doc/product/components/select.mdx
+++ b/demo/react/doc/product/components/select.mdx
@@ -1,5 +1,5 @@
 ```javascript import
-import { Select, List, ListItem, ListItemSize, Size, TextField, Chip, ListDivider, Icon, ListSubheader } from 'LumX';
+import { Select, List, ListItem, Size, TextField, Chip, ListDivider, Icon, ListSubheader } from 'LumX';
 import { useBooleanState } from 'LumX/core/react/hooks';
 import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from '@mdi/js';
 ```
@@ -52,13 +52,13 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
                               isSelected={values.includes(choice)}
                               key={index}
                               onItemSelected={() => onItemSelectedHandler(choice)}
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                           >
                               {choice}
                           </ListItem>
                       ))
                     : [
-                          <ListItem key={0} size={ListItemSize.tiny}>
+                          <ListItem key={0} size={Size.tiny}>
                               No data
                           </ListItem>,
                       ]}
@@ -113,13 +113,13 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
                               isSelected={values.includes(choice)}
                               key={index}
                               onItemSelected={() => onItemSelectedHandler(choice)}
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                           >
                               {choice}
                           </ListItem>
                       ))
                     : [
-                          <ListItem key={0} size={ListItemSize.tiny}>
+                          <ListItem key={0} size={Size.tiny}>
                               No data
                           </ListItem>,
                       ]}
@@ -230,26 +230,26 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
                         value={filterValue}
                         onChange={setFilterValue}
                         icon={mdiMagnify}
-                        size={ListItemSize.tiny}
+                        size={Size.tiny}
                     />
                 </ListSubheader>
                 <ListDivider />
                 {filteredChoices.length > 0
                     ? filteredChoices.map((choice, index) => (
                           <ListItem
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                               isClickable
                               isSelected={values.includes(choice.label)}
                               key={index}
                               onItemSelected={() => onItemSelectedHandler(choice.label)}
                               before={<Icon size={Size.xs} icon={choice.icon} />}
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                           >
                               <div>{choice.label}</div>
                           </ListItem>
                       ))
                     : [
-                          <ListItem key={0} size={ListItemSize.tiny}>
+                          <ListItem key={0} size={Size.tiny}>
                               No data
                           </ListItem>,
                       ]}
@@ -304,13 +304,13 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
                               isSelected={values.includes(choice)}
                               key={index}
                               onItemSelected={() => onItemSelectedHandler(choice)}
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                           >
                               {choice}
                           </ListItem>
                       ))
                     : [
-                          <ListItem key={0} size={ListItemSize.tiny}>
+                          <ListItem key={0} size={Size.tiny}>
                               No data
                           </ListItem>,
                       ]}
@@ -365,13 +365,13 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
                               isSelected={values.includes(choice)}
                               key={index}
                               onItemSelected={() => onItemSelectedHandler(choice)}
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                           >
                               {choice}
                           </ListItem>
                       ))
                     : [
-                          <ListItem key={0} size={ListItemSize.tiny}>
+                          <ListItem key={0} size={Size.tiny}>
                               No data
                           </ListItem>,
                       ]}
@@ -425,13 +425,13 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
                               isSelected={values.includes(choice)}
                               key={index}
                               onItemSelected={() => onItemSelectedHandler(choice)}
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                           >
                               {choice}
                           </ListItem>
                       ))
                     : [
-                          <ListItem key={0} size={ListItemSize.tiny}>
+                          <ListItem key={0} size={Size.tiny}>
                               No data
                           </ListItem>,
                       ]}
@@ -486,13 +486,13 @@ import { mdiAccessPoint, mdiAccountBadge, mdiAlphaF, mdiMagnify, mdiClose } from
                               isSelected={values.includes(choice)}
                               key={index}
                               onItemSelected={() => onItemSelectedHandler(choice)}
-                              size={ListItemSize.tiny}
+                              size={Size.tiny}
                           >
                               {choice}
                           </ListItem>
                       ))
                     : [
-                          <ListItem key={0} size={ListItemSize.tiny}>
+                          <ListItem key={0} size={Size.tiny}>
                               No data
                           </ListItem>,
                       ]}

--- a/src/components/icon/react/Icon.tsx
+++ b/src/components/icon/react/Icon.tsx
@@ -11,6 +11,8 @@ import { handleBasicClasses } from 'LumX/core/utils';
 
 /////////////////////////////
 
+type IconSizes = Size.xxs | Size.xs | Size.s | Size.m | Size.l | Size.xl | Size.xxl;
+
 /**
  * Defines the props of the component.
  */
@@ -39,7 +41,7 @@ interface IIconProps extends IGenericProps {
     /**
      * The icon size.
      */
-    size?: Size;
+    size?: IconSizes;
 }
 type IconProps = IIconProps;
 

--- a/src/components/list/react/ListItem.tsx
+++ b/src/components/list/react/ListItem.tsx
@@ -4,19 +4,22 @@ import classNames from 'classnames';
 
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 
-import { Theme } from 'LumX';
+import { Size, Theme } from 'LumX';
 import { Callback, IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses, onEnterPressed } from 'LumX/core/utils';
 
 /**
  *  Authorized size values.
+ *  @deprecated use Size instead.
  */
-enum ListItemSize {
-    tiny = 'tiny',
-    regular = 'regular',
-    big = 'big',
-    huge = 'huge',
-}
+const ListItemSize = {
+    big: Size.big,
+    huge: Size.huge,
+    regular: Size.regular,
+    tiny: Size.tiny,
+};
+
+type ListItemSizes = Size.tiny | Size.regular | Size.big | Size.huge;
 
 /////////////////////////////
 
@@ -46,7 +49,7 @@ interface IListItemProps extends IGenericProps {
     isSelected?: boolean;
 
     /** List item size. */
-    size?: ListItemSize;
+    size?: ListItemSizes;
 
     /** Theme. */
     theme?: Theme;
@@ -87,7 +90,7 @@ const DEFAULT_PROPS: IDefaultPropsType = {
     isClickable: false,
     isHighlighted: false,
     isSelected: false,
-    size: ListItemSize.regular,
+    size: Size.regular,
     theme: Theme.light,
 };
 /////////////////////////////


### PR DESCRIPTION
# General summary

Uniformizes the use of the Size enum everywhere.
Deprecated `ListItemSize` in favor of `Size`

# Check list

-   [x] (if has react) Check through the [react dev check list]
-   [x] Request a frontend review

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
