### PR TITLE
fix(text-field): fix access to native input type prop

### DIFF
--- a/CHANGELOG.react.md
+++ b/CHANGELOG.react.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   _[BREAKING]_ Changed `type` prop to `multiline` flag prop in the `TextField` component
+
 ## [0.19.0][] - 2020-01-02
 
 ### Changed

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, RefObject, useRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Dropdown, Offset, Placement, TextField, TextFieldType, Theme } from '@lumx/react';
+import { Dropdown, Offset, Placement, TextField, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
@@ -264,7 +264,6 @@ const Autocomplete: React.FC<AutocompleteProps> = (props: AutocompleteProps): Re
                 label={label}
                 placeholder={placeholder}
                 theme={theme}
-                type={TextFieldType.input}
             />
             <Dropdown
                 anchorRef={anchorToInput ? inputRef : textFieldRef}

--- a/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`<Autocomplete> Props should render correctly when the dropdown is close
         "current": null,
       }
     }
-    type="input"
     value=""
   />
   <Dropdown
@@ -115,7 +114,6 @@ exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
         "current": null,
       }
     }
-    type="input"
     value=""
   />
   <Dropdown

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -7,7 +7,7 @@ import { build } from 'test-data-bot';
 import { ICommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
 import { getBasicClass } from '@lumx/react/utils';
 
-import { CLASSNAME, DEFAULT_PROPS, TextField, TextFieldProps, TextFieldType } from './TextField';
+import { CLASSNAME, TextField, TextFieldProps } from './TextField';
 
 /////////////////////////////
 
@@ -77,17 +77,17 @@ describe(`<${TextField.displayName}>`, () => {
             expect(wrapper).toHaveClassName(`${CLASSNAME}--theme-light`);
 
             expect(inputNative).toExist();
-            expect(inputNative.type()).toEqual(DEFAULT_PROPS.type);
+            expect(inputNative.type()).toEqual('input');
         });
 
         it('should render textarea', () => {
-            const { wrapper, inputNative } = setup({ id: 'fixedId', type: TextFieldType.textarea });
+            const { wrapper, inputNative } = setup({ id: 'fixedId', multiline: true });
             expect(wrapper).toMatchSnapshot();
 
             expect(wrapper).toExist();
 
             expect(inputNative).toExist();
-            expect(inputNative.type()).toEqual(TextFieldType.textarea);
+            expect(inputNative.type()).toEqual('textarea');
         });
     });
 
@@ -108,7 +108,7 @@ describe(`<${TextField.displayName}>`, () => {
 
             const { wrapper } = setup({ ...modifiedProps });
 
-            Object.keys(modifiedProps).forEach((prop: string): void => {
+            Object.keys(modifiedProps).forEach((prop) => {
                 const propType =
                     prop === 'icon' || prop === 'label' || prop === 'placeholder'
                         ? `has${prop.charAt(0).toUpperCase() + prop.slice(1)}`
@@ -128,7 +128,7 @@ describe(`<${TextField.displayName}>`, () => {
 
             const { wrapper } = setup({ ...modifiedProps });
 
-            Object.keys(modifiedProps).forEach((prop: string): void => {
+            Object.keys(modifiedProps).forEach((prop) => {
                 expect(wrapper).toHaveClassName(
                     getBasicClass({ prefix: CLASSNAME, type: prop, value: modifiedProps[prop] }),
                 );

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -11,11 +11,6 @@ import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react
 
 /////////////////////////////
 
-enum TextFieldType {
-    input = 'input',
-    textarea = 'textarea',
-}
-
 /**
  * Defines the props of the component.
  */
@@ -56,7 +51,10 @@ interface ITextFieldProps extends IGenericProps {
     /** Whether custom colors are applied to this component. */
     useCustomColors?: boolean;
 
-    /** Minimum rows to be displayed in a text area. */
+    /** Switches the input to a textarea. */
+    multiline?: boolean;
+
+    /** Minimum rows to be displayed (requires multiline to be enabled). */
     minimumRows?: number;
 
     /** A ref that will be passed to the input or text area element. */
@@ -64,9 +62,6 @@ interface ITextFieldProps extends IGenericProps {
 
     /** Text field value. */
     value: string;
-
-    /** Text field type (input or textarea). */
-    type?: TextFieldType;
 
     /** A ref that will be passed to the wrapper element. */
     textFieldRef?: RefObject<HTMLDivElement>;
@@ -114,8 +109,8 @@ const DEFAULT_PROPS: Partial<TextFieldProps> = {
     isDisabled: false,
     isValid: false,
     minimumRows: MIN_ROWS,
+    multiline: false,
     theme: Theme.light,
-    type: TextFieldType.input,
 };
 /**
  * Hook that allows to calculate the number of rows needed for a text area.
@@ -168,9 +163,9 @@ interface IInputNativeProps {
     id?: string;
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
     isDisabled?: boolean;
+    multiline?: boolean;
     maxLength?: number;
     placeholder?: string;
-    type?: TextFieldType;
     value: string;
     rows: number;
     setFocus(focus: boolean): void;
@@ -185,7 +180,7 @@ const renderInputNative = (props: IInputNativeProps): ReactElement => {
         id,
         isDisabled,
         placeholder,
-        type,
+        multiline,
         value,
         setFocus,
         onChange,
@@ -214,30 +209,27 @@ const renderInputNative = (props: IInputNativeProps): ReactElement => {
     };
 
     const handleChange = (event: React.ChangeEvent): void => {
-        if (type === TextFieldType.textarea) {
+        if (multiline) {
             recomputeNumberOfRows(event);
         }
 
         onChange(get(event, 'target.value'));
     };
 
-    if (type === TextFieldType.textarea) {
-        return (
-            <textarea
-                id={id}
-                disabled={isDisabled}
-                placeholder={placeholder}
-                value={value}
-                rows={rows}
-                onFocus={onTextFieldFocus}
-                onBlur={onTextFieldBlur}
-                onChange={handleChange}
-                ref={inputRef as RefObject<HTMLTextAreaElement>}
-                {...forwardedProps}
-            />
-        );
-    }
-    return (
+    return multiline ? (
+        <textarea
+            id={id}
+            disabled={isDisabled}
+            placeholder={placeholder}
+            value={value}
+            rows={rows}
+            onFocus={onTextFieldFocus}
+            onBlur={onTextFieldBlur}
+            onChange={handleChange}
+            ref={inputRef as RefObject<HTMLTextAreaElement>}
+            {...forwardedProps}
+        />
+    ) : (
         <input
             id={id}
             disabled={isDisabled}
@@ -278,7 +270,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
         minimumRows = DEFAULT_PROPS.minimumRows as number,
         inputRef = React.useRef(null),
         theme = DEFAULT_PROPS.theme,
-        type = DEFAULT_PROPS.type,
+        multiline = DEFAULT_PROPS.multiline,
         useCustomColors,
         textFieldRef,
         value,
@@ -312,11 +304,11 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                     hasChips: Boolean(chips),
                     hasError: !isValid && hasError,
                     hasIcon: Boolean(icon),
-                    hasInput: type === TextFieldType.input,
+                    hasInput: !multiline,
                     hasInputClear: isClearable && isNotEmpty,
                     hasLabel: Boolean(label),
                     hasPlaceholder: Boolean(placeholder),
-                    hasTextarea: type === TextFieldType.textarea,
+                    hasTextarea: multiline,
                     hasValue: Boolean(value),
                     isClearable,
                     isDisabled,
@@ -363,6 +355,7 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                             inputRef,
                             isDisabled,
                             maxLength,
+                            multiline,
                             onBlur,
                             onChange,
                             onFocus,
@@ -370,7 +363,6 @@ const TextField: React.FC<TextFieldProps> = (props: TextFieldProps): ReactElemen
                             recomputeNumberOfRows,
                             rows,
                             setFocus,
-                            type,
                             value,
                             ...forwardedProps,
                         })}
@@ -404,4 +396,4 @@ TextField.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, TextField, TextFieldType, TextFieldProps };
+export { CLASSNAME, DEFAULT_PROPS, TextField, TextFieldProps };

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -86,7 +86,7 @@ export { Tabs, TabsProps, TabsLayout, TabsPosition } from './components/tabs/Tab
 
 export { Tab, TabProps } from './components/tabs/Tab';
 
-export { TextField, TextFieldProps, TextFieldType } from './components/text-field/TextField';
+export { TextField, TextFieldProps } from './components/text-field/TextField';
 
 export { Tooltip, TooltipProps, TooltipPlacement } from './components/tooltip/Tooltip';
 

--- a/packages/site-demo/content/product/components/text-field/react/text-area-invalid.tsx
+++ b/packages/site-demo/content/product/components/text-field/react/text-area-invalid.tsx
@@ -5,9 +5,7 @@ import { TextField } from '@lumx/react';
 const App = ({ theme }) => {
     const [value, setValue] = useState('Invalid value');
 
-    return (
-        <TextField label="Textfield label" value={value} onChange={setValue} hasError theme={theme} type="textarea" />
-    );
+    return <TextField label="Textfield label" value={value} onChange={setValue} hasError theme={theme} multiline />;
 };
 
 export default App;

--- a/packages/site-demo/content/product/components/text-field/react/text-area-valid.tsx
+++ b/packages/site-demo/content/product/components/text-field/react/text-area-valid.tsx
@@ -5,9 +5,7 @@ import { TextField } from '@lumx/react';
 const App = ({ theme }) => {
     const [value, setValue] = useState('Valid value');
 
-    return (
-        <TextField label="Textfield label" value={value} onChange={setValue} isValid theme={theme} type="textarea" />
-    );
+    return <TextField label="Textfield label" value={value} onChange={setValue} isValid theme={theme} multiline />;
 };
 
 export default App;

--- a/packages/site-demo/content/product/components/text-field/react/text-area.tsx
+++ b/packages/site-demo/content/product/components/text-field/react/text-area.tsx
@@ -5,7 +5,7 @@ import { TextField } from '@lumx/react';
 const App = ({ theme }) => {
     const [value, setValue] = useState('');
 
-    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} type="textarea" />;
+    return <TextField label="Textfield label" value={value} onChange={setValue} theme={theme} multiline />;
 };
 
 export default App;


### PR DESCRIPTION
# General summary

The previously defined `type` prop on the `TextField` component prevented the access to the native `type` prop on the input element.

This PR removes the custom `type` prop and add the `multiline` flag prop instead.

<!-- Please describe the PR content -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
