### PR TITLE
fix(chip): fix click propagation on after/before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
+
 -   _[BREAKING]_ Changed `thumbnailProps` prop type from `LinkPreview` to avoid typescript throwing an error
 if `thumbnailProps.image` was not specified even though it is already set by the `image` prop.
+-   Allow event propagation on before/after element on `Chip` component when no handler is provided.
 
 ## [0.24.2][] - 2020-06-18
 

--- a/packages/lumx-react/src/components/chip/Chip.stories.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.stories.tsx
@@ -1,7 +1,22 @@
+/* tslint:disable:jsx-no-lambda */
 import React from 'react';
 
-import { Chip } from '@lumx/react';
+import { mdiClose, mdiViewList } from '@lumx/icons';
+import { Chip, Icon } from '@lumx/react';
 
 export default { title: 'LumX components/Chip' };
 
 export const simple = ({ theme }: any) => <Chip theme={theme}>The chip</Chip>;
+
+export const withAfterAndBefore = ({ theme }: any) => (
+    <Chip
+        theme={theme}
+        after={<Icon icon={mdiClose} />}
+        onAfterClick={() => alert('clicked on close')}
+        before={<Icon icon={mdiViewList} />}
+        onClick={() => alert('clicked on chip')}
+        isClickable
+    >
+        content
+    </Chip>
+);


### PR DESCRIPTION
# General summary

Fix https://lumapps.atlassian.net/browse/LUM-9356

# Test 

1. run `yarn && yarn storybook:react`
2. Go to http://localhost:9000/?path=/story/lumx-components-chip--with-after-and-before
3. Click on the list icon before the chip text (=> you should see "Clicked on chip")
4. Click on the chip text (=> you should see "Clicked on chip")
5. Click on the close icon after the chip text (=> you should see "Clicked on close")

