### PR TITLE
fix(textfield): put chips after icon

### DIFF
--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.stories.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 
 import { AutocompleteMultiple, Chip, ChipGroup, Icon, List, ListItem, Size } from '@lumx/react';
 
-import { mdiClose } from '@lumx/icons';
+import { mdiClose, mdiFlag } from '@lumx/icons';
 
 export default { title: 'LumX components/Autocomplete Multiple' };
 
@@ -148,6 +148,7 @@ export const simple = ({ theme }: any) => {
             fitToAnchorWidth={true}
             onBlur={onBlur}
             selectedChipRender={renderChip}
+            icon={mdiFlag}
         >
             <List isClickable theme={theme}>
                 {filteredCities.map((city, index) => {

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -345,8 +345,6 @@ const TextField: React.FC<TextFieldProps> = (props) => {
             )}
 
             <div className={`${CLASSNAME}__wrapper`} ref={textFieldRef}>
-                {chips && <div className={`${CLASSNAME}__chips`}>{chips}</div>}
-
                 {icon && (
                     <Icon
                         className={`${CLASSNAME}__input-icon`}
@@ -355,6 +353,8 @@ const TextField: React.FC<TextFieldProps> = (props) => {
                         size={Size.xs}
                     />
                 )}
+
+                {chips && <div className={`${CLASSNAME}__chips`}>{chips}</div>}
 
                 <div className={`${CLASSNAME}__input-wrapper`}>
                     <div className={`${CLASSNAME}__input-native`}>


### PR DESCRIPTION
# General summary

In autocomplete, chips were put before the right icon.

# Screenshots

![Peek 11-05-2020 14-09](https://user-images.githubusercontent.com/2828353/81560289-63ac5200-9391-11ea-90eb-c51792f047fc.gif)
![Peek 11-05-2020 14-10](https://user-images.githubusercontent.com/2828353/81560291-64dd7f00-9391-11ea-9f81-217b00da96d2.gif)


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
