### PR TITLE
fix: create custom SCSS format to fix grey icon style on material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `Mosaic` component is now correctly displayed on IE11.
+-   Fix missing grey color (in material theme) in the generated SCSS color palette
 
 ## [0.24.0][] - 2020-06-11
 

--- a/packages/lumx-core/src/scss/core/generated/lumapps/_variables.scss
+++ b/packages/lumx-core/src/scss/core/generated/lumapps/_variables.scss
@@ -1,7 +1,7 @@
-/*
-  Do not edit directly
-  Generated on Tue, 02 Jun 2020 10:24:31 GMT
-*/
+/**
+ * Do not edit directly
+ * Generated on Thu, 18 Jun 2020 13:00:52 GMT
+ */
 
 $lumx-color-dark-N: #28336d !default; // Neutral dark color
 $lumx-color-dark-L1: rgba(40, 51, 109, 0.8) !default; // Base dark color with 80% opacity
@@ -231,4 +231,4 @@ $lumx-core: (
             'L6': $lumx-color-orange-L6
         )
     )
-);
+) !default;

--- a/packages/lumx-core/src/scss/core/generated/material/_variables.scss
+++ b/packages/lumx-core/src/scss/core/generated/material/_variables.scss
@@ -1,7 +1,7 @@
-/*
-  Do not edit directly
-  Generated on Tue, 02 Jun 2020 10:24:31 GMT
-*/
+/**
+ * Do not edit directly
+ * Generated on Thu, 18 Jun 2020 13:00:52 GMT
+ */
 
 $lumx-color-dark-N: rgba(0, 0, 0, 0.87) !default; // Neutral dark color
 $lumx-color-dark-L1: rgba(0, 0, 0, 0.8) !default; // Base dark color with 80% opacity
@@ -247,4 +247,4 @@ $lumx-core: (
             'L6': $lumx-color-orange-L6
         )
     )
-);
+) !default;

--- a/packages/lumx-core/style-dictionary/config/gen-ts-variables.js
+++ b/packages/lumx-core/style-dictionary/config/gen-ts-variables.js
@@ -25,10 +25,7 @@ StyleDictionary.registerFormat({
     formatter(dictionary) {
         const properties = this.pickFields ? pickFieldsInTree(dictionary.properties, this.pickFields) : dictionary.properties;
         return `
-            /**
-             * Do not edit directly
-             * Generated on ${new Date().toUTCString()}
-             */
+            ${require('./utils/_genHeader')()}
 
             export const CORE = ${JSON.stringify(properties, null, 2)}
         `;

--- a/packages/lumx-core/style-dictionary/config/utils/_genHeader.js
+++ b/packages/lumx-core/style-dictionary/config/utils/_genHeader.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+    return `/**\n * Do not edit directly\n * Generated on ${new Date().toUTCString()}\n */`;
+}


### PR DESCRIPTION
# General summary

The default generated SCSS color map generated by the style dictionary lib could be overridden and thus the grey color (existing in the material theme only) could not be accessed.

This resulted in the material grey icon not being correctly colored. 

This PR fixes this by creating a custom style dictionary SCSS format identical to the `scss/map-deep` format but with an extra `!default` tag added on the generated SCSS map variable.
