### PR TITLE
Add ReactNode as an allowed type for SideNavigationItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   New component in React: `Mosaic`
 -   Added `size` prop to `WebBookmark` component
 
+### Changed
+
+- Added ReactNode as an allowed type for the label of the `SideNavigationItem` for typescript support
+
 ## [0.21.9][] - 2020-02-20
 
 ### Added

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -28,7 +28,7 @@ interface ISideNavigationItemProps extends IGenericProps {
     emphasis?: Emphasis;
 
     /** Menu item label. */
-    label: string;
+    label: string | ReactNode;
 
     /** Menu item icon (SVG path code). */
     icon?: string;


### PR DESCRIPTION
# General summary

Add ReactNode as an allowed type for SideNavigationItem to allow for component as labels.
This is only for typescript support to avoid hacky workarounds.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
