### PR TITLE
Add ReactNode as allowed type to Tab label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Rename `IInputHelperProps` as `InputHelperProps`
 -   _[BREAKING]_ Rename `IInputLabelProps` as `InputLabelProps`
 -   _[BREAKING]_ Rename `IFocusPoint` as `FocusPoint`
+- Added ReactNode as an allowed type for the label of the `Tab` component for typescript support
 
 ### Fixed
 

--- a/packages/lumx-react/src/components/tabs/Tab.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.tsx
@@ -1,4 +1,11 @@
-import React, { AnchorHTMLAttributes, KeyboardEventHandler, MouseEventHandler, SyntheticEvent } from 'react';
+import React, {
+    AnchorHTMLAttributes,
+    KeyboardEventHandler,
+    MouseEventHandler,
+    ReactElement,
+    ReactNode,
+    SyntheticEvent,
+} from 'react';
 
 import classNames from 'classnames';
 
@@ -19,7 +26,7 @@ interface TabProps extends GenericProps {
     /** Is tab disabled */
     isDisabled?: boolean;
     /** Tab label */
-    label?: string;
+    label?: string | ReactNode;
     /** Function to trigger on tab click */
     onTabClick?(e: { event: SyntheticEvent; index?: number }): void;
 }


### PR DESCRIPTION
# General summary

Add ReactNode as allowed type to Tab label
This is only for typescript support to avoid hacky workarounds.

# Check list

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
