### PR TITLE
Fix padding top issue with material theme

### DIFF
--- a/src/components/text-field/style/material/_index.scss
+++ b/src/components/text-field/style/material/_index.scss
@@ -6,7 +6,7 @@
     $self: &;
 
     position: relative;
-    padding-top: $lumx-spacing-unit * 4;
+    padding-top: $lumx-spacing-unit;
     padding-bottom: $lumx-spacing-unit;
 
     &__label {


### PR DESCRIPTION
# General summary

Propose a fix to a padding-top issue with the TextField component with material theme

<!-- Please describe the PR content -->

# Screenshots
These are screenshots of the Toolbar component documentation for angular

Before
<a href="https://ibb.co/8sZvFfK"><img src="https://i.ibb.co/C8GCxY1/Screenshot-2019-11-10-at-23-24-56.png" alt="Screenshot-2019-11-10-at-23-24-56" border="0" /></a>

After
<a href="https://ibb.co/XVmDg2w"><img src="https://i.ibb.co/52qkyM7/Screenshot-2019-11-10-at-23-24-32.png" alt="Screenshot-2019-11-10-at-23-24-32" border="0"></a>

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [x] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
