### PR TITLE
Fix/LUM-9878 Textarea nb rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   _[BREAKING]_ Replaced `today` and `monthOffset` props by `selectedMonth` for `DatePickerControlled` component.
+-   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering
+
 ## [0.23.0][] - 2020-05-29
 
 ### Added
@@ -20,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   _[BREAKING]_ Replaced `today` and `monthOffset` props by `selectedMonth` for `DatePickerControlled` component.
--   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering
 
 ### Fixed
 

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -57,3 +57,55 @@ export const textFieldWithError = ({ theme }: any) => (
         }
     />
 );
+
+export const TextArea = ({ theme }: any) => {
+    const [value, setValue] = React.useState('my value');
+    return (
+        <TextField
+            value={value}
+            label={text('Label', 'I am the label')}
+            placeholder={text('Placeholder', 'ex: A value')}
+            multiline
+            minimumRows={1}
+            theme={theme}
+            onChange={setValue}
+            helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
+        />
+    );
+};
+export const TextAreaWith2Lines = ({ theme }: any) => {
+    const [value, setValue] = React.useState('the value');
+    return (
+        <TextField
+            value={value}
+            label={text('Label', 'I am the label')}
+            placeholder={text('Placeholder', 'ex: A value')}
+            multiline
+            minimumRows={2}
+            theme={theme}
+            onChange={setValue}
+            helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
+        />
+    );
+};
+
+export const TextAreaWithManyLines = ({ theme }: any) => {
+    const myvalue = `I
+am
+a
+multiline
+text`;
+    const [value, setValue] = React.useState(myvalue);
+    return (
+        <TextField
+            value={value}
+            label={text('Label', 'I am the label')}
+            placeholder={text('Placeholder', 'ex: A value')}
+            multiline
+            minimumRows={2}
+            theme={theme}
+            onChange={setValue}
+            helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
+        />
+    );
+};

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -129,11 +129,11 @@ const useComputeNumberOfRows = (
      * Callback in order to recalculate the number of rows due to a change on the text area
      * @param event Change event.
      */
-    recomputeNumberOfRows(event: React.ChangeEvent): void;
+    recomputeNumberOfRows(target: Element): void;
 } => {
     const [rows, setRows] = useState(minimumRows);
 
-    const recompute = (event: React.ChangeEvent) => {
+    const recompute = (target: Element) => {
         /**
          * HEAD's UP! This part is a little bit tricky. The idea here is to only
          * display the necessary rows on the textarea. In order to dynamically adjust
@@ -148,9 +148,9 @@ const useComputeNumberOfRows = (
          * 5. In case there is any other update on the component that changes the UI, we need to keep the number of rows
          * on the state in order to allow React to re-render. Therefore, we save them using `useState`
          */
-        (event.target as HTMLTextAreaElement).rows = minimumRows;
-        const currentRows = event.target.scrollHeight / (event.target.clientHeight / minimumRows);
-        (event.target as HTMLTextAreaElement).rows = currentRows;
+        (target as HTMLTextAreaElement).rows = minimumRows;
+        const currentRows = target.scrollHeight / (target.clientHeight / minimumRows);
+        (target as HTMLTextAreaElement).rows = currentRows;
 
         setRows(currentRows);
     };
@@ -172,7 +172,7 @@ interface InputNativeProps {
     value?: string | number;
     rows: number;
     setFocus(focus: boolean): void;
-    recomputeNumberOfRows(event: React.ChangeEvent): void;
+    recomputeNumberOfRows(target: Element): void;
     onChange(value: string): void;
     onFocus?(value: React.FocusEvent): void;
     onBlur?(value: React.FocusEvent): void;
@@ -196,6 +196,13 @@ const renderInputNative: React.FC<InputNativeProps> = (props) => {
         ...forwardedProps
     } = props;
 
+    React.useEffect(() => {
+        // Recompute the number of rows for the first rendering
+        if (multiline && inputRef && inputRef.current) {
+            recomputeNumberOfRows(inputRef.current);
+        }
+    }, [inputRef]);
+
     const onTextFieldFocus = (event: React.FocusEvent) => {
         if (onFocus) {
             onFocus(event);
@@ -214,7 +221,7 @@ const renderInputNative: React.FC<InputNativeProps> = (props) => {
 
     const handleChange = (event: React.ChangeEvent) => {
         if (multiline) {
-            recomputeNumberOfRows(event);
+            recomputeNumberOfRows(event.target);
         }
 
         onChange(get(event, 'target.value'));


### PR DESCRIPTION
# General summary

Fix https://lumapps.atlassian.net/browse/LUM-9878

When we have a TextField multiple with content in many lines, the component only displays the `minimum rows`.
This PR call the function used to compute the number of rows directly instead of waiting for change.

# Screenshots

<img width="394" alt="Capture d’écran 2020-06-01 à 11 11 58" src="https://user-images.githubusercontent.com/14941730/83394359-bdd08e00-a3f8-11ea-9b89-ed9d7a51ef55.png">

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
