### PR TITLE
FIX/LUM-10327: Date picker weeks display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Changed `thumbnailProps` prop type from `LinkPreview` to avoid typescript throwing an error if `thumbnailProps.image` was not specified even though it is already set by the `image` prop.
 -   Allow event propagation on before/after element on `Chip` component when no handler is provided.
 -   Fix error in storybook using `useComputePosition`-based components.
+-   Fix calendar display for the `DatePicker`.
 
 ## [0.24.2][] - 2020-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Remove required prop on `lx-text-field` and `lx-select` input label
+-   Fix calendar display for the `DatePicker`.
 
 ## [0.24.3][] - 2020-06-24
 
@@ -22,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Changed `thumbnailProps` prop type from `LinkPreview` to avoid typescript throwing an error if `thumbnailProps.image` was not specified even though it is already set by the `image` prop.
 -   Allow event propagation on before/after element on `Chip` component when no handler is provided.
 -   Fix error in storybook using `useComputePosition`-based components.
--   Fix calendar display for the `DatePicker`.
 
 ## [0.24.2][] - 2020-06-18
 

--- a/packages/lumx-core/src/js/date-picker.ts
+++ b/packages/lumx-core/src/js/date-picker.ts
@@ -42,17 +42,18 @@ function getMonthCalendar(locale: string, selectedMonth?: Moment): Moment[] {
         .startOf('month');
     const endDay = moment(selectedMonth)
         .locale(locale)
-        .endOf('month');
+        .endOf('month')
+        .add(1, 'day');
 
-    const monthRange = moment.range(firstDay, endDay);
-
+    const monthRange = moment().range(firstDay.toDate(), endDay.toDate());
     const weeks = Array.from(monthRange.by('week'));
-
     const calendar = [];
+
     for (const week of weeks) {
         const firstWeekDay = moment(week).startOf('week');
         const lastWeekDay = moment(week).endOf('week');
         const weekRange = moment.range(firstWeekDay, lastWeekDay);
+
         calendar.push(...Array.from(weekRange.by('day')));
     }
 

--- a/packages/lumx-core/src/js/date-picker.ts
+++ b/packages/lumx-core/src/js/date-picker.ts
@@ -37,27 +37,13 @@ function getWeekDays(locale: string): Moment[] {
  * @return The list of days in a week based on locale.
  */
 function getMonthCalendar(locale: string, selectedMonth?: Moment): Moment[] {
-    const firstDay = moment(selectedMonth)
-        .locale(locale)
-        .startOf('month');
-    const endDay = moment(selectedMonth)
-        .locale(locale)
-        .endOf('month')
-        .add(1, 'day');
+    const firstDayOfMonth = moment(selectedMonth).startOf('month');
+    const endDayOfMonth = moment(selectedMonth).endOf('month');
+    // The first day of the week depends on the locale used. In FR the first day is a monday but in EN the first day is sunday
+    const firstDay = firstDayOfMonth.locale(locale).startOf('week');
+    const monthRange = moment.range(firstDay.toDate(), endDayOfMonth.toDate());
 
-    const monthRange = moment().range(firstDay.toDate(), endDay.toDate());
-    const weeks = Array.from(monthRange.by('week'));
-    const calendar = [];
-
-    for (const week of weeks) {
-        const firstWeekDay = moment(week).startOf('week');
-        const lastWeekDay = moment(week).endOf('week');
-        const weekRange = moment.range(firstWeekDay, lastWeekDay);
-
-        calendar.push(...Array.from(weekRange.by('day')));
-    }
-
-    return calendar;
+    return Array.from(monthRange.by('day'));
 }
 
 /**

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -48,6 +48,14 @@ const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
     todayOrSelectedDateRef,
     value,
 }) => {
+    const days = React.useMemo(() => {
+        return getAnnotatedMonthCalendar(locale, minDate, maxDate, selectedMonth);
+    }, [locale, minDate, maxDate, selectedMonth]);
+
+    const weekDays = React.useMemo(() => {
+        return getWeekDays(locale);
+    }, [locale]);
+
     return (
         <div className={`${CLASSNAME}`}>
             <Toolbar
@@ -64,7 +72,7 @@ const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
             />
             <div className={`${CLASSNAME}__calendar`}>
                 <div className={`${CLASSNAME}__week-days ${CLASSNAME}__days-wrapper`}>
-                    {getWeekDays(locale).map((weekDay) => (
+                    {weekDays.map((weekDay) => (
                         <div key={weekDay.unix()} className={`${CLASSNAME}__day-wrapper`}>
                             <span className={`${CLASSNAME}__week-day`}>
                                 {weekDay
@@ -77,7 +85,7 @@ const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
                 </div>
 
                 <div className={`${CLASSNAME}__month-days ${CLASSNAME}__days-wrapper`}>
-                    {getAnnotatedMonthCalendar(locale, minDate, maxDate, selectedMonth).map((annotatedDate) => {
+                    {days.map((annotatedDate) => {
                         if (annotatedDate.isDisplayed) {
                             return (
                                 <div key={annotatedDate.date.unix()} className={`${CLASSNAME}__day-wrapper`}>

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
@@ -113,3 +113,18 @@ export const withIncompatibleString = ({ theme }: any) => {
         />
     );
 };
+
+export const with28FebruarySelected = ({ theme }: any) => {
+    const [value, setValue] = React.useState<DatePickerProps['value']>(new Date('2019-02-28'));
+
+    return (
+        <DatePickerField
+            locale="fr"
+            label="Start date"
+            placeholder="Pick a date"
+            theme={theme}
+            onChange={setValue}
+            value={value}
+        />
+    );
+};

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
@@ -110,10 +110,6 @@ exports[`<DatePickerControlled> Snapshots and structure should render correctly 
     >
       <div
         className="lumx-date-picker__day-wrapper"
-        key="-349200"
-      />
-      <div
-        className="lumx-date-picker__day-wrapper"
         key="-262800"
       />
       <div

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
@@ -110,6 +110,10 @@ exports[`<DatePickerControlled> Snapshots and structure should render correctly 
     >
       <div
         className="lumx-date-picker__day-wrapper"
+        key="-349200"
+      />
+      <div
+        className="lumx-date-picker__day-wrapper"
         key="-262800"
       />
       <div
@@ -554,10 +558,6 @@ exports[`<DatePickerControlled> Snapshots and structure should render correctly 
           </span>
         </button>
       </div>
-      <div
-        className="lumx-date-picker__day-wrapper"
-        key="2674800"
-      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
# General summary

fix the display of the calendar. 
Number of weeks were not well compute by `moment-range` 

# Screenshots

![Capture d’écran 2020-06-24 à 15 39 59](https://user-images.githubusercontent.com/14941730/85567514-378f1c80-b631-11ea-88e1-6d0b67405346.png)
![Capture d’écran 2020-06-24 à 15 40 04](https://user-images.githubusercontent.com/14941730/85567519-38c04980-b631-11ea-8098-94cbd661455c.png)


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
