### PR TITLE
fix(list): remove useless auto-focus on mount if is clickable (LUM-7678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Remove useless `List` auto-focus on mount if is clickable
+
 ## [0.21.0-alpha.0][] - 2020-01-30
 
 ### Changed

--- a/packages/lumx-react/src/components/list/List.tsx
+++ b/packages/lumx-react/src/components/list/List.tsx
@@ -1,4 +1,4 @@
-import React, { Children, ReactElement, ReactNode, RefObject, cloneElement, useEffect, useRef, useState } from 'react';
+import React, { Children, ReactElement, ReactNode, RefObject, cloneElement, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -200,13 +200,6 @@ const List: React.FC<ListProps> & IList = ({
         }
         return nextIdx;
     };
-
-    // Let's place the focus on the list so we can navigate with the keyboard.
-    useEffect(() => {
-        if (isClickable && listElementRef && listElementRef.current) {
-            listElementRef.current.focus();
-        }
-    }, [isClickable]);
 
     return (
         <ul


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->
Remove List component  auto-focus on mount if is clickable.
List focus is handled according the context with the hook.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
