### PR TITLE
fix(demo): fix console error on break line in MDX

### DIFF
--- a/packages/site-demo/webpack-loader/mdx-loader/index.js
+++ b/packages/site-demo/webpack-loader/mdx-loader/index.js
@@ -32,7 +32,8 @@ module.exports = async function mdxLoader(source) {
     const cb = this.async();
     // MDX to JSX.
     const jsx = await mdx(source, {
-        remarkPlugins: [mdxBreakLine, mdxDemoCodeExtractor(this.resourcePath)],
+        remarkPlugins: [mdxDemoCodeExtractor(this.resourcePath)],
+        rehypePlugins: [mdxBreakLine],
         preserveNewlines: true,
     });
 

--- a/packages/site-demo/webpack-loader/mdx-loader/mdx-break-line.js
+++ b/packages/site-demo/webpack-loader/mdx-loader/mdx-break-line.js
@@ -27,7 +27,7 @@ function replaceNewLineWithBreakLine(node) {
         });
     }
 
-    if (node.type === 'paragraph') {
+    if (node.type === 'element' && node.tagName === 'p') {
         return {
             ...node,
             children: flatMap(node.children, replaceNewLineWithBreakLine),


### PR DESCRIPTION
# General summary

This fix should correclty generate `<br/>` break line in MDX paragraph without error in the console