### PR TITLE
fix(link-preview): fix thumbnailProps typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+-   _[BREAKING]_ Changed `thumbnailProps` prop type from `LinkPreview` to avoid typescript throwing an error
+if `thumbnailProps.image` was not specified even though it is already set by the `image` prop.
+
 ## [0.24.2][] - 2020-06-18
 
 ### Fixed

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
@@ -26,8 +26,11 @@ interface LinkPreviewProps extends GenericProps {
     theme?: Theme;
     /** Thumbnail image source */
     thumbnail?: string;
-    /** Thumbnail component props. */
-    thumbnailProps?: ThumbnailProps;
+    /** Thumbnail component props, without the props set by the component. */
+    thumbnailProps?: Omit<
+        ThumbnailProps,
+        'image' | 'onClick' | 'role' | 'tabIndex' | 'image' | 'aspectRatio' | 'fillHeight'
+    >;
     /** Link title */
     title?: string;
 }


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Typescript threw an error when the `thumbnailProps` prop from the `LinkPreview` component didn't have an `image` value.
![image](https://user-images.githubusercontent.com/7147342/85153970-21f7ac80-b257-11ea-97c3-b1f9a85f459b.png)

This could be fixed by setting the `image` field with any value, but that's not very pretty :sweat_smile: 
```
<LinkPreview
    size={Size.big}
    url={url}
    thumbnail={images[0]}
    title={title}
    description={description}
    thumbnailProps={{
        isCrossOriginEnabled: false,
        image: '',
    }}
/>
```

This PR fixes the typing by omitting all thumbnail props that are already set by the component.

This will however break any component that used the `image: ''` hack, since it is now an omitted value... 

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
