### PR TITLE
feat(select): allow on Blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `onBlur` prop to `Select` component
+
 ## [0.21.8][] - 2020-02-19
 
 ### Added

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -97,4 +97,4 @@ Avatar.displayName = COMPONENT_NAME;
 
 /////////////////////////////
 
-export { CLASSNAME, DEFAULT_PROPS, Avatar, AvatarProps };
+export { CLASSNAME, DEFAULT_PROPS, Avatar, AvatarProps, AvatarSize };

--- a/packages/lumx-react/src/components/select/Select.stories.tsx
+++ b/packages/lumx-react/src/components/select/Select.stories.tsx
@@ -11,6 +11,9 @@ export const simpleSelect = ({ theme }: any) => {
     const selectedItem = select('Selected item', CHOICES, CHOICES[0]);
     // tslint:disable-next-line: no-unused
     const [isOpen, closeSelect, openSelect, toggleSelect] = useBooleanState(true);
+    const onBlur = () => {
+        alert('on blur!');
+    };
 
     return (
         <Select
@@ -21,6 +24,7 @@ export const simpleSelect = ({ theme }: any) => {
             theme={theme}
             onInputClick={toggleSelect}
             onDropdownClose={closeSelect}
+            onBlur={onBlur}
         >
             <List theme={theme} isClickable>
                 {CHOICES.map((choice, index) => (

--- a/packages/lumx-react/src/components/select/Select.stories.tsx
+++ b/packages/lumx-react/src/components/select/Select.stories.tsx
@@ -1,6 +1,7 @@
-import { List, ListItem, Select, Size } from '@lumx/react';
+import { List, ListItem, Select, Size, TextField } from '@lumx/react';
 import { useBooleanState } from '@lumx/react/hooks';
 import { text } from '@storybook/addon-knobs';
+import noop from 'lodash/noop';
 import React, { SyntheticEvent } from 'react';
 
 export default { title: 'Select' };
@@ -24,12 +25,9 @@ export const simpleSelect = ({ theme }: any) => {
         if (values.includes(item)) {
             return;
         }
+
         closeSelect();
         setValues([item]);
-    };
-
-    const onBlur = () => {
-        alert('on Blur!');
     };
 
     return (
@@ -43,7 +41,6 @@ export const simpleSelect = ({ theme }: any) => {
             theme={theme}
             onInputClick={toggleSelect}
             onDropdownClose={closeSelect}
-            onBlur={onBlur}
         >
             <List isClickable>
                 {CHOICES.length > 0
@@ -64,6 +61,78 @@ export const simpleSelect = ({ theme }: any) => {
                       ]}
             </List>
         </Select>
+    );
+};
+
+export const selectWithAnotherField = ({ theme }: any) => {
+    const PLACEHOLDER = 'Select a value';
+    const LABEL = 'Select label';
+
+    const [values, setValues] = React.useState<string[]>([]);
+    const [blurred, setWasBlurred] = React.useState('');
+    // tslint:disable-next-line:no-unused
+    const [isOpen, closeSelect, openSelect, toggleSelect] = useBooleanState(false);
+
+    const clearSelected = (event: SyntheticEvent, value: string) => {
+        event.stopPropagation();
+        setValues(value ? values.filter((val) => val !== value) : []);
+    };
+
+    const selectItem = (item: string) => () => {
+        if (values.includes(item)) {
+            return;
+        }
+
+        closeSelect();
+        setValues([item]);
+    };
+
+    const onBlur = () => {
+        setWasBlurred('was blurred');
+    };
+
+    return (
+        <>
+            <TextField
+                value={text('Value', 'myvalue')}
+                label={text('Label', 'I am the label')}
+                placeholder={text('Placeholder', 'ex: A value')}
+                theme={theme}
+                onChange={noop}
+            />
+            <Select
+                style={{ width: '100%' }}
+                isOpen={isOpen}
+                value={values}
+                onClear={clearSelected}
+                label={LABEL}
+                placeholder={PLACEHOLDER}
+                theme={theme}
+                onInputClick={toggleSelect}
+                onDropdownClose={closeSelect}
+                onBlur={onBlur}
+            >
+                <List isClickable>
+                    {CHOICES.length > 0
+                        ? CHOICES.map((choice, index) => (
+                              <ListItem
+                                  isSelected={values.includes(choice)}
+                                  key={index}
+                                  onItemSelected={selectItem(choice)}
+                                  size={Size.tiny}
+                              >
+                                  {choice}
+                              </ListItem>
+                          ))
+                        : [
+                              <ListItem key={0} size={Size.tiny}>
+                                  No data
+                              </ListItem>,
+                          ]}
+                </List>
+            </Select>
+            {blurred}
+        </>
     );
 };
 

--- a/packages/lumx-react/src/components/select/Select.stories.tsx
+++ b/packages/lumx-react/src/components/select/Select.stories.tsx
@@ -1,37 +1,67 @@
 import { List, ListItem, Select, Size } from '@lumx/react';
 import { useBooleanState } from '@lumx/react/hooks';
-import { select, text } from '@storybook/addon-knobs';
-import React from 'react';
+import { text } from '@storybook/addon-knobs';
+import React, { SyntheticEvent } from 'react';
 
 export default { title: 'Select' };
 
 const CHOICES = ['First item', 'Second item', 'Third item'];
 
 export const simpleSelect = ({ theme }: any) => {
-    const selectedItem = select('Selected item', CHOICES, CHOICES[0]);
-    // tslint:disable-next-line: no-unused
-    const [isOpen, closeSelect, openSelect, toggleSelect] = useBooleanState(true);
+    const PLACEHOLDER = 'Select a value';
+    const LABEL = 'Select label';
+
+    const [values, setValues] = React.useState<string[]>([]);
+    // tslint:disable-next-line:no-unused
+    const [isOpen, closeSelect, openSelect, toggleSelect] = useBooleanState(false);
+
+    const clearSelected = (event: SyntheticEvent, value: string) => {
+        event.stopPropagation();
+        setValues(value ? values.filter((val) => val !== value) : []);
+    };
+
+    const selectItem = (item: string) => () => {
+        if (values.includes(item)) {
+            return;
+        }
+        closeSelect();
+        setValues([item]);
+    };
+
     const onBlur = () => {
-        alert('on blur!');
+        alert('on Blur!');
     };
 
     return (
         <Select
+            style={{ width: '100%' }}
             isOpen={isOpen}
-            value={[selectedItem]}
-            label={text('label', 'My select')}
-            placeholder={text('placeholder', 'Placeholder')}
+            value={values}
+            onClear={clearSelected}
+            label={LABEL}
+            placeholder={PLACEHOLDER}
             theme={theme}
             onInputClick={toggleSelect}
             onDropdownClose={closeSelect}
             onBlur={onBlur}
         >
-            <List theme={theme} isClickable>
-                {CHOICES.map((choice, index) => (
-                    <ListItem isSelected={choice === selectedItem} key={index} size={Size.tiny}>
-                        {choice}
-                    </ListItem>
-                ))}
+            <List isClickable>
+                {CHOICES.length > 0
+                    ? CHOICES.map((choice, index) => (
+                          <ListItem
+                              isSelected={values.includes(choice)}
+                              key={index}
+                              onItemSelected={selectItem(choice)}
+                              size={Size.tiny}
+                          >
+                              {choice}
+                          </ListItem>
+                      ))
+                    : [
+                          <ListItem key={0} size={Size.tiny}>
+                              No data
+                          </ListItem>,
+                      ]}
             </List>
         </Select>
     );

--- a/packages/lumx-react/src/components/select/Select.test.tsx
+++ b/packages/lumx-react/src/components/select/Select.test.tsx
@@ -198,11 +198,15 @@ describe(`<${Select.displayName}>`, () => {
             expect(container).not.toHaveClassName(getBasicClass({ prefix: CLASSNAME, type: 'isEmpty', value: true }));
         });
 
-        it('should pass the given `onDropdownClose` to the dropdown', () => {
+        it('should trigger the given `onDropdownClose` on dropdown close', () => {
             const onDropdownClose = jest.fn();
             const { dropdown } = setup({ onDropdownClose });
 
-            expect(dropdown).toHaveProp('onClose', onDropdownClose);
+            const props: any = dropdown.props();
+
+            props.onClose();
+
+            expect(onDropdownClose).toHaveBeenCalled();
         });
 
         it('should pass the given `isOpen` to the dropdown', () => {

--- a/packages/lumx-react/src/components/select/Select.tsx
+++ b/packages/lumx-react/src/components/select/Select.tsx
@@ -304,21 +304,6 @@ const Select: React.FC<SelectProps> = ({
         [selectRef],
     );
 
-    // Any click away from the dropdown container will close it.
-    useClickAway(
-        selectRef,
-        () => {
-            if (!onBlur) {
-                return;
-            }
-
-            if (!isOpen && !isFocus) {
-                onBlur();
-            }
-        },
-        [selectRef],
-    );
-
     const handleKeyboardNav = useCallback(
         (evt: React.KeyboardEvent<HTMLElement>) => {
             if (

--- a/packages/lumx-react/src/components/select/Select.tsx
+++ b/packages/lumx-react/src/components/select/Select.tsx
@@ -217,9 +217,7 @@ function useHandleElementFocus(element: HTMLElement | null, setIsFocus: (b: bool
         }
 
         const setFocus = () => {
-            if (onFocus) {
-                onFocus();
-            }
+            onFocus();
             setIsFocus(true);
         };
 
@@ -288,7 +286,10 @@ const Select: React.FC<SelectProps> = ({
     useFocus(anchorRef.current, Boolean(isOpen));
     useHandleElementFocus(anchorRef.current, setIsFocus, onSelectFocus);
 
-    // Any click away from the dropdown container will close it.
+    /**
+     * Since the select is not really an input, we need to fake the onBlur event.
+     * We can do this by listening to the click away event, which is basically an "onBlur"
+     */
     useClickAway(
         selectRef,
         () => {
@@ -296,8 +297,13 @@ const Select: React.FC<SelectProps> = ({
                 return;
             }
 
+            /**
+             * The select was really blurred if the dropdown is not open, the dropdown was in a focused state and
+             * we did not yet trigger the blur event
+             */
             if (!isOpen && isFocus && !wasBlurred) {
                 onBlur();
+                /** Setting the wasBlurred state to true in order to prevent further blur events when clicking away */
                 setWasBlurred(true);
             }
         },

--- a/packages/lumx-react/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/lumx-react/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`<Select> Snapshots and structure should render correctly 1`] = `
     }
     closeOnClick={true}
     closeOnEscape={true}
+    onClose={[Function]}
     placement="auto-start"
     showDropdown={false}
   >

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -2,7 +2,7 @@ import 'focus-visible';
 
 export * from './components';
 
-export { Avatar, AvatarProps } from './components/avatar/Avatar';
+export { Avatar, AvatarProps, AvatarSize } from './components/avatar/Avatar';
 
 export { Autocomplete, AutocompleteProps } from './components/autocomplete/Autocomplete';
 


### PR DESCRIPTION
# General summary
Added the possibility to detect whether the `Select` component was blurred or not:
- Since the Select is actually not an input, we need to fake the `blur` with a click away
- Updated the main story since it did not change the option selected upon clicking the option

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
