### PR TITLE
feat(storybook): Added themes

### DIFF
--- a/packages/lumx-react/.storybook/webpack.config.js
+++ b/packages/lumx-react/.storybook/webpack.config.js
@@ -4,7 +4,11 @@ module.exports = async ({ config, mode }) => {
     /** SCSS Loader */
     config.module.rules.push({
         test: /\.scss$/,
-        loaders: ['style-loader', 'css-loader', 'sass-loader'],
+        loaders: [
+            { loader: 'style-loader', options: { attrs: { id: 'injected-styles' } } },
+            'css-loader',
+            'sass-loader',
+        ],
     });
 
     config.module.rules = [...config.module.rules, ...baseWebpackConfig.module.rules];

--- a/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
@@ -1,60 +1,57 @@
 import React from 'react';
 
-import '@lumx/core/lumx-theme-lumapps.scss';
-import '@lumx/core/lumx-theme-material.scss';
-
 import { mdiDelete, mdiEye, mdiPencil } from '@lumx/icons';
 import { Avatar, Emphasis, IconButton, Size } from '@lumx/react';
 
-import { withA11y } from '@storybook/addon-a11y';
-import { text, withKnobs } from '@storybook/addon-knobs';
+import { decorators } from '@lumx/react/story-block';
 
-export default { title: 'Avatar', decorators: [withKnobs, withA11y] };
+import { text } from '@storybook/addon-knobs';
 
+export default { title: 'Avatar', decorators };
+
+/**
+ * Avatar stories showing a simple Avatar with different sizes.
+ * @return component with different sizes.
+ */
 export const xs = () => <Avatar image={text('Image', 'http://i.pravatar.cc/40')} size={Size.xs} />;
-
 export const s = () => <Avatar image={text('Image', 'http://i.pravatar.cc/48')} size={Size.s} />;
 export const m = () => <Avatar image={text('Image', 'http://i.pravatar.cc/72')} size={Size.m} />;
 export const l = () => <Avatar image={text('Image', 'http://i.pravatar.cc/128')} size={Size.l} />;
 
-export const avatarWithActions = () => {
-    return (
-        <Avatar
-            image={text('Image', 'http://i.pravatar.cc/256')}
-            size={Size.xl}
-            actions={
-                <div style={{ display: 'flex', justifyContent: 'center' }}>
-                    <div className="lumx-spacing-margin-right-regular">
-                        <IconButton
-                            color="dark"
-                            emphasis={Emphasis.low}
-                            hasBackground={true}
-                            icon={mdiPencil}
-                            size={Size.s}
-                        />
-                    </div>
-
-                    <div className="lumx-spacing-margin-right-regular">
-                        <IconButton
-                            color="dark"
-                            emphasis={Emphasis.low}
-                            hasBackground={true}
-                            icon={mdiEye}
-                            size={Size.s}
-                        />
-                    </div>
-
-                    <div>
-                        <IconButton
-                            color="dark"
-                            emphasis={Emphasis.low}
-                            hasBackground={true}
-                            icon={mdiDelete}
-                            size={Size.s}
-                        />
-                    </div>
+/**
+ * Avatar storiy showing a simple avatar with different actions.
+ * @return component with different actions.
+ */
+export const avatarWithActions = () => (
+    <Avatar
+        image={text('Image', 'http://i.pravatar.cc/256')}
+        size={Size.xl}
+        actions={
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+                <div className="lumx-spacing-margin-right-regular">
+                    <IconButton
+                        color="dark"
+                        emphasis={Emphasis.low}
+                        hasBackground={true}
+                        icon={mdiPencil}
+                        size={Size.s}
+                    />
                 </div>
-            }
-        />
-    );
-};
+
+                <div className="lumx-spacing-margin-right-regular">
+                    <IconButton color="dark" emphasis={Emphasis.low} hasBackground={true} icon={mdiEye} size={Size.s} />
+                </div>
+
+                <div>
+                    <IconButton
+                        color="dark"
+                        emphasis={Emphasis.low}
+                        hasBackground={true}
+                        icon={mdiDelete}
+                        size={Size.s}
+                    />
+                </div>
+            </div>
+        }
+    />
+);

--- a/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
@@ -19,7 +19,7 @@ export const m = () => <Avatar image={text('Image', 'http://i.pravatar.cc/72')} 
 export const l = () => <Avatar image={text('Image', 'http://i.pravatar.cc/128')} size={Size.l} />;
 
 /**
- * Avatar storiy showing a simple avatar with different actions.
+ * Avatar story showing a simple avatar with different actions.
  * @return component with different actions.
  */
 export const avatarWithActions = () => (

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -6,4 +6,4 @@ import { decorators } from '@lumx/react/story-block';
 
 export default { title: 'Button', decorators };
 
-export const simpleButton = () => <Button>Simple button</Button>;
+export const simpleButton = ({ theme }) => <Button theme={theme}>Simple button</Button>;

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { Button } from '@lumx/react';
+
+import { decorators } from '@lumx/react/story-block';
+
+export default { title: 'Button', decorators };
+
+export const simpleButton = () => <Button>Simple button</Button>;

--- a/packages/lumx-react/src/story-block/StoryBlock.jsx
+++ b/packages/lumx-react/src/story-block/StoryBlock.jsx
@@ -1,26 +1,81 @@
 /* eslint-disable react/jsx-no-bind */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
-import '@lumx/core/lumx-theme-lumapps.scss';
+/**
+ * Please make sure that these themes are in the same order
+ * as the `THEMES` constant.
+ */
 import '@lumx/core/lumx-theme-material.scss';
+import '@lumx/core/lumx-theme-lumapps.scss';
 
 import { Chip, Size } from '@lumx/react';
 
 import { styles } from './styles';
+
+const THEMES = ['material', 'lumapps'];
+
+const stylesNodes = [];
 
 const CLASSNAME = 'story-block';
 const StoryBlock = (props) => {
     const [theme, setTheme] = useState('lumapps');
     const { children } = props;
 
+    const changeTheme = (newTheme) => {
+        setTheme(newTheme);
+    };
+
+    useEffect(() => {
+        /**
+         * This effect retrieves all the injected styles that were added
+         * by storybook, and only adds the ones associated to the current theme.
+         *
+         * Upon clicking the theme selector chips, we can update the theme
+         * currently used, and execute this effect once again to determine which
+         * theme we want to use.
+         *
+         * In the first execution, we cache the styles that were added, in order to
+         * use them later on once the theme changing starts.
+         */
+        const currentStyle = THEMES.indexOf(theme);
+        const nodes = document.querySelectorAll('style#injected-styles');
+
+        if (stylesNodes.length === 0) {
+            /**
+             * In the first execution, we cache the styles that were added, in order to
+             * use them later on once the theme changing starts.
+             *
+             * We also take the opportunity to remove all the other styles that are not needed.
+             */
+            nodes.forEach((node, position) => {
+                stylesNodes.push(node.cloneNode(true));
+
+                if (position !== currentStyle) {
+                    node.remove();
+                }
+            });
+        } else {
+            /**
+             * In this step, we have already remove the initial unnecesary styles,
+             * we just need to add the selected theme. We remove all the current styles
+             * and only add the stylesheet needed from the cached list.
+             */
+            nodes.forEach((node) => {
+                node.remove();
+            });
+
+            document.head.appendChild(stylesNodes[currentStyle]);
+        }
+    });
+
     return (
         <div className={CLASSNAME} style={styles.block}>
-            <div className={`${CLASSNAME}__theme-selector`}>
+            <div className={`${CLASSNAME}__theme-selector`} style={styles.selector}>
                 <Chip
                     className="lumx-spacing-margin-right-tiny"
                     isSelected={theme === 'lumapps'}
                     size={Size.s}
-                    onClick={() => setTheme('lumapps')}
+                    onClick={() => changeTheme('lumapps')}
                 >
                     LumApps
                 </Chip>
@@ -28,7 +83,7 @@ const StoryBlock = (props) => {
                     className="lumx-spacing-margin-right-tiny"
                     isSelected={theme === 'material'}
                     size={Size.s}
-                    onClick={() => setTheme('material')}
+                    onClick={() => changeTheme('material')}
                 >
                     Material
                 </Chip>

--- a/packages/lumx-react/src/story-block/StoryBlock.jsx
+++ b/packages/lumx-react/src/story-block/StoryBlock.jsx
@@ -1,0 +1,28 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+
+import '@lumx/core/lumx-theme-lumapps.scss';
+import '@lumx/core/lumx-theme-material.scss';
+
+import { withA11y } from '@storybook/addon-a11y';
+import { withKnobs } from '@storybook/addon-knobs';
+
+import { styles } from './styles';
+
+const CLASSNAME = 'story-block';
+const StoryBlock = (props) => {
+    const { children } = props;
+
+    return (
+        <div className={CLASSNAME} style={styles.block}>
+            {children}
+        </div>
+    );
+};
+
+// eslint-disable-next-line react/no-multi-comp
+const withStoryBlockDecorator = (storyFn) => <StoryBlock>{storyFn()}</StoryBlock>;
+
+const decorators = [withA11y, withKnobs, withStoryBlockDecorator];
+
+export { StoryBlock, decorators };

--- a/packages/lumx-react/src/story-block/StoryBlock.jsx
+++ b/packages/lumx-react/src/story-block/StoryBlock.jsx
@@ -1,28 +1,41 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import React from 'react';
+/* eslint-disable react/jsx-no-bind */
+import React, { useState } from 'react';
 
 import '@lumx/core/lumx-theme-lumapps.scss';
 import '@lumx/core/lumx-theme-material.scss';
 
-import { withA11y } from '@storybook/addon-a11y';
-import { withKnobs } from '@storybook/addon-knobs';
+import { Chip, Size } from '@lumx/react';
 
 import { styles } from './styles';
 
 const CLASSNAME = 'story-block';
 const StoryBlock = (props) => {
+    const [theme, setTheme] = useState('lumapps');
     const { children } = props;
 
     return (
         <div className={CLASSNAME} style={styles.block}>
+            <div className={`${CLASSNAME}__theme-selector`}>
+                <Chip
+                    className="lumx-spacing-margin-right-tiny"
+                    isSelected={theme === 'lumapps'}
+                    size={Size.s}
+                    onClick={() => setTheme('lumapps')}
+                >
+                    LumApps
+                </Chip>
+                <Chip
+                    className="lumx-spacing-margin-right-tiny"
+                    isSelected={theme === 'material'}
+                    size={Size.s}
+                    onClick={() => setTheme('material')}
+                >
+                    Material
+                </Chip>
+            </div>
             {children}
         </div>
     );
 };
 
-// eslint-disable-next-line react/no-multi-comp
-const withStoryBlockDecorator = (storyFn) => <StoryBlock>{storyFn()}</StoryBlock>;
-
-const decorators = [withA11y, withKnobs, withStoryBlockDecorator];
-
-export { StoryBlock, decorators };
+export { StoryBlock };

--- a/packages/lumx-react/src/story-block/StoryBlock.jsx
+++ b/packages/lumx-react/src/story-block/StoryBlock.jsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/jsx-no-bind */
 import React, { useState, useEffect } from 'react';
 
+import classnames from 'classnames';
+
 /**
  * Please make sure that these themes are in the same order
  * as the `THEMES` constant.
@@ -8,7 +10,7 @@ import React, { useState, useEffect } from 'react';
 import '@lumx/core/lumx-theme-material.scss';
 import '@lumx/core/lumx-theme-lumapps.scss';
 
-import { Chip, Size } from '@lumx/react';
+import { Chip, Size, Switch, SwitchPosition, Theme } from '@lumx/react';
 
 import { styles } from './styles';
 
@@ -19,10 +21,20 @@ const stylesNodes = [];
 const CLASSNAME = 'story-block';
 const StoryBlock = (props) => {
     const [theme, setTheme] = useState('lumapps');
+    const [colorTheme, setColorTheme] = useState(Theme.light);
+
     const { children } = props;
 
     const changeTheme = (newTheme) => {
         setTheme(newTheme);
+    };
+
+    const toggleTheme = (checked) => {
+        if (checked) {
+            setColorTheme(Theme.dark);
+        } else {
+            setColorTheme(Theme.light);
+        }
     };
 
     useEffect(() => {
@@ -68,13 +80,18 @@ const StoryBlock = (props) => {
         }
     });
 
-    return (
-        <div className={CLASSNAME} style={styles.block}>
+    return [
+        <div
+            key="story"
+            className={classnames(CLASSNAME, { 'lumx-theme-background-dark-N': colorTheme === Theme.dark })}
+            style={styles.block}
+        >
             <div className={`${CLASSNAME}__theme-selector`} style={styles.selector}>
                 <Chip
                     className="lumx-spacing-margin-right-tiny"
                     isSelected={theme === 'lumapps'}
                     size={Size.s}
+                    theme={colorTheme}
                     onClick={() => changeTheme('lumapps')}
                 >
                     LumApps
@@ -83,14 +100,21 @@ const StoryBlock = (props) => {
                     className="lumx-spacing-margin-right-tiny"
                     isSelected={theme === 'material'}
                     size={Size.s}
+                    theme={colorTheme}
                     onClick={() => changeTheme('material')}
                 >
                     Material
                 </Chip>
             </div>
-            {children}
-        </div>
-    );
+
+            {children({ theme: colorTheme })}
+        </div>,
+        <div key="switcher" className={`${CLASSNAME}__color-theme-selector`} style={styles.colorThemeSelector}>
+            <Switch checked={colorTheme === Theme.dark} position={SwitchPosition.right} onToggle={toggleTheme}>
+                Dark Background
+            </Switch>
+        </div>,
+    ];
 };
 
 export { StoryBlock };

--- a/packages/lumx-react/src/story-block/decorators.js
+++ b/packages/lumx-react/src/story-block/decorators.js
@@ -7,7 +7,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 
 import { StoryBlock } from './StoryBlock';
 
-const withStoryBlockDecorator = (storyFn) => <StoryBlock>{storyFn()}</StoryBlock>;
+const withStoryBlockDecorator = (storyFn) => <StoryBlock>{({ theme }) => storyFn({ theme })}</StoryBlock>;
 
 const decorators = [withA11y, withKnobs, withStoryBlockDecorator];
 

--- a/packages/lumx-react/src/story-block/decorators.js
+++ b/packages/lumx-react/src/story-block/decorators.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+
+import { withA11y } from '@storybook/addon-a11y';
+import { withKnobs } from '@storybook/addon-knobs';
+
+import { StoryBlock } from './StoryBlock';
+
+const withStoryBlockDecorator = (storyFn) => <StoryBlock>{storyFn()}</StoryBlock>;
+
+const decorators = [withA11y, withKnobs, withStoryBlockDecorator];
+
+export { decorators };

--- a/packages/lumx-react/src/story-block/index.jsx
+++ b/packages/lumx-react/src/story-block/index.jsx
@@ -1,0 +1,1 @@
+export * from './StoryBlock';

--- a/packages/lumx-react/src/story-block/index.jsx
+++ b/packages/lumx-react/src/story-block/index.jsx
@@ -1,1 +1,3 @@
 export * from './StoryBlock';
+
+export * from './decorators';

--- a/packages/lumx-react/src/story-block/styles.js
+++ b/packages/lumx-react/src/story-block/styles.js
@@ -5,6 +5,10 @@ const styles = {
     selector: {
         marginBottom: '20px',
     },
+    colorThemeSelector: {
+        width: '200px',
+        padding: '20px',
+    },
 };
 
 export { styles };

--- a/packages/lumx-react/src/story-block/styles.js
+++ b/packages/lumx-react/src/story-block/styles.js
@@ -6,7 +6,7 @@ const styles = {
         marginBottom: '20px',
     },
     colorThemeSelector: {
-        width: '200px',
+        width: '220px',
         padding: '20px',
     },
 };

--- a/packages/lumx-react/src/story-block/styles.js
+++ b/packages/lumx-react/src/story-block/styles.js
@@ -1,0 +1,10 @@
+const styles = {
+    block: {
+        padding: '20px',
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+    },
+};
+
+export { styles };

--- a/packages/lumx-react/src/story-block/styles.js
+++ b/packages/lumx-react/src/story-block/styles.js
@@ -2,6 +2,9 @@ const styles = {
     block: {
         padding: '20px',
     },
+    selector: {
+        marginBottom: '20px',
+    },
 };
 
 export { styles };

--- a/packages/lumx-react/src/story-block/styles.js
+++ b/packages/lumx-react/src/story-block/styles.js
@@ -1,9 +1,6 @@
 const styles = {
     block: {
         padding: '20px',
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: 'center',
     },
 };
 


### PR DESCRIPTION
# General summary
Added themes for storybook.

The basic idea comes from the `demo` site implementation, but with a little twist in order to adapt it to storybook:
- Created a base Story Block component in order to abstract the functionality and apply the theme selector to all stories
- Upon clicking on the theme switcher, we remove the stylesheet associated with a specific theme and apply the other one.
- I also added a specific identifier to each injected style in order to make sure that we are only manipulating the styles added by the loader and nothing else.

# Screenshots
![h5yTYHXVTW](https://user-images.githubusercontent.com/13719066/69731325-fdf14400-1129-11ea-9e6d-decbbe33cb33.gif)

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [X] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
