### PR TITLE
DatePicker and DPField accept a Date object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   The `<DatePicker />` and `<DatePickerFields />` components now accept a javascript Date object as value.
+-   The `DatePicker` and `DatePickerFields` components now accept a javascript Date object or string as value.
 
 ## [0.22.0][] - 2020-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `type="button"` to `TextField` "clear" button when `isClearable` is `true` to avoid clearing field when user tries to submit a form.
 -   Moved `useFocusedImage` to `hooks` folder.
 
+### Changed
+
+-   The `<DatePicker />` and `<DatePickerFields />` components now accept a javascript Date object as value.
+
 ## [0.22.0][] - 2020-04-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering
 
+### Changed
+
+-   The `DatePicker` and `DatePickerFields` components now accept a javascript Date object or string as value.
+
 ## [0.23.0][] - 2020-05-29
 
 ### Added
@@ -33,10 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Fixed prop Interfaces of `Autocomplete` and `Dropdown` by changing `onInfinite` to `onInfiniteScroll`.
 -   Added `type="button"` to `TextField` "clear" button when `isClearable` is `true` to avoid clearing field when user tries to submit a form.
 -   Moved `useFocusedImage` to `hooks` folder.
-
-### Changed
-
--   The `DatePicker` and `DatePickerFields` components now accept a javascript Date object or string as value.
 
 ## [0.22.0][] - 2020-04-21
 

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -70,6 +70,9 @@ const DatePicker = (props: DatePickerProps) => {
     else if (defaultMonth) {
         castedValue = moment(defaultMonth);
     }
+    if (castedValue && !castedValue.isValid()) {
+        console.warn(`[@lumx/react/DatePicker] Invalid date provided ${castedValue}`)
+    }
     const today = castedValue && castedValue.isValid() ? castedValue : moment();
 
     const [monthOffset, setMonthOffset] = useState(0);

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -62,7 +62,16 @@ const DEFAULT_PROPS: Partial<DatePickerProps> = {
  * @return The component.
  */
 const DatePicker = (props: DatePickerProps) => {
-    const today = moment(props.value);
+    let castedValue;
+    const { value, defaultMonth } = props
+    if (value) {
+        castedValue = moment(value);
+    }
+    else if (defaultMonth) {
+        castedValue = moment(defaultMonth);
+    }
+    const today = castedValue && castedValue.isValid() ? castedValue : moment();
+
     const [monthOffset, setMonthOffset] = useState(0);
 
     const setPrevMonth = () => setMonthOffset(monthOffset - 1);

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -27,7 +27,7 @@ interface DatePickerProps extends GenericProps {
     todayOrSelectedDateRef?: RefObject<HTMLButtonElement>;
 
     /** Value. */
-    value: moment.Moment | undefined;
+    value: Date | moment.Moment | undefined;
 
     /** Month to display by default */
     defaultMonth?: moment.Moment;
@@ -61,7 +61,7 @@ const DEFAULT_PROPS: Partial<DatePickerProps> = {
  * @return The component.
  */
 const DatePicker = (props: DatePickerProps) => {
-    const today = props.value || props.defaultMonth || moment();
+    const today = moment(props.value);
     const [monthOffset, setMonthOffset] = useState(0);
 
     const setPrevMonth = () => setMonthOffset(monthOffset - 1);

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -31,7 +31,7 @@ interface DatePickerProps extends GenericProps {
     value: DatePickerValueProp;
 
     /** Month to display by default */
-    defaultMonth?: moment.Moment;
+    defaultMonth?: DatePickerValueProp;
 
     /** On change. */
     onChange(value: moment.Moment | undefined): void;
@@ -63,15 +63,14 @@ const DEFAULT_PROPS: Partial<DatePickerProps> = {
  */
 const DatePicker = (props: DatePickerProps) => {
     let castedValue;
-    const { value, defaultMonth } = props
+    const { value, defaultMonth } = props;
     if (value) {
         castedValue = moment(value);
-    }
-    else if (defaultMonth) {
+    } else if (defaultMonth) {
         castedValue = moment(defaultMonth);
     }
     if (castedValue && !castedValue.isValid()) {
-        console.warn(`[@lumx/react/DatePicker] Invalid date provided ${castedValue}`)
+        console.warn(`[@lumx/react/DatePicker] Invalid date provided ${castedValue}`);
     }
     const today = castedValue && castedValue.isValid() ? castedValue : moment();
 

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -8,6 +8,7 @@ import { GenericProps } from '@lumx/react/utils';
 import { getRootClassName } from '../../utils/getRootClassName';
 
 import { DatePickerControlled } from './DatePickerControlled';
+import DatePickerValueProp from './DatePickerValueProp';
 
 /**
  * Defines the props of the component.
@@ -27,7 +28,7 @@ interface DatePickerProps extends GenericProps {
     todayOrSelectedDateRef?: RefObject<HTMLButtonElement>;
 
     /** Value. */
-    value: Date | moment.Moment | undefined;
+    value: DatePickerValueProp;
 
     /** Month to display by default */
     defaultMonth?: moment.Moment;

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
@@ -83,3 +83,33 @@ export const withDateObject = ({ theme }: any) => {
         />
     );
 };
+
+export const withCompatibleString = ({ theme }: any) => {
+    const [value, setValue] = React.useState<DatePickerProps['value']>('2020-05-22');
+
+    return (
+        <DatePickerField
+            locale="fr"
+            label="Start date"
+            placeholder="Pick a date"
+            theme={theme}
+            onChange={setValue}
+            value={value}
+        />
+    );
+};
+
+export const withIncompatibleString = ({ theme }: any) => {
+    const [value, setValue] = React.useState<DatePickerProps['value']>('not a real date');
+
+    return (
+        <DatePickerField
+            locale="fr"
+            label="Start date"
+            placeholder="Pick a date"
+            theme={theme}
+            onChange={setValue}
+            value={value}
+        />
+    );
+};

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
@@ -68,3 +68,18 @@ export const customMonth = ({ theme }: any) => {
         />
     );
 };
+
+export const withDateObject = ({ theme }: any) => {
+    const [value, setValue] = React.useState<DatePickerProps['value']>(new Date('2020-05-18'));
+
+    return (
+        <DatePickerField
+            locale="fr"
+            label="Start date"
+            placeholder="Pick a date"
+            theme={theme}
+            onChange={setValue}
+            value={value}
+        />
+    );
+};

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
@@ -75,30 +75,6 @@ describe(`<${DatePickerField.displayName}>`, () => {
             const { wrapper } = setup({ value: 'not a real date' });
             expect(wrapper).toMatchSnapshot();
         });
-        it('should render correctly when passed a date object', () => {
-            const { wrapper } = setup({ value: new Date('January 18, 1970') });
-            expect(wrapper).toMatchSnapshot();
-        });
-        it('should render correctly when passed a compatible string', () => {
-            const { wrapper } = setup({ value: '1970-01-18' });
-            expect(wrapper).toMatchSnapshot();
-        });
-        it('should render without selected date when passed a invalid string', () => {
-            const { wrapper } = setup({ value: 'not a real date' });
-            expect(wrapper).toMatchSnapshot();
-        });
-        it('should render correctly when passed a date object', () => {
-            const { wrapper } = setup({ value: new Date('January 18, 1970') });
-            expect(wrapper).toMatchSnapshot();
-        });
-        it('should render correctly when passed a compatible string', () => {
-            const { wrapper } = setup({ value: '1970-01-18' });
-            expect(wrapper).toMatchSnapshot();
-        });
-        it('should render without selected date when passed a invalid string', () => {
-            const { wrapper } = setup({ value: 'not a real date' });
-            expect(wrapper).toMatchSnapshot();
-        });
     });
 
     // 2. Test defaultProps value and important props custom values.

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
@@ -27,6 +27,7 @@ type SetupProps = Partial<DatePickerFieldProps>;
  */
 interface Setup extends CommonSetup {
     props: SetupProps;
+    withDateObjectWrapper: Wrapper;
 }
 
 /**
@@ -49,10 +50,14 @@ const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean
     const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<DatePickerField {...props} />);
+    const withDateObjectWrapper: Wrapper = renderer(
+        <DatePickerField {...props} value={new Date('January 18, 1970')} />,
+    );
 
     return {
         props,
         wrapper,
+        withDateObjectWrapper,
     };
 };
 
@@ -60,8 +65,9 @@ describe(`<${DatePickerField.displayName}>`, () => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', () => {
         it('should render correctly', () => {
-            const { wrapper } = setup();
+            const { wrapper, withDateObjectWrapper } = setup();
             expect(wrapper).toMatchSnapshot();
+            expect(withDateObjectWrapper).toMatchSnapshot();
         });
     });
 

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
@@ -75,6 +75,30 @@ describe(`<${DatePickerField.displayName}>`, () => {
             const { wrapper } = setup({ value: 'not a real date' });
             expect(wrapper).toMatchSnapshot();
         });
+        it('should render correctly when passed a date object', () => {
+            const { wrapper } = setup({ value: new Date('January 18, 1970') });
+            expect(wrapper).toMatchSnapshot();
+        });
+        it('should render correctly when passed a compatible string', () => {
+            const { wrapper } = setup({ value: '1970-01-18' });
+            expect(wrapper).toMatchSnapshot();
+        });
+        it('should render without selected date when passed a invalid string', () => {
+            const { wrapper } = setup({ value: 'not a real date' });
+            expect(wrapper).toMatchSnapshot();
+        });
+        it('should render correctly when passed a date object', () => {
+            const { wrapper } = setup({ value: new Date('January 18, 1970') });
+            expect(wrapper).toMatchSnapshot();
+        });
+        it('should render correctly when passed a compatible string', () => {
+            const { wrapper } = setup({ value: '1970-01-18' });
+            expect(wrapper).toMatchSnapshot();
+        });
+        it('should render without selected date when passed a invalid string', () => {
+            const { wrapper } = setup({ value: 'not a real date' });
+            expect(wrapper).toMatchSnapshot();
+        });
     });
 
     // 2. Test defaultProps value and important props custom values.

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
@@ -27,7 +27,6 @@ type SetupProps = Partial<DatePickerFieldProps>;
  */
 interface Setup extends CommonSetup {
     props: SetupProps;
-    withDateObjectWrapper: Wrapper;
 }
 
 /**
@@ -50,14 +49,10 @@ const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean
     const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
 
     const wrapper: Wrapper = renderer(<DatePickerField {...props} />);
-    const withDateObjectWrapper: Wrapper = renderer(
-        <DatePickerField {...props} value={new Date('January 18, 1970')} />,
-    );
 
     return {
         props,
         wrapper,
-        withDateObjectWrapper,
     };
 };
 
@@ -65,9 +60,20 @@ describe(`<${DatePickerField.displayName}>`, () => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', () => {
         it('should render correctly', () => {
-            const { wrapper, withDateObjectWrapper } = setup();
+            const { wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
-            expect(withDateObjectWrapper).toMatchSnapshot();
+        });
+        it('should render correctly when passed a date object', () => {
+            const { wrapper } = setup({ value: new Date('January 18, 1970') });
+            expect(wrapper).toMatchSnapshot();
+        });
+        it('should render correctly when passed a compatible string', () => {
+            const { wrapper } = setup({ value: '1970-01-18' });
+            expect(wrapper).toMatchSnapshot();
+        });
+        it('should render without selected date when passed a invalid string', () => {
+            const { wrapper } = setup({ value: 'not a real date' });
+            expect(wrapper).toMatchSnapshot();
         });
     });
 

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { ENTER_KEY_CODE, SPACE_KEY_CODE } from '@lumx/react/constants';
 import { CLASSNAME, DatePicker } from './DatePicker';
+import DatePickerValueProp from './DatePickerValueProp';
 
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { GenericProps } from '@lumx/react/utils';
@@ -28,7 +29,7 @@ interface DatePickerFieldProps extends GenericProps {
     minDate?: Date;
 
     /** Value. */
-    value: Date | moment.Moment | undefined;
+    value: DatePickerValueProp;
 
     /** Month to display by default */
     defaultMonth?: moment.Moment;

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -128,12 +128,13 @@ const DatePickerField = ({
         closeSimpleMenu();
     };
 
+    const castedValue = value && moment(value).isValid() ? moment(value) : undefined
     return (
         <>
             <TextField
                 forceFocusStyle={isOpen}
                 textFieldRef={anchorRef}
-                value={value ? moment(value).format('LL') : ''}
+                value={castedValue ? castedValue.format('LL') : ''}
                 onClick={toggleSimpleMenu}
                 onChange={onTextFieldChange}
                 onKeyPress={handleKeyboardNav}
@@ -158,7 +159,7 @@ const DatePickerField = ({
                             locale={locale}
                             maxDate={maxDate}
                             minDate={minDate}
-                            value={value}
+                            value={castedValue}
                             onChange={onDatePickerChange}
                             todayOrSelectedDateRef={todayOrSelectedDateRef}
                             defaultMonth={defaultMonth}

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -32,7 +32,7 @@ interface DatePickerFieldProps extends GenericProps {
     value: DatePickerValueProp;
 
     /** Month to display by default */
-    defaultMonth?: moment.Moment;
+    defaultMonth?: DatePickerValueProp;
 
     /** On change. */
     onChange(value: moment.Moment | undefined): void;
@@ -129,6 +129,7 @@ const DatePickerField = ({
     };
 
     const castedValue = value && moment(value).isValid() ? moment(value) : undefined
+    const castedDefaultMonth = defaultMonth && moment(defaultMonth).isValid() ? moment(defaultMonth) : undefined
     return (
         <>
             <TextField
@@ -162,7 +163,7 @@ const DatePickerField = ({
                             value={castedValue}
                             onChange={onDatePickerChange}
                             todayOrSelectedDateRef={todayOrSelectedDateRef}
-                            defaultMonth={defaultMonth}
+                            defaultMonth={castedDefaultMonth}
                         />
                     </div>
                 </Popover>

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -28,7 +28,7 @@ interface DatePickerFieldProps extends GenericProps {
     minDate?: Date;
 
     /** Value. */
-    value: moment.Moment | undefined;
+    value: Date | moment.Moment | undefined;
 
     /** Month to display by default */
     defaultMonth?: moment.Moment;
@@ -132,7 +132,7 @@ const DatePickerField = ({
             <TextField
                 forceFocusStyle={isOpen}
                 textFieldRef={anchorRef}
-                value={value ? value.format('LL') : ''}
+                value={value ? moment(value).format('LL') : ''}
                 onClick={toggleSimpleMenu}
                 onChange={onTextFieldChange}
                 onKeyPress={handleKeyboardNav}

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -130,6 +130,9 @@ const DatePickerField = ({
 
     const castedValue = value && moment(value).isValid() ? moment(value) : undefined
     const castedDefaultMonth = defaultMonth && moment(defaultMonth).isValid() ? moment(defaultMonth) : undefined
+    if ((value && !moment(value).isValid()) || (defaultMonth && !moment(defaultMonth).isValid())) {
+        console.warn(`[@lumx/react/DatePickerField] Invalid date provided '${value}'`)
+    }
     return (
         <>
             <TextField

--- a/packages/lumx-react/src/components/date-picker/DatePickerValueProp.ts
+++ b/packages/lumx-react/src/components/date-picker/DatePickerValueProp.ts
@@ -1,0 +1,5 @@
+import moment from 'moment';
+
+type DatePickerValueProp = Date | moment.Moment | string | undefined;
+
+export default DatePickerValueProp;

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`<DatePickerField> Snapshots and structure should render correctly 1`] =
 </Fragment>
 `;
 
-exports[`<DatePickerField> Snapshots and structure should render correctly 2`] = `
+exports[`<DatePickerField> Snapshots and structure should render correctly when passed a compatible string 1`] = `
 <Fragment>
   <TextField
     forceFocusStyle={false}
@@ -34,6 +34,44 @@ exports[`<DatePickerField> Snapshots and structure should render correctly 2`] =
       }
     }
     value="January 18, 1970"
+  />
+</Fragment>
+`;
+
+exports[`<DatePickerField> Snapshots and structure should render correctly when passed a date object 1`] = `
+<Fragment>
+  <TextField
+    forceFocusStyle={false}
+    label="DatePickerField"
+    onChange={[Function]}
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    readOnly={true}
+    textFieldRef={
+      Object {
+        "current": null,
+      }
+    }
+    value="January 18, 1970"
+  />
+</Fragment>
+`;
+
+exports[`<DatePickerField> Snapshots and structure should render without selected date when passed a invalid string 1`] = `
+<Fragment>
+  <TextField
+    forceFocusStyle={false}
+    label="DatePickerField"
+    onChange={[Function]}
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    readOnly={true}
+    textFieldRef={
+      Object {
+        "current": null,
+      }
+    }
+    value=""
   />
 </Fragment>
 `;

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
@@ -18,3 +18,22 @@ exports[`<DatePickerField> Snapshots and structure should render correctly 1`] =
   />
 </Fragment>
 `;
+
+exports[`<DatePickerField> Snapshots and structure should render correctly 2`] = `
+<Fragment>
+  <TextField
+    forceFocusStyle={false}
+    label="DatePickerField"
+    onChange={[Function]}
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    readOnly={true}
+    textFieldRef={
+      Object {
+        "current": null,
+      }
+    }
+    value="January 18, 1970"
+  />
+</Fragment>
+`;


### PR DESCRIPTION
# General summary

Allow `<DatePicker />` and `<DatePickerField />` to accept a javascript Date object as property.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
