### PR TITLE
feat(react-thumbnail): add fallback to images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added optional `defaultMonth` prop to components `DatePickerField` and `DatePicker`.
--   Added optional `imgProps` prop to component `Thumbnail`
+-   Added optional `imgProps` prop to component `Thumbnail`.
+-   Added optional `fallback` prop (svg string or react node) to component `Thumbnail`.
 -   Added `thumbnailProps` prop to `LinkPreview`.
+-   Added `useImage` hook to preload an image and get states from it (isLoaded and hasError).
 
 ### Changed
 
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed `Mosaic` thumbnails showing as clickable even though `onClick` wasn't defined.
 -   _[BREAKING]_ Fixed prop Interfaces of `Autocomplete` and `Dropdown` by changing `onInfinite` to `onInfiniteScroll`.
 -   Added `type="button"` to `TextField` "clear" button when `isClearable` is `true` to avoid clearing field when user tries to submit a form.
+-   Moved `useFocusedImage` to `hooks` folder.
 
 ## [0.22.0][] - 2020-04-21
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -1,8 +1,8 @@
-import React, { ImgHTMLAttributes, ReactElement } from 'react';
+import React, { ImgHTMLAttributes, ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Alignment, AspectRatio, FocusPoint, Size, Theme } from '@lumx/react';
+import { Alignment, AspectRatio, FocusPoint, Icon, Size, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
@@ -12,6 +12,7 @@ import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } fr
 
 import useFocusedImage from './useFocusedImage';
 
+import { mdiImageBrokenVariant } from '@lumx/icons';
 import { useImage } from '@lumx/react/hooks/useImage';
 import { isInternetExplorer } from '@lumx/react/utils/isInternetExplorer';
 
@@ -98,6 +99,8 @@ interface ThumbnailProps extends GenericProps {
     resizeDebounceTime?: number;
     /** props that will be passed directly to the `img` tag */
     imgProps?: ImgHTMLAttributes<HTMLImageElement>;
+    /** Fallback svg or react node. */
+    fallback: string | ReactNode;
 }
 
 /**
@@ -123,6 +126,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
     isCrossOriginEnabled: true,
     crossOrigin: CrossOrigin.anonymous,
     aspectRatio: AspectRatio.original,
+    fallback: mdiImageBrokenVariant,
     fillHeight: false,
     focusPoint: { x: 0, y: 0 },
     loading: ImageLoading.lazy,
@@ -147,6 +151,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     isFollowingWindowSize = DEFAULT_PROPS.isFollowingWindowSize,
     align = DEFAULT_PROPS.align,
     aspectRatio = DEFAULT_PROPS.aspectRatio,
+    fallback = DEFAULT_PROPS.fallback,
     fillHeight = DEFAULT_PROPS.fillHeight,
     loading = DEFAULT_PROPS.loading,
     size = DEFAULT_PROPS.size,
@@ -173,7 +178,11 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     };
 
     if (hasError) {
-        return <span>Image broken</span>;
+        if (typeof fallback === 'string') {
+            return <Icon icon={fallback} size={Size.m} theme={theme} />;
+        }
+
+        return <>{fallback}</>;
     }
 
     if (isLoaded) {

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -12,6 +12,7 @@ import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } fr
 
 import useFocusedImage from './useFocusedImage';
 
+import { useImage } from '@lumx/react/hooks/useImage';
 import { isInternetExplorer } from '@lumx/react/utils/isInternetExplorer';
 
 /**
@@ -158,55 +159,65 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     imgProps,
     ...props
 }: ThumbnailProps): ReactElement => {
+    const { isLoaded, hasError } = useImage(image);
     const focusImageRef = useFocusedImage(
         focusPoint!,
         aspectRatio!,
         size!,
         resizeDebounceTime!,
         isFollowingWindowSize!,
+        isLoaded,
     );
     const setCrossOrigin = () => {
         return !isInternetExplorer() && isCrossOriginEnabled ? crossOrigin : undefined;
     };
 
-    return (
-        <div
-            className={classNames(
-                className,
-                handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant }),
-                {
-                    [`${CLASSNAME}--fill-height`]: fillHeight,
-                },
-            )}
-            tabIndex={isFunction(onClick) ? 0 : -1}
-            onClick={onClick}
-            onKeyDown={onEnterPressed(onClick)}
-            {...props}
-        >
-            {aspectRatio === AspectRatio.original ? (
-                <img
-                    {...(imgProps || {})}
-                    ref={focusImageRef}
-                    className={`${CLASSNAME}__image`}
-                    src={image}
-                    alt={alt}
-                    loading={loading}
-                />
-            ) : (
-                <div className={`${CLASSNAME}__background`}>
+    if (hasError) {
+        return <span>Image broken</span>;
+    }
+
+    if (isLoaded) {
+        return (
+            <div
+                className={classNames(
+                    className,
+                    handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant }),
+                    {
+                        [`${CLASSNAME}--fill-height`]: fillHeight,
+                    },
+                )}
+                tabIndex={isFunction(onClick) ? 0 : -1}
+                onClick={onClick}
+                onKeyDown={onEnterPressed(onClick)}
+                {...props}
+            >
+                {aspectRatio === AspectRatio.original ? (
                     <img
                         {...(imgProps || {})}
                         ref={focusImageRef}
-                        className={`${CLASSNAME}__focused-image`}
-                        crossOrigin={setCrossOrigin()}
+                        className={`${CLASSNAME}__image`}
                         src={image}
                         alt={alt}
                         loading={loading}
                     />
-                </div>
-            )}
-        </div>
-    );
+                ) : (
+                    <div className={`${CLASSNAME}__background`}>
+                        <img
+                            {...(imgProps || {})}
+                            ref={focusImageRef}
+                            className={`${CLASSNAME}__focused-image`}
+                            crossOrigin={setCrossOrigin()}
+                            src={image}
+                            alt={alt}
+                            loading={loading}
+                        />
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    return <></>;
 };
 Thumbnail.displayName = COMPONENT_NAME;
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -98,7 +98,7 @@ interface ThumbnailProps extends GenericProps {
     /** props that will be passed directly to the `img` tag */
     imgProps?: ImgHTMLAttributes<HTMLImageElement>;
     /** Fallback svg or react node. */
-    fallback: string | ReactNode;
+    fallback?: string | ReactNode;
 }
 
 /**

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -195,7 +195,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
                 (typeof fallback === 'string' ? (
                     <Icon icon={fallback as string} size={size} theme={theme} />
                 ) : (
-                    <>{fallback}</>
+                    fallback
                 ))}
 
             {isLoaded &&

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -128,7 +128,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
     size: undefined,
     theme: Theme.light,
     variant: ThumbnailVariant.squared,
-    debounceTime: 20,
+    resizeDebounceTime: 20,
     isFollowingWindowSize: true,
 };
 
@@ -142,7 +142,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     className = '',
     isCrossOriginEnabled = DEFAULT_PROPS.isCrossOriginEnabled,
     crossOrigin = DEFAULT_PROPS.crossOrigin,
-    debounceTime = DEFAULT_PROPS.debounceTime,
+    resizeDebounceTime = DEFAULT_PROPS.resizeDebounceTime,
     isFollowingWindowSize = DEFAULT_PROPS.isFollowingWindowSize,
     align = DEFAULT_PROPS.align,
     aspectRatio = DEFAULT_PROPS.aspectRatio,
@@ -158,8 +158,13 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     imgProps,
     ...props
 }: ThumbnailProps): ReactElement => {
-    const focusImageRef = useFocusedImage(focusPoint!, aspectRatio!, size!, debounceTime!, isFollowingWindowSize!);
-
+    const focusImageRef = useFocusedImage(
+        focusPoint!,
+        aspectRatio!,
+        size!,
+        resizeDebounceTime!,
+        isFollowingWindowSize!,
+    );
     const setCrossOrigin = () => {
         return !isInternetExplorer() && isCrossOriginEnabled ? crossOrigin : undefined;
     };

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -176,30 +176,29 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
         return !isInternetExplorer() && isCrossOriginEnabled ? crossOrigin : undefined;
     };
 
-    if (hasError) {
-        if (typeof fallback === 'string') {
-            return <Icon icon={fallback} size={size} theme={theme} />;
-        }
+    return (
+        <div
+            className={classNames(
+                className,
+                handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant }),
+                {
+                    [`${CLASSNAME}--fill-height`]: fillHeight,
+                },
+            )}
+            tabIndex={isFunction(onClick) ? 0 : -1}
+            onClick={onClick}
+            onKeyDown={onEnterPressed(onClick)}
+            {...props}
+        >
+            {hasError &&
+                (typeof fallback === 'string' ? (
+                    <Icon icon={fallback as string} size={size} theme={theme} />
+                ) : (
+                    <>{fallback}</>
+                ))}
 
-        return <>{fallback}</>;
-    }
-
-    if (isLoaded) {
-        return (
-            <div
-                className={classNames(
-                    className,
-                    handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant }),
-                    {
-                        [`${CLASSNAME}--fill-height`]: fillHeight,
-                    },
-                )}
-                tabIndex={isFunction(onClick) ? 0 : -1}
-                onClick={onClick}
-                onKeyDown={onEnterPressed(onClick)}
-                {...props}
-            >
-                {aspectRatio === AspectRatio.original ? (
+            {isLoaded &&
+                (aspectRatio === AspectRatio.original ? (
                     <img
                         {...(imgProps || {})}
                         ref={focusImageRef}
@@ -220,12 +219,9 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
                             loading={loading}
                         />
                     </div>
-                )}
-            </div>
-        );
-    }
-
-    return <></>;
+                ))}
+        </div>
+    );
 };
 Thumbnail.displayName = COMPONENT_NAME;
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -11,7 +11,8 @@ import isFunction from 'lodash/isFunction';
 import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
 
 import { mdiImageBrokenVariant } from '@lumx/icons';
-import { useFocusedImage, useImage } from '@lumx/react/hooks';
+import { useFocusedImage } from '@lumx/react/hooks/useFocusedImage';
+import { useImage } from '@lumx/react/hooks/useImage';
 import { isInternetExplorer } from '@lumx/react/utils/isInternetExplorer';
 
 /**

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -10,10 +10,8 @@ import isFunction from 'lodash/isFunction';
 
 import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
 
-import useFocusedImage from './useFocusedImage';
-
 import { mdiImageBrokenVariant } from '@lumx/icons';
-import { useImage } from '@lumx/react/hooks/useImage';
+import { useFocusedImage, useImage } from '@lumx/react/hooks';
 import { isInternetExplorer } from '@lumx/react/utils/isInternetExplorer';
 
 /**
@@ -140,6 +138,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
 /**
  * Simple component used to display image with square or round shape.
  * Convenient to display image previews or user avatar.
+ * Has a fallback image when the source image is in error.
  *
  * @return The component.
  */
@@ -179,7 +178,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
 
     if (hasError) {
         if (typeof fallback === 'string') {
-            return <Icon icon={fallback} size={Size.m} theme={theme} />;
+            return <Icon icon={fallback} size={size} theme={theme} />;
         }
 
         return <>{fallback}</>;

--- a/packages/lumx-react/src/components/thumbnail/useFocusedImage.tsx
+++ b/packages/lumx-react/src/components/thumbnail/useFocusedImage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { AspectRatio, Size } from '..';
 import { FocusedImage, LumHTMLImageElement } from './FocusedImage';
@@ -10,25 +10,37 @@ const useFocusedImage = (
     size: Size,
     debounceTime: number,
     isFollowingWindowSize: boolean,
+    isLoaded: boolean,
 ) => {
     const focusRef = useRef<FocusedImage | null>(null);
 
     useEffect(() => {
-        focusRef.current?.setFocus(focus!);
+        if (focusRef.current) {
+            focusRef.current.setFocus(focus!);
+        }
     }, [focusRef.current, focus?.x, focus?.y, size]);
 
-    return (f: HTMLImageElement) => {
-        if (aspectRatio === AspectRatio.original) {
+    useEffect(() => {
+        if (aspectRatio === AspectRatio.original || !isLoaded) {
             focusRef.current = null;
-        } else if (!focusRef.current) {
-            focusRef.current = new FocusedImage(f as LumHTMLImageElement, {
-                debounceTime,
-                focus,
-                updateOnWindowResize: isFollowingWindowSize,
-                updateOnContainerResize: isFollowingWindowSize,
-            });
         }
-    };
+    }, [aspectRatio, isLoaded]);
+
+    return useCallback(
+        (f: HTMLImageElement) => {
+            if (aspectRatio === AspectRatio.original || !isLoaded) {
+                focusRef.current = null;
+            } else if (!focusRef.current) {
+                focusRef.current = new FocusedImage(f as LumHTMLImageElement, {
+                    debounceTime,
+                    focus,
+                    updateOnWindowResize: isFollowingWindowSize,
+                    updateOnContainerResize: isFollowingWindowSize,
+                });
+            }
+        },
+        [focusRef.current, aspectRatio, isLoaded],
+    );
 };
 
 export default useFocusedImage;

--- a/packages/lumx-react/src/hooks/index.tsx
+++ b/packages/lumx-react/src/hooks/index.tsx
@@ -16,4 +16,6 @@ export * from './useChipGroupNavigation';
 
 export * from './useFocus';
 
+export * from './useFocusedImage';
+
 export * from './useImage';

--- a/packages/lumx-react/src/hooks/index.tsx
+++ b/packages/lumx-react/src/hooks/index.tsx
@@ -15,3 +15,5 @@ export * from './useInfiniteScroll';
 export * from './useChipGroupNavigation';
 
 export * from './useFocus';
+
+export * from './useImage';

--- a/packages/lumx-react/src/hooks/useFocusedImage.tsx
+++ b/packages/lumx-react/src/hooks/useFocusedImage.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-import { AspectRatio, Size } from '../components';
-import { FocusedImage, LumHTMLImageElement } from '../components/thumbnail/FocusedImage';
-import { FocusPoint } from '../components/thumbnail/FocusedImageOptions';
+import { AspectRatio, Size } from '@lumx/react/components';
+import { FocusedImage, LumHTMLImageElement } from '@lumx/react/components/thumbnail/FocusedImage';
+import { FocusPoint } from '@lumx/react/components/thumbnail/FocusedImageOptions';
 
 /**
  * Handle the focus point and the aspect ratio of an image.

--- a/packages/lumx-react/src/hooks/useFocusedImage.tsx
+++ b/packages/lumx-react/src/hooks/useFocusedImage.tsx
@@ -1,9 +1,20 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-import { AspectRatio, Size } from '..';
-import { FocusedImage, LumHTMLImageElement } from './FocusedImage';
-import { FocusPoint } from './FocusedImageOptions';
+import { AspectRatio, Size } from '../components';
+import { FocusedImage, LumHTMLImageElement } from '../components/thumbnail/FocusedImage';
+import { FocusPoint } from '../components/thumbnail/FocusedImageOptions';
 
+/**
+ * Handle the focus point and the aspect ratio of an image.
+ *
+ * @param   focus                 Focus point value.
+ * @param   aspectRatio           Aspect ratio of the image.
+ * @param   size                  Size of the image.
+ * @param   debounceTime          Debounce time when resizing.
+ * @param   isFollowingWindowSize Update on resize.
+ * @param   isLoaded              Loaded state of the image.
+ * @return                        Function to handle ref.
+ */
 const useFocusedImage = (
     focus: FocusPoint,
     aspectRatio: AspectRatio,
@@ -43,4 +54,4 @@ const useFocusedImage = (
     );
 };
 
-export default useFocusedImage;
+export { useFocusedImage };

--- a/packages/lumx-react/src/hooks/useImage.tsx
+++ b/packages/lumx-react/src/hooks/useImage.tsx
@@ -15,13 +15,21 @@ interface ImageStates {
 const useImage = (src: string): ImageStates => {
     const [isLoaded, setIsLoaded] = useState(false);
     const [hasError, setHasError] = useState(false);
+    const [isNew, setIsNew] = useState(true);
+
+    useEffect(() => {
+        setIsNew(true);
+        setIsLoaded(false);
+        setHasError(false);
+    }, [src]);
 
     useEffect(() => {
         const img = new Image();
         img.src = src;
         img.onload = () => setIsLoaded(true);
         img.onerror = () => setHasError(true);
-    }, [src]);
+        setIsNew(false);
+    }, [src, isNew]);
 
     return { isLoaded, hasError };
 };

--- a/packages/lumx-react/src/hooks/useImage.tsx
+++ b/packages/lumx-react/src/hooks/useImage.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+interface ImageStates {
+    isLoaded: boolean;
+    hasError: boolean;
+}
+
+/**
+ * Hook to preload an image and get states from it.
+ *
+ * @param  src Source of the image.
+ *
+ * @return States from the image.
+ */
+const useImage = (src: string): ImageStates => {
+    const [isLoaded, setIsLoaded] = useState(false);
+    const [hasError, setHasError] = useState(false);
+
+    useEffect(() => {
+        const img = new Image();
+        img.src = src;
+        img.onload = () => setIsLoaded(true);
+        img.onerror = () => setHasError(true);
+    }, [src]);
+
+    return { isLoaded, hasError };
+};
+
+export { useImage };


### PR DESCRIPTION
# General summary

-   Added optional `fallback` prop (svg string or react node) to component `Thumbnail`.
-   Added `useImage` hook to preload an image and get states from it (isLoaded and hasError).
-   Moved `useFocusedImage` to `hooks` folder.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
