### PR TITLE
fix Interface typo onInfinite to onInfiniteScroll for Autocomplete and Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Trigger the infinite scroll callback on display if enough space with the `useInfiniteScroll` hook.
 -   Fixed chips taking place before icons in `TextField` component.
 -   Fixed `Mosaic` thumbnails showing as clickable even though `onClick` wasn't defined.
+-   Fixed prop Interfaces of `Autocomplete` and `Dropdown` by changing `onInfinite` to `onInfiniteScroll`.
 
 ## [0.22.0][] - 2020-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Trigger the infinite scroll callback on display if enough space with the `useInfiniteScroll` hook.
 -   Fixed chips taking place before icons in `TextField` component.
 -   Fixed `Mosaic` thumbnails showing as clickable even though `onClick` wasn't defined.
--   Fixed prop Interfaces of `Autocomplete` and `Dropdown` by changing `onInfinite` to `onInfiniteScroll`.
+-   _[BREAKING]_ Fixed prop Interfaces of `Autocomplete` and `Dropdown` by changing `onInfinite` to `onInfiniteScroll`.
 
 ## [0.22.0][] - 2020-04-21
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -142,7 +142,7 @@ interface AutocompleteProps extends GenericProps {
 
     /**
      * The callback function called when the bottom of the dropdown is reached.
-     * @see {@link DropdownProps#onInfinite}
+     * @see {@link DropdownProps#onInfiniteScroll}
      */
     onInfiniteScroll?: VoidFunction;
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -144,7 +144,7 @@ interface AutocompleteProps extends GenericProps {
      * The callback function called when the bottom of the dropdown is reached.
      * @see {@link DropdownProps#onInfinite}
      */
-    onInfinite?: VoidFunction;
+    onInfiniteScroll?: VoidFunction;
 
     /**
      * Text field value change handler.

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -40,7 +40,7 @@ interface DropdownProps extends GenericProps {
     /**
      * The callback function called when the bottom of the dropdown is reached.
      */
-    onInfinite?: VoidFunction;
+    onInfiniteScroll?: VoidFunction;
 }
 
 /**


### PR DESCRIPTION
# General summary
Autocomplete and Dropdown's interfaces had the prop called `onInfinite` but in the components themselves, the prop was called `onInfiniteScroll`.

[In the Interface](https://github.com/lumapps/design-system/blob/master/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx#L147) 
[In the Component props](https://github.com/lumapps/design-system/blob/master/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx#L224)
(Same for Dropdown Component)

<!-- Please describe the PR content -->
Fixed issue described above.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [X] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
