### PR TITLE
fix nested click away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering.
 -   Fix centering issue on fallback icon in `Thumbnail` component when using `fillHeight`prop.
+-   Fix nested click away for `Dialog`, `Dropdown`, `Select` and `Autocomplete` (this fixes the dialog automatically closing when clicking on a nested select or dropdown.)
 
 ### Changed
 

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -1,11 +1,11 @@
 import { Placement, Popover, TextField } from '@lumx/react';
-import { useClickAway } from '@lumx/react/hooks/useClickAway';
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { onEscapePressed } from '@lumx/react/utils';
+import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 
 import moment from 'moment';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ENTER_KEY_CODE, SPACE_KEY_CODE } from '@lumx/react/constants';
 import { CLASSNAME, DatePicker } from './DatePicker';
@@ -67,9 +67,9 @@ const DatePickerField = ({
         setIsOpen(!isOpen);
     };
 
-    const closeSimpleMenu = () => {
+    const closeSimpleMenu = useCallback(() => {
         setIsOpen(false);
-    };
+    }, []);
 
     const { computedPosition, isVisible } = Popover.useComputePosition(
         Placement.BOTTOM_START!,
@@ -100,18 +100,6 @@ const DatePickerField = ({
             window.removeEventListener('keydown', onEscapeHandler);
         };
     }, [isOpen, closeSimpleMenu, onEscapeHandler]);
-
-    useClickAway(
-        wrapperRef,
-        () => {
-            if (!isOpen) {
-                return;
-            }
-
-            closeSimpleMenu();
-        },
-        [anchorRef],
-    );
 
     // Handle focus trap.
     const todayOrSelectedDateRef = useRef<HTMLButtonElement>(null);
@@ -146,30 +134,32 @@ const DatePickerField = ({
                 {...textFieldProps}
             />
             {isOpen ? (
-                <Popover
-                    popoverRect={computedPosition}
-                    popoverRef={popoverRef}
-                    isVisible={isVisible}
-                    placement={Placement.BOTTOM_START}
-                >
-                    <div
-                        ref={wrapperRef}
-                        style={{
-                            maxHeight: computedPosition.maxHeight,
-                            minWidth: 0,
-                        }}
+                <ClickAwayProvider callback={closeSimpleMenu} refs={[wrapperRef, anchorRef]}>
+                    <Popover
+                        popoverRect={computedPosition}
+                        popoverRef={popoverRef}
+                        isVisible={isVisible}
+                        placement={Placement.BOTTOM_START}
                     >
-                        <DatePicker
-                            locale={locale}
-                            maxDate={maxDate}
-                            minDate={minDate}
-                            value={castedValue}
-                            onChange={onDatePickerChange}
-                            todayOrSelectedDateRef={todayOrSelectedDateRef}
-                            defaultMonth={castedDefaultMonth}
-                        />
-                    </div>
-                </Popover>
+                        <div
+                            ref={wrapperRef}
+                            style={{
+                                maxHeight: computedPosition.maxHeight,
+                                minWidth: 0,
+                            }}
+                        >
+                            <DatePicker
+                                locale={locale}
+                                maxDate={maxDate}
+                                minDate={minDate}
+                                value={castedValue}
+                                onChange={onDatePickerChange}
+                                todayOrSelectedDateRef={todayOrSelectedDateRef}
+                                defaultMonth={castedDefaultMonth}
+                            />
+                        </div>
+                    </Popover>
+                </ClickAwayProvider>
             ) : null}
         </>
     );

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -128,10 +128,10 @@ const DatePickerField = ({
         closeSimpleMenu();
     };
 
-    const castedValue = value && moment(value).isValid() ? moment(value) : undefined
-    const castedDefaultMonth = defaultMonth && moment(defaultMonth).isValid() ? moment(defaultMonth) : undefined
+    const castedValue = value && moment(value).isValid() ? moment(value) : undefined;
+    const castedDefaultMonth = defaultMonth && moment(defaultMonth).isValid() ? moment(defaultMonth) : undefined;
     if ((value && !moment(value).isValid()) || (defaultMonth && !moment(defaultMonth).isValid())) {
-        console.warn(`[@lumx/react/DatePickerField] Invalid date provided '${value}'`)
+        console.warn(`[@lumx/react/DatePickerField] Invalid date provided '${value}'`);
     }
     return (
         <>

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -217,13 +217,7 @@ export const dialogWithFocusableElements = ({ theme }: any) => {
     return (
         <>
             {button}
-            <Dialog
-                isOpen={isOpen}
-                onClose={closeDialog}
-                parentElement={buttonRef}
-                preventAutoClose
-                focusElement={inputRef}
-            >
+            <Dialog isOpen={isOpen} onClose={closeDialog} parentElement={buttonRef} focusElement={inputRef}>
                 <header>
                     <Toolbar
                         label={<span className="lumx-typography-title">Dialog header</span>}

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -9,11 +9,11 @@ import { DIALOG_TRANSITION_DURATION } from '@lumx/react/constants';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
-import { useClickAway } from '@lumx/react/hooks/useClickAway';
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useIntersectionObserver } from '@lumx/react/hooks/useIntersectionObserver';
 import { GenericProps, getRootClassName, handleBasicClasses, isComponent, partitionMulti } from '@lumx/react/utils';
+import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
 
@@ -174,14 +174,6 @@ const Dialog: React.FC<DialogProps> = (props) => {
     const footerChildProps = (footerChild as ReactElement)?.props;
     const footerChildContent = footerChildProps?.children;
 
-    useClickAway(wrapperRef, () => {
-        if (preventAutoClose) {
-            return;
-        }
-
-        onClose?.();
-    });
-
     useEffect(() => {
         if (isOpen) {
             onOpen?.();
@@ -208,56 +200,59 @@ const Dialog: React.FC<DialogProps> = (props) => {
                   <div className={`${CLASSNAME}__overlay`} />
 
                   <section className={`${CLASSNAME}__container`} role="dialog">
-                      <div className={`${CLASSNAME}__wrapper`} ref={wrapperRef}>
-                          {(header || headerChildContent) && (
-                              <header
-                                  {...headerChildProps}
-                                  className={classNames(
-                                      `${CLASSNAME}__header`,
-                                      (forceHeaderDivider || hasTopIntersection) && `${CLASSNAME}__header--has-divider`,
-                                      headerChildProps?.className,
-                                  )}
-                              >
-                                  {header}
-                                  {headerChildContent}
-                              </header>
-                          )}
+                      <ClickAwayProvider callback={!preventAutoClose && onClose} refs={[wrapperRef]}>
+                          <div className={`${CLASSNAME}__wrapper`} ref={wrapperRef}>
+                              {(header || headerChildContent) && (
+                                  <header
+                                      {...headerChildProps}
+                                      className={classNames(
+                                          `${CLASSNAME}__header`,
+                                          (forceHeaderDivider || hasTopIntersection) &&
+                                              `${CLASSNAME}__header--has-divider`,
+                                          headerChildProps?.className,
+                                      )}
+                                  >
+                                      {header}
+                                      {headerChildContent}
+                                  </header>
+                              )}
 
-                          <div ref={contentRef} className={`${CLASSNAME}__content`}>
-                              <div
-                                  className={`${CLASSNAME}__sentinel ${CLASSNAME}__sentinel--top`}
-                                  ref={setSentinelTop}
-                              />
+                              <div ref={contentRef} className={`${CLASSNAME}__content`}>
+                                  <div
+                                      className={`${CLASSNAME}__sentinel ${CLASSNAME}__sentinel--top`}
+                                      ref={setSentinelTop}
+                                  />
 
-                              {content}
+                                  {content}
 
-                              <div
-                                  className={`${CLASSNAME}__sentinel ${CLASSNAME}__sentinel--bottom`}
-                                  ref={setSentinelBottom}
-                              />
-                          </div>
-
-                          {(footer || footerChildContent) && (
-                              <footer
-                                  {...footerChildProps}
-                                  className={classNames(
-                                      `${CLASSNAME}__footer`,
-                                      (forceFooterDivider || hasBottomIntersection) &&
-                                          `${CLASSNAME}__footer--has-divider`,
-                                      footerChildProps?.className,
-                                  )}
-                              >
-                                  {footer}
-                                  {footerChildContent}
-                              </footer>
-                          )}
-
-                          {isLoading && (
-                              <div className={`${CLASSNAME}__progress-overlay`}>
-                                  <Progress variant={ProgressVariant.circular} />
+                                  <div
+                                      className={`${CLASSNAME}__sentinel ${CLASSNAME}__sentinel--bottom`}
+                                      ref={setSentinelBottom}
+                                  />
                               </div>
-                          )}
-                      </div>
+
+                              {(footer || footerChildContent) && (
+                                  <footer
+                                      {...footerChildProps}
+                                      className={classNames(
+                                          `${CLASSNAME}__footer`,
+                                          (forceFooterDivider || hasBottomIntersection) &&
+                                              `${CLASSNAME}__footer--has-divider`,
+                                          footerChildProps?.className,
+                                      )}
+                                  >
+                                      {footer}
+                                      {footerChildContent}
+                                  </footer>
+                              )}
+
+                              {isLoading && (
+                                  <div className={`${CLASSNAME}__progress-overlay`}>
+                                      <Progress variant={ProgressVariant.circular} />
+                                  </div>
+                              )}
+                          </div>
+                      </ClickAwayProvider>
                   </section>
               </div>,
               document.body,

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -112,7 +112,6 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithFocusabl
         "current": undefined,
       }
     }
-    preventAutoClose={true}
   >
     <header>
       <Toolbar

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -5,11 +5,12 @@ import classNames from 'classnames';
 import { List } from '@lumx/react/components/list/List';
 import { Offset, Placement, Popover } from '@lumx/react/components/popover/Popover';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
+import { useComputePosition } from '@lumx/react/hooks';
 import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
-import { useClickAway } from '@lumx/react/hooks/useClickAway';
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { useInfiniteScroll } from '@lumx/react/hooks/useInfiniteScroll';
 import { GenericProps, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
+import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 
 /**
  * Defines the props of the component.
@@ -95,7 +96,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     const popoverRef: React.RefObject<HTMLDivElement> = useRef(null);
     const listElementRef: React.RefObject<HTMLUListElement> = useRef(null);
 
-    const { computedPosition, isVisible } = Popover.useComputePosition(
+    const { computedPosition, isVisible } = useComputePosition(
         placement!,
         anchorRef,
         popoverRef,
@@ -134,19 +135,6 @@ const Dropdown: React.FC<DropdownProps> = ({
 
     useCallbackOnEscape(onClose, showDropdown && closeOnEscape);
 
-    // Any click away from the dropdown container will close it.
-    useClickAway(
-        wrapperRef,
-        () => {
-            if (!closeOnClick || !onClose || !showDropdown) {
-                return;
-            }
-
-            onClose();
-        },
-        [anchorRef],
-    );
-
     // Set the focus on the list when the dropdown opens,
     // in order to enable keyboard controls.
     useFocus(listElementRef.current, isVisible && shouldFocusOnOpen);
@@ -162,7 +150,9 @@ const Dropdown: React.FC<DropdownProps> = ({
             placement={placement}
             zIndex={zIndex}
         >
-            {popperElement}
+            <ClickAwayProvider callback={closeOnClick && onClose} refs={[wrapperRef, anchorRef]}>
+                {popperElement}
+            </ClickAwayProvider>
         </Popover>
     ) : null;
 };

--- a/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -16,22 +16,35 @@ exports[`<Dropdown> Snapshots and structure should render correctly 1`] = `
     }
   }
 >
-  <div
-    className="lumx-dropdown__menu lumx-dropdown"
-    style={
-      Object {
-        "maxHeight": undefined,
-        "minWidth": undefined,
-      }
+  <ClickAwayProvider
+    refs={
+      Array [
+        Object {
+          "current": null,
+        },
+        Object {
+          "current": null,
+        },
+      ]
     }
   >
     <div
-      className="lumx-dropdown__content"
+      className="lumx-dropdown__menu lumx-dropdown"
+      style={
+        Object {
+          "maxHeight": undefined,
+          "minWidth": undefined,
+        }
+      }
     >
-      <div>
-        This is the content of the dropdown
+      <div
+        className="lumx-dropdown__content"
+      >
+        <div>
+          This is the content of the dropdown
+        </div>
       </div>
     </div>
-  </div>
+  </ClickAwayProvider>
 </Popover>
 `;

--- a/packages/lumx-react/src/hooks/useClickAway.tsx
+++ b/packages/lumx-react/src/hooks/useClickAway.tsx
@@ -1,48 +1,46 @@
-import React, { useEffect } from 'react';
+import { RefObject, useEffect } from 'react';
 
-type HandledEventType = MouseEvent | TouchEvent;
-type EventCallback = (evt: HandledEventType) => void;
+import { Falsy } from '@lumx/react/utils';
 
-const EVENT_TYPES: string[] = ['mousedown', 'touchstart'];
+import isEmpty from 'lodash/isEmpty';
 
-/**
- * Listen to clicks away from a given element and callback the passed in function.
- *
- * @param  ref              A reference to an element we want to detect click away for.
- * @param  [callback]       A callback function to call when the user clicks away from the ref element.
- * @param  [additionalRefs] An array of additional references to elements we want to detect click away for.
- */
-function useClickAway(
-    ref: React.RefObject<HTMLElement>,
-    callback: EventCallback,
-    additionalRefs?: Array<React.RefObject<HTMLElement>>,
-) {
-    useEffect(() => {
-        if (!callback) {
-            return undefined;
-        }
+const EVENT_TYPES = ['mousedown', 'touchstart'];
 
-        const listener: EventCallback = (evt: HandledEventType) => {
-            const refs = additionalRefs ? [ref, ...additionalRefs] : [ref];
-            const isClickAway = !refs.some!(
-                (r: React.RefObject<HTMLElement>) => r && r.current !== null && r.current.contains(evt.target as Node),
-            );
-
-            const elementsUndefined = refs.every((r: React.RefObject<HTMLElement>) => !r || !r.current);
-
-            if (elementsUndefined || !isClickAway) {
-                return;
-            }
-
-            callback(evt);
-        };
-
-        EVENT_TYPES.forEach((evtType: string) => document.addEventListener(evtType, listener as EventListener));
-
-        return () => {
-            EVENT_TYPES.forEach((evtType: string) => document.removeEventListener(evtType, listener as EventListener));
-        };
-    }, [callback]);
+function isClickAway(target: HTMLElement, refs: Array<RefObject<HTMLElement>>): boolean {
+    // The target element is not contained in any of the listed element references.
+    return !refs.some((e) => e && e.current && e.current.contains(target));
 }
 
-export { useClickAway };
+export interface ClickAwayParameters {
+    /**
+     * A callback function to call when the user clicks away from the elements.
+     */
+    callback: EventListener | Falsy;
+    /**
+     * Elements from which we want to detect the click away.
+     */
+    refs: Array<RefObject<HTMLElement>>;
+}
+
+/**
+ * Listen to clicks away from the given elements and callback the passed in function.
+ *
+ * Warning: If you need to detect click away on nested React portals, please use the `ClickAwayProvider` component.
+ */
+export function useClickAway({ callback, refs }: ClickAwayParameters) {
+    useEffect(() => {
+        if (!callback || !refs || isEmpty(refs)) {
+            return;
+        }
+        const listener: EventListener = (evt) => {
+            if (isClickAway(evt.target as HTMLElement, refs)) {
+                setTimeout(() => callback(evt));
+            }
+        };
+
+        EVENT_TYPES.forEach((evtType) => document.addEventListener(evtType, listener));
+        return () => {
+            EVENT_TYPES.forEach((evtType) => document.removeEventListener(evtType, listener));
+        };
+    }, [callback, refs]);
+}

--- a/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.stories.tsx
+++ b/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.stories.tsx
@@ -1,0 +1,68 @@
+/* tslint:disable:jsx-no-lambda */
+import { Button } from '@lumx/react';
+import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
+import React, { useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export default { title: 'LumX components/ClickAwayProvider' };
+
+const Card = React.forwardRef<any, any>(({ children, close }, ref) => (
+    <ClickAwayProvider callback={close} refs={[ref as any]}>
+        {createPortal(
+            <div className="lumx-spacing-padding" ref={ref} style={{ border: '1px solid red' }}>
+                {children}
+            </div>,
+            document.body,
+        )}
+    </ClickAwayProvider>
+));
+
+/**
+ * This story showcases the detection of click away inside a nested React portal tree.
+ *
+ * @return Component story.
+ */
+export const NestedClickAway = () => {
+    const ref1 = useRef<HTMLDivElement>();
+    const [isOpen1, setOpen1] = useState(false);
+    const open1 = useCallback(() => setOpen1(true), []);
+    const close1 = useCallback(() => {
+        setOpen1(false);
+        setOpen2(false);
+        setOpen3(false);
+    }, []);
+
+    const ref2 = useRef<HTMLDivElement>();
+    const [isOpen2, setOpen2] = useState(false);
+    const open2 = useCallback(() => setOpen2(true), []);
+    const close2 = useCallback(() => {
+        setOpen2(false);
+        setOpen3(false);
+    }, []);
+
+    const ref3 = useRef<HTMLDivElement>();
+    const [isOpen3, setOpen3] = useState(false);
+    const open3 = useCallback(() => setOpen3(true), []);
+    const close3 = useCallback(() => setOpen3(false), []);
+
+    return (
+        <>
+            Level 0 - <Button onClick={open1}>Open level 1</Button>
+            {isOpen1 && (
+                <Card ref={ref1} close={close1}>
+                    Level 1 - <Button onClick={open2}>Open level 2</Button>
+                    {isOpen2 && (
+                        <Card ref={ref2} close={close2}>
+                            Level 2 - <Button onClick={open3}>Open level 3</Button>
+                            {isOpen3 && (
+                                <Card ref={ref3} close={close3}>
+                                    Level 3
+                                </Card>
+                            )}
+                        </Card>
+                    )}
+                </Card>
+            )}
+        </>
+    );
+};

--- a/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.tsx
+++ b/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+import { ClickAwayParameters, useClickAway } from '@lumx/react/hooks';
+
+import uniq from 'lodash/uniq';
+
+type appendChildrenRefsType = (refs: ClickAwayParameters['refs']) => void;
+const ClickAwayAncestorContext = createContext<appendChildrenRefsType | null>(null);
+
+/**
+ * The `ClickAwayProvider` component combines the `useClickAway` hook with a React context to hook into the React
+ * component tree and make sure we take into account both the DOM tree and the React tree we trying to detect click away.
+ *
+ * @return the react component.
+ */
+export const ClickAwayProvider: React.FC<ClickAwayParameters> = ({ children, callback, refs }) => {
+    const appendAncestorChildrenRefs = useContext(ClickAwayAncestorContext);
+    const [childrenRefs, setChildrenRefs] = useState<ClickAwayParameters['refs']>([]);
+
+    const appendChildrenRefs = useCallback(
+        (newChildrenRefs: ClickAwayParameters['refs']) => {
+            setChildrenRefs(uniq([...childrenRefs, ...newChildrenRefs]));
+        },
+        [childrenRefs, setChildrenRefs],
+    );
+
+    const clickAwayRefs = useMemo(() => {
+        // Use current refs and children refs in click away detection.
+        const concatenatedRefs = [...refs, ...childrenRefs];
+
+        // Forward refs to parent click away context.
+        appendAncestorChildrenRefs?.(concatenatedRefs);
+
+        return concatenatedRefs;
+    }, [refs, childrenRefs]);
+
+    useClickAway({ callback, refs: clickAwayRefs });
+    return <ClickAwayAncestorContext.Provider value={appendChildrenRefs} children={children} />;
+};
+ClickAwayProvider.displayName = 'ClickAwayProvider';

--- a/packages/lumx-react/src/utils/ClickAwayProvider/index.ts
+++ b/packages/lumx-react/src/utils/ClickAwayProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './ClickAwayProvider';

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -122,6 +122,12 @@ const isComponent = <C>(component: React.FC<C> | string) => (instance: ReactNode
     );
 };
 
+/**
+ * JS falsy values.
+ * (excluding `NaN` as it can't be distinguished from `number`)
+ */
+type Falsy = false | undefined | null | 0 | '';
+
 export {
     isComponent,
     Predicate,
@@ -132,4 +138,5 @@ export {
     Omit,
     ComponentType,
     GenericProps,
+    Falsy,
 };


### PR DESCRIPTION
# General summary

Fix nested click away
This fixes the dialog automatically closing when clicking on a nested select or dropdown.

# Test scenario

1. run `yarn && yarn storybook:react`
2. Go to http://localhost:9000/?path=/story/lumx-components-dialog--dialog-with-focusable-elements
3. Click in the select at the bottom of the dialog
   => A value should be selected and the dialog should not close
5. Click outside the dialog
   => The dialog should close normally