### PR TITLE
fix(react-thumbnail): fix centering issue on fallback and add a default size 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering
+-   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering.
+-   Fix centering issue on fallback icon in `Thumbnail` component when using `fillHeight`prop.
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Renamed SCSS mixin `lumx-theme-best-color()` into `$lumx-best-color()`
 -   _[BREAKING]_ Renamed CSS classes `.lumx-theme-color-*` into `.lumx-color-font-*`
 -   _[BREAKING]_ Renamed CSS classes `.lumx-theme-background-*` into `.lumx-color-background-*`
+-   Handle default size on fallback icon in `Thumbnail` component (Size.m).
 
 ## [0.23.0][] - 2020-05-29
 

--- a/packages/lumx-core/src/scss/components/thumbnail/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/lumapps/_index.scss
@@ -59,6 +59,11 @@
             border-radius: $lumx-border-radius;
         }
     }
+
+    &__fallback {
+        /* Center fallback icon when using fill-height prop */
+        margin: 0 auto;
+    }
 }
 
 /* Thumbnail sizes

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -50,7 +50,7 @@ export const defaultThumbnail = ({ theme }: { theme: Theme }) => {
     );
 };
 
-export const defaultThumbnailWithCustomImgProps = ({ theme }: { theme: Theme }) => {
+export const thumbnailWithCustomImgProps = ({ theme }: { theme: Theme }) => {
     const [image, setImage] = React.useState('https://not-found');
     const onError = () => {
         setImage('https://i.picsum.photos/id/1001/2400/1400.jpg');
@@ -90,3 +90,16 @@ export const defaultThumbnailWithCustomImgProps = ({ theme }: { theme: Theme }) 
         />
     );
 };
+
+export const brokenThumbnailWithFallbackProps = ({ theme }: { theme: Theme }) => (
+    <Thumbnail
+        align={select<Alignment>('Alignment', Alignment, Alignment.left, 'Options')}
+        aspectRatio={select<AspectRatio>('Aspect ratio', AspectRatio, AspectRatio.square, 'Options')}
+        isCrossOriginEnabled={boolean('Enable CORS', true, 'Options')}
+        crossOrigin={select('CORS', CrossOrigin, CrossOrigin.anonymous, 'Options')}
+        fillHeight={boolean('Fill Height', false, 'Options')}
+        image={text('Url image', 'https://i.picsum.photos/id/1001/2400/1400.jp', 'Options')}
+        theme={theme}
+        variant={select<ThumbnailVariant>('Variant', ThumbnailVariant, ThumbnailVariant.squared, 'Options')}
+    />
+);

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -193,7 +193,12 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
         >
             {hasError &&
                 (typeof fallback === 'string' ? (
-                    <Icon className={`${CLASSNAME}__fallback`} icon={fallback as string} size={size} theme={theme} />
+                    <Icon
+                        className={`${CLASSNAME}__fallback`}
+                        icon={fallback as string}
+                        size={size || Size.m}
+                        theme={theme}
+                    />
                 ) : (
                     fallback
                 ))}

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -193,7 +193,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
         >
             {hasError &&
                 (typeof fallback === 'string' ? (
-                    <Icon icon={fallback as string} size={size} theme={theme} />
+                    <Icon className={`${CLASSNAME}__fallback`} icon={fallback as string} size={size} theme={theme} />
                 ) : (
                     fallback
                 ))}


### PR DESCRIPTION
# General summary

-   Fix centering issue on fallback icon in `Thumbnail` component when using `fillHeight`prop.
-   Handle default size on fallback icon in `Thumbnail` component (Size.m).

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
