### PR TITLE
chore(demo): replace highlight.js with prism

### DIFF
--- a/packages/site-demo/package.json
+++ b/packages/site-demo/package.json
@@ -12,14 +12,13 @@
         "@lumx/react": "^0.17.0",
         "angular": "^1.7.8",
         "classnames": "^2.2.6",
-        "highlight.js": "^9.16.2",
         "intersection-observer": "^0.7.0",
         "jquery": "^3.3.1",
         "lodash": "^4.17.15",
+        "prismjs": "^1.17.1",
         "react": "^16.11.0",
         "react-angular": "^0.4.0",
         "react-dom": "^16.11.0",
-        "react-highlight": "^0.12.0",
         "react-router-dom": "^5.1.2"
     },
     "devDependencies": {

--- a/packages/site-demo/src/index.tsx
+++ b/packages/site-demo/src/index.tsx
@@ -8,6 +8,7 @@ import { reactAngularModule } from 'react-angular';
 
 import '@lumx/angularjs';
 
+// @ts-ignore
 angular.module('design-system', ['lumx', reactAngularModule(false).name]);
 
 /////////////////////////////

--- a/packages/site-demo/src/layout/DemoBlock.tsx
+++ b/packages/site-demo/src/layout/DemoBlock.tsx
@@ -1,13 +1,12 @@
+import { useHighlightedCode } from '@lumx/demo/layout/utils/useHighlightedCode';
+
 import { mdiCodeTags } from '@lumx/icons';
 import { Button, Emphasis, Switch, SwitchPosition, Theme } from '@lumx/react';
-import classNames from 'classnames';
-import get from 'lodash/get';
-import React, { ReactElement, useEffect, useState } from 'react';
-import AngularTemplate from 'react-angular';
-import Highlight from 'react-highlight';
 
-// Code highlighting style
-import 'highlight.js/styles/github.css';
+import classNames from 'classnames';
+import React, { ReactElement, useEffect, useState } from 'react';
+
+import AngularTemplate from 'react-angular';
 
 interface IDemoBlockProps {
     demo: string;
@@ -82,8 +81,8 @@ async function loadAngularjsDemo(code: ICode): Promise<IDemoModule | null> {
 const useLoadDemo = (code: ICode, engine: string): IDemoModule | null | undefined => {
     const [demo, setDemo] = useState<IDemoModule | null>();
 
-    useEffect((): void => {
-        (async (): Promise<void> => {
+    useEffect(() => {
+        (async () => {
             setDemo(undefined);
             try {
                 setDemo(engine === 'react' ? await loadReactDemo(code) : await loadAngularjsDemo(code));
@@ -126,8 +125,8 @@ const DemoBlock: React.FC<IDemoBlockProps> = ({
     const toggleShowCode = (): void => setShowCode(!showCode);
 
     const demo = useLoadDemo(code, engine);
-    const sourceCode = get(code, [engine, 'code']);
-    const langClasses = engine === 'react' ? 'javascript jsx' : 'html';
+
+    const highlightedCode = useHighlightedCode(code[engine].code, engine === 'react' ? 'tsx' : 'html');
 
     return (
         <div className="demo-block">
@@ -137,7 +136,7 @@ const DemoBlock: React.FC<IDemoBlockProps> = ({
             <div className="demo-block__toolbar">
                 <div className="demo-block__code-toggle">
                     <Button
-                        disabled={!sourceCode}
+                        disabled={!highlightedCode}
                         emphasis={Emphasis.low}
                         leftIcon={mdiCodeTags}
                         onClick={toggleShowCode}
@@ -160,9 +159,11 @@ const DemoBlock: React.FC<IDemoBlockProps> = ({
                 )}
             </div>
 
-            {showCode && sourceCode && (
+            {showCode && highlightedCode && (
                 <div className="demo-block__code">
-                    <Highlight className={langClasses}>{sourceCode.replace(/\\n/g, '\n')}</Highlight>
+                    <pre>
+                        <code dangerouslySetInnerHTML={{ __html: highlightedCode }} />
+                    </pre>
                 </div>
             )}
         </div>

--- a/packages/site-demo/src/layout/utils/useHighlightedCode.ts
+++ b/packages/site-demo/src/layout/utils/useHighlightedCode.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+
+import Prism from 'prismjs';
+
+import 'prismjs/components/prism-typescript';
+
+import 'prismjs/components/prism-jsx';
+
+import 'prismjs/components/prism-tsx';
+
+import 'prismjs/themes/prism-coy.css';
+
+function useHighlightedCode(sourceCode: string, language: string): string {
+    return useMemo(() => {
+        if (!sourceCode || !language) {
+            return null;
+        }
+        return Prism.highlight(sourceCode.trim(), Prism.languages[language], language);
+    }, [sourceCode]);
+}
+
+export { useHighlightedCode };

--- a/packages/site-demo/src/style/demo/_demo-block.scss
+++ b/packages/site-demo/src/style/demo/_demo-block.scss
@@ -28,10 +28,13 @@
     &__code {
         border-top: 1px solid lumx-theme-color-variant(dark, L4);
 
-        .hljs {
+        code {
+            display: block;
             padding: $lumx-spacing-unit * 2;
             background-color: transparent;
+            color: #333;
             font-size: 14px;
+            overflow-x: auto;
         }
     }
 

--- a/packages/site-demo/webpack.config.js
+++ b/packages/site-demo/webpack.config.js
@@ -72,7 +72,7 @@ if (!IS_CI) {
 
 module.exports = {
     bail: true,
-    devtool: isDev ? 'source-map' : '',
+    devtool: 'source-map',
     mode,
     name: PKG_NAME,
     externals: ['angular'],
@@ -175,10 +175,7 @@ module.exports = {
                         loader: 'babel-loader?cacheDirectory=true',
                         options: {
                             ...CONFIGS.babel,
-                            plugins: [
-                                ['angularjs-annotate', { explicitOnly: true }],
-                                ...CONFIGS.babel.plugins,
-                            ],
+                            plugins: [['angularjs-annotate', { explicitOnly: true }], ...CONFIGS.babel.plugins],
                             presets: ['@babel/preset-react', ...CONFIGS.babel.presets],
                         },
                     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9857,7 +9857,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^9.11.0, highlight.js@^9.16.2:
+highlight.js@^9.16.2:
   version "9.16.2"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.16.2.tgz#68368d039ffe1c6211bcc07e483daf95de3e403e"
   integrity sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw==
@@ -15279,7 +15279,7 @@ pretty-time@^1.1.0:
   resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"
   integrity sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==
 
-prismjs@^1.15.0, prismjs@^1.8.4, prismjs@~1.17.0:
+prismjs@^1.15.0, prismjs@^1.17.1, prismjs@^1.8.4, prismjs@~1.17.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
   integrity sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==
@@ -15738,13 +15738,6 @@ react-helmet-async@^1.0.2:
     prop-types "^15.7.2"
     react-fast-compare "^2.0.4"
     shallowequal "^1.1.0"
-
-react-highlight@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/react-highlight/-/react-highlight-0.12.0.tgz#34de986a0bfdf228904d0c269b69538d95b35802"
-  integrity sha512-j04EWbYOFM0PryhF5Vvl0FDa/dD3M6q0Sl+nFN9kTvWQ9hFkfISNNs85+ssL4TSkDM+4pQTpMdxlDRi8yfIxjw==
-  dependencies:
-    highlight.js "^9.11.0"
 
 react-hotkeys@2.0.0-pre4:
   version "2.0.0-pre4"


### PR DESCRIPTION
# General summary

Replace highlight.js with prism for better TSX code highlighting and a lighter JS bundle

# Screenshots

![Capture d’écran de 2019-11-27 17-06-23](https://user-images.githubusercontent.com/939567/69739611-4d3e7100-1138-11ea-9c71-52af890b2481.png)
![Capture d’écran de 2019-11-27 17-06-36](https://user-images.githubusercontent.com/939567/69739612-4d3e7100-1138-11ea-9679-dc4512e94f25.png)
