### PR TITLE
fix(color palettes): updated yellows for both themes

### DIFF
--- a/packages/lumx-core/src/scss/core/theme/lumapps/_color-palette.scss
+++ b/packages/lumx-core/src/scss/core/theme/lumapps/_color-palette.scss
@@ -31,8 +31,8 @@ $lumx-theme-blue: (
 ) !default;
 
 $lumx-theme-yellow: (
-    'D2': #fea41c,
-    'D1': #ffb71f,
+    'D2': #e16b00,
+    'D1': #fea41c,
     'N': #ffc525,
     'L1': rgba(#ffc525, 0.8),
     'L2': rgba(#ffc525, 0.6),

--- a/packages/lumx-core/src/scss/core/theme/lumapps/_color-palette.scss
+++ b/packages/lumx-core/src/scss/core/theme/lumapps/_color-palette.scss
@@ -35,11 +35,11 @@ $lumx-theme-yellow: (
     'D1': #fea41c,
     'N': #ffc525,
     'L1': rgba(#ffc525, 0.8),
-    'L2': rgba(#ffc525, 0.6),
-    'L3': rgba(#ffc525, 0.4),
-    'L4': rgba(#ffc525, 0.2),
-    'L5': rgba(#ffc525, 0.1),
-    'L6': rgba(#ffc525, 0.05)
+    'L2': rgba(#ffc525, 0.7),
+    'L3': rgba(#ffc525, 0.6),
+    'L4': rgba(#ffc525, 0.4),
+    'L5': rgba(#ffc525, 0.2),
+    'L6': rgba(#ffc525, 0.1)
 ) !default;
 
 $lumx-theme-red: (

--- a/packages/lumx-core/src/scss/core/theme/material/_color-palette.scss
+++ b/packages/lumx-core/src/scss/core/theme/material/_color-palette.scss
@@ -31,15 +31,15 @@ $lumx-theme-blue: (
 );
 
 $lumx-theme-yellow: (
-    'D2': #ffa000,
-    'D1': #ffb300,
-    'N': #ffc107,
-    'L1': rgba(#ffc107, 0.8),
-    'L2': rgba(#ffc107, 0.6),
-    'L3': rgba(#ffc107, 0.4),
-    'L4': rgba(#ffc107, 0.2),
-    'L5': rgba(#ffc107, 0.1),
-    'L6': rgba(#ffc107, 0.05)
+    'D2': #ff6f00,
+    'D1': #ff8f00,
+    'N': #ffb300,
+    'L1': rgba(#ffb300, 0.8),
+    'L2': rgba(#ffb300, 0.6),
+    'L3': rgba(#ffb300, 0.4),
+    'L4': rgba(#ffb300, 0.2),
+    'L5': rgba(#ffb300, 0.1),
+    'L6': rgba(#ffb300, 0.05)
 );
 
 $lumx-theme-red: (

--- a/packages/lumx-core/src/scss/core/theme/material/_color-palette.scss
+++ b/packages/lumx-core/src/scss/core/theme/material/_color-palette.scss
@@ -35,11 +35,11 @@ $lumx-theme-yellow: (
     'D1': #ff8f00,
     'N': #ffb300,
     'L1': rgba(#ffb300, 0.8),
-    'L2': rgba(#ffb300, 0.6),
-    'L3': rgba(#ffb300, 0.4),
-    'L4': rgba(#ffb300, 0.2),
-    'L5': rgba(#ffb300, 0.1),
-    'L6': rgba(#ffb300, 0.05)
+    'L2': rgba(#ffb300, 0.7),
+    'L3': rgba(#ffb300, 0.6),
+    'L4': rgba(#ffb300, 0.4),
+    'L5': rgba(#ffb300, 0.2),
+    'L6': rgba(#ffb300, 0.1)
 );
 
 $lumx-theme-red: (


### PR DESCRIPTION
# General summary

Update of yellow color in both theme palette in order to achieve better contrast ratios

# Screenshots

## Material theme
<img width="751" alt="Capture d’écran 2019-12-20 à 10 55 55" src="https://user-images.githubusercontent.com/15898440/71246711-80c78200-2317-11ea-97f0-e02762ae3a35.png">


## LumApps theme
<img width="761" alt="Capture d’écran 2019-12-20 à 10 55 50" src="https://user-images.githubusercontent.com/15898440/71246716-8329dc00-2317-11ea-87d9-7ee239ddbbe3.png">



# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
