### PR TITLE
fix(mosaic): fix thumbnails showing as clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Trigger the infinite scroll callback on display if enough space with the `useInfiniteScroll` hook.
 -   Fixed chips taking place before icons in `TextField` component.
+-   Fixed `Mosaic` thumbnails showing as clickable even though `onClick` wasn't defined.
 
 ## [0.22.0][] - 2020-04-21
 

--- a/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
@@ -63,9 +63,28 @@ export const fourThumbnails = ({ theme }: any) => {
     );
 };
 
+export const clickableThumbnails = ({ theme }: any) => {
+    const wrapperStyle = { width: 250 };
+    const onClick = (index: number) => alert(`Clicked n°${index}`);
+
+    return (
+        <div style={wrapperStyle}>
+            <Mosaic
+                theme={theme}
+                thumbnails={[
+                    { url: 'https://picsum.photos/200', onClick },
+                    { url: 'https://picsum.photos/210', onClick },
+                    { url: 'https://picsum.photos/220', onClick },
+                    { url: 'https://picsum.photos/230', onClick },
+                ]}
+            />
+        </div>
+    );
+};
+
 export const sixThumbnails = ({ theme }: any) => {
     const wrapperStyle = { width: 250 };
-    const [activeIndex, setActiveIndex] = useState();
+    const [activeIndex, setActiveIndex] = useState<number>();
     const lightBoxParent = useRef(null);
     const thumbnails = [
         { onClick: setActiveIndex, url: 'https://picsum.photos/640/480/?image=24' },
@@ -76,7 +95,7 @@ export const sixThumbnails = ({ theme }: any) => {
         { onClick: setActiveIndex, url: 'https://picsum.photos/640/480/?image=29' },
     ];
     const closeLightBox = useCallback(() => {
-        setActiveIndex(null);
+        setActiveIndex(0);
     }, [setActiveIndex]);
 
     return (

--- a/packages/lumx-react/src/components/mosaic/Mosaic.test.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.test.tsx
@@ -87,6 +87,27 @@ describe(`<${Mosaic.displayName}>`, () => {
                 expect(thumbnail.prop('theme')).toBe(expectedTheme);
             });
         });
+
+        it('should only set tabIndex at 0 if thumbnail has onClick', () => {
+            const expectedTheme = Theme.dark;
+            const onClick = jest.fn();
+            const { thumbnails } = setup({
+                theme: expectedTheme,
+                thumbnails: [
+                    { url: 'https://picsum.photos/200' },
+                    { url: 'https://picsum.photos/210', onClick },
+                    { url: 'https://picsum.photos/220' },
+                    { url: 'https://picsum.photos/230', onClick },
+                ],
+            });
+            thumbnails.forEach((thumbnail: Wrapper, index: number) => {
+                if (index === 1 || index === 3) {
+                    expect(thumbnail.prop('tabIndex')).toBe('0');
+                } else {
+                    expect(thumbnail.prop('tabIndex')).toBeUndefined();
+                }
+            });
+        });
     });
 
     // 3. Test events.

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -58,7 +58,7 @@ const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme,
                 return (
                     <div key={index} className={`${CLASSNAME}__thumbnail`}>
                         <Thumbnail
-                            tabIndex="0"
+                            tabIndex={thumbnail.onClick && '0'}
                             onClick={handleClick}
                             aspectRatio={AspectRatio.free}
                             fillHeight

--- a/packages/lumx-react/src/components/mosaic/__snapshots__/Mosaic.test.tsx.snap
+++ b/packages/lumx-react/src/components/mosaic/__snapshots__/Mosaic.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`] = `
+exports[`<Mosaic> Snapshots and structure should render story clickableThumbnails 1`] = `
 <div
   className="lumx-mosaic lumx-mosaic--theme-light lumx-mosaic--has-4-thumbnails"
 >
@@ -63,6 +63,65 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
 </div>
 `;
 
+exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`] = `
+<div
+  className="lumx-mosaic lumx-mosaic--theme-light lumx-mosaic--has-4-thumbnails"
+>
+  <div
+    className="lumx-mosaic__wrapper"
+  >
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="0"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/200"
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="1"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/210"
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="2"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/220"
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="3"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/230"
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Mosaic> Snapshots and structure should render story oneThumbnail 1`] = `
 <div
   className="lumx-mosaic lumx-mosaic--theme-light"
@@ -79,7 +138,6 @@ exports[`<Mosaic> Snapshots and structure should render story oneThumbnail 1`] =
         fillHeight={true}
         image="https://picsum.photos/200"
         onClick={[Function]}
-        tabIndex="0"
         theme="light"
       />
     </div>
@@ -174,7 +232,6 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
         fillHeight={true}
         image="https://picsum.photos/200"
         onClick={[Function]}
-        tabIndex="0"
         theme="light"
       />
     </div>
@@ -187,7 +244,6 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
         fillHeight={true}
         image="https://picsum.photos/210"
         onClick={[Function]}
-        tabIndex="0"
         theme="light"
       />
     </div>
@@ -200,7 +256,6 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
         fillHeight={true}
         image="https://picsum.photos/220"
         onClick={[Function]}
-        tabIndex="0"
         theme="light"
       />
     </div>
@@ -224,7 +279,6 @@ exports[`<Mosaic> Snapshots and structure should render story twoThumbnails 1`] 
         fillHeight={true}
         image="https://picsum.photos/200"
         onClick={[Function]}
-        tabIndex="0"
         theme="light"
       />
     </div>
@@ -237,7 +291,6 @@ exports[`<Mosaic> Snapshots and structure should render story twoThumbnails 1`] 
         fillHeight={true}
         image="https://picsum.photos/210"
         onClick={[Function]}
-        tabIndex="0"
         theme="light"
       />
     </div>


### PR DESCRIPTION
# General summary

Fixed Mosaic elements showing as clickable even though `onClick` wasn't defined

<!-- Please describe the PR content -->

# Screenshots

**Before**
![sa-mosaic-click-before](https://user-images.githubusercontent.com/7147342/81790144-44cecc80-9505-11ea-941d-ce10ea8e6162.gif)

**Now**
![sa-mosaic-click-after](https://user-images.githubusercontent.com/7147342/81790177-5021f800-9505-11ea-8d19-630ae668e5f6.gif)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
