### PR TITLE
feat(thumbnail): Img props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added optional `defaultMonth` prop to components `DatePickerField` and `DatePicker`.
+-   Added optional `imgProps` prop to component `Thumbnail`
 
 ### Changed
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -49,3 +49,44 @@ export const defaultThumbnail = ({ theme }: { theme: Theme }) => {
         />
     );
 };
+
+export const defaultThumbnailWithCustomImgProps = ({ theme }: { theme: Theme }) => {
+    const [image, setImage] = React.useState('https://not-found');
+    const onError = () => {
+        setImage('https://i.picsum.photos/id/1001/2400/1400.jpg');
+    };
+
+    return (
+        <Thumbnail
+            align={select<Alignment>('Alignment', Alignment, Alignment.left, 'Options')}
+            aspectRatio={select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Options')}
+            isCrossOriginEnabled={boolean('Enable CORS', true, 'Options')}
+            crossOrigin={select('CORS', CrossOrigin, CrossOrigin.anonymous, 'Options')}
+            fillHeight={boolean('Fill Height', false, 'Options')}
+            focusPoint={{
+                x: number('focusX', 0, numberKnobOtions, 'Options'),
+                y: number('focusY', 0, numberKnobOtions, 'Options'),
+            }}
+            image={image}
+            size={select(
+                'Size',
+                {
+                    XXS: Size.xxs,
+                    XS: Size.xs,
+                    S: Size.s,
+                    M: Size.m,
+                    L: Size.l,
+                    XL: Size.xl,
+                    XXL: Size.xxl,
+                },
+                Size.xxl,
+                'Options',
+            )}
+            theme={theme}
+            isFollowingWindowSize={boolean('Update on window resize', true, 'Options')}
+            resizeDebounceTime={number('Debounce time after resize', 20, undefined, 'Options')}
+            variant={select<ThumbnailVariant>('Variant', ThumbnailVariant, ThumbnailVariant.squared, 'Options')}
+            imgProps={{ onError }}
+        />
+    );
+};

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -180,23 +180,23 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
         >
             {aspectRatio === AspectRatio.original ? (
                 <img
+                    {...(imgProps || {})}
                     ref={focusImageRef}
                     className={`${CLASSNAME}__image`}
                     src={image}
                     alt={alt}
                     loading={loading}
-                    {...(imgProps || {})}
                 />
             ) : (
                 <div className={`${CLASSNAME}__background`}>
                     <img
+                        {...(imgProps || {})}
                         ref={focusImageRef}
                         className={`${CLASSNAME}__focused-image`}
                         crossOrigin={setCrossOrigin()}
                         src={image}
                         alt={alt}
                         loading={loading}
-                        {...(imgProps || {})}
                     />
                 </div>
             )}

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -95,6 +95,7 @@ interface ThumbnailProps extends GenericProps {
     isFollowingWindowSize?: boolean;
     /** Time before recalculating focal point if isFollowingWindowSize is activated */
     resizeDebounceTime?: number;
+    /** props that will be passed directly to the `img` tag */
     imgProps?: ImgHTMLAttributes<HTMLImageElement>;
 }
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -130,7 +130,6 @@ const DEFAULT_PROPS: DefaultPropsType = {
     variant: ThumbnailVariant.squared,
     debounceTime: 20,
     isFollowingWindowSize: true,
-    imgProps: {},
 };
 
 /**
@@ -156,7 +155,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     alt = 'Thumbnail',
     onClick = null,
     focusPoint = DEFAULT_PROPS.focusPoint,
-    imgProps = DEFAULT_PROPS.imgProps,
+    imgProps,
     ...props
 }: ThumbnailProps): ReactElement => {
     const focusImageRef = useFocusedImage(focusPoint!, aspectRatio!, size!, debounceTime!, isFollowingWindowSize!);
@@ -186,7 +185,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
                     src={image}
                     alt={alt}
                     loading={loading}
-                    {...imgProps}
+                    {...(imgProps || {})}
                 />
             ) : (
                 <div className={`${CLASSNAME}__background`}>
@@ -197,7 +196,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
                         src={image}
                         alt={alt}
                         loading={loading}
-                        {...imgProps}
+                        {...(imgProps || {})}
                     />
                 </div>
             )}

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ImgHTMLAttributes, ReactElement } from 'react';
 
 import classNames from 'classnames';
 
@@ -95,6 +95,7 @@ interface ThumbnailProps extends GenericProps {
     isFollowingWindowSize?: boolean;
     /** Time before recalculating focal point if isFollowingWindowSize is activated */
     resizeDebounceTime?: number;
+    imgProps?: ImgHTMLAttributes<HTMLImageElement>;
 }
 
 /**
@@ -128,6 +129,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
     variant: ThumbnailVariant.squared,
     debounceTime: 20,
     isFollowingWindowSize: true,
+    imgProps: {},
 };
 
 /**
@@ -153,6 +155,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     alt = 'Thumbnail',
     onClick = null,
     focusPoint = DEFAULT_PROPS.focusPoint,
+    imgProps = DEFAULT_PROPS.imgProps,
     ...props
 }: ThumbnailProps): ReactElement => {
     const focusImageRef = useFocusedImage(focusPoint!, aspectRatio!, size!, debounceTime!, isFollowingWindowSize!);
@@ -176,7 +179,14 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             {...props}
         >
             {aspectRatio === AspectRatio.original ? (
-                <img ref={focusImageRef} className={`${CLASSNAME}__image`} src={image} alt={alt} loading={loading} />
+                <img
+                    ref={focusImageRef}
+                    className={`${CLASSNAME}__image`}
+                    src={image}
+                    alt={alt}
+                    loading={loading}
+                    {...imgProps}
+                />
             ) : (
                 <div className={`${CLASSNAME}__background`}>
                     <img
@@ -186,6 +196,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
                         src={image}
                         alt={alt}
                         loading={loading}
+                        {...imgProps}
                     />
                 </div>
             )}


### PR DESCRIPTION
# General summary
- From the new Search UI, we want to add fallbacks to our images, since we have several scenarios where the images that we show are broken/not found.
- Therefore, we want to add a prop to Thumbnail that passes additional attributes to the `img` tag, so we can add, for example, an `onError`.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
