### PR TITLE
fix(textfield-value): add the number as the value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Allow number type on `TextField` component value
+
 ## [0.21.12][] - 2020-03-16
 
 ### Fixed

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -1,5 +1,5 @@
 import { TextField } from '@lumx/react';
-import { text } from '@storybook/addon-knobs';
+import { number, text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React from 'react';
 
@@ -12,6 +12,16 @@ export default { title: 'LumX components/TextField' };
 export const simpleTextField = ({ theme }: any) => (
     <TextField
         value={text('Value', 'myvalue')}
+        label={text('Label', 'I am the label')}
+        placeholder={text('Placeholder', 'ex: A value')}
+        theme={theme}
+        onChange={noop}
+    />
+);
+
+export const simpleTextNumberField = ({ theme }: any) => (
+    <TextField
+        value={number('Value', 2)}
         label={text('Label', 'I am the label')}
         placeholder={text('Placeholder', 'ex: A value')}
         theme={theme}

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -26,6 +26,7 @@ export const simpleTextNumberField = ({ theme }: any) => (
         placeholder={text('Placeholder', 'ex: A value')}
         theme={theme}
         onChange={noop}
+        type="number"
     />
 );
 

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -145,6 +145,20 @@ describe(`<${TextField.displayName}>`, () => {
             });
         });
 
+        it('should have text as value', () => {
+            const value = 'test';
+            const { inputNative } = setup({ value });
+
+            expect(inputNative).toHaveValue(value);
+        });
+
+        it('should have no value', () => {
+            const value = undefined;
+            const { inputNative } = setup({ value });
+
+            expect(inputNative).toHaveValue(value);
+        });
+
         it('should have number as value', () => {
             const value = 2;
             const { inputNative } = setup({ value });

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -145,6 +145,13 @@ describe(`<${TextField.displayName}>`, () => {
             });
         });
 
+        it('should have number as value', () => {
+            const value = 2;
+            const { inputNative } = setup({ value });
+
+            expect(inputNative).toHaveValue(value);
+        });
+
         it('should have helper text', () => {
             const { helper } = setup({
                 helper: 'test',

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -77,7 +77,7 @@ interface TextFieldProps extends GenericProps {
     textFieldRef?: RefObject<HTMLDivElement>;
 
     /** Text field value change handler. */
-    onChange(value: any): void;
+    onChange(value: string): void;
 
     /** Text field focus change handler. */
     onFocus?(event: React.FocusEvent): void;
@@ -173,7 +173,7 @@ interface InputNativeProps {
     rows: number;
     setFocus(focus: boolean): void;
     recomputeNumberOfRows(event: React.ChangeEvent): void;
-    onChange(value: any): void;
+    onChange(value: string): void;
     onFocus?(value: React.FocusEvent): void;
     onBlur?(value: React.FocusEvent): void;
 }

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -71,13 +71,13 @@ interface TextFieldProps extends GenericProps {
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
 
     /** Text field value. */
-    value: string;
+    value: string | number;
 
     /** A ref that will be passed to the wrapper element. */
     textFieldRef?: RefObject<HTMLDivElement>;
 
     /** Text field value change handler. */
-    onChange(value: string): void;
+    onChange(value: any): void;
 
     /** Text field focus change handler. */
     onFocus?(event: React.FocusEvent): void;
@@ -169,11 +169,11 @@ interface InputNativeProps {
     multiline?: boolean;
     maxLength?: number;
     placeholder?: string;
-    value: string;
+    value: string | number;
     rows: number;
     setFocus(focus: boolean): void;
     recomputeNumberOfRows(event: React.ChangeEvent): void;
-    onChange(value: string): void;
+    onChange(value: string | number): void;
     onFocus?(value: React.FocusEvent): void;
     onBlur?(value: React.FocusEvent): void;
 }
@@ -289,7 +289,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
 
     const [isFocus, setFocus] = useState(false);
     const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(minimumRows);
-    const valueLength = (value && value.length) || 0;
+    const valueLength = (value && `${value}`.length) || 0;
     const isNotEmpty = valueLength > 0;
 
     /**

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -9,6 +9,8 @@ import { Emphasis, Icon, IconButton, InputHelper, InputLabel, Kind, Size, Theme 
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
+type TextFieldValue = string | number | undefined;
+
 /**
  * Defines the props of the component.
  */
@@ -71,7 +73,7 @@ interface TextFieldProps extends GenericProps {
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
 
     /** Text field value. */
-    value: string | number;
+    value: TextFieldValue;
 
     /** A ref that will be passed to the wrapper element. */
     textFieldRef?: RefObject<HTMLDivElement>;
@@ -169,11 +171,11 @@ interface InputNativeProps {
     multiline?: boolean;
     maxLength?: number;
     placeholder?: string;
-    value: string | number;
+    value: TextFieldValue;
     rows: number;
     setFocus(focus: boolean): void;
     recomputeNumberOfRows(event: React.ChangeEvent): void;
-    onChange(value: string | number): void;
+    onChange(value: TextFieldValue): void;
     onFocus?(value: React.FocusEvent): void;
     onBlur?(value: React.FocusEvent): void;
 }

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -9,8 +9,6 @@ import { Emphasis, Icon, IconButton, InputHelper, InputLabel, Kind, Size, Theme 
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
-type TextFieldValue = string | number | undefined;
-
 /**
  * Defines the props of the component.
  */
@@ -73,7 +71,7 @@ interface TextFieldProps extends GenericProps {
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
 
     /** Text field value. */
-    value: TextFieldValue;
+    value?: string | number;
 
     /** A ref that will be passed to the wrapper element. */
     textFieldRef?: RefObject<HTMLDivElement>;
@@ -171,11 +169,11 @@ interface InputNativeProps {
     multiline?: boolean;
     maxLength?: number;
     placeholder?: string;
-    value: TextFieldValue;
+    value?: string | number;
     rows: number;
     setFocus(focus: boolean): void;
     recomputeNumberOfRows(event: React.ChangeEvent): void;
-    onChange(value: TextFieldValue): void;
+    onChange(value: any): void;
     onFocus?(value: React.FocusEvent): void;
     onBlur?(value: React.FocusEvent): void;
 }


### PR DESCRIPTION
# General summary

The idea is to be able to handle number type in the TextField component

The onChange accept `any` as a type because it's more simple for the moment.
Maybe we can create a TextFieldValue type that will be string | number


# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
