### PR TITLE
fix(infinite-scroll): trigger infinite when container is fully displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Trigger the infinite scroll callback on display if enough space with the `useInfiniteScroll` hook.
+
 ## [0.22.0][] - 2020-04-21
 
 ### Changed

--- a/packages/lumx-react/src/components/select/Select.stories.tsx
+++ b/packages/lumx-react/src/components/select/Select.stories.tsx
@@ -2,7 +2,7 @@ import { List, ListItem, Select, Size, TextField } from '@lumx/react';
 import { useBooleanState } from '@lumx/react/hooks';
 import { text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
-import React, { SyntheticEvent } from 'react';
+import React, { SyntheticEvent, useState } from 'react';
 import { SelectVariant } from './constants';
 
 export default { title: 'LumX components/Select' };
@@ -36,6 +36,57 @@ export const simpleSelect = ({ theme }: any) => {
             <List isClickable>
                 {CHOICES.length > 0
                     ? CHOICES.map((choice, index) => (
+                          <ListItem
+                              isSelected={value === choice}
+                              key={index}
+                              onItemSelected={selectItem(choice)}
+                              size={Size.tiny}
+                          >
+                              {choice}
+                          </ListItem>
+                      ))
+                    : [
+                          <ListItem key={0} size={Size.tiny}>
+                              No data
+                          </ListItem>,
+                      ]}
+            </List>
+        </Select>
+    );
+};
+
+export const simpleSelectWithInfiniteScroll = ({ theme }: any) => {
+    const PLACEHOLDER = 'Select a value';
+    const LABEL = 'Select label';
+    const [items, setItems] = useState(CHOICES);
+    const [value, setValue] = React.useState<string>('');
+    // tslint:disable-next-line:no-unused
+    const [isOpen, closeSelect, openSelect, toggleSelect] = useBooleanState(false);
+
+    const selectItem = (item: string) => () => {
+        closeSelect();
+        setValue(item);
+    };
+
+    const onInfinite = () => {
+        setItems([...items, `item ${items.length + 1}`]);
+    };
+
+    return (
+        <Select
+            style={{ width: '100%' }}
+            isOpen={isOpen}
+            value={value}
+            label={LABEL}
+            placeholder={PLACEHOLDER}
+            theme={theme}
+            onInputClick={toggleSelect}
+            onDropdownClose={closeSelect}
+            onInfiniteScroll={onInfinite}
+        >
+            <List isClickable>
+                {items.length > 0
+                    ? items.map((choice, index) => (
                           <ListItem
                               isSelected={value === choice}
                               key={index}

--- a/packages/lumx-react/src/hooks/useInfiniteScroll.tsx
+++ b/packages/lumx-react/src/hooks/useInfiniteScroll.tsx
@@ -6,13 +6,13 @@ type useInfiniteScrollType = (
     callbackOnMount?: boolean,
 ) => void;
 type EventCallback = (evt?: Event) => void;
-// CONSTANTS
 
 /**
  * Listen to clicks away from a given element and callback the passed in function.
  *
- * @param  ref              A reference to the element on which you want to listen scroll event.
- * @param  [callback]       A callback function to call when the bottom of the reference element is reached.
+ * @param  ref               A reference to the element on which you want to listen scroll event.
+ * @param  [callback]        A callback function to call when the bottom of the reference element is reached.
+ * @param  [callbackOnMount] A callback function to call when the component is mounted.
  */
 const useInfiniteScroll: useInfiniteScrollType = (
     ref: React.RefObject<HTMLElement>,
@@ -22,7 +22,7 @@ const useInfiniteScroll: useInfiniteScrollType = (
     const isAtBottom = (): boolean =>
         Boolean(ref.current && ref.current.scrollTop + ref.current.clientHeight >= ref.current.scrollHeight);
 
-    const onScroll: EventListener = (e?: Event) => {
+    const onScroll = (e?: Event): void => {
         if (isAtBottom() && callback) {
             callback(e);
         }
@@ -33,6 +33,11 @@ const useInfiniteScroll: useInfiniteScrollType = (
             ref.current.addEventListener('scroll', onScroll);
             ref.current.addEventListener('resize', onScroll);
         }
+
+        if (isAtBottom()) {
+            onScroll();
+        }
+
         return () => {
             if (ref.current) {
                 ref.current.removeEventListener('scroll', onScroll);


### PR DESCRIPTION
# General summary
For autocompletes and select with infinite scroll, when there is enough place on screen to display the first batch of results, making the container unscrollable, it becomes impossible to trigger the infinite scroll.
The fix : When the container is displayed we check if the last item is visible, if so, we call the infinite scroll callback. 

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
