### PR TITLE
Release v0.18.0

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0][] - 2019-11-28
+
 ## [0.17.0][] - 2019-11-28
 
 ## [0.16.4-alpha.0][] - 2019-11-26
@@ -128,3 +130,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.16.4-alpha.0]: https://github.com/lumapps/design-system/tree/v0.16.4-alpha.0
 [unreleased]: https://github.com/lumapps/design-system/compare/v0.17.0...HEAD
 [0.17.0]: https://github.com/lumapps/design-system/tree/v0.17.0
+[unreleased]: https://github.com/lumapps/design-system/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/lumapps/design-system/tree/v0.18.0

--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0][] - 2019-11-28
+
 ## [0.16.4-alpha.0][] - 2019-11-26
 
 ### Changed
@@ -124,3 +126,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.15.3]: https://github.com/lumapps/design-system/tree/v0.15.3
 [unreleased]: https://github.com/lumapps/design-system/compare/v0.16.4-alpha.0...HEAD
 [0.16.4-alpha.0]: https://github.com/lumapps/design-system/tree/v0.16.4-alpha.0
+[unreleased]: https://github.com/lumapps/design-system/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/lumapps/design-system/tree/v0.17.0

--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,7 @@
             "message": "chore(release): release %s"
         }
     },
-    "version": "0.17.0",
+    "version": "0.18.0",
     "useWorkspaces": true,
     "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "husky": {
         "hooks": {
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-            "pre-commit": "lint-staged && changelog-verify CHANGELOG.react.md"
+            "pre-commit": "lint-staged"
         }
     },
     "keywords": [

--- a/packages/lumx-angularjs/package.json
+++ b/packages/lumx-angularjs/package.json
@@ -6,8 +6,8 @@
         "url": "https://github.com/lumapps/design-system/issues"
     },
     "dependencies": {
-        "@lumx/core": "^0.17.0",
-        "@lumx/icons": "^0.17.0",
+        "@lumx/core": "^0.18.0",
+        "@lumx/icons": "^0.18.0",
         "angular": "^1.7.8",
         "focus-visible": "^5.0.2",
         "jquery": "^3.3.1",
@@ -41,7 +41,7 @@
         "build": "webpack",
         "prepublish": "yarn build"
     },
-    "version": "0.17.0",
+    "version": "0.18.0",
     "devDependencies": {
         "babel-plugin-angularjs-annotate": "^0.10.0",
         "clean-webpack-plugin": "^3.0.0",

--- a/packages/lumx-core/package.json
+++ b/packages/lumx-core/package.json
@@ -37,7 +37,7 @@
         "postbuild": "rm -rf ./dist/*.js ./dist/*.js.map",
         "prepublish": "yarn build"
     },
-    "version": "0.17.0",
+    "version": "0.18.0",
     "devDependencies": {
         "autoprefixer": "^9.7.1",
         "clean-webpack-plugin": "^3.0.0",

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -20,5 +20,5 @@
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"
     },
-    "version": "0.17.0"
+    "version": "0.18.0"
 }

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -6,8 +6,8 @@
         "url": "https://github.com/lumapps/design-system/issues"
     },
     "dependencies": {
-        "@lumx/core": "^0.17.0",
-        "@lumx/icons": "^0.17.0",
+        "@lumx/core": "^0.18.0",
+        "@lumx/icons": "^0.18.0",
         "body-scroll-lock": "^2.6.4",
         "classnames": "^2.2.6",
         "focus-trap-react": "^6.0.0",
@@ -104,5 +104,5 @@
         "test": "jest --config jest/index.js --coverage --notify --passWithNoTests --detectOpenHandles",
         "storybook": "start-storybook -p 9000"
     },
-    "version": "0.17.0"
+    "version": "0.18.0"
 }

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -100,7 +100,7 @@
     "scripts": {
         "build": "webpack",
         "prepublish": "yarn build",
-        "preversion": "version-changelog ../../CHANGELOG.react.md && git add ../../CHANGELOG.react.md",
+        "postversion": "version-changelog ../../CHANGELOG.react.md && git add ../../CHANGELOG.react.md && git commit --amend",
         "test": "jest --config jest/index.js --coverage --notify --passWithNoTests --detectOpenHandles",
         "storybook": "start-storybook -p 9000"
     },

--- a/packages/site-demo/package.json
+++ b/packages/site-demo/package.json
@@ -6,10 +6,10 @@
         "url": "https://github.com/lumapps/design-system/issues"
     },
     "dependencies": {
-        "@lumx/angularjs": "^0.17.0",
-        "@lumx/core": "^0.17.0",
-        "@lumx/icons": "^0.17.0",
-        "@lumx/react": "^0.17.0",
+        "@lumx/angularjs": "^0.18.0",
+        "@lumx/core": "^0.18.0",
+        "@lumx/icons": "^0.18.0",
+        "@lumx/react": "^0.18.0",
         "angular": "^1.7.8",
         "classnames": "^2.2.6",
         "intersection-observer": "^0.7.0",
@@ -73,5 +73,5 @@
         "build": "webpack",
         "start": "NODE_ENV=development webpack-dev-server"
     },
-    "version": "0.17.0"
+    "version": "0.18.0"
 }

--- a/packages/yo-generators/package.json
+++ b/packages/yo-generators/package.json
@@ -12,5 +12,5 @@
     "main": "generators/index.js",
     "name": "generator-lumx-component",
     "private": true,
-    "version": "0.17.0"
+    "version": "0.18.0"
 }


### PR DESCRIPTION
# General summary

Release v0.18.0

Minor tooling fixes: 
- Fixed automatic changelog version script to act **after** the version bump
- Removed `changelog-verify` on CHANGELOG.react.md: 
`changelog-verify` checks that every versions in the changelog contains
changes.
But since we now have a monorepo with a single version system, the
@lumx/react package will sometimes have new version without changes.