### PR TITLE
fix(text-field): fix clear button type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed chips taking place before icons in `TextField` component.
 -   Fixed `Mosaic` thumbnails showing as clickable even though `onClick` wasn't defined.
 -   _[BREAKING]_ Fixed prop Interfaces of `Autocomplete` and `Dropdown` by changing `onInfinite` to `onInfiniteScroll`.
+-   Added `type="button"` to `TextField` "clear" button when `isClearable` is `true` to avoid clearing field when user tries to submit a form.
 
 ## [0.22.0][] - 2020-04-21
 

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -394,6 +394,7 @@ const TextField: React.FC<TextFieldProps> = (props) => {
                             size={Size.s}
                             theme={theme}
                             onClick={onClear}
+                            type="button"
                         />
                     )}
                 </div>


### PR DESCRIPTION
# General summary

When `TextField` had `isClearable` set at `true` and is the only field of a form without another submit button, pressing enter triggered the `onClear` action.

Fixed by setting the button type to "button".

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
