### PR TITLE
feat(side-navigation-item-link): add props to link in side nav item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `linkProps` prop to `SideNavigationItem` component
+
 ## [0.21.16][] - 2020-04-10
 
 ### Fixed

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
@@ -148,6 +148,16 @@ describe(`<${SideNavigationItem.displayName}>`, () => {
 
             expect(icon).toExist();
         });
+
+        it('should add props to link when provided', () => {
+            const { link } = setup({
+                linkProps: {
+                    href: '/',
+                },
+            });
+
+            expect(link.prop('href')).toEqual('/');
+        });
     });
 
     // 5. Test state => no state

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -39,6 +39,9 @@ interface SideNavigationItemProps extends GenericProps {
     /** Whether or not the menu is selected. */
     isSelected?: boolean;
 
+    /** props that will be passed on to the Link */
+    linkProps?: Record<string, string>;
+
     /** On click handler. */
     onClick?(evt: React.MouseEvent): void;
 }
@@ -72,6 +75,7 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
         isOpen = DEFAULT_PROPS.isOpen,
         isSelected = DEFAULT_PROPS.isSelected,
         onClick,
+        linkProps,
         ...otherProps
     } = props;
 
@@ -94,6 +98,7 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
                 tabIndex={0}
                 onClick={onClick}
                 onKeyDown={onClick ? onEnterPressed(onClick as Callback) : undefined}
+                {...(linkProps || {})}
             >
                 {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />}
                 <span>{label}</span>

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -40,7 +40,7 @@ interface SideNavigationItemProps extends GenericProps {
     isSelected?: boolean;
 
     /** props that will be passed on to the Link */
-    linkProps?: Record<string, string>;
+    linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
 
     /** On click handler. */
     onClick?(evt: React.MouseEvent): void;
@@ -94,11 +94,11 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
             {...otherProps}
         >
             <a
+                {...(linkProps || {})}
                 className={`${CLASSNAME}__link`}
                 tabIndex={0}
                 onClick={onClick}
                 onKeyDown={onClick ? onEnterPressed(onClick as Callback) : undefined}
-                {...(linkProps || {})}
             >
                 {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />}
                 <span>{label}</span>


### PR DESCRIPTION
# General summary
- Added a prop `linkProps` for the `SideNavigationItem` in order to provide additional props to the `a`, more importantly the `href` prop
- The prop was created in order to avoid confusions and mix up with the props related to the `li` on the top level, and differentiate where we want those props to go.
- For some reason I could not add a DEFAULT_PROP for this component, since tests were broken when I added to the `DEFAULT_PROPS` object a prop `linkProps: {}`. See photo in screenshots section

# Screenshots
<img width="916" alt="Screenshot 2020-04-03 at 10 55 51" src="https://user-images.githubusercontent.com/13719066/78342567-c6901980-7599-11ea-9496-342b1bca92d8.png">

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [X] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
