### PR TITLE
feat(react-image-block): use children instead of thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `children` prop to `ImageBlock` component (to pass `Thumbnail` component)
+
+### Changed
+
+-   _[BREAKING]_ Remove `Thumbnail` component from `ImageBlock` component
+
 ## [0.21.7][] - 2020-02-14
 
 ### Added

--- a/packages/lumx-core/src/scss/components/image-block/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/image-block/lumapps/_index.scss
@@ -97,6 +97,18 @@
         top: $lumx-spacing-unit * 1.5;
         right: $lumx-spacing-unit * 1.5;
     }
+
+    &--align-left .#{$lumx-base-prefix}-thumbnail {
+        margin-right: auto;
+    }
+
+    &--align-center .#{$lumx-base-prefix}-thumbnail {
+        margin: 0 auto;
+    }
+
+    &--align-right .#{$lumx-base-prefix}-thumbnail {
+        margin-left: auto;
+    }
 }
 
 /* Image block sizes

--- a/packages/lumx-core/src/scss/components/thumbnail/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/lumapps/_index.scss
@@ -43,18 +43,6 @@
         min-height: 1px;
         max-height: 100%;
 
-        #{$self}--align-left & {
-            margin-right: auto;
-        }
-
-        #{$self}--align-center & {
-            margin: 0 auto;
-        }
-
-        #{$self}--align-right & {
-            margin-left: auto;
-        }
-
         #{$self}--variant-rounded & {
             border-radius: $lumx-theme-border-radius;
         }

--- a/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
@@ -17,6 +17,7 @@ export const defaultImageBlock = ({ theme }: any) => {
     const aspectRatio = select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Image block');
     const title = text('Title', 'Hello world', 'Image block');
     const description = text('Description', 'My awesome description', 'Image block');
+    const isFillHeight = boolean('Fill height', false, 'Image block');
     const isDisplayedTags = boolean('Display tags', true, 'Image block');
     const tags = (
         <ChipGroup align={Alignment.left}>
@@ -31,6 +32,7 @@ export const defaultImageBlock = ({ theme }: any) => {
     );
 
     const aspectRatioThumbnail = select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Thumbnail');
+    const isFillHeightThumbnail = boolean('Fill height', false, 'Thumbnail');
     const focusPoint = {
         x: number('Focus X', 1, numberKnobOptions, 'Thumbnail'),
         y: number('Focus Y', 0, numberKnobOptions, 'Thumbnail'),
@@ -38,16 +40,7 @@ export const defaultImageBlock = ({ theme }: any) => {
     const imageUrl = text('Url image', 'https://i.picsum.photos/id/1001/2400/1400.jpg', 'Thumbnail');
     const sizeThumbnail = select(
         'Size',
-        {
-            XXS: Size.xxs,
-            // tslint:disable-next-line: object-literal-sort-keys
-            XS: Size.xs,
-            S: Size.s,
-            M: Size.m,
-            L: Size.l,
-            XL: Size.xl,
-            XXL: Size.xxl,
-        },
+        [Size.xxs, Size.xs, Size.s, Size.m, Size.l, Size.xl, Size.xxl],
         Size.xxl,
         'Thumbnail',
     );
@@ -58,12 +51,14 @@ export const defaultImageBlock = ({ theme }: any) => {
             align={align}
             aspectRatio={aspectRatio}
             description={description}
+            fillHeight={isFillHeight}
             tags={isDisplayedTags && tags}
             title={title}
             theme={theme}
         >
             <Thumbnail
                 aspectRatio={aspectRatioThumbnail}
+                fillHeight={isFillHeightThumbnail}
                 focusPoint={focusPoint}
                 image={imageUrl}
                 size={sizeThumbnail}

--- a/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { Alignment, AspectRatio, Chip, ChipGroup, ImageBlock, Size, Thumbnail, ThumbnailVariant } from '@lumx/react';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
+
+export default { title: 'Image Block' };
+
+const numberKnobOptions = {
+    max: 1,
+    min: -1,
+    range: true,
+    step: 0.1,
+};
+
+export const defaultImageBlock = ({ theme }: any) => {
+    const align = select<Alignment>('Alignment', Alignment, Alignment.center, 'Image block');
+    const aspectRatio = select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Image block');
+    const title = text('Title', 'Hello world', 'Image block');
+    const description = text('Description', 'My awesome description', 'Image block');
+    const isDisplayedTags = boolean('Display tags', true, 'Image block');
+    const tags = (
+        <ChipGroup align={Alignment.left}>
+            <Chip size={Size.s} theme={theme}>
+                Tag 1
+            </Chip>
+
+            <Chip size={Size.s} theme={theme}>
+                Tag 2
+            </Chip>
+        </ChipGroup>
+    );
+
+    const aspectRatioThumbnail = select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Thumbnail');
+    const focusPoint = {
+        x: number('Focus X', 1, numberKnobOptions, 'Thumbnail'),
+        y: number('Focus Y', 0, numberKnobOptions, 'Thumbnail'),
+    };
+    const imageUrl = text('Url image', 'https://i.picsum.photos/id/1001/2400/1400.jpg', 'Thumbnail');
+    const sizeThumbnail = select(
+        'Size',
+        {
+            XXS: Size.xxs,
+            // tslint:disable-next-line: object-literal-sort-keys
+            XS: Size.xs,
+            S: Size.s,
+            M: Size.m,
+            L: Size.l,
+            XL: Size.xl,
+            XXL: Size.xxl,
+        },
+        Size.xxl,
+        'Thumbnail',
+    );
+    const variant = select<ThumbnailVariant>('Variant', ThumbnailVariant, ThumbnailVariant.squared, 'Thumbnail');
+
+    return (
+        <ImageBlock
+            align={align}
+            aspectRatio={aspectRatio}
+            description={description}
+            tags={isDisplayedTags && tags}
+            title={title}
+            theme={theme}
+        >
+            <Thumbnail
+                aspectRatio={aspectRatioThumbnail}
+                focusPoint={focusPoint}
+                image={imageUrl}
+                size={sizeThumbnail}
+                theme={theme}
+                variant={variant}
+            />
+        </ImageBlock>
+    );
+};

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -138,7 +138,7 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
         )}
         {...props}
     >
-        {children ? children : null}
+        {children}
         {(title || description || tags) && (
             <div className={`${CLASSNAME}__wrapper`} style={captionStyle}>
                 {(title || description) && (

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import isObject from 'lodash/isObject';
 
-import { Alignment, AspectRatio, Size, Theme, Thumbnail } from '@lumx/react';
+import { Alignment, AspectRatio, Size, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
@@ -36,6 +36,8 @@ interface IImageBlockProps extends IGenericProps {
     captionPosition?: ImageBlockCaptionPosition;
     /** The style to apply to the caption section. */
     captionStyle?: CSSProperties;
+    /** ImageBlock content. */
+    children?: ReactNode;
     /** The image description. Can be either a string, or sanitized html. */
     description?:
         | string
@@ -44,8 +46,6 @@ interface IImageBlockProps extends IGenericProps {
           };
     /** Whether the image has to fill its container's height. */
     fillHeight?: boolean;
-    /** The url of the image we want to display in the image-block. */
-    image: string;
     /** The image block size. */
     size?: ImageBlockSize;
     /** Tags elements to be transcluded into the component */
@@ -111,68 +111,54 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
     className = '',
     captionPosition = DEFAULT_PROPS.captionPosition,
     captionStyle = DEFAULT_PROPS.captionStyle,
+    children,
     description = DEFAULT_PROPS.description,
     fillHeight = DEFAULT_PROPS.fillHeight,
-    image,
     size = DEFAULT_PROPS.size,
     tags = DEFAULT_PROPS.tags,
     theme = DEFAULT_PROPS.theme,
     title = DEFAULT_PROPS.title,
     ...props
-}: ImageBlockProps): ReactElement => {
-    const { onClick = null, ...restProps } = props;
-
-    return (
-        <div
-            className={classNames(
-                className,
-                handleBasicClasses({
-                    align,
-                    aspectRatio,
-                    captionPosition,
-                    prefix: CLASSNAME,
-                    size,
-                    theme,
-                }),
-                {
-                    [`${CLASSNAME}--fill-height`]: fillHeight,
-                    [`${CLASSNAME}--format-crop`]: aspectRatio && aspectRatio !== AspectRatio.original,
-                    [`${CLASSNAME}--format-original`]: !aspectRatio || aspectRatio === AspectRatio.original,
-                },
-            )}
-            {...restProps}
-        >
-            <Thumbnail
-                align={align}
-                className={`${CLASSNAME}__image`}
-                aspectRatio={aspectRatio}
-                size={size}
-                fillHeight={fillHeight}
-                image={image}
-                onClick={onClick}
-                theme={theme}
-            />
-            {(title || description || tags) && (
-                <div className={`${CLASSNAME}__wrapper`} style={captionStyle}>
-                    {(title || description) && (
-                        <div className={`${CLASSNAME}__caption`}>
-                            {title && <span className={`${CLASSNAME}__title`}>{title}</span>}
-                            {/* Add an `&nbsp;` when there is description and title. */}
-                            {title && description && '\u00A0'}
-                            {isObject(description) && description.__html ? (
-                                <span dangerouslySetInnerHTML={description} className={`${CLASSNAME}__description`} />
-                            ) : (
-                                <span className={`${CLASSNAME}__description`}>{description}</span>
-                            )}
-                        </div>
-                    )}
-                    {tags && <div className={`${CLASSNAME}__tags`}>{tags}</div>}
-                </div>
-            )}
-            {actions && <div className={`${CLASSNAME}__actions`}>{actions}</div>}
-        </div>
-    );
-};
+}: ImageBlockProps): ReactElement => (
+    <div
+        className={classNames(
+            className,
+            handleBasicClasses({
+                align,
+                captionPosition,
+                prefix: CLASSNAME,
+                size,
+                theme,
+            }),
+            {
+                [`${CLASSNAME}--fill-height`]: fillHeight,
+                [`${CLASSNAME}--format-crop`]: aspectRatio && aspectRatio !== AspectRatio.original,
+                [`${CLASSNAME}--format-original`]: !aspectRatio || aspectRatio === AspectRatio.original,
+            },
+        )}
+        {...props}
+    >
+        {children ? children : null}
+        {(title || description || tags) && (
+            <div className={`${CLASSNAME}__wrapper`} style={captionStyle}>
+                {(title || description) && (
+                    <div className={`${CLASSNAME}__caption`}>
+                        {title && <span className={`${CLASSNAME}__title`}>{title}</span>}
+                        {/* Add an `&nbsp;` when there is description and title. */}
+                        {title && description && '\u00A0'}
+                        {isObject(description) && description.__html ? (
+                            <span dangerouslySetInnerHTML={description} className={`${CLASSNAME}__description`} />
+                        ) : (
+                            <span className={`${CLASSNAME}__description`}>{description}</span>
+                        )}
+                    </div>
+                )}
+                {tags && <div className={`${CLASSNAME}__tags`}>{tags}</div>}
+            </div>
+        )}
+        {actions && <div className={`${CLASSNAME}__actions`}>{actions}</div>}
+    </div>
+);
 ImageBlock.displayName = COMPONENT_NAME;
 
 /////////////////////////////

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -22,21 +22,7 @@ export const defaultThumbnail = ({ theme }: { theme: Theme }) => {
         y: number('Focus Y', 0, numberKnobOptions, 'Thumbnail'),
     };
     const imageUrl = text('Url image', 'https://i.picsum.photos/id/1001/2400/1400.jpg', 'Thumbnail');
-    const size = select(
-        'Size',
-        {
-            XXS: Size.xxs,
-            // tslint:disable-next-line: object-literal-sort-keys
-            XS: Size.xs,
-            S: Size.s,
-            M: Size.m,
-            L: Size.l,
-            XL: Size.xl,
-            XXL: Size.xxl,
-        },
-        Size.xxl,
-        'Thumbnail',
-    );
+    const size = select('Size', [Size.xxs, Size.xs, Size.s, Size.m, Size.l, Size.xl, Size.xxl], Size.xxl, 'Thumbnail');
     const variant = select<ThumbnailVariant>('Variant', ThumbnailVariant, ThumbnailVariant.squared, 'Thumbnail');
 
     return (

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -1,10 +1,10 @@
-import { Alignment, AspectRatio, Size, Theme, Thumbnail, ThumbnailVariant } from '@lumx/react';
+import { AspectRatio, Size, Theme, Thumbnail, ThumbnailVariant } from '@lumx/react';
 import { number, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
 export default { title: 'Thumbnail' };
 
-const numberKnobOtions = {
+const numberKnobOptions = {
     max: 1,
     min: -1,
     range: true,
@@ -16,31 +16,37 @@ const numberKnobOtions = {
  * @return simple Thumbnail.
  */
 export const defaultThumbnail = ({ theme }: { theme: Theme }) => {
+    const aspectRatio = select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Thumbnail');
+    const focusPoint = {
+        x: number('Focus X', 0, numberKnobOptions, 'Thumbnail'),
+        y: number('Focus Y', 0, numberKnobOptions, 'Thumbnail'),
+    };
+    const imageUrl = text('Url image', 'https://i.picsum.photos/id/1001/2400/1400.jpg', 'Thumbnail');
+    const size = select(
+        'Size',
+        {
+            XXS: Size.xxs,
+            // tslint:disable-next-line: object-literal-sort-keys
+            XS: Size.xs,
+            S: Size.s,
+            M: Size.m,
+            L: Size.l,
+            XL: Size.xl,
+            XXL: Size.xxl,
+        },
+        Size.xxl,
+        'Thumbnail',
+    );
+    const variant = select<ThumbnailVariant>('Variant', ThumbnailVariant, ThumbnailVariant.squared, 'Thumbnail');
+
     return (
         <Thumbnail
-            align={select<Alignment>('Alignment', Alignment, Alignment.left, 'Options')}
-            aspectRatio={select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Options')}
-            focusPoint={{
-                x: number('focusX', 0, numberKnobOtions, 'Options'),
-                y: number('focusY', 0, numberKnobOtions, 'Options'),
-            }}
-            image={text('Url image', 'https://i.picsum.photos/id/1001/2400/1400.jpg', 'Options')}
-            size={select(
-                'Size',
-                {
-                    XXS: Size.xxs,
-                    XS: Size.xs,
-                    S: Size.s,
-                    M: Size.m,
-                    L: Size.l,
-                    XL: Size.xl,
-                    XXL: Size.xxl,
-                },
-                Size.xxl,
-                'Options',
-            )}
+            aspectRatio={aspectRatio}
+            focusPoint={focusPoint}
+            image={imageUrl}
+            size={size}
             theme={theme}
-            variant={select<ThumbnailVariant>('Variant', ThumbnailVariant, ThumbnailVariant.squared, 'Options')}
+            variant={variant}
         />
     );
 };

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Alignment, AspectRatio, Size, Theme } from '@lumx/react';
+import { AspectRatio, Size, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
@@ -59,8 +59,6 @@ enum ImageLoading {
  * Defines the props of the component.
  */
 interface IThumbnailProps extends IGenericProps {
-    /** The thumbnail alignment. */
-    align?: Alignment;
     /** The image aspect ratio. */
     aspectRatio?: AspectRatio;
     /** Whether the image has to fill its container's height. */
@@ -108,7 +106,6 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: IDefaultPropsType = {
-    align: Alignment.left,
     aspectRatio: AspectRatio.original,
     fillHeight: false,
     focusPoint: { x: 0, y: 0 },
@@ -127,7 +124,6 @@ const DEFAULT_PROPS: IDefaultPropsType = {
  */
 const Thumbnail: React.FC<ThumbnailProps> = ({
     className = '',
-    align = DEFAULT_PROPS.align,
     aspectRatio = DEFAULT_PROPS.aspectRatio,
     fillHeight = DEFAULT_PROPS.fillHeight,
     loading = DEFAULT_PROPS.loading,
@@ -146,7 +142,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
         <div
             className={classNames(
                 className,
-                handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant }),
+                handleBasicClasses({ aspectRatio, prefix: CLASSNAME, size, theme, variant }),
                 {
                     [`${CLASSNAME}--fill-height`]: fillHeight,
                 },


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->
Modify Image Block components to accept a children instead of using Thumbnail component.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
