### PR TITLE
fix(tooltip): rounding coordinates in integer for sharper display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed blurry Tooltip
+
 ## [0.21.14][] - 2020-03-27
 
 ### Added

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -160,7 +160,7 @@ const Tooltip: React.FC<TooltipProps> = ({
         () => ({
             display: isVisible ? 'block' : 'none',
             position: 'fixed',
-            transform: `translate3d(${computedPosition.x}px, ${computedPosition.y}px, 0)`,
+            transform: `translate3d(${Math.round(computedPosition.x)}px, ${Math.round(computedPosition.y)}px, 0)`,
         }),
         [isVisible, computedPosition],
     );


### PR DESCRIPTION
# General summary

Fix blurry Tooltip by rounding the coordinates to the nearest integers.