### PR TITLE
fix(select): fix arrow icon on empty selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `TextField` component is now computing the number of rows (if `multiple` is set) at the first rendering.
 -   Fix centering issue on fallback icon in `Thumbnail` component when using `fillHeight`prop.
 -   Fix nested click away for `Dialog`, `Dropdown`, `Select` and `Autocomplete` (this fixes the dialog automatically closing when clicking on a nested select or dropdown.)
+-   Fix position of the dropdown arrow icon when the select has no value (Material theme).
 
 ### Changed
 

--- a/packages/lumx-react/src/components/select/Select.tsx
+++ b/packages/lumx-react/src/components/select/Select.tsx
@@ -91,22 +91,16 @@ const SelectField: React.FC<SelectProps> = ({
                         onKeyDown={handleKeyboardNav}
                         tabIndex={0}
                     >
-                        {isEmpty && placeholder && (
-                            <div
-                                className={classNames([
-                                    `${CLASSNAME}__input-native`,
-                                    `${CLASSNAME}__input-native--placeholder`,
-                                ])}
-                            >
-                                <span>{placeholder}</span>
-                            </div>
-                        )}
+                        <div
+                            className={classNames([
+                                `${CLASSNAME}__input-native`,
+                                isEmpty && placeholder && `${CLASSNAME}__input-native--placeholder`,
+                            ])}
+                        >
+                            {!isEmpty && <span>{selectedValueRender!(value)}</span>}
 
-                        {!isEmpty && (
-                            <div className={`${CLASSNAME}__input-native`}>
-                                <span>{selectedValueRender!(value)}</span>
-                            </div>
-                        )}
+                            {isEmpty && placeholder && <span>{placeholder}</span>}
+                        </div>
 
                         {(isValid || hasError) && (
                             <div className={`${CLASSNAME}__input-validity`}>


### PR DESCRIPTION
# General summary

Fix position of the dropdown arrow icon when the select has no value

# Test scenario
1. run `yarn && yarn storybook:react`
2. Go to http://localhost:9000/?path=/story/lumx-components-dialog--dialog-with-focusable-elements
3. The select should like the screenshot below (screenshots > after)

# Screenshots

**Before**
![2020-06-09-110715_765x46_scrot](https://user-images.githubusercontent.com/939567/84129151-e16f8600-aa41-11ea-844d-d6df43304c50.png)

**After**
![2020-06-09-110727_769x49_scrot](https://user-images.githubusercontent.com/939567/84129155-e3d1e000-aa41-11ea-83fc-59762c111e81.png)

