### PR TITLE
Feat/file attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   New component in React : `Link`
 -   New component in React : `WebBookmark`
+-   New component in React : `FileAttachment`
+-   New component in React : `FileAttachmentMultiple`
 
 ## [0.21.8][] - 2020-02-19
 

--- a/packages/lumx-core/src/scss/components/file-attachment-multiple/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/file-attachment-multiple/lumapps/_index.scss
@@ -1,0 +1,55 @@
+/* ==========================================================================
+   File Attachment Multiple
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-file-attachment-multiple {
+    &--theme-light {
+        background-color: lumx-theme-color-variant('dark', 'L6');
+    }
+
+    &--theme-dark {
+        background-color: lumx-theme-color-variant('light', 'L6');
+    }
+
+    &__file {
+        padding-right: $lumx-spacing-unit * 2;
+        padding-left: $lumx-spacing-unit * 2;
+    }
+
+    &__link {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__divider {
+        margin: 0 $lumx-spacing-unit * 2 0 $lumx-spacing-unit * 8.5 !important;
+        margin-left: 68px;
+    }
+
+    &__file-icon {
+        position: relative;
+        cursor: pointer;
+
+        &::after {
+            @include lumx-state-transition;
+
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            border-radius: $lumx-spacing-unit / 2;
+            content: '';
+            pointer-events: none;
+        }
+
+        &:hover::after {
+            @include lumx-state(lumx-base-const('state', 'HOVER'), lumx-base-const('emphasis', 'LOW'), 'dark');
+        }
+
+        &:active::after {
+            @include lumx-state(lumx-base-const('state', 'ACTIVE'), lumx-base-const('emphasis', 'LOW'), 'dark');
+        }
+    }
+}

--- a/packages/lumx-core/src/scss/components/file-attachment/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/file-attachment/lumapps/_index.scss
@@ -1,0 +1,83 @@
+/* ==========================================================================
+   File Attachment
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-file-attachment {
+    $self: &;
+
+    display: flex;
+    align-items: center;
+
+    padding: $lumx-spacing-unit * 2;
+
+    &--theme-light {
+        background-color: lumx-theme-color-variant('dark', 'L6');
+    }
+
+    &--theme-dark {
+        background-color: lumx-theme-color-variant('light', 'L6');
+    }
+
+    &__icon {
+        position: relative;
+        cursor: pointer;
+
+        &::after {
+            @include lumx-state-transition;
+
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            border-radius: $lumx-spacing-unit / 2;
+            content: '';
+            pointer-events: none;
+        }
+
+        &:hover::after {
+            @include lumx-state(lumx-base-const('state', 'HOVER'), lumx-base-const('emphasis', 'LOW'), 'dark');
+        }
+
+        &:active::after {
+            @include lumx-state(lumx-base-const('state', 'ACTIVE'), lumx-base-const('emphasis', 'LOW'), 'dark');
+        }
+    }
+
+    &__infos {
+        display: flex;
+        overflow: hidden;
+        width: 100%;
+        flex-direction: column;
+        justify-content: center;
+        padding-left: $lumx-spacing-unit * 2;
+    }
+
+    &__title,
+    &__description,
+    &__link {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__title {
+        @include lumx-typography('subtitle1');
+    }
+
+    &__description {
+        @include lumx-typography('body1');
+
+        #{$self}--theme-light & {
+            color: lumx-theme-color-variant('dark', 'L2');
+        }
+
+        #{$self}--theme-dark & {
+            color: lumx-theme-color-variant('light', 'L2');
+        }
+    }
+
+    &__link {
+        @include lumx-typography('body1');
+    }
+}

--- a/packages/lumx-core/src/scss/lumx-theme-lumapps.scss
+++ b/packages/lumx-core/src/scss/lumx-theme-lumapps.scss
@@ -22,6 +22,8 @@
 @import './components/dropdown/lumapps/index';
 @import './components/expansion-panel/lumapps/index';
 @import './components/grid/lumapps/index';
+@import './components/file-attachment/lumapps/index';
+@import './components/file-attachment-multiple/lumapps/index';
 @import './components/icon/lumapps/index';
 @import './components/image-block/lumapps/index';
 @import './components/input-helper/lumapps/index';

--- a/packages/lumx-react/jest/index.js
+++ b/packages/lumx-react/jest/index.js
@@ -11,7 +11,7 @@ const moduleNameMapper = fromPairs(
 );
 
 module.exports = {
-    collectCoverageFrom: ['**/*.{ts,tsx}', '!**/node_modules/**'],
+    collectCoverageFrom: ['**/*.{ts,tsx}', '!**/*.stories.{ts,tsx}', '!**/node_modules/**'],
     coverageDirectory: '<rootDir>jest/reports/coverage',
     coverageReporters: ['json', 'lcov', 'html', 'text'],
     moduleDirectories: [`${CONFIGS.path.ROOT_PATH}/node_modules`],

--- a/packages/lumx-react/src/components/file-attachment/FileAttachment.stories.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachment.stories.tsx
@@ -1,99 +1,45 @@
-import { mdiFilePdfBox, mdiSend } from '@lumx/icons';
+import { mdiFilePdfBox } from '@lumx/icons';
 import { FileAttachment } from '@lumx/react';
 import { files, text } from '@storybook/addon-knobs';
 import React from 'react';
-import { Size } from '..';
-import { Avatar } from '../avatar/Avatar';
-import { Icon } from '../icon/Icon';
-import { List } from '../list/List';
-import { ListDivider } from '../list/ListDivider';
-import { ListItem } from '../list/ListItem';
-import { Thumbnail, ThumbnailVariant } from '../thumbnail/Thumbnail';
-import { FileAttachmentMultiple } from './FileAttachmentMultiple';
+import { Theme } from '..';
+import { Thumbnail } from '../thumbnail/Thumbnail';
 
 export default { title: 'File Attachment' };
 
-export const simpleFileAttachment = () => (
+export const simpleFileAttachment = ({ theme }: { theme: Theme }) => (
     <FileAttachment
+        theme={theme}
         fileTitle={text('File title', 'Presentation 2020')}
         fileDescription={text('File description', 'New presentation')}
         fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
     />
 );
 
-export const simpleFileAttachmentWithCustomIcon = () => (
+export const simpleFileAttachmentWithCustomIcon = ({ theme }: { theme: Theme }) => (
     <FileAttachment
+        theme={theme}
         fileTitle={text('File title', 'Presentation 2020')}
         fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
         fileDescription={text('File description', 'New presentation')}
-        fileIcon={<Icon size={Size.l} icon={mdiFilePdfBox} />}
+        fileIcon={{ icon: mdiFilePdfBox }}
     />
 );
 
-export const simpleFileAttachmentWithImage = () => (
+export const simpleFileAttachmentWithImage = ({ theme }: { theme: Theme }) => (
     <>
         <FileAttachment
-            fileTitle={text('File title', 'Presentation 2020')}
-            fileDescription={text('File description', 'New presentation')}
-            fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
-        />
-
-        <div style={{ margin: 20 }} />
-
-        <FileAttachment
+            theme={theme}
             fileTitle={text('File title', 'Presentation 2020')}
             fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
             fileDescription={text('File description', 'New presentation')}
-            fileIcon={<Icon size={Size.l} icon={mdiFilePdfBox} />}
+            fileThumbnail={{ image: files('File image', 'image/*', ['https://loremflickr.com/320/240'])[0] }}
         />
+    </>
+);
 
-        <div style={{ margin: 20 }} />
-
-        <FileAttachment
-            fileTitle={text('File title', 'Presentation 2020')}
-            fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
-            fileDescription={text('File description', 'New presentation')}
-            fileImage={files('File image', 'image/*', ['https://loremflickr.com/320/240'])[0]}
-        />
-        <div style={{ margin: 20 }} />
-
-        <FileAttachmentMultiple
-            files={[
-                {
-                    fileImage: 'https://loremflickr.com/320/240',
-                    fileUrl: 'https:// cdn.com/api/pdf/presentation-2020.pdf',
-                },
-                {
-                    fileIcon: <Icon size={Size.m} icon={mdiFilePdfBox} />,
-                    fileUrl: 'https:// cdn.com/api/pdf/presentation-2020.pdf',
-                },
-                {
-                    fileUrl: 'https:// cdn.com/api/pdf/presentation-2020.pdf',
-                },
-            ]}
-        />
-        <div style={{ margin: 20 }} />
-
-        <List isClickable style={{ backgroundColor: 'rgba(40, 51, 109, 0.05)' }}>
-            <ListItem before={<Icon icon={mdiSend} size={Size.xs} />}>Single-line item</ListItem>
-            <ListDivider
-                style={{
-                    margin: '0px 16px',
-                    marginLeft: '68px',
-                }}
-            />
-            <ListItem
-                before={<Thumbnail variant={ThumbnailVariant.rounded} image="https://picsum.photos/72" size={Size.m} />}
-            >
-                Single-line item
-            </ListItem>
-            <ListDivider
-                style={{
-                    margin: '0px 16px',
-                    marginLeft: '68px',
-                }}
-            />
-            <ListItem before={<Avatar image="http://i.pravatar.cc/72" size={Size.m} />}>Single-line item</ListItem>
-        </List>
+export const pouet = ({ theme }: { theme: Theme }) => (
+    <>
+        <Thumbnail image={mdiFilePdfBox} />
     </>
 );

--- a/packages/lumx-react/src/components/file-attachment/FileAttachment.stories.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachment.stories.tsx
@@ -1,0 +1,99 @@
+import { mdiFilePdfBox, mdiSend } from '@lumx/icons';
+import { FileAttachment } from '@lumx/react';
+import { files, text } from '@storybook/addon-knobs';
+import React from 'react';
+import { Size } from '..';
+import { Avatar } from '../avatar/Avatar';
+import { Icon } from '../icon/Icon';
+import { List } from '../list/List';
+import { ListDivider } from '../list/ListDivider';
+import { ListItem } from '../list/ListItem';
+import { Thumbnail, ThumbnailVariant } from '../thumbnail/Thumbnail';
+import { FileAttachmentMultiple } from './FileAttachmentMultiple';
+
+export default { title: 'File Attachment' };
+
+export const simpleFileAttachment = () => (
+    <FileAttachment
+        fileTitle={text('File title', 'Presentation 2020')}
+        fileDescription={text('File description', 'New presentation')}
+        fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+    />
+);
+
+export const simpleFileAttachmentWithCustomIcon = () => (
+    <FileAttachment
+        fileTitle={text('File title', 'Presentation 2020')}
+        fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+        fileDescription={text('File description', 'New presentation')}
+        fileIcon={<Icon size={Size.l} icon={mdiFilePdfBox} />}
+    />
+);
+
+export const simpleFileAttachmentWithImage = () => (
+    <>
+        <FileAttachment
+            fileTitle={text('File title', 'Presentation 2020')}
+            fileDescription={text('File description', 'New presentation')}
+            fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+        />
+
+        <div style={{ margin: 20 }} />
+
+        <FileAttachment
+            fileTitle={text('File title', 'Presentation 2020')}
+            fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+            fileDescription={text('File description', 'New presentation')}
+            fileIcon={<Icon size={Size.l} icon={mdiFilePdfBox} />}
+        />
+
+        <div style={{ margin: 20 }} />
+
+        <FileAttachment
+            fileTitle={text('File title', 'Presentation 2020')}
+            fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+            fileDescription={text('File description', 'New presentation')}
+            fileImage={files('File image', 'image/*', ['https://loremflickr.com/320/240'])[0]}
+        />
+        <div style={{ margin: 20 }} />
+
+        <FileAttachmentMultiple
+            files={[
+                {
+                    fileImage: 'https://loremflickr.com/320/240',
+                    fileUrl: 'https:// cdn.com/api/pdf/presentation-2020.pdf',
+                },
+                {
+                    fileIcon: <Icon size={Size.m} icon={mdiFilePdfBox} />,
+                    fileUrl: 'https:// cdn.com/api/pdf/presentation-2020.pdf',
+                },
+                {
+                    fileUrl: 'https:// cdn.com/api/pdf/presentation-2020.pdf',
+                },
+            ]}
+        />
+        <div style={{ margin: 20 }} />
+
+        <List isClickable style={{ backgroundColor: 'rgba(40, 51, 109, 0.05)' }}>
+            <ListItem before={<Icon icon={mdiSend} size={Size.xs} />}>Single-line item</ListItem>
+            <ListDivider
+                style={{
+                    margin: '0px 16px',
+                    marginLeft: '68px',
+                }}
+            />
+            <ListItem
+                before={<Thumbnail variant={ThumbnailVariant.rounded} image="https://picsum.photos/72" size={Size.m} />}
+            >
+                Single-line item
+            </ListItem>
+            <ListDivider
+                style={{
+                    margin: '0px 16px',
+                    marginLeft: '68px',
+                }}
+            />
+            <ListItem before={<Avatar image="http://i.pravatar.cc/72" size={Size.m} />}>Single-line item</ListItem>
+        </List>
+    </>
+);

--- a/packages/lumx-react/src/components/file-attachment/FileAttachment.stories.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachment.stories.tsx
@@ -3,43 +3,34 @@ import { FileAttachment } from '@lumx/react';
 import { files, text } from '@storybook/addon-knobs';
 import React from 'react';
 import { Theme } from '..';
-import { Thumbnail } from '../thumbnail/Thumbnail';
 
 export default { title: 'File Attachment' };
 
 export const simpleFileAttachment = ({ theme }: { theme: Theme }) => (
     <FileAttachment
         theme={theme}
-        fileTitle={text('File title', 'Presentation 2020')}
-        fileDescription={text('File description', 'New presentation')}
-        fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+        title={text('File title', 'Presentation 2020')}
+        description={text('File description', 'New presentation')}
+        url={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
     />
 );
 
 export const simpleFileAttachmentWithCustomIcon = ({ theme }: { theme: Theme }) => (
     <FileAttachment
         theme={theme}
-        fileTitle={text('File title', 'Presentation 2020')}
-        fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
-        fileDescription={text('File description', 'New presentation')}
+        title={text('File title', 'Presentation 2020')}
+        url={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+        description={text('File description', 'New presentation')}
         fileIcon={{ icon: mdiFilePdfBox }}
     />
 );
 
 export const simpleFileAttachmentWithImage = ({ theme }: { theme: Theme }) => (
-    <>
-        <FileAttachment
-            theme={theme}
-            fileTitle={text('File title', 'Presentation 2020')}
-            fileUrl={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
-            fileDescription={text('File description', 'New presentation')}
-            fileThumbnail={{ image: files('File image', 'image/*', ['https://loremflickr.com/320/240'])[0] }}
-        />
-    </>
-);
-
-export const pouet = ({ theme }: { theme: Theme }) => (
-    <>
-        <Thumbnail image={mdiFilePdfBox} />
-    </>
+    <FileAttachment
+        theme={theme}
+        title={text('File title', 'Presentation 2020')}
+        url={text('File URL', 'https://cdn.com/api/pdf/presentation-2020.pdf')}
+        description={text('File description', 'New presentation')}
+        thumbnail={{ image: files('File image', 'image/*', ['https://loremflickr.com/320/240'])[0] }}
+    />
 );

--- a/packages/lumx-react/src/components/file-attachment/FileAttachment.test.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachment.test.tsx
@@ -1,0 +1,166 @@
+import React, { ReactElement } from 'react';
+
+import { mount, shallow } from 'enzyme';
+import 'jest-enzyme';
+
+import { ICommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
+import { getBasicClass } from '@lumx/react/utils';
+
+import { mdiFile, mdiFilePdfBox } from '@lumx/icons';
+import { Theme } from '..';
+import { CLASSNAME, DEFAULT_PROPS, FileAttachment, FileAttachmentProps } from './FileAttachment';
+
+/////////////////////////////
+
+/**
+ * Define the overriding properties waited by the `setup` function.
+ */
+type ISetupProps = Partial<FileAttachmentProps>;
+
+/**
+ * Defines what the `setup` function will return.
+ */
+interface ISetup extends ICommonSetup {
+    props: ISetupProps;
+
+    /**
+     * The wrapper of the file attachment.
+     */
+    wrapper: Wrapper;
+    /**
+     * The thumbnail of the file attachment.
+     */
+    thumbnail: Wrapper;
+    /**
+     * The icon of the file attachment.
+     */
+    icon: Wrapper;
+    /**
+     * The Link containing the file name.
+     */
+    fileNameLink: Wrapper;
+}
+
+/////////////////////////////
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ *
+ * @param  props  The props to use to override the default props of the component.
+ * @param  [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return An object with the props, the component wrapper and some shortcut to some element inside of the component.
+ */
+const setup = (props: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+
+    // @ts-ignore
+    const wrapper: Wrapper = renderer(<FileAttachment {...props} />);
+
+    return {
+        fileNameLink: wrapper.find(`.${CLASSNAME}__link`),
+        icon: wrapper.find('Icon'),
+        props,
+        thumbnail: wrapper.find('Thumbnail'),
+        wrapper,
+    };
+};
+
+describe(`<${FileAttachment.displayName}>`, () => {
+    // 1. Test render via snapshot (default states of component).
+    describe('Snapshots and structure', () => {
+        // Here is an example of a basic rendering check, with snapshot.
+
+        it('should render correctly', () => {
+            const { wrapper } = setup();
+            expect(wrapper).toMatchSnapshot();
+
+            expect(wrapper).toExist();
+            expect(wrapper).toHaveClassName(CLASSNAME);
+        });
+    });
+
+    /////////////////////////////
+
+    // 2. Test defaultProps value and important props custom values.
+    describe('Props', () => {
+        // Here are some examples of basic props check.
+
+        it('should use default props', () => {
+            const { wrapper, icon } = setup();
+            Object.keys(DEFAULT_PROPS).forEach((prop: string) => {
+                expect(wrapper).toHaveClassName(
+                    getBasicClass({ prefix: CLASSNAME, type: prop, value: DEFAULT_PROPS[prop] }),
+                );
+            });
+            expect(icon).toHaveProp('icon', mdiFile);
+        });
+
+        it('should pass the theme to the Icon', () => {
+            const expectedTheme = Theme.dark;
+            const { icon } = setup({ theme: expectedTheme });
+            expect(icon).toHaveProp('theme', expectedTheme);
+        });
+
+        it('should pass the icon to the Icon component', () => {
+            const expectedIcon = mdiFilePdfBox;
+            const { icon } = setup({
+                icon: {
+                    icon: expectedIcon,
+                },
+            });
+            expect(icon).toHaveProp('icon', expectedIcon);
+        });
+
+        it('should display the file name correctly', () => {
+            const expectedFileName = 'test.pdf';
+            const { fileNameLink } = setup({
+                url: 'https://sometest.url/path/to/file/test.pdf',
+            });
+            expect(fileNameLink).toHaveProp('children', expectedFileName);
+        });
+    });
+
+    /////////////////////////////
+
+    // 3. Test events.
+    describe('Events', () => {
+        const expectedUrl = 'https://expected.url';
+        const { thumbnail } = setup({
+            thumbnail: {
+                image: 'path/to/test.png',
+            },
+            url: expectedUrl,
+        });
+        window.open = jest.fn();
+        thumbnail.simulate('click');
+        expect(window.open).toHaveBeenCalledWith(expectedUrl, '_blank');
+    });
+    /////////////////////////////
+
+    // 4. Test conditions (i.e. things that display or not in the UI based on props).
+    describe('Conditions', () => {
+        it('should display Thumbnail and no Icon if thumbnail is defined', () => {
+            const { icon, thumbnail } = setup({ thumbnail: { image: 'Pouet' } });
+            expect(thumbnail).toExist();
+            expect(icon).not.toExist();
+        });
+
+        it('should display Icon and no Thumbnail if thumbnail is not defined', () => {
+            const { icon, thumbnail } = setup({ icon: { icon: mdiFilePdfBox } });
+            expect(icon).toExist();
+            expect(thumbnail).not.toExist();
+        });
+    });
+
+    /////////////////////////////
+
+    // 5. Test state.
+    describe('State', () => {
+        // Nothing to do here.
+    });
+
+    /////////////////////////////
+
+    // Common tests suite.
+    commonTestsSuite(setup, {}, { className: CLASSNAME });
+});

--- a/packages/lumx-react/src/components/file-attachment/FileAttachment.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachment.tsx
@@ -1,0 +1,89 @@
+import { mdiFile } from '@lumx/icons';
+import { COMPONENT_PREFIX } from '@lumx/react/constants';
+import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import classNames from 'classnames';
+import React, { ReactElement, ReactNode, useMemo } from 'react';
+import { AspectRatio, Size } from '..';
+import { Icon } from '../icon/Icon';
+import { Thumbnail, ThumbnailVariant } from '../thumbnail/Thumbnail';
+
+/////////////////////////////
+
+/**
+ * Defines the props of the component.
+ */
+interface IBaseFileAttachmentProps extends IGenericProps {
+    /**
+     * FileAttachment content.
+     */
+    children?: ReactNode;
+
+    fileUrl?: string;
+
+    fileTitle?: string;
+
+    fileImage?: string;
+
+    fileIcon?: ReactNode;
+
+    fileDescription?: string;
+}
+
+/////////////////////////////
+//                         //
+//    Public attributes    //
+//                         //
+/////////////////////////////
+
+/**
+ * The display name of the component.
+ */
+const COMPONENT_NAME = `${COMPONENT_PREFIX}FileAttachment`;
+
+/**
+ * The default class name and classes prefix for this component.
+ */
+const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
+
+/**
+ * The default value of props.
+ */
+const DEFAULT_PROPS: IBaseFileAttachmentProps = {
+    fileIcon: <Icon size={Size.l} icon={mdiFile} />,
+};
+
+const FileAttachment: React.FC<IBaseFileAttachmentProps> = ({
+    className,
+    fileIcon = DEFAULT_PROPS.fileIcon,
+    fileImage,
+    fileTitle,
+    fileUrl,
+    fileDescription,
+    ...props
+}: IBaseFileAttachmentProps): ReactElement => {
+    const fileName = useMemo(() => fileUrl?.substr(fileUrl.lastIndexOf('/') + 1) || '', [fileUrl]);
+
+    return (
+        <div className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
+            {fileImage ? (
+                <Thumbnail
+                    size={Size.l}
+                    variant={ThumbnailVariant.rounded}
+                    aspectRatio={AspectRatio.square}
+                    image={fileImage}
+                />
+            ) : (
+                fileIcon
+            )}
+            <div className={`${CLASSNAME}__infos`}>
+                <p className={`${CLASSNAME}__title`}>{fileTitle}</p>
+                <p className={`${CLASSNAME}__description`}>{fileDescription}</p>
+                <p className={`${CLASSNAME}__link`}>{fileName}</p>
+            </div>
+        </div>
+    );
+};
+
+FileAttachment.displayName = COMPONENT_NAME;
+
+export { CLASSNAME, DEFAULT_PROPS, FileAttachment, IBaseFileAttachmentProps };

--- a/packages/lumx-react/src/components/file-attachment/FileAttachment.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachment.tsx
@@ -2,32 +2,23 @@ import { mdiFile } from '@lumx/icons';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
-import React, { ReactElement, ReactNode, useMemo } from 'react';
-import { AspectRatio, Size } from '..';
+import React, { useCallback, useMemo } from 'react';
+import { AspectRatio, ColorPalette, ColorVariant, Size, Theme } from '..';
 import { Icon } from '../icon/Icon';
+import { Link } from '../link/Link';
 import { Thumbnail, ThumbnailVariant } from '../thumbnail/Thumbnail';
+import { IFile } from './types';
 
 /////////////////////////////
 
 /**
  * Defines the props of the component.
  */
-interface IBaseFileAttachmentProps extends IGenericProps {
-    /**
-     * FileAttachment content.
-     */
-    children?: ReactNode;
-
-    fileUrl?: string;
-
-    fileTitle?: string;
-
-    fileImage?: string;
-
-    fileIcon?: ReactNode;
-
-    fileDescription?: string;
+interface IFileAttachmentProps extends IGenericProps, IFile {
+    /** The theme. */
+    theme?: Theme;
 }
+type FileAttachmentProps = IFileAttachmentProps;
 
 /////////////////////////////
 //                         //
@@ -48,37 +39,65 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: IBaseFileAttachmentProps = {
-    fileIcon: <Icon size={Size.l} icon={mdiFile} />,
+const DEFAULT_PROPS: Partial<FileAttachmentProps> = {
+    theme: Theme.light,
 };
 
-const FileAttachment: React.FC<IBaseFileAttachmentProps> = ({
+const FileAttachment: React.FC<FileAttachmentProps> = ({
     className,
-    fileIcon = DEFAULT_PROPS.fileIcon,
-    fileImage,
-    fileTitle,
-    fileUrl,
-    fileDescription,
+    icon = DEFAULT_PROPS.icon,
+    thumbnail,
+    title,
+    url = '',
+    description,
+    theme = DEFAULT_PROPS.theme,
     ...props
-}: IBaseFileAttachmentProps): ReactElement => {
-    const fileName = useMemo(() => fileUrl?.substr(fileUrl.lastIndexOf('/') + 1) || '', [fileUrl]);
-
+}) => {
+    const fileName = useMemo(() => url.substr(url.lastIndexOf('/') + 1) || '', [url]);
+    const onFileClick = useCallback(() => window.open(url, '_blank'), [url]);
     return (
-        <div className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} {...props}>
-            {fileImage ? (
+        <div className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))} {...props}>
+            {thumbnail ? (
                 <Thumbnail
-                    size={Size.l}
+                    role="link"
                     variant={ThumbnailVariant.rounded}
+                    onClick={onFileClick}
+                    tabIndex={0}
+                    {...thumbnail}
+                    size={Size.l}
                     aspectRatio={AspectRatio.square}
-                    image={fileImage}
                 />
             ) : (
-                fileIcon
+                <Icon
+                    role="link"
+                    tabIndex={0}
+                    onClick={onFileClick}
+                    icon={mdiFile}
+                    theme={theme}
+                    color={theme === Theme.light ? ColorPalette.dark : ColorPalette.light}
+                    {...icon}
+                    className={classNames(`${CLASSNAME}__icon`, icon?.className)}
+                    size={Size.l}
+                />
             )}
             <div className={`${CLASSNAME}__infos`}>
-                <p className={`${CLASSNAME}__title`}>{fileTitle}</p>
-                <p className={`${CLASSNAME}__description`}>{fileDescription}</p>
-                <p className={`${CLASSNAME}__link`}>{fileName}</p>
+                <Link
+                    className={`${CLASSNAME}__title`}
+                    color={theme === Theme.light ? ColorPalette.dark : ColorPalette.light}
+                    colorVariant={ColorVariant.N}
+                    href={url}
+                >
+                    {title}
+                </Link>
+                <p className={`${CLASSNAME}__description`}>{description}</p>
+                <Link
+                    className={`${CLASSNAME}__link`}
+                    color={theme === Theme.light ? ColorPalette.blue : ColorPalette.light}
+                    colorVariant={ColorVariant.N}
+                    href={url}
+                >
+                    {fileName}
+                </Link>
             </div>
         </div>
     );
@@ -86,4 +105,4 @@ const FileAttachment: React.FC<IBaseFileAttachmentProps> = ({
 
 FileAttachment.displayName = COMPONENT_NAME;
 
-export { CLASSNAME, DEFAULT_PROPS, FileAttachment, IBaseFileAttachmentProps };
+export { CLASSNAME, DEFAULT_PROPS, FileAttachment, FileAttachmentProps };

--- a/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.stories.tsx
@@ -1,0 +1,6 @@
+import { FileAttachment } from '@lumx/react';
+import React from 'react';
+
+export default { title: 'Badge' };
+
+export const simpleBadgeWithValue = () => <FileAttachment />;

--- a/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.stories.tsx
@@ -1,6 +1,25 @@
-import { FileAttachment } from '@lumx/react';
+import { mdiFilePdfBox } from '@lumx/icons';
 import React from 'react';
+import { Theme } from '..';
+import { FileAttachmentMultiple } from './FileAttachmentMultiple';
 
-export default { title: 'Badge' };
+export default { title: 'File Attachment' };
 
-export const simpleBadgeWithValue = () => <FileAttachment />;
+export const multipleAttachmentFile = ({ theme }: { theme: Theme }) => (
+    <FileAttachmentMultiple
+        theme={theme}
+        files={[
+            {
+                fileThumbnail: { image: 'https://loremflickr.com/320/240' },
+                fileUrl: 'https://cdn.com/api/pdf/presentation-2020.pdf',
+            },
+            {
+                fileIcon: { icon: mdiFilePdfBox },
+                fileUrl: 'https://cdn.com/api/pdf/presentation-2020.pdf',
+            },
+            {
+                fileUrl: 'https://cdn.com/api/pdf/presentation-2020.pdf',
+            },
+        ]}
+    />
+);

--- a/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.stories.tsx
@@ -10,15 +10,15 @@ export const multipleAttachmentFile = ({ theme }: { theme: Theme }) => (
         theme={theme}
         files={[
             {
-                fileThumbnail: { image: 'https://loremflickr.com/320/240' },
-                fileUrl: 'https://cdn.com/api/pdf/presentation-2020.pdf',
+                thumbnail: { image: 'https://loremflickr.com/320/240' },
+                url: 'https://cdn.com/api/pdf/presentation-2020.pdf',
             },
             {
-                fileIcon: { icon: mdiFilePdfBox },
-                fileUrl: 'https://cdn.com/api/pdf/presentation-2020.pdf',
+                icon: { icon: mdiFilePdfBox },
+                url: 'https://cdn.com/api/pdf/presentation-2020.pdf',
             },
             {
-                fileUrl: 'https://cdn.com/api/pdf/presentation-2020.pdf',
+                url: 'https://cdn.com/api/pdf/presentation-2020.pdf',
             },
         ]}
     />

--- a/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.test.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.test.tsx
@@ -1,0 +1,199 @@
+import React, { ReactElement } from 'react';
+
+import { mount, shallow } from 'enzyme';
+import 'jest-enzyme';
+
+import { ICommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
+import { getBasicClass } from '@lumx/react/utils';
+
+import { mdiFile, mdiFilePdfBox } from '@lumx/icons';
+import { Theme } from '..';
+import {
+    CLASSNAME,
+    DEFAULT_PROPS,
+    FileAttachmentMultiple,
+    FileAttachmentMultipleProps,
+} from './FileAttachmentMultiple';
+
+/////////////////////////////
+
+/**
+ * Define the overriding properties waited by the `setup` function.
+ */
+type ISetupProps = Partial<FileAttachmentMultipleProps>;
+
+/**
+ * Defines what the `setup` function will return.
+ */
+interface ISetup extends ICommonSetup {
+    props: ISetupProps;
+
+    /**
+     * The wrapper of the file attachment.
+     */
+    wrapper: Wrapper;
+    /**
+     * The ListItem components.
+     */
+    listItems: Wrapper;
+}
+
+/////////////////////////////
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ *
+ * @param  props  The props to use to override the default props of the component.
+ * @param  [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
+ * @return An object with the props, the component wrapper and some shortcut to some element inside of the component.
+ */
+const setup = (props: ISetupProps = {}, shallowRendering: boolean = true): ISetup => {
+    const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
+
+    // @ts-ignore
+    const wrapper: Wrapper = renderer(<FileAttachmentMultiple {...props} />);
+
+    return {
+        listItems: wrapper.find('ListItem'),
+        props,
+        wrapper,
+    };
+};
+
+const files = [
+    {
+        thumbnail: { image: 'https://loremflickr.com/320/240' },
+        url: 'https://cdn.com/api/pdf/presentation-2020.pdf',
+    },
+    {
+        icon: { icon: mdiFilePdfBox },
+        url: 'https://cdn.com/api/pdf/presentation-2020-2.pdf',
+    },
+    {
+        url: 'https://cdn.com/api/pdf/presentation-2020-3.pdf',
+    },
+];
+
+describe(`<${FileAttachmentMultiple.displayName}>`, () => {
+    // 1. Test render via snapshot (default states of component).
+    describe('Snapshots and structure', () => {
+        // Here is an example of a basic rendering check, with snapshot.
+
+        it('should render correctly', () => {
+            const { wrapper } = setup({
+                files,
+            });
+            expect(wrapper).toMatchSnapshot();
+
+            expect(wrapper).toExist();
+            expect(wrapper).toHaveClassName(CLASSNAME);
+        });
+    });
+
+    /////////////////////////////
+
+    // 2. Test defaultProps value and important props custom values.
+    describe('Props', () => {
+        // Here are some examples of basic props check.
+
+        it('should use default props', () => {
+            const { wrapper } = setup({ files });
+            Object.keys(DEFAULT_PROPS).forEach((prop: string) => {
+                expect(wrapper).toHaveClassName(
+                    getBasicClass({ prefix: CLASSNAME, type: prop, value: DEFAULT_PROPS[prop] }),
+                );
+            });
+        });
+
+        it('should pass the theme to the Icons', () => {
+            const expectedTheme = Theme.dark;
+            const { listItems } = setup({ files, theme: expectedTheme }, false);
+            listItems.find('Icon').forEach((icon: Wrapper) => {
+                expect(icon).toHaveProp('theme', expectedTheme);
+            });
+        });
+
+        it('should pass the corresponding classNames to the Icons', () => {
+            const expectedClassName = ['test-1', 'test-2'];
+            const { listItems } = setup(
+                {
+                    files: [
+                        {
+                            icon: { icon: mdiFile, className: 'test-1' },
+                            url: 'https://sometest.url/path/to/file/test1.pdf',
+                        },
+                        {
+                            icon: { icon: mdiFile, className: 'test-2' },
+                            url: 'https://sometest.url/path/to/file/test2.pdf',
+                        },
+                    ],
+                },
+                false,
+            );
+            listItems.forEach((listItem: Wrapper, index: number) => {
+                expect(listItem.find('Icon')).toHaveClassName(expectedClassName[index]);
+            });
+        });
+
+        it('should display the files names correctly', () => {
+            const expectedFileNames = ['test.pdf', 'test2.pdf'];
+            const { listItems } = setup({
+                files: [
+                    { url: 'https://sometest.url/path/to/file/test.pdf' },
+                    { url: 'https://sometest.url/path/to/file/test2.pdf' },
+                ],
+            });
+            listItems.forEach((listItem: Wrapper, index: number) => {
+                expect(listItem.find('Link')).toHaveProp('children', expectedFileNames[index]);
+            });
+        });
+    });
+
+    /////////////////////////////
+
+    // 3. Test events.
+    describe('Events', () => {
+        it('should open the corresponding link in a new tab when you click on Thumbnail or Icon', () => {
+            const { listItems } = setup(
+                {
+                    files,
+                },
+                false,
+            );
+            window.open = jest.fn();
+            listItems.forEach((listItem: Wrapper, index: number) => {
+                const thumbnail = listItem.find('Thumbnail');
+                const beforeElement = thumbnail.exists() ? thumbnail : listItem.find('Icon');
+
+                if (beforeElement.exists()) {
+                    beforeElement.simulate('click');
+
+                    expect(window.open).toHaveBeenCalledWith(files[index].url, '_blank');
+                }
+            });
+        });
+    });
+    /////////////////////////////
+
+    // 4. Test conditions (i.e. things that display or not in the UI based on props).
+    describe('Conditions', () => {
+        it('should display Thumbnail if thumbnail is defined and Icon if not', () => {
+            const { wrapper } = setup({ files }, false);
+
+            expect(wrapper.find('Icon').length).toBe(2);
+            expect(wrapper.find('Thumbnail').length).toBe(1);
+        });
+    });
+
+    /////////////////////////////
+
+    // 5. Test state.
+    describe('State', () => {
+        // Nothing to do here.
+    });
+
+    /////////////////////////////
+
+    // Common tests suite.
+    commonTestsSuite(setup, {}, { className: CLASSNAME });
+});

--- a/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.tsx
@@ -1,0 +1,101 @@
+import { mdiFile } from '@lumx/icons';
+import { COMPONENT_PREFIX } from '@lumx/react/constants';
+import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import classNames from 'classnames';
+import React, { ReactElement, ReactNode } from 'react';
+import { AspectRatio, Size } from '..';
+import { Icon } from '../icon/Icon';
+import { List } from '../list/List';
+import { ListDivider } from '../list/ListDivider';
+import { ListItem } from '../list/ListItem';
+import { Thumbnail, ThumbnailVariant } from '../thumbnail/Thumbnail';
+
+/////////////////////////////
+
+/**
+ * Defines the props of the component.
+ */
+interface IBaseFileAttachmentMultipleProps extends IGenericProps {
+    /**
+     * FileAttachmentMultiple content.
+     */
+    children?: ReactNode;
+    files: Array<{
+        fileUrl?: string;
+
+        fileTitle?: string;
+
+        fileImage?: string;
+
+        fileIcon?: ReactElement;
+
+        fileDescription?: string;
+    }>;
+}
+
+/////////////////////////////
+//                         //
+//    Public attributes    //
+//                         //
+/////////////////////////////
+
+/**
+ * The display name of the component.
+ */
+const COMPONENT_NAME = `${COMPONENT_PREFIX}FileAttachmentMultiple`;
+
+/**
+ * The default class name and classes prefix for this component.
+ */
+const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
+
+/**
+ * The default value of props.
+ */
+const DEFAULT_PROPS: IBaseFileAttachmentMultipleProps = {
+    files: [],
+};
+
+const FileAttachmentMultiple: React.FC<IBaseFileAttachmentMultipleProps> = ({
+    className,
+    files,
+}: IBaseFileAttachmentMultipleProps): ReactElement => {
+    return (
+        <List isClickable className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}>
+            {files.map(({ fileImage, fileIcon = <Icon icon={mdiFile} size={Size.m} />, fileUrl }, index) => {
+                return (
+                    <>
+                        <ListItem
+                            before={
+                                fileImage ? (
+                                    <Thumbnail
+                                        size={Size.m}
+                                        variant={ThumbnailVariant.rounded}
+                                        aspectRatio={AspectRatio.square}
+                                        image={fileImage}
+                                    />
+                                ) : (
+                                    fileIcon
+                                )
+                            }
+                        >
+                            <p className={`${CLASSNAME}__link`}>{fileUrl?.substr(fileUrl.lastIndexOf('/') + 1)}</p>
+                        </ListItem>
+                        {index < files.length - 1 && (
+                            <ListDivider
+                                style={{
+                                    margin: '0px 16px',
+                                    marginLeft: '68px',
+                                }}
+                            />
+                        )}
+                    </>
+                );
+            })}
+        </List>
+    );
+};
+
+FileAttachmentMultiple.displayName = COMPONENT_NAME;
+
+export { CLASSNAME, DEFAULT_PROPS, FileAttachmentMultiple, IBaseFileAttachmentMultipleProps };

--- a/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.tsx
+++ b/packages/lumx-react/src/components/file-attachment/FileAttachmentMultiple.tsx
@@ -2,36 +2,32 @@ import { mdiFile } from '@lumx/icons';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { IGenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
-import React, { ReactElement, ReactNode } from 'react';
-import { AspectRatio, Size } from '..';
+import React, { Fragment, ReactElement, ReactNode } from 'react';
+import { AspectRatio, ColorPalette, ColorVariant, Size, Theme } from '..';
 import { Icon } from '../icon/Icon';
+import { Link } from '../link/Link';
 import { List } from '../list/List';
 import { ListDivider } from '../list/ListDivider';
 import { ListItem } from '../list/ListItem';
 import { Thumbnail, ThumbnailVariant } from '../thumbnail/Thumbnail';
+import { IFile } from './types';
 
 /////////////////////////////
 
 /**
  * Defines the props of the component.
  */
-interface IBaseFileAttachmentMultipleProps extends IGenericProps {
+interface IFileAttachmentMultipleProps extends IGenericProps {
+    /** Theme. */
+    theme: Theme;
     /**
      * FileAttachmentMultiple content.
      */
     children?: ReactNode;
-    files: Array<{
-        fileUrl?: string;
-
-        fileTitle?: string;
-
-        fileImage?: string;
-
-        fileIcon?: ReactElement;
-
-        fileDescription?: string;
-    }>;
+    /** Array of files you want to display. */
+    files: IFile[];
 }
+type FileAttachmentMultipleProps = IFileAttachmentMultipleProps;
 
 /////////////////////////////
 //                         //
@@ -52,44 +48,63 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: IBaseFileAttachmentMultipleProps = {
-    files: [],
+const DEFAULT_PROPS: Partial<FileAttachmentMultipleProps> = {
+    theme: Theme.light,
 };
 
-const FileAttachmentMultiple: React.FC<IBaseFileAttachmentMultipleProps> = ({
+const makeOnFileClick = (url?: string) => () => window.open(url, '_blank');
+
+const FileAttachmentMultiple: React.FC<FileAttachmentMultipleProps> = ({
     className,
     files,
-}: IBaseFileAttachmentMultipleProps): ReactElement => {
+    theme = DEFAULT_PROPS.theme,
+    ...props
+}) => {
     return (
-        <List isClickable className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}>
-            {files.map(({ fileImage, fileIcon = <Icon icon={mdiFile} size={Size.m} />, fileUrl }, index) => {
+        <List className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))} {...props}>
+            {files.map(({ thumbnail, icon = { icon: mdiFile }, url }, index) => {
                 return (
-                    <>
+                    <Fragment key={url}>
                         <ListItem
+                            className={`${CLASSNAME}__file`}
                             before={
-                                fileImage ? (
+                                thumbnail ? (
                                     <Thumbnail
-                                        size={Size.m}
+                                        role="link"
                                         variant={ThumbnailVariant.rounded}
+                                        onClick={makeOnFileClick(url)}
+                                        tabIndex={0}
+                                        {...thumbnail}
+                                        size={Size.m}
                                         aspectRatio={AspectRatio.square}
-                                        image={fileImage}
                                     />
                                 ) : (
-                                    fileIcon
+                                    <Icon
+                                        role="link"
+                                        icon={mdiFile}
+                                        color={theme === Theme.light ? ColorPalette.dark : ColorPalette.light}
+                                        theme={theme}
+                                        onClick={makeOnFileClick(url)}
+                                        tabIndex={0}
+                                        {...icon}
+                                        className={classNames(`${CLASSNAME}__file-icon`, icon.className)}
+                                        size={Size.m}
+                                    />
                                 )
                             }
                         >
-                            <p className={`${CLASSNAME}__link`}>{fileUrl?.substr(fileUrl.lastIndexOf('/') + 1)}</p>
+                            <Link
+                                className={`${CLASSNAME}__link`}
+                                href={url}
+                                target="_blank"
+                                color={theme === Theme.light ? ColorPalette.blue : ColorPalette.light}
+                                colorVariant={ColorVariant.N}
+                            >
+                                {url.substr(url.lastIndexOf('/') + 1)}
+                            </Link>
                         </ListItem>
-                        {index < files.length - 1 && (
-                            <ListDivider
-                                style={{
-                                    margin: '0px 16px',
-                                    marginLeft: '68px',
-                                }}
-                            />
-                        )}
-                    </>
+                        {index < files.length - 1 && <ListDivider className={`${CLASSNAME}__divider`} />}
+                    </Fragment>
                 );
             })}
         </List>
@@ -98,4 +113,4 @@ const FileAttachmentMultiple: React.FC<IBaseFileAttachmentMultipleProps> = ({
 
 FileAttachmentMultiple.displayName = COMPONENT_NAME;
 
-export { CLASSNAME, DEFAULT_PROPS, FileAttachmentMultiple, IBaseFileAttachmentMultipleProps };
+export { CLASSNAME, DEFAULT_PROPS, FileAttachmentMultiple, FileAttachmentMultipleProps };

--- a/packages/lumx-react/src/components/file-attachment/__snapshots__/FileAttachment.test.tsx.snap
+++ b/packages/lumx-react/src/components/file-attachment/__snapshots__/FileAttachment.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FileAttachment> Snapshots and structure should render correctly 1`] = `
+<div
+  className="lumx-file-attachment lumx-file-attachment--theme-light"
+>
+  <Icon
+    className="lumx-file-attachment__icon"
+    color="dark"
+    icon="M13,9V3.5L18.5,9M6,2C4.89,2 4,2.89 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6Z"
+    onClick={[Function]}
+    role="link"
+    size="l"
+    tabIndex={0}
+    theme="light"
+  />
+  <div
+    className="lumx-file-attachment__infos"
+  >
+    <Link
+      className="lumx-file-attachment__title"
+      color="dark"
+      colorVariant="N"
+      href=""
+    />
+    <p
+      className="lumx-file-attachment__description"
+    />
+    <Link
+      className="lumx-file-attachment__link"
+      color="blue"
+      colorVariant="N"
+      href=""
+    />
+  </div>
+</div>
+`;

--- a/packages/lumx-react/src/components/file-attachment/__snapshots__/FileAttachmentMultiple.test.tsx.snap
+++ b/packages/lumx-react/src/components/file-attachment/__snapshots__/FileAttachmentMultiple.test.tsx.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FileAttachmentMultiple> Snapshots and structure should render correctly 1`] = `
+<List
+  className="lumx-file-attachment-multiple lumx-file-attachment-multiple--theme-light"
+>
+  <ListItem
+    before={
+      <Thumbnail
+        aspectRatio="square"
+        image="https://loremflickr.com/320/240"
+        onClick={[Function]}
+        role="link"
+        size="m"
+        tabIndex={0}
+        variant="rounded"
+      />
+    }
+    className="lumx-file-attachment-multiple__file"
+  >
+    <Link
+      className="lumx-file-attachment-multiple__link"
+      color="blue"
+      colorVariant="N"
+      href="https://cdn.com/api/pdf/presentation-2020.pdf"
+      target="_blank"
+    >
+      presentation-2020.pdf
+    </Link>
+  </ListItem>
+  <ListDivider
+    className="lumx-file-attachment-multiple__divider"
+  />
+  <ListItem
+    before={
+      <Icon
+        className="lumx-file-attachment-multiple__file-icon"
+        color="dark"
+        icon="M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5C3.89,21 3,20.1 3,19V5C3,3.89 3.89,3 5,3H19M10.59,10.08C10.57,10.13 10.3,11.84 8.5,14.77C8.5,14.77 5,16.58 5.83,17.94C6.5,19 8.15,17.9 9.56,15.27C9.56,15.27 11.38,14.63 13.79,14.45C13.79,14.45 17.65,16.19 18.17,14.34C18.69,12.5 15.12,12.9 14.5,13.09C14.5,13.09 12.46,11.75 12,9.89C12,9.89 13.13,5.95 11.38,6C9.63,6.05 10.29,9.12 10.59,10.08M11.4,11.13C11.43,11.13 11.87,12.33 13.29,13.58C13.29,13.58 10.96,14.04 9.9,14.5C9.9,14.5 10.9,12.75 11.4,11.13M15.32,13.84C15.9,13.69 17.64,14 17.58,14.32C17.5,14.65 15.32,13.84 15.32,13.84M8.26,15.7C7.73,16.91 6.83,17.68 6.6,17.67C6.37,17.66 7.3,16.07 8.26,15.7M11.4,8.76C11.39,8.71 11.03,6.57 11.4,6.61C11.94,6.67 11.4,8.71 11.4,8.76Z"
+        onClick={[Function]}
+        role="link"
+        size="m"
+        tabIndex={0}
+        theme="light"
+      />
+    }
+    className="lumx-file-attachment-multiple__file"
+  >
+    <Link
+      className="lumx-file-attachment-multiple__link"
+      color="blue"
+      colorVariant="N"
+      href="https://cdn.com/api/pdf/presentation-2020-2.pdf"
+      target="_blank"
+    >
+      presentation-2020-2.pdf
+    </Link>
+  </ListItem>
+  <ListDivider
+    className="lumx-file-attachment-multiple__divider"
+  />
+  <ListItem
+    before={
+      <Icon
+        className="lumx-file-attachment-multiple__file-icon"
+        color="dark"
+        icon="M13,9V3.5L18.5,9M6,2C4.89,2 4,2.89 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2H6Z"
+        onClick={[Function]}
+        role="link"
+        size="m"
+        tabIndex={0}
+        theme="light"
+      />
+    }
+    className="lumx-file-attachment-multiple__file"
+  >
+    <Link
+      className="lumx-file-attachment-multiple__link"
+      color="blue"
+      colorVariant="N"
+      href="https://cdn.com/api/pdf/presentation-2020-3.pdf"
+      target="_blank"
+    >
+      presentation-2020-3.pdf
+    </Link>
+  </ListItem>
+</List>
+`;

--- a/packages/lumx-react/src/components/file-attachment/types.ts
+++ b/packages/lumx-react/src/components/file-attachment/types.ts
@@ -1,0 +1,15 @@
+import { IconProps, ThumbnailProps } from '@lumx/react';
+import { Omit } from '@lumx/react/utils';
+
+export interface IFile {
+    /** The file url. */
+    url: string;
+    /** The file title, displayed on top of the block. */
+    title?: string;
+    /** The file image preview. */
+    thumbnail?: Omit<ThumbnailProps, 'size' | 'aspectRatio'>;
+    /** The icon to display if no image is specified, displays a file Icon by default. */
+    icon?: Omit<IconProps, 'size' | 'hasShape'>;
+    /** The description of the file. */
+    description?: string;
+}

--- a/packages/lumx-react/src/components/icon/Icon.test.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.test.tsx
@@ -118,7 +118,7 @@ describe(`<${Icon.displayName}>`, () => {
                     expect(path).toHaveProp('d', modifiedProps[prop]);
                 } else {
                     expect(i).toHaveClassName(
-                        getBasicClass({ prefix: CLASSNAME, type: prop, value: modifiedProps[prop] }),
+                        getBasicClass({ prefix: CLASSNAME, type: prop, value: (modifiedProps as any)[prop] }),
                     );
                 }
             });

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -6,13 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import { Color, ColorPalette, ColorVariant, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import {
-    IGenericProps,
-    ValidateParameters,
-    getRootClassName,
-    handleBasicClasses,
-    validateComponent,
-} from '@lumx/react/utils';
+import { ValidateParameters, getRootClassName, handleBasicClasses, validateComponent } from '@lumx/react/utils';
 
 /////////////////////////////
 
@@ -21,7 +15,7 @@ type IconSizes = Size.xxs | Size.xs | Size.s | Size.m | Size.l | Size.xl | Size.
 /**
  * Defines the props of the component.
  */
-interface IIconProps extends IGenericProps {
+interface IIconProps extends HTMLAttributes<HTMLElement> {
     /**
      * The icon SVG path draw code (`d` property of the `<path>` SVG element).
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths}

--- a/packages/lumx-react/src/components/post-block/PostBlock.tsx
+++ b/packages/lumx-react/src/components/post-block/PostBlock.tsx
@@ -110,7 +110,7 @@ const PostBlock: React.FC<PostBlockProps> = ({
                         theme={theme}
                         onClick={onClick}
                         variant={ThumbnailVariant.rounded}
-                        tabIndex="0"
+                        tabIndex={0}
                     />
                 </div>
             )}

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { HTMLAttributes, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -8,7 +8,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
 import isFunction from 'lodash/isFunction';
 
-import { IGenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { Callback, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
 
 import useFocusedImage from './useFocusedImage';
 
@@ -57,7 +57,7 @@ enum ImageLoading {
 /**
  * Defines the props of the component.
  */
-interface IThumbnailProps extends IGenericProps {
+interface IThumbnailProps extends HTMLAttributes<HTMLDivElement> {
     /** The thumbnail alignment. */
     align?: Alignment;
     /** The image aspect ratio. */
@@ -74,7 +74,8 @@ interface IThumbnailProps extends IGenericProps {
     theme?: Theme;
     /** Variant. */
     variant?: ThumbnailVariant;
-
+    /** Alt of the img. */
+    alt?: string;
     /** Focal Point coordinates. */
     focusPoint?: IFocusPoint;
 }
@@ -135,7 +136,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     variant = DEFAULT_PROPS.variant,
     image,
     alt = 'Thumbnail',
-    onClick = null,
+    onClick,
     focusPoint = DEFAULT_PROPS.focusPoint,
     ...props
 }: ThumbnailProps): ReactElement => {
@@ -152,7 +153,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             )}
             tabIndex={isFunction(onClick) ? 0 : -1}
             onClick={onClick}
-            onKeyDown={onEnterPressed(onClick)}
+            onKeyDown={onClick ? onEnterPressed(onClick as Callback) : undefined}
             {...props}
         >
             {aspectRatio === AspectRatio.original ? (

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -30,6 +30,8 @@ export { Divider, DividerProps } from './components/divider/Divider';
 
 export { Dropdown, DropdownProps } from './components/dropdown/Dropdown';
 
+export { FileAttachment } from './components/file-attachment/FileAttachment';
+
 export { Icon, IconProps, IconSizes } from './components/icon/Icon';
 
 export { IconButton, IconButtonProps } from './components/button/IconButton';


### PR DESCRIPTION
# General summary
Add two components FileAttachment and FileAttachmentMultiple
<!-- Please describe the PR content -->

# Screenshots
FileAttachment : 
When the prop `thumbnail` is not defined, it displays an `Icon` the mdiFile icon is the default one.
![image](https://user-images.githubusercontent.com/10506209/75052232-897f3480-54cf-11ea-8331-24623e6d2d19.png)
When the prop `thumbnail` is defined, a `Thumbnail` is displayed.
![image](https://user-images.githubusercontent.com/10506209/75052373-ca774900-54cf-11ea-9230-948e3a45fb19.png)
The Thumbnail and Icon should be focusable and clickable.
![image](https://user-images.githubusercontent.com/10506209/75052520-090d0380-54d0-11ea-93ff-9f253b684a6a.png)

FileAttachmentMultiple : 
You can mix icons and thumbnails file attachment in you list.
![image](https://user-images.githubusercontent.com/10506209/75052455-ef6bbc00-54cf-11ea-8b8d-00e09df8317e.png)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
