### PR TITLE
feat(link): add React version of Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   New component in React : `Link`
+
 ## [0.21.8][] - 2020-02-19
 
 ### Added

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -1,0 +1,39 @@
+import { ColorPalette, ColorVariant, Link } from '@lumx/react';
+import { boolean, select, text } from '@storybook/addon-knobs';
+import React from 'react';
+
+const colors = {
+    Blue: ColorPalette.blue,
+    Dark: ColorPalette.dark,
+    Green: ColorPalette.green,
+    Light: ColorPalette.light,
+    Primary: ColorPalette.primary,
+    Red: ColorPalette.red,
+    Secondary: ColorPalette.secondary,
+    Yellow: ColorPalette.yellow,
+};
+
+const colorVariants = {
+    D1: ColorVariant.D1,
+    D2: ColorVariant.D2,
+    L1: ColorVariant.L1,
+    L2: ColorVariant.L2,
+    L3: ColorVariant.L3,
+    L4: ColorVariant.L4,
+    L5: ColorVariant.L5,
+    L6: ColorVariant.L6,
+    N: ColorVariant.N,
+};
+
+export default { title: 'Link' };
+
+export const simpleLink = () => (
+    <Link
+        href={text('Href', 'https://google.com')}
+        target={boolean('target blank', false) && '_blank'}
+        color={select('Color', colors, ColorPalette.blue)}
+        colorVariant={select('Color Variant', colorVariants, ColorVariant.N)}
+    >
+        {text('Value', 'Here is a link')}
+    </Link>
+);

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -2,37 +2,14 @@ import { ColorPalette, ColorVariant, Link } from '@lumx/react';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
-const colors = {
-    Blue: ColorPalette.blue,
-    Dark: ColorPalette.dark,
-    Green: ColorPalette.green,
-    Light: ColorPalette.light,
-    Primary: ColorPalette.primary,
-    Red: ColorPalette.red,
-    Secondary: ColorPalette.secondary,
-    Yellow: ColorPalette.yellow,
-};
-
-const colorVariants = {
-    D1: ColorVariant.D1,
-    D2: ColorVariant.D2,
-    L1: ColorVariant.L1,
-    L2: ColorVariant.L2,
-    L3: ColorVariant.L3,
-    L4: ColorVariant.L4,
-    L5: ColorVariant.L5,
-    L6: ColorVariant.L6,
-    N: ColorVariant.N,
-};
-
 export default { title: 'Link' };
 
 export const simpleLink = () => (
     <Link
         href={text('Href', 'https://google.com')}
-        target={boolean('target blank', false) && '_blank'}
-        color={select('Color', colors, ColorPalette.blue)}
-        colorVariant={select('Color Variant', colorVariants, ColorVariant.N)}
+        target={boolean('target blank', false) ? '_blank' : ''}
+        color={select('Color', ColorPalette, ColorPalette.blue)}
+        colorVariant={select('Color Variant', ColorVariant, ColorVariant.N)}
     >
         {text('Value', 'Here is a link')}
     </Link>

--- a/packages/lumx-react/src/components/link/Link.test.tsx
+++ b/packages/lumx-react/src/components/link/Link.test.tsx
@@ -1,0 +1,98 @@
+import React, { ReactElement } from 'react';
+
+import { mount, shallow } from 'enzyme';
+import 'jest-enzyme';
+
+import { ColorPalette, ColorVariant } from '@lumx/react';
+import { ICommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
+import { CLASSNAME, Link, LinkProps } from './Link';
+
+/////////////////////////////
+
+/**
+ * Define the overriding properties waited by the `setup` function.
+ */
+type ISetupProps = Partial<LinkProps>;
+
+/**
+ * Defines what the `setup` function will return.
+ */
+interface ISetup extends ICommonSetup {
+    props: ISetupProps;
+}
+
+/////////////////////////////
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ *
+ * @param props  The props to use to override the default props of the component.
+ * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
+ *                       component.
+ */
+const setup = ({ ...propsOverrides }: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
+    const props: LinkProps = {
+        ...propsOverrides,
+    };
+
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+
+    const wrapper: Wrapper = renderer(<Link {...props} />);
+
+    return {
+        props,
+        wrapper,
+    };
+};
+
+describe(`<${Link.displayName}>`, () => {
+    // 1. Test render via snapshot (default states of component).
+    describe('Snapshots and structure', () => {
+        it('should render correctly', () => {
+            const { wrapper } = setup();
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it('should render color & color variant', () => {
+            const { wrapper } = setup({ color: ColorPalette.primary, colorVariant: ColorVariant.D1 });
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+
+    /////////////////////////////
+
+    // 2. Test defaultProps value and important props custom values.
+    describe('Props', () => {
+        // Nothing to do here.
+    });
+
+    /////////////////////////////
+
+    // 3. Test events.
+    describe('Events', () => {
+        // Nothing to do here.
+    });
+    /////////////////////////////
+
+    // 4. Test conditions (i.e. things that display or not in the UI based on props).
+    describe('Conditions', () => {
+        // Nothing to do here
+    });
+
+    /////////////////////////////
+
+    // 5. Test state.
+    describe('State', () => {
+        // Nothing to do here.
+    });
+
+    /////////////////////////////
+
+    // Common tests suite.
+    commonTestsSuite(
+        setup,
+        { className: 'wrapper', prop: 'wrapper' },
+        { className: CLASSNAME, prop: 'href', propValue: 'https://google.com' },
+    );
+});

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { HTMLProps } from 'react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import classNames from 'classnames';
 
 import { Color, ColorVariant } from '@lumx/react';
-import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /////////////////////////////
 
@@ -12,7 +12,7 @@ import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react
  * Defines the props of the component.
  */
 
-interface ILinkProps extends IGenericProps {
+interface ILinkProps extends HTMLProps<HTMLAnchorElement> {
     /** The icon color. */
     color?: Color;
 

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { COMPONENT_PREFIX } from '@lumx/react/constants';
+import classNames from 'classnames';
+
+import { Color, ColorVariant } from '@lumx/react';
+import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+
+/////////////////////////////
+
+/**
+ * Defines the props of the component.
+ */
+
+interface ILinkProps extends IGenericProps {
+    /** The icon color. */
+    color?: Color;
+
+    /** The icon color variant. */
+    colorVariant?: ColorVariant;
+}
+type LinkProps = ILinkProps;
+
+/////////////////////////////
+
+/////////////////////////////
+//                         //
+//    Public attributes    //
+//                         //
+/////////////////////////////
+
+/**
+ * The display name of the component.
+ */
+const COMPONENT_NAME = `${COMPONENT_PREFIX}Link`;
+
+/**
+ * The default class name and classes prefix for this component.
+ */
+const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
+
+/**
+ * The default value of props.
+ */
+const DEFAULT_PROPS: Partial<LinkProps> = {};
+
+/////////////////////////////
+
+/**
+ * Simple component used to pick a date (semi-controlled implementation).
+ *
+ * @return The component.
+ */
+const Link = ({ children, className, color, colorVariant, ...props }: LinkProps) => {
+    return (
+        <a className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }))} {...props}>
+            {children}
+        </a>
+    );
+};
+Link.displayName = COMPONENT_NAME;
+
+/////////////////////////////
+
+export { CLASSNAME, COMPONENT_NAME, DEFAULT_PROPS, Link, LinkProps };

--- a/packages/lumx-react/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/packages/lumx-react/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Link> Snapshots and structure should render color & color variant 1`] = `
+<a
+  className="lumx-link lumx-link--color-primary lumx-link--color-variant-D1"
+  icon="mdiPlus"
+/>
+`;
+
+exports[`<Link> Snapshots and structure should render correctly 1`] = `
+<a
+  className="lumx-link"
+  icon="mdiPlus"
+/>
+`;

--- a/packages/lumx-react/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/packages/lumx-react/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -3,13 +3,11 @@
 exports[`<Link> Snapshots and structure should render color & color variant 1`] = `
 <a
   className="lumx-link lumx-link--color-primary lumx-link--color-variant-D1"
-  icon="mdiPlus"
 />
 `;
 
 exports[`<Link> Snapshots and structure should render correctly 1`] = `
 <a
   className="lumx-link"
-  icon="mdiPlus"
 />
 `;

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -46,6 +46,8 @@ export { ImageBlock, ImageBlockProps, ImageBlockCaptionPosition } from './compon
 
 export { Lightbox, LightboxProps } from './components/lightbox/Lightbox';
 
+export { Link, LinkProps } from './components/link/Link';
+
 export { List, ListProps } from './components/list/List';
 
 export { ListDivider, ListDividerProps } from './components/list/ListDivider';


### PR DESCRIPTION
# General summary

Add the React version of the `Link` component.
Only takes a color and a colorVariant, every other props is passed to the `a` tag.
<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
