### PR TITLE
feat(tree-shake): tree shake lodash

### DIFF
--- a/src/components/comment-block/react/CommentBlock.tsx
+++ b/src/components/comment-block/react/CommentBlock.tsx
@@ -8,7 +8,7 @@ import { Avatar, Size, Theme } from 'LumX';
 import { ENTER_KEY_CODE } from 'LumX/core/constants';
 import { IGenericProps, getRootClassName } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
-import { isFunction } from 'lodash';
+import isFunction from 'lodash/isFunction';
 
 /////////////////////////////
 

--- a/src/components/expansion-panel/react/ExpansionPanel.tsx
+++ b/src/components/expansion-panel/react/ExpansionPanel.tsx
@@ -7,7 +7,9 @@ import { ColorPalette, DragHandle, Emphasis, IconButton, Theme } from 'LumX';
 import { COMPONENT_PREFIX } from 'LumX/core/react/constants';
 import { Callback, IGenericProps, getRootClassName, isComponent, partitionMulti } from 'LumX/core/react/utils';
 import { handleBasicClasses } from 'LumX/core/utils';
-import { get, isEmpty, isFunction } from 'lodash';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import isFunction from 'lodash/isFunction';
 
 /////////////////////////////
 

--- a/src/components/side-navigation/react/SideNavigationItem.tsx
+++ b/src/components/side-navigation/react/SideNavigationItem.tsx
@@ -7,7 +7,7 @@ import { mdiChevronDown, mdiChevronUp } from 'LumX/icons';
 import { COMPONENT_PREFIX } from 'LumX/react/constants';
 import { Callback, IGenericProps, getRootClassName, isComponent } from 'LumX/react/utils';
 import classNames from 'classnames';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * Defines the props of the component.

--- a/src/core/react/utils.ts
+++ b/src/core/react/utils.ts
@@ -11,7 +11,11 @@ import trimStart from 'lodash/trimStart';
 
 import { CSS_PREFIX } from '../constants';
 
-import { concat, dropRight, last, partition, reduce } from 'lodash';
+import concat from 'lodash/concat';
+import dropRight from 'lodash/dropRight';
+import last from 'lodash/last';
+import partition from 'lodash/partition';
+import reduce from 'lodash/reduce';
 import { COMPONENT_PREFIX } from './constants';
 
 /////////////////////////////
@@ -316,18 +320,16 @@ function validateComponent(
 
                     if (!isOfOneAllowedType) {
                         let allowedTypesString = '';
-                        allowedTypes.forEach(
-                            (allowedType: string | ComponentType, idx: number): void => {
-                                if (!isEmpty(allowedTypesString)) {
-                                    allowedTypesString += idx < allowedTypes.length - 1 ? ', ' : ' or ';
-                                }
+                        allowedTypes.forEach((allowedType: string | ComponentType, idx: number): void => {
+                            if (!isEmpty(allowedTypesString)) {
+                                allowedTypesString += idx < allowedTypes.length - 1 ? ', ' : ' or ';
+                            }
 
-                                const typeName: string | ComponentType = getTypeName(allowedType);
-                                allowedTypesString +=
-                                    (isString(typeName) ? `${typeName === 'text' ? typeName : `<${typeName}>`}` : '') ||
-                                    '<Unknown component type>';
-                            },
-                        );
+                            const typeName: string | ComponentType = getTypeName(allowedType);
+                            allowedTypesString +=
+                                (isString(typeName) ? `${typeName === 'text' ? typeName : `<${typeName}>`}` : '') ||
+                                '<Unknown component type>';
+                        });
 
                         console.debug('Non matching type', newChild, '\nResulted in', getTypeName(newChild));
                         throw new Error(


### PR DESCRIPTION
# General summary
While taking a look at the generate bundle for production using `webpack-bundle-analyzer`, I noticed that we were importing the entire `lodash` dependency, but we are actually only using some modules:
![Screenshot 2019-11-05 at 17 25 03](https://user-images.githubusercontent.com/13719066/68226392-48334980-fff2-11e9-864e-f0934a3a20c8.png)

This was currently adding 20 KB (GZipped) to the final bundle that we are using in our product.

Changing the imports in order to allow tree shaking, we can see that the bundle decreased:
![Screenshot 2019-11-05 at 17 25 10](https://user-images.githubusercontent.com/13719066/68226516-7f095f80-fff2-11e9-977f-005cb7522f30.png)

Before tree shaking:
62.26 KB GZipped.

After tree shaking:
40.72 KB GZipped.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [X] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
