### PR TITLE
fix(date-picker): remove hook in loop

### DIFF
--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback } from 'react';
+import React, { ReactElement } from 'react';
 
 import moment from 'moment';
 
@@ -94,7 +94,6 @@ const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
 
                 <div className={`${CLASSNAME}__month-days ${CLASSNAME}__days-wrapper`}>
                     {getAnnotatedMonthCalendar(locale, minDate, maxDate, today, monthOffset).map((annotatedDate) => {
-                        const onClick = useCallback(() => onChange(annotatedDate.date), [annotatedDate]);
                         if (annotatedDate.isDisplayed) {
                             return (
                                 <div key={annotatedDate.date.unix()} className={`${CLASSNAME}__day-wrapper`}>
@@ -105,7 +104,8 @@ const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
                                                 annotatedDate.isClickable && annotatedDate.isToday,
                                         })}
                                         disabled={!annotatedDate.isClickable}
-                                        onClick={onClick}
+                                        // tslint:disable-next-line: jsx-no-lambda
+                                        onClick={() => onChange(annotatedDate.date)}
                                     >
                                         <span>{annotatedDate.date.format('DD')}</span>
                                     </button>


### PR DESCRIPTION
# General summary

Date picker failed to navigate before March 2019. It was because of the use of hook inside a loop.

# Screenshots

![before](https://user-images.githubusercontent.com/2828353/71018115-2d2b1d80-20f8-11ea-9531-e606cea9804e.gif)

![after](https://user-images.githubusercontent.com/2828353/71018119-30260e00-20f8-11ea-8931-326b826e3d88.gif)

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
