### PR TITLE
feat(notification): prevent showing notification when !isOpen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Correctly init value by ignoring time on `DatePicker` component
 -   Move `textFieldRef` to `TextField` component wrapper
+-   Prevent `Notification` to be visible when `isOpen` is false
 
 ## [0.21.5][] - 2020-02-10
 

--- a/packages/lumx-angularjs/src/components/dialog/dialog_directive.js
+++ b/packages/lumx-angularjs/src/components/dialog/dialog_directive.js
@@ -1,4 +1,4 @@
-import { CSS_PREFIX, ESCAPE_KEY_CODE } from '@lumx/core/js/constants';
+import { CSS_PREFIX, DIALOG_TRANSITION_DURATION, ESCAPE_KEY_CODE } from '@lumx/core/js/constants';
 
 import template from './dialog.html';
 
@@ -34,15 +34,6 @@ function DialogController(
     const _DEFAULT_PROPS = {
         size: 'big',
     };
-
-    /**
-     * The dialog open/close transition duration.
-     *
-     * @type {number}
-     * @constant
-     * @readonly
-     */
-    const _TRANSITION_DURATION = 400;
 
     /**
      * The dialog.
@@ -157,7 +148,7 @@ function DialogController(
             LxFocusTrapService.disable();
 
             $rootScope.$broadcast('lx-dialog__close-end', lx.id, canceled, params);
-        }, _TRANSITION_DURATION);
+        }, DIALOG_TRANSITION_DURATION);
     }
 
     /**
@@ -273,7 +264,7 @@ function DialogController(
 
         $timeout(() => {
             $rootScope.$broadcast('lx-dialog__open-end', lx.id, params);
-        }, _TRANSITION_DURATION);
+        }, DIALOG_TRANSITION_DURATION);
     }
 
     /**

--- a/packages/lumx-angularjs/src/components/notification/notification_service.js
+++ b/packages/lumx-angularjs/src/components/notification/notification_service.js
@@ -1,6 +1,6 @@
 import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons';
 
-import { CSS_PREFIX } from '@lumx/core/js/constants';
+import { CSS_PREFIX, NOTIFICATION_TRANSITION_DURATION } from '@lumx/core/js/constants';
 
 /////////////////////////////
 
@@ -25,13 +25,13 @@ function NotificationService($compile, $rootScope, $timeout, LxDepthService, LxD
     const _HIDE_DELAY = 6000;
 
     /**
-     * The notification open transition duration.
+     * The delay before displaying next transition.
      *
      * @type {number}
      * @constant
      * @readonly
      */
-    const _TRANSITION_DURATION = 200;
+    const _DELAY_BEFORE_DISPLAY_NEXT = 300;
 
     /**
      * The notification icon and colors according to their type.
@@ -73,7 +73,7 @@ function NotificationService($compile, $rootScope, $timeout, LxDepthService, LxD
 
         $timeout(function waitBeforeDeleting() {
             notification.remove();
-        }, _TRANSITION_DURATION);
+        }, NOTIFICATION_TRANSITION_DURATION);
     }
 
     /**
@@ -157,7 +157,7 @@ function NotificationService($compile, $rootScope, $timeout, LxDepthService, LxD
 
             $timeout(function waitBeforeShowingNext() {
                 _build(content, type, actionLabel, actionCallback);
-            }, _TRANSITION_DURATION);
+            }, _DELAY_BEFORE_DISPLAY_NEXT);
         } else {
             _build(content, type, actionLabel, actionCallback);
         }

--- a/packages/lumx-core/src/js/constants.ts
+++ b/packages/lumx-core/src/js/constants.ts
@@ -54,6 +54,11 @@ const UP_KEY_CODE = 38;
  */
 const BACKSPACE_KEY_CODE = 8;
 
+/** Animation constants. Take into consideration that if you change one of these variables, you need to update their scss counterpart as well */
+const DIALOG_TRANSITION_DURATION = 400;
+
+const NOTIFICATION_TRANSITION_DURATION = 200;
+
 /////////////////////////////
 
 export {
@@ -67,4 +72,6 @@ export {
     RIGHT_KEY_CODE,
     TAB_KEY_CODE,
     UP_KEY_CODE,
+    DIALOG_TRANSITION_DURATION,
+    NOTIFICATION_TRANSITION_DURATION,
 };

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames';
 
 import { Progress, ProgressVariant, Size } from '@lumx/react';
 
+import { DIALOG_TRANSITION_DURATION } from '@lumx/react/constants';
+
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { useFocus } from '@lumx/react/hooks/useFocus';
@@ -202,7 +204,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
         }
     }, [isOpen]);
 
-    const isVisible = useDelayedVisibility(Boolean(isOpen));
+    const isVisible = useDelayedVisibility(Boolean(isOpen), DIALOG_TRANSITION_DURATION);
 
     return isOpen || isVisible
         ? createPortal(

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -12,6 +12,8 @@ import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useIntersectionObserver } from '@lumx/react/hooks/useIntersectionObserver';
 import { IGenericProps, getRootClassName, handleBasicClasses, isComponent, partitionMulti } from '@lumx/react/utils';
 
+import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
+
 /////////////////////////////
 
 /**
@@ -200,15 +202,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
         }
     }, [isOpen]);
 
-    // Delay visibility to account for the 400ms of CSS opacity animation.
-    const [isVisible, setVisible] = useState(isOpen);
-    useEffect(() => {
-        if (isOpen) {
-            setVisible(true);
-        } else {
-            setTimeout(() => setVisible(false), 400);
-        }
-    }, [isOpen]);
+    const isVisible = useDelayedVisibility(Boolean(isOpen));
 
     return isOpen || isVisible
         ? createPortal(

--- a/packages/lumx-react/src/components/notification/Notification.test.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.test.tsx
@@ -125,6 +125,13 @@ describe(`<${Notification.displayName}>`, () => {
             expect(notification).toHaveClassName(CLASSNAME);
             expect(notification).toHaveClassName(`${CLASSNAME}--color-dark`);
         });
+
+        it('should render nothing since the notification is closed', () => {
+            const { wrapper, notification } = setup({ ...properties.info, isOpen: false });
+            expect(wrapper).toMatchSnapshot();
+
+            expect(notification).not.toExist();
+        });
     });
 
     /////////////////////////////

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -108,7 +108,7 @@ const Notification: React.FC<NotificationProps> = ({
     ...props
 }) => {
     const hasAction: boolean = Boolean(actionCallback) && Boolean(actionLabel);
-    // Delay visibility to account for the 400ms of CSS opacity animation.
+
     const isVisible = useDelayedVisibility(isOpen);
 
     const handleCallback = (evt: React.MouseEvent) => {

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -7,6 +7,8 @@ import isFunction from 'lodash/isFunction';
 
 import { Button, Emphasis, Icon, Size, Theme } from '@lumx/react';
 
+import { NOTIFICATION_TRANSITION_DURATION } from '@lumx/react/constants';
+
 import { NOTIFICATION_CONFIGURATION } from '@lumx/react/components/notification/constants';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
@@ -109,7 +111,7 @@ const Notification: React.FC<NotificationProps> = ({
 }) => {
     const hasAction: boolean = Boolean(actionCallback) && Boolean(actionLabel);
 
-    const isVisible = useDelayedVisibility(isOpen);
+    const isVisible = useDelayedVisibility(isOpen, NOTIFICATION_TRANSITION_DURATION);
 
     const handleCallback = (evt: React.MouseEvent) => {
         if (isFunction(actionCallback)) {

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -11,6 +11,8 @@ import { NOTIFICATION_CONFIGURATION } from '@lumx/react/components/notification/
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
+import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
+
 /////////////////////////////
 
 /**
@@ -105,11 +107,9 @@ const Notification: React.FC<NotificationProps> = ({
     zIndex = DEFAULT_PROPS.zIndex,
     ...props
 }) => {
-    if (!isOpen) {
-        return null;
-    }
-
     const hasAction: boolean = Boolean(actionCallback) && Boolean(actionLabel);
+    // Delay visibility to account for the 400ms of CSS opacity animation.
+    const isVisible = useDelayedVisibility(isOpen);
 
     const handleCallback = (evt: React.MouseEvent) => {
         if (isFunction(actionCallback)) {
@@ -118,7 +118,7 @@ const Notification: React.FC<NotificationProps> = ({
         evt.stopPropagation();
     };
 
-    return type
+    return type && isVisible
         ? createPortal(
               <div
                   className={classNames(

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -105,6 +105,10 @@ const Notification: React.FC<NotificationProps> = ({
     zIndex = DEFAULT_PROPS.zIndex,
     ...props
 }) => {
+    if (!isOpen) {
+        return null;
+    }
+
     const hasAction: boolean = Boolean(actionCallback) && Boolean(actionLabel);
 
     const handleCallback = (evt: React.MouseEvent) => {

--- a/packages/lumx-react/src/components/notification/Notifications.stories.tsx
+++ b/packages/lumx-react/src/components/notification/Notifications.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { Button, Notification, NotificationType } from '@lumx/react';
+
+import noop from 'lodash/noop';
+
+export default { title: 'Notification' };
+
+const properties = {
+    error: {
+        content: 'Error',
+        handleClick: noop,
+        isOpen: true,
+        type: NotificationType.error,
+    },
+    info: {
+        content: 'Info',
+        handleClick: noop,
+        isOpen: true,
+        type: NotificationType.info,
+    },
+    infoWithCallback: {
+        actionCallback: noop,
+        actionLabel: 'Undo',
+        content: 'Info with callback',
+        handleClick: noop,
+        isOpen: true,
+        type: NotificationType.info,
+    },
+    success: {
+        content: 'Success',
+        handleClick: noop,
+        isOpen: true,
+        type: NotificationType.success,
+    },
+
+    warning: {
+        content: 'Warning',
+        handleClick: noop,
+        isOpen: true,
+        type: NotificationType.warning,
+    },
+};
+
+export const error = () => <Notification {...properties.error} />;
+
+export const info = () => <Notification {...properties.info} />;
+
+export const infoWithCallback = () => <Notification {...properties.infoWithCallback} />;
+
+export const success = () => <Notification {...properties.success} />;
+
+export const warning = () => <Notification {...properties.warning} />;
+
+export const onTrigger = () => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const onClick = () => setIsOpen(!isOpen);
+
+    return [
+        <Button onClick={onClick}>{!isOpen ? 'Show Notification' : 'Close Notification'}</Button>,
+        <Notification {...properties.error} isOpen={isOpen} />,
+    ];
+};

--- a/packages/lumx-react/src/components/notification/__snapshots__/Notification.test.tsx.snap
+++ b/packages/lumx-react/src/components/notification/__snapshots__/Notification.test.tsx.snap
@@ -29,3 +29,5 @@ exports[`<Notification> Snapshots and structure should render defaults 1`] = `
   </div>
 </Portal>
 `;
+
+exports[`<Notification> Snapshots and structure should render nothing since the notification is closed 1`] = `""`;

--- a/packages/lumx-react/src/components/notification/constants.ts
+++ b/packages/lumx-react/src/components/notification/constants.ts
@@ -27,9 +27,4 @@ const NOTIFICATION_CONFIGURATION = {
     },
 };
 
-/**
- * The notification open transition duration.
- */
-const TRANSITION_DURATION = 200;
-
-export { HIDE_DELAY, NOTIFICATION_CONFIGURATION, TRANSITION_DURATION };
+export { HIDE_DELAY, NOTIFICATION_CONFIGURATION };

--- a/packages/lumx-react/src/constants.ts
+++ b/packages/lumx-react/src/constants.ts
@@ -15,6 +15,8 @@ export {
     RIGHT_KEY_CODE,
     TAB_KEY_CODE,
     UP_KEY_CODE,
+    DIALOG_TRANSITION_DURATION,
+    NOTIFICATION_TRANSITION_DURATION,
 } from '@lumx/core/js/constants';
 
 /**

--- a/packages/lumx-react/src/hooks/index.tsx
+++ b/packages/lumx-react/src/hooks/index.tsx
@@ -1,5 +1,7 @@
 export * from './useClickAway';
 
+export * from './useDelayedVisibility';
+
 export * from './useComputePosition';
 
 export * from './useInterval';

--- a/packages/lumx-react/src/hooks/useDelayedVisibility.tsx
+++ b/packages/lumx-react/src/hooks/useDelayedVisibility.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useState } from 'react';
 
-const ANIMATION_DELAY = 400;
-
 /**
  * Returns true if the component is visible taking into account the component's
  * own visibility and the animations delay
  *
- * @param isComponentVisible Whether the component intends to be visible or not
+ * @param isComponentVisible Whether the component intends to be visible or not.
+ * @param transitionDuration time in ms that the transition takes for the specific component.
  * @return true if the component should be rendered
  */
-function useDelayedVisibility(isComponentVisible: boolean) {
+function useDelayedVisibility(isComponentVisible: boolean, transitionDuration: number) {
     // Delay visibility to account for the 400ms of CSS opacity animation.
     const [isVisible, setVisible] = useState(isComponentVisible);
 
@@ -17,7 +16,7 @@ function useDelayedVisibility(isComponentVisible: boolean) {
         if (isComponentVisible) {
             setVisible(true);
         } else {
-            setTimeout(() => setVisible(false), ANIMATION_DELAY);
+            setTimeout(() => setVisible(false), transitionDuration);
         }
     }, [isComponentVisible]);
 

--- a/packages/lumx-react/src/hooks/useDelayedVisibility.tsx
+++ b/packages/lumx-react/src/hooks/useDelayedVisibility.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const ANIMATION_DELAY = 400;
+
+/**
+ * Returns true if the component is visible taking into account the component's
+ * own visibility and the animations delay
+ *
+ * @param isComponentVisible Whether the component intends to be visible or not
+ * @return true if the component should be rendered
+ */
+function useDelayedVisibility(isComponentVisible: boolean) {
+    // Delay visibility to account for the 400ms of CSS opacity animation.
+    const [isVisible, setVisible] = useState(isComponentVisible);
+
+    useEffect(() => {
+        if (isComponentVisible) {
+            setVisible(true);
+        } else {
+            setTimeout(() => setVisible(false), ANIMATION_DELAY);
+        }
+    }, [isComponentVisible]);
+
+    return isComponentVisible || isVisible;
+}
+
+export { useDelayedVisibility };

--- a/packages/site-demo/content/product/components/notification/react/default.tsx
+++ b/packages/site-demo/content/product/components/notification/react/default.tsx
@@ -1,115 +1,92 @@
-import { Button, Notification, NotificationProps, NotificationType } from '@lumx/react';
+import { Button, Notification, NotificationType } from '@lumx/react';
 
-import isFunction from 'lodash/isFunction';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 
 const App = ({ theme }: any) => {
-    // tslint:disable-next-line:no-object-literal-type-assertion
-    const [notificationProps, setNotificationProps] = useState({} as NotificationProps);
-    const notificationPropsRef = useRef(notificationProps);
-    notificationPropsRef.current = notificationProps;
-
-    const [timer, setTimer] = useState<number | null>(null);
-
-    const open = (type: keyof typeof properties) => () => {
-        if (notificationProps && notificationProps.isOpen) {
-            close(() => {
-                setNotificationProps({ ...properties[type] });
-                setupTimer();
-            });
-        } else {
-            setNotificationProps({ ...properties[type] });
-            setupTimer();
-        }
-    };
-
-    const close = (callback?: any) => {
-        setNotificationProps({ ...notificationPropsRef.current, isOpen: false });
-
-        setTimeout(() => {
-            setNotificationProps({ type: undefined });
-
-            if (isFunction(callback)) {
-                callback();
-            }
-        }, 200);
-    };
-
     const properties = {
-        ['info']: {
-            content: 'Info',
-            handleClick: close,
-            isOpen: true,
-            type: NotificationType.info,
-        },
-        ['success']: {
-            content: 'Success',
-            handleClick: close,
-            isOpen: true,
-            type: NotificationType.success,
-        },
-        ['warning']: {
-            content: 'Warning',
-            handleClick: close,
-            isOpen: true,
-            type: NotificationType.warning,
-        },
-        ['error']: {
+        error: {
             content: 'Error',
-            handleClick: close,
-            isOpen: true,
             type: NotificationType.error,
         },
-        ['infoWithCallback']: {
-            actionCallback() {
-                close(() => {
-                    setNotificationProps({
-                        content: 'Callback',
-                        handleClick: close,
-                        isOpen: true,
-                        type: NotificationType.success,
-                    });
-                    setupTimer();
-                });
-            },
+        info: {
+            content: 'Info',
+            type: NotificationType.info,
+        },
+        infoWithCallback: {
             actionLabel: 'Undo',
             content: 'Info with callback',
-            handleClick: close,
-            isOpen: true,
             type: NotificationType.info,
+        },
+        success: {
+            content: 'Success',
+            type: NotificationType.success,
+        },
+        warning: {
+            content: 'Warning',
+            type: NotificationType.warning,
         },
     };
 
-    const setupTimer = () => {
+    const [type, setType] = useState<keyof typeof properties | null>(null);
+    const [timer, setTimer] = useState(0);
+    const [isOpen, setIsOpen] = useState(false);
+
+    const close = () => {
+        setIsOpen(false);
+    };
+
+    const open = (typeToDisplay: keyof typeof properties) => {
+        setType(typeToDisplay);
+        setIsOpen(true);
+        setTimer(window.setTimeout(close, 5000));
+    };
+
+    const onClick = (typeToDisplay: keyof typeof properties) => () => {
         if (timer) {
             clearTimeout(timer);
         }
-        setTimer(window.setTimeout(close, 5000));
+
+        /** If the notification is displayed, we need to close it, let the state be reflected and then open the notification once more */
+        if (isOpen) {
+            close();
+            setTimeout(() => {
+                open(typeToDisplay);
+            }, 500);
+        } else {
+            open(typeToDisplay);
+        }
     };
 
     return (
         <div className="demo-grid">
-            <Button type="button" theme={theme} onClick={open('info')}>
+            <Button type="button" theme={theme} onClick={onClick('info')}>
                 Info
             </Button>
 
-            <Button type="button" theme={theme} onClick={open('success')}>
+            <Button type="button" theme={theme} onClick={onClick('success')}>
                 Success
             </Button>
 
-            <Button type="button" theme={theme} onClick={open('warning')}>
+            <Button type="button" theme={theme} onClick={onClick('warning')}>
                 Warning
             </Button>
 
-            <Button type="button" theme={theme} onClick={open('error')}>
+            <Button type="button" theme={theme} onClick={onClick('error')}>
                 Error
             </Button>
 
-            <Button type="button" theme={theme} onClick={open('infoWithCallback')}>
+            <Button type="button" theme={theme} onClick={onClick('infoWithCallback')}>
                 Info with callback
             </Button>
 
-            {notificationProps !== null && <Notification {...notificationProps} />}
+            {type && (
+                <Notification
+                    isOpen={isOpen}
+                    handleClick={close}
+                    actionCallback={onClick('success')}
+                    {...properties[type]}
+                />
+            )}
         </div>
     );
 };

--- a/packages/site-demo/content/product/components/notification/react/default.tsx
+++ b/packages/site-demo/content/product/components/notification/react/default.tsx
@@ -38,7 +38,7 @@ const App = ({ theme }: any) => {
     const open = (typeToDisplay: keyof typeof properties) => {
         setType(typeToDisplay);
         setIsOpen(true);
-        setTimer(window.setTimeout(close, 5000));
+        setTimer(window.setTimeout(close, 3000));
     };
 
     const onClick = (typeToDisplay: keyof typeof properties) => () => {
@@ -51,7 +51,7 @@ const App = ({ theme }: any) => {
             close();
             setTimeout(() => {
                 open(typeToDisplay);
-            }, 500);
+            }, 300);
         } else {
             open(typeToDisplay);
         }


### PR DESCRIPTION
# General summary
The notification component is visible for a split second even if `isOpen = false`. In order to prevent that, we render `null` when `isOpen = false`

# Screenshots
Before:
![Feb-18-2020 09-38-39](https://user-images.githubusercontent.com/13719066/74718451-89163d80-5232-11ea-9277-a3350baf8de4.gif)

After:
![iFUs9CFIWU](https://user-images.githubusercontent.com/13719066/74718477-98958680-5232-11ea-8d8f-ace0893f1cf2.gif)

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [X] (if has react) Check through the [react dev check list]
-   [X] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
