### PR TITLE
feat(autocomplete-multi): change Chip deletion logic.

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `isHighlighted` prop for `Chip` component [#209](https://github.com/lumapps/design-system/pull/209)
 -   Added `isClearable` and `chips` props for Autocomplete [#209](https://github.com/lumapps/design-system/pull/209)
 
+### Changed
+
+-   `Popover` bug that made the content be displayed on the top left corner.
+-   Make autocomplete multiple demo remove a value upon clicking on the entire chip.
+
+### Removed
+
+-   Remove `cursor: pointer` for after-Chip icon.
+
 ## [0.13.0][] - 2019-11-04
 
 ### Changed

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -351,10 +351,12 @@ import { mdiClose } from '@lumx/icons';
             inputRef={inputRef}
             selectedChipRender={(city, index) => (
                         <Chip
+                            isClickable
                             key={index}
                             after={<Icon icon={mdiClose} size={Size.xxs} />}
                             size={Size.s}
                             onAfterClick={event => clearSelectedValue(event, city)}
+                            onClick={event => clearSelectedValue(event, city)}
                             isHighlighted={index === activeChip}
                         >
                             {city.text}

--- a/demo/react/doc/product/components/autocomplete.mdx
+++ b/demo/react/doc/product/components/autocomplete.mdx
@@ -222,7 +222,10 @@ import { mdiClose } from '@lumx/icons';
      * Callback executed when the autocomplete closes.
      * In that scenario, we need to update the internal state to `false`.
      */
-    const closeAutocomplete = () => setShowSuggestions(INITIAL_STATE_SHOW_SUGGESTIONS);
+    const closeAutocomplete = () => {
+        setShowSuggestions(false);
+        resetChipNavigation();
+    };
 
     /**
      * Callback triggered when a city is selected from the list. In this case, we want
@@ -330,11 +333,10 @@ import { mdiClose } from '@lumx/icons';
     }
 
     /**
-     * Callback triggered when the Text field is focused on. In this scenario,
-     * we want to show the suggestion list if there is some text entered.
+     * Callback triggered when the Text field is blurred. In this scenario, we want
+     * to hide the suggestions box and reset the chip navigation
      */
     const onBlur = (evt) => {
-        setShowSuggestions(false);
         resetChipNavigation();
     }
 
@@ -346,11 +348,12 @@ import { mdiClose } from '@lumx/icons';
             value={navigationSuggestionValue || filterValue}
             onChange={onChange}
             onFocus={onFocus}
-            onBlur={onBlur}
             values={selectedValues}
             inputRef={inputRef}
+            onBlur={onBlur}
             selectedChipRender={(city, index) => (
                         <Chip
+                            theme={theme}
                             isClickable
                             key={index}
                             after={<Icon icon={mdiClose} size={Size.xxs} />}
@@ -363,11 +366,12 @@ import { mdiClose } from '@lumx/icons';
                         </Chip>
             )}
         >
-            <List>
+            <List theme={theme}>
                 {filteredCities.map((city, index) => (
                     <ListItem
                         size={Size.tiny}
                         isClickable
+                        theme={theme}
                         key={city.id}
                         isHighlighted={index === activeItemIndex}
                         onItemSelected={() => setSelectedCity(city)}

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -8,6 +8,8 @@ import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { handleBasicClasses } from 'LumX/core/utils';
 import { IGenericProps, getRootClassName } from 'LumX/react/utils';
 
+import { useFocusOnClose } from 'LumX/core/react/hooks/useFocusOnClose';
+
 /////////////////////////////
 
 /**
@@ -219,6 +221,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
     } = props;
 
     const textFieldRef = useRef(null);
+    useFocusOnClose(inputRef.current, isOpen);
 
     return (
         <div

--- a/src/components/autocomplete/react/Autocomplete.tsx
+++ b/src/components/autocomplete/react/Autocomplete.tsx
@@ -259,6 +259,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 placement={placement}
                 fitToAnchorWidth={fitToAnchorWidth}
                 onInfiniteScroll={onInfiniteScroll}
+                theme={theme}
             >
                 {children}
             </Dropdown>

--- a/src/components/chip/style/lumapps/_index.scss
+++ b/src/components/chip/style/lumapps/_index.scss
@@ -66,14 +66,6 @@
     cursor: pointer;
 }
 
-.#{$lumx-base-prefix}-chip--is-highlighted {
-    @include lumx-state('state-focus', 'emphasis-medium', 'dark');
-}
-
-.#{$lumx-base-prefix}-chip--is-highlighted {
-    @include lumx-state('state-focus', 'emphasis-medium', 'dark');
-}
-
 @each $key, $color in $lumx-theme-color-palette {
     .#{$lumx-base-prefix}-chip--is-unselected.#{$lumx-base-prefix}-chip--color-#{$key} {
         @include lumx-state('state-default', 'emphasis-medium', $key);
@@ -86,7 +78,8 @@
             @include lumx-state('state-active', 'emphasis-medium', $key);
         }
 
-        &.#{$lumx-base-prefix}-chip--is-clickable[data-focus-visible-added] {
+        &.#{$lumx-base-prefix}-chip--is-clickable[data-focus-visible-added],
+        &.#{$lumx-base-prefix}-chip--is-highlighted {
             @include lumx-state('state-focus', 'emphasis-medium', $key);
         }
     }

--- a/src/components/chip/style/lumapps/_mixins.scss
+++ b/src/components/chip/style/lumapps/_mixins.scss
@@ -34,5 +34,4 @@
 @mixin lumx-chip-after() {
     flex-shrink: 0;
     margin-left: $lumx-spacing-unit;
-    cursor: pointer;
 }

--- a/src/components/popover/react/Popover.test.tsx
+++ b/src/components/popover/react/Popover.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, RefObject } from 'react';
 
 import { mount, shallow } from 'enzyme';
 
@@ -37,6 +37,8 @@ interface ISetup extends ICommonSetup {
  *                       component.
  */
 const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
+    const popoverRef = React.createRef();
+
     const props: PopoverProps = {
         // tslint:disable-next-line no-unused
         children: 'This is the content of the popover',
@@ -47,9 +49,15 @@ const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolea
             x: 0,
             y: 0,
         },
-        popoverRef: React.createRef(),
+        popoverRef: popoverRef as RefObject<HTMLDivElement>,
         ...propsOverrides,
     };
+
+    /**
+     * Here, we are mounting the component in order to retrieve the reference,
+     * and use it to render the component.
+     */
+    mount(<Popover {...props} />);
 
     const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 

--- a/src/components/popover/react/Popover.tsx
+++ b/src/components/popover/react/Popover.tsx
@@ -131,12 +131,24 @@ const Popover: React.FC<PopoverProps> & IPopover = ({
     isVisible,
     ...props
 }: PopoverProps): ReactElement => {
+    /**
+     * Depending on which is assigned first, the `popoverRect` or `popoverRef`,
+     * there are scenarios where the reference to the popover is still not assigned,
+     * which makes the popover to be shown at (0,0), then it moves under the anchor.
+     * Since the position is calculated with a `useEffect`, the first time it is calculated,
+     * `popoverRef` is still not defined, and the hook defaults to a (0,0) position. Once the reference
+     * is set and the `useEffect` has the `popoverRef` as dependency, it can recalculate the position and
+     * provide the accurate one. In order to fix this border case, we simply state that, for the popover
+     * to be visible, `isVisible` needs to be true and the ref needs to be defined.
+     */
+    const isPopoverVisible = isVisible && popoverRef && popoverRef.current;
+
     const cssPopover: CSSProperties = {
         left: 0,
         position: 'fixed',
         top: 0,
         transform: `translate(${popoverRect.x}px, ${popoverRect.y}px)`,
-        visibility: isVisible ? 'visible' : 'hidden',
+        visibility: isPopoverVisible ? 'visible' : 'hidden',
         zIndex: 9999,
     };
 

--- a/src/components/popover/react/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/popover/react/__snapshots__/Popover.test.tsx.snap
@@ -2,7 +2,20 @@
 
 exports[`<Popover> Snapshots and structure should render correctly 1`] = `
 <Portal
-  containerInfo={<body />}
+  containerInfo={
+    <body>
+      <div
+        class="lumx-popover lumx-popover--elevation-3"
+        style="left: 0px; position: fixed; top: 0px; transform: translate(0px, 0px); visibility: hidden; z-index: 9999;"
+      >
+        <div
+          class="lumx-popover__wrapper"
+        >
+          This is the content of the popover
+        </div>
+      </div>
+    </body>
+  }
 >
   <div
     className="lumx-popover lumx-popover--elevation-3"

--- a/src/components/select/react/Select.tsx
+++ b/src/components/select/react/Select.tsx
@@ -13,6 +13,8 @@ import { ENTER_KEY_CODE, SPACE_KEY_CODE } from 'LumX/core/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
 
+import { useFocusOnClose } from 'LumX/core/react/hooks/useFocusOnClose';
+
 /////////////////////////////
 
 /**
@@ -205,21 +207,6 @@ function useHandleElementFocus(element: HTMLElement | null, setIsFocus: (b: bool
             element.removeEventListener('blur', setBlur);
         };
     }, [element]);
-}
-
-/**
- * Re-focus the element when the select is closed.
- *
- * @param element Element to focus.
- * @param isOpen  Whether or not the select is open.
- */
-function useFocusOnClose(element: HTMLElement | null, isOpen: boolean | undefined): void {
-    useEffect(() => {
-        if (!isOpen && element) {
-            // Re-focus the button when the select is closed.
-            element.focus();
-        }
-    }, [isOpen]);
 }
 
 /**

--- a/src/core/react/hooks/index.tsx
+++ b/src/core/react/hooks/index.tsx
@@ -11,3 +11,5 @@ export { useBooleanState } from './useBooleanState';
 export { useInfiniteScroll } from './useInfiniteScroll';
 
 export { useChipGroupNavigation, useChipGroupNavigationType } from './useChipGroupNavigation';
+
+export { useFocusOnClose } from './useFocusOnClose';

--- a/src/core/react/hooks/useFocusOnClose.tsx
+++ b/src/core/react/hooks/useFocusOnClose.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+/**
+ * Re-focus the element when the select is closed.
+ *
+ * @param element Element to focus.
+ * @param isOpen  Whether or not the select is open.
+ */
+function useFocusOnClose(element: HTMLElement | null, isOpen: boolean | undefined): void {
+    useEffect(() => {
+        if (!isOpen && element) {
+            // Re-focus the button when the select is closed.
+            element.focus();
+        }
+    }, [isOpen]);
+}
+
+export { useFocusOnClose };


### PR DESCRIPTION
# General summary
- Fixes a bug related to the Popover component that made the content be displayed on the top left corner. (see screenshots section)
- Remove cursor pointer for chips
- Remove a selected chip by clicking on the entire Chip for Autocomplete multi.

# Screenshots
Notice the dropdown appearing for a split second on the top left corner.
![Nov-05-2019 10-56-48](https://user-images.githubusercontent.com/13719066/68208525-9e43c500-ffd1-11e9-935e-67a48bd051e6.gif)

# Check list

-   [X] (if has react) Check through the [react dev check list]
-   [X] (if has style) Request an integration review
-   [X] (if has docs) Request a doc review
-   [X] Request a frontend review
-   [X] (if fix or feature) Request a test

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
