### PR TITLE
fix(react): fix build typescript declaration file

### DIFF
--- a/packages/lumx-react/webpack.config.js
+++ b/packages/lumx-react/webpack.config.js
@@ -78,7 +78,7 @@ if (!IS_CI) {
 
 module.exports = {
     entry: {
-        'lumx.react': `${SRC_PATH}/index`,
+        'lumx.react': `${SRC_PATH}/index.ts`,
     },
 
     externals: [


### PR DESCRIPTION
# General summary

WIP fix the generation of the typescript declaration file (that should be located under `dist/lumx.react.d.ts`)

Currently in error: 
https://github.com/unimonkiez/ts-declaration-webpack-plugin/issues/4