### PR TITLE
fix(storybook): fix lumapps/material theme switcher

### DIFF
--- a/packages/lumx-react/.storybook/story-block/useInjectTheme.ts
+++ b/packages/lumx-react/.storybook/story-block/useInjectTheme.ts
@@ -5,11 +5,10 @@ import { GlobalTheme } from '@lumx/core/js/types';
 
 /**
  * Please make sure that these themes are in the same order
- * as the `THEMES` constant.
+ * as the `GLOBAL_THEMES` constant.
  */
-import '@lumx/core/scss/lumx-theme-material.scss';
-
 import '@lumx/core/scss/lumx-theme-lumapps.scss';
+import '@lumx/core/scss/lumx-theme-material.scss';
 
 const GLOBAL_THEMES = Object.keys(CORE) as GlobalTheme[];
 const stylesNodes: Node[] = [];


### PR DESCRIPTION
# General summary

Fix lumapps/material theme switcher on storybook.

## Test 

1. run `yarn && yarn storybook:react`
2. Go to localhost:9000
3. Make sure the default theme is lumapps and when you switch to material, the theme is correclty applied
