### PR TITLE
feat(autocomplete): stories and fixes

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   When we are using the AutocompleteMultiple, you can now just display the suggestions with the same size as the input.
+-   For the Autocomplete simple, we add the possibility to prevent refocus on close.
+
 ## [0.18.8][] - 2019-12-12
 
 ## [0.18.7][] - 2019-12-06

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.stories.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.stories.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import { Autocomplete, List, ListItem, Size } from '@lumx/react';
+
+import { decorators } from '@lumx/react/story-block';
+
+export default { title: 'Autocomplete', decorators };
+
+const CITIES = [
+    {
+        text: 'Los Angeles',
+        id: 'losangeles',
+    },
+    {
+        text: 'San Francisco',
+        id: 'sanfrancisco',
+    },
+    {
+        text: 'Paris',
+        id: 'paris',
+    },
+    {
+        text: 'Montpellier',
+        id: 'montpellier',
+    },
+    {
+        text: 'Bordeaux',
+        id: 'bordeaux',
+    },
+    {
+        text: 'Toulouse',
+        id: 'toulouse',
+    },
+    {
+        text: 'Lyon',
+        id: 'lyon',
+    },
+    {
+        text: 'Montevideo',
+        id: 'montevideo',
+    },
+];
+
+export const simple = ({ theme }) => {
+    const [showSuggestions, setShowSuggestions] = React.useState(false);
+    const [filterValue, setFilterValue] = React.useState('');
+    const inputRef = React.useRef(null);
+
+    const filteredCities = CITIES.filter((city) => {
+        const noSpacesCity = city.text.replace(' ', '').toLowerCase();
+        return noSpacesCity.includes(filterValue.replace(' ', '').toLowerCase());
+    });
+
+    const closeAutocomplete = () => setShowSuggestions(false);
+
+    const setSelectedCity = (city) => {
+        setFilterValue(city.text);
+        setShowSuggestions(false);
+    };
+
+    const onChange = (value) => {
+        setFilterValue(value);
+        setShowSuggestions(value.length > 0);
+    };
+
+    const { activeItemIndex } = List.useKeyboardListNavigation(filteredCities, inputRef, setSelectedCity);
+
+    const onFocus = () => {
+        setShowSuggestions(filterValue.length > 0);
+    };
+
+    const hasSuggestions = filteredCities.length > 0;
+
+    return (
+        <Autocomplete
+            theme={theme}
+            isOpen={showSuggestions && hasSuggestions}
+            onClose={closeAutocomplete}
+            value={filterValue}
+            onChange={onChange}
+            onFocus={onFocus}
+            inputRef={inputRef}
+        >
+            {hasSuggestions && (
+                <List>
+                    {filteredCities.map((city, index) => (
+                        <ListItem
+                            size={Size.tiny}
+                            isClickable
+                            key={city.id}
+                            isHighlighted={index === activeItemIndex}
+                            onItemSelected={() => setSelectedCity(city)}
+                        >
+                            <div>{city.text}</div>
+                        </ListItem>
+                    ))}
+                </List>
+            )}
+        </Autocomplete>
+    );
+};

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -15,6 +15,12 @@ import { useFocusOnClose } from '@lumx/react/hooks/useFocusOnClose';
  * Defines the props of the component.
  */
 interface IAutocompleteProps extends IGenericProps {
+    /**
+     * Whether the suggestions list should display anchored to the input
+     * If false, it will be anchored to the text field wrapper.
+     */
+    anchorToInput: boolean;
+
     /** A ref that will be passed to the input or textarea element. */
     inputRef?: RefObject<HTMLInputElement>;
 
@@ -41,6 +47,11 @@ interface IAutocompleteProps extends IGenericProps {
      * @see {@link TextFieldProps#hasError}
      */
     hasError?: boolean;
+
+    /**
+     * Whether the text box should be focused upon closing the suggestions
+     */
+    shouldFocusOnClose?: boolean;
 
     /**
      * Whether the text field displays a clear button or not.
@@ -176,9 +187,11 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: Partial<AutocompleteProps> = {
+    anchorToInput: false,
     closeOnClick: true,
     closeOnEscape: true,
     isOpen: undefined,
+    shouldFocusOnClose: false,
 };
 
 /////////////////////////////
@@ -191,6 +204,7 @@ const DEFAULT_PROPS: Partial<AutocompleteProps> = {
  */
 const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): ReactElement => {
     const {
+        anchorToInput = DEFAULT_PROPS.anchorToInput,
         className,
         children,
         chips,
@@ -212,6 +226,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
         theme,
         onClose,
         offset,
+        shouldFocusOnClose = DEFAULT_PROPS.shouldFocusOnClose,
         placement,
         inputRef = useRef(null),
         fitToAnchorWidth,
@@ -220,7 +235,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
     } = props;
 
     const textFieldRef = useRef(null);
-    useFocusOnClose(inputRef.current, isOpen);
+    useFocusOnClose(inputRef.current, isOpen, shouldFocusOnClose);
 
     return (
         <div
@@ -252,7 +267,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 type={TextFieldType.input}
             />
             <Dropdown
-                anchorRef={textFieldRef as React.RefObject<HTMLElement>}
+                anchorRef={anchorToInput ? inputRef : textFieldRef}
                 showDropdown={isOpen}
                 closeOnClick={closeOnClick}
                 closeOnEscape={closeOnEscape}

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.stories.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+
+import { AutocompleteMultiple, Chip, ChipGroup, Icon, List, ListItem, Size } from '@lumx/react';
+
+import { mdiClose } from '@lumx/icons';
+
+import { decorators } from '@lumx/react/story-block';
+
+export default { title: 'Autocomplete Multiple', decorators };
+
+const CITIES = [
+    {
+        text: 'Los Angeles',
+        id: 'losangeles',
+    },
+    {
+        text: 'San Francisco',
+        id: 'sanfrancisco',
+    },
+    {
+        text: 'Paris',
+        id: 'paris',
+    },
+    {
+        text: 'Montpellier',
+        id: 'montpellier',
+    },
+    {
+        text: 'Bordeaux',
+        id: 'bordeaux',
+    },
+    {
+        text: 'Toulouse',
+        id: 'toulouse',
+    },
+    {
+        text: 'Lyon',
+        id: 'lyon',
+    },
+    {
+        text: 'Montevideo',
+        id: 'montevideo',
+    },
+];
+
+export const simple = ({ theme }) => {
+    const INITIAL_STATE_SHOW_SUGGESTIONS = false;
+    const INITIAL_STATE_NAVIGATION_SUGGESTION = undefined;
+
+    const [showSuggestions, setShowSuggestions] = React.useState(INITIAL_STATE_SHOW_SUGGESTIONS);
+    const [filterValue, setFilterValue] = React.useState('');
+    const [navigationSuggestionValue, setNavigationSuggestionValue] = React.useState(
+        INITIAL_STATE_NAVIGATION_SUGGESTION,
+    );
+    const [selectedValues, setSelectedValues] = React.useState([]);
+    const inputRef = React.useRef(null);
+
+    const filteredCities = CITIES.filter((city) => {
+        const noSpacesCity = city.text.replace(' ', '').toLowerCase();
+        return noSpacesCity.includes(filterValue.replace(' ', '').toLowerCase());
+    });
+
+    const hasSuggestions = filteredCities.length > 0;
+
+    const onChipDeleted = () => {
+        selectedValues.pop();
+        setSelectedValues(selectedValues);
+    };
+
+    const {
+        activeChip,
+        onBackspacePressed: chipBackspaceNavigation,
+        resetChipNavigation,
+    } = ChipGroup.useChipGroupNavigation(selectedValues, onChipDeleted);
+
+    const closeAutocomplete = () => {
+        setShowSuggestions(false);
+        resetChipNavigation();
+    };
+
+    const setSelectedCity = (city) => {
+        setSelectedValues([...selectedValues, city]);
+        setFilterValue('');
+        setShowSuggestions(INITIAL_STATE_SHOW_SUGGESTIONS);
+        setNavigationSuggestionValue(INITIAL_STATE_NAVIGATION_SUGGESTION);
+    };
+
+    const onNewCityCreated = (newCity) => {
+        if (newCity && newCity.length > 0) {
+            setSelectedCity({
+                text: newCity,
+                id: newCity.replace(' ', '').toLowerCase(),
+            });
+
+            setNavigationSuggestionValue(INITIAL_STATE_NAVIGATION_SUGGESTION);
+        }
+    };
+
+    const clearSelectedValue = (event, city) => {
+        inputRef.current.focus();
+        setSelectedValues(city ? selectedValues.filter((c) => c.id !== city.id) : []);
+    };
+
+    const onChange = (value) => {
+        setFilterValue(value);
+        setShowSuggestions(value.length > 0);
+        setNavigationSuggestionValue(INITIAL_STATE_NAVIGATION_SUGGESTION);
+        resetChipNavigation();
+    };
+
+    const onItemNavigated = (city) => {
+        if (city && showSuggestions) {
+            setNavigationSuggestionValue(city.text);
+        }
+    };
+
+    const isTextFieldEmpty = () => filterValue.length === 0 && !navigationSuggestionValue;
+
+    const onBackspacePressed = () => {
+        if (isTextFieldEmpty()) {
+            chipBackspaceNavigation();
+        } else if (navigationSuggestionValue) {
+            onChange(navigationSuggestionValue);
+            setNavigationSuggestionValue(INITIAL_STATE_NAVIGATION_SUGGESTION);
+            resetChipNavigation();
+        }
+    };
+
+    const { activeItemIndex } = List.useKeyboardListNavigation(
+        filteredCities,
+        inputRef,
+        setSelectedCity,
+        onItemNavigated,
+        onNewCityCreated,
+        onBackspacePressed,
+        true,
+    );
+
+    const onFocus = () => {
+        setShowSuggestions(filterValue.length > 0);
+    };
+
+    const onBlur = () => {
+        resetChipNavigation();
+    };
+
+    const renderChip = (city, index) => (
+        <Chip
+            theme={theme}
+            isClickable
+            key={index}
+            after={<Icon icon={mdiClose} size={Size.xxs} />}
+            size={Size.s}
+            onAfterClick={(event) => clearSelectedValue(event, city)}
+            onClick={(event) => clearSelectedValue(event, city)}
+            isHighlighted={index === activeChip}
+        >
+            {city.text}
+        </Chip>
+    );
+
+    return (
+        <AutocompleteMultiple
+            anchorToInput
+            theme={theme}
+            isOpen={showSuggestions && hasSuggestions}
+            onClose={closeAutocomplete}
+            value={navigationSuggestionValue || filterValue}
+            onChange={onChange}
+            onFocus={onFocus}
+            values={selectedValues}
+            inputRef={inputRef}
+            shouldFocusOnClose
+            fitToAnchorWidth={false}
+            onBlur={onBlur}
+            selectedChipRender={renderChip}
+        >
+            <List theme={theme}>
+                {filteredCities.map((city, index) => (
+                    <ListItem
+                        size={Size.tiny}
+                        isClickable
+                        theme={theme}
+                        key={city.id}
+                        isHighlighted={index === activeItemIndex}
+                        onItemSelected={() => setSelectedCity(city)}
+                    >
+                        <div>{city.text}</div>
+                    </ListItem>
+                ))}
+            </List>
+        </AutocompleteMultiple>
+    );
+};

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
@@ -97,6 +97,7 @@ const DEFAULT_PROPS: Partial<AutocompleteMultipleProps> = {
  */
 const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props: AutocompleteMultipleProps): ReactElement => {
     const {
+        anchorToInput,
         className,
         children,
         chipsAlignment,
@@ -125,6 +126,7 @@ const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props: Autoco
         offset,
         placement,
         fitToAnchorWidth,
+        shouldFocusOnClose,
         onInfiniteScroll,
         selectedChipRender = DEFAULT_PROPS.selectedChipRender,
         ...forwardedProps
@@ -132,6 +134,7 @@ const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props: Autoco
 
     return (
         <Autocomplete
+            anchorToInput={anchorToInput}
             className={classNames(
                 className,
                 handleBasicClasses({
@@ -142,6 +145,7 @@ const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props: Autoco
             onChange={onChange}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
+            shouldFocusOnClose={shouldFocusOnClose}
             onFocus={onFocus}
             hasError={hasError}
             helper={helper}

--- a/packages/lumx-react/src/hooks/useComputePosition.tsx
+++ b/packages/lumx-react/src/hooks/useComputePosition.tsx
@@ -95,8 +95,8 @@ const useComputePosition: useComputePositionType = (
         const boundingPopover = popoverRef.current.getBoundingClientRect();
         const { horizontal = 0, vertical = 0 } = offset;
         let newPosition: ElementPosition = {
-            anchorHeight: boundingAnchor.height,
-            anchorWidth: boundingAnchor.width,
+            anchorHeight: hasParentHeight ? boundingAnchor.height : 0,
+            anchorWidth: hasParentWidth ? boundingAnchor.width : 0,
             height: boundingPopover.height,
             width: boundingPopover.width,
             x: horizontal,

--- a/packages/lumx-react/src/hooks/useFocusOnClose.tsx
+++ b/packages/lumx-react/src/hooks/useFocusOnClose.tsx
@@ -3,16 +3,25 @@ import { useEffect } from 'react';
 /**
  * Re-focus the element when the select is closed.
  *
- * @param element Element to focus.
- * @param isOpen  Whether or not the select is open.
+ * @param element             Element to focus.
+ * @param isOpen              Whether or not the select is open.
+ * @param shouldFocusOnClose  Whether or not the select is open.
  */
-function useFocusOnClose(element: HTMLElement | null, isOpen: boolean | undefined): void {
+function useFocusOnClose(
+    element: HTMLElement | null,
+    isOpen: boolean | undefined,
+    shouldFocusOnClose: boolean | undefined = true,
+): void {
     useEffect(() => {
-        if (!isOpen && element) {
+        /**
+         * `shouldFocusOnClose` is passed on and evaluated here in order to avoid
+         * breaking the rules of hooks: https://reactjs.org/docs/hooks-rules.html
+         */
+        if (shouldFocusOnClose && !isOpen && element) {
             // Re-focus the button when the select is closed.
             element.focus();
         }
-    }, [isOpen]);
+    }, [isOpen, shouldFocusOnClose]);
 }
 
 export { useFocusOnClose };

--- a/packages/lumx-react/src/hooks/useKeyboardListNavigation.tsx
+++ b/packages/lumx-react/src/hooks/useKeyboardListNavigation.tsx
@@ -1,6 +1,6 @@
 import { RefObject, SetStateAction, useEffect, useState } from 'react';
 
-import { BACKSPACE_KEY_CODE, DOWN_KEY_CODE, ENTER_KEY_CODE, UP_KEY_CODE } from '@lumx/react/constants';
+import { BACKSPACE_KEY_CODE, DOWN_KEY_CODE, ENTER_KEY_CODE, TAB_KEY_CODE, UP_KEY_CODE } from '@lumx/react/constants';
 
 import get from 'lodash/get';
 
@@ -26,6 +26,7 @@ type useKeyboardListNavigationType = (
     onBackspacePressed: () => {},
     keepFocusAfterSelection: boolean,
     initialIndex: number,
+    preventTabOnEnteredValue: boolean,
 ) => IUseKeyboardListNavigationType;
 
 /////////////////////////////
@@ -46,6 +47,7 @@ const INITIAL_INDEX = -1;
  * @param onBackspacePressed callback to be executed when the BACKSPACE key is pressed
  * @param keepFocusAfterSelection determines whether after selecting an item, the focus should be maintained on the current target or not
  * @param initialIndex where should the navigation start from. it defaults to `-1`, so the first item navigated is the item on position `0`
+ * @param preventTabOnEnteredValue determines whether upon TAB, if there is a value entered, the event is prevented or not
  */
 const useKeyboardListNavigation: useKeyboardListNavigationType = (
     items: object[],
@@ -56,6 +58,7 @@ const useKeyboardListNavigation: useKeyboardListNavigationType = (
     onBackspacePressed?: (evt: KeyboardEvent) => {},
     keepFocusAfterSelection: boolean = false,
     initialIndex: number = INITIAL_INDEX,
+    preventTabOnEnteredValue: boolean = true,
 ): IUseKeyboardListNavigationType => {
     const [activeItemIndex, setActiveItemIndex] = useState(initialIndex);
 
@@ -149,6 +152,18 @@ const useKeyboardListNavigation: useKeyboardListNavigationType = (
     };
 
     /**
+     * Handles when the TAB key is pressed
+     * @param evt - key pressed event
+     */
+    const onTabKeyPressed = (evt: KeyboardEvent): void => {
+        const value = get(evt, 'target.value');
+
+        if (preventTabOnEnteredValue && value && value.length > 0) {
+            preventDefaultAndStopPropagation(evt);
+        }
+    };
+
+    /**
      * In order to make it easier in the future to add new events depending on the key
      * a map was created to add these handlers. In the future, if there is another event
      * that we need to manage depending on a specific key, we just need to add the key code
@@ -156,6 +171,7 @@ const useKeyboardListNavigation: useKeyboardListNavigationType = (
      */
     const eventsForKeyPressed = {
         [DOWN_KEY_CODE]: onArrowPressed,
+        [TAB_KEY_CODE]: onTabKeyPressed,
         [UP_KEY_CODE]: onArrowPressed,
         [ENTER_KEY_CODE]: onEnterKeyPressed,
         [BACKSPACE_KEY_CODE]: onBackspaceKeyPressed,

--- a/packages/site-demo/content/product/components/autocomplete/react/multiple.tsx
+++ b/packages/site-demo/content/product/components/autocomplete/react/multiple.tsx
@@ -206,8 +206,10 @@ const App = ({ theme }) => {
             value={navigationSuggestionValue || filterValue}
             onChange={onChange}
             onFocus={onFocus}
+            shouldFocusOnClose
             values={selectedValues}
             inputRef={inputRef}
+            fitToAnchorWidth
             onBlur={onBlur}
             selectedChipRender={(city, index) => (
                 <Chip


### PR DESCRIPTION
# General summary
In this PR, the following changes were introduced:
- Autocomplete and AutocompleteMultiple stories
- When we are using the AutocompleteMultiple, there is a necessity to just display the suggestions with the same size as the input. This implies two changes:
    - Tell the Autocomplete component that sometimes we want to anchor the suggestions to the input rather than the wrapper
    - `useComputePosition` ignored the `hasParentWidth` parameter when setting the minimum width for the dropdown. This PR changes that in order to ensure that the minimum width is not set when we want to have the same width as the parent
- For the Autocomplete simple, we do not want to focus upon close, so we pass down a prop in order to signal that we do not want to apply the `useFocusOnClose` hook.
- This is all configurable via props, so if we want the old behaviour, we certainly can !

# Screenshots
![8Tvz0XIN4P](https://user-images.githubusercontent.com/13719066/69801616-ee303900-11d7-11ea-9331-88e59973bcd7.gif)

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
