### PR TITLE
feat(button): add loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `ListItem` component is now able to use a link as HTML element to wrap content
+-   `Button` component handle isLoading state
 
 ### Fixed
 

--- a/packages/lumx-core/src/scss/components/button/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/button/lumapps/_index.scss
@@ -11,6 +11,26 @@
         top: -$lumx-spacing-unit / 2;
         right: -$lumx-spacing-unit / 2;
     }
+
+    &--is-loading {
+        .#{$lumx-base-prefix}-progress .#{$lumx-base-prefix}-progress-linear {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+        .#{$lumx-base-prefix}-progress--theme-light .#{$lumx-base-prefix}-progress-linear__line1,
+        .#{$lumx-base-prefix}-progress--theme-light .#{$lumx-base-prefix}-progress-linear__line2 {
+            background-color: lumx-color-variant('light', 'L5');
+        }
+
+        .#{$lumx-base-prefix}-progress--theme-dark .#{$lumx-base-prefix}-progress-linear__line1,
+        .#{$lumx-base-prefix}-progress--theme-dark .#{$lumx-base-prefix}-progress-linear__line2 {
+            background-color: lumx-color-variant('dark', 'L5');
+        }
+    }
 }
 
 /* Button sizes

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -18,8 +18,33 @@ export const simpleButton = ({ theme }: any) => {
             isSelected={boolean('isSelected', Boolean(DEFAULT_PROPS.isSelected))}
             color={select('color', ColorPalette, DEFAULT_PROPS.color)}
             hasBackground={boolean('hasBackground', Boolean(DEFAULT_PROPS.hasBackground))}
+            isLoading={boolean('isLoading', false)}
         >
             {text('Button content', 'Simple button')}
         </Button>
+    );
+};
+
+export const isLoading = ({ theme }: any) => {
+    const commonProps = {
+        ...DEFAULT_PROPS,
+        theme,
+        isLoading: true,
+    };
+
+    return (
+        <>
+            <Button {...commonProps} emphasis={Emphasis.high}>
+                {text('High Button content', 'High emphasis')}
+            </Button>
+            <br />
+            <Button {...commonProps} emphasis={Emphasis.low}>
+                {text('Low Button content', 'Low emphasis')}
+            </Button>
+            <br />
+            <Button {...commonProps} emphasis={Emphasis.medium}>
+                {text('Medium Button content', 'Medium emphasis')}
+            </Button>
+        </>
     );
 };

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { Color, ColorPalette, Emphasis, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 import { GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { Progress, ProgressVariant } from '../progress/Progress';
 
 /**
  * The authorized values for the `size` prop.
@@ -63,6 +64,11 @@ interface BaseButtonProps extends GenericProps {
      * Whether custom colors are applied to this component.
      */
     useCustomColors?: boolean;
+
+    /**
+     * If the button is loading? It also disable the component
+     */
+    isLoading?: boolean;
 }
 
 interface ButtonRootProps extends BaseButtonProps {
@@ -79,6 +85,8 @@ const BUTTON_CLASSNAME = `${CSS_PREFIX}-button`;
 
 /**
  * Render a button wrapper with the ButtonRoot inside.
+ * @param props Button props
+ * @return The component wrapped
  */
 const renderButtonWrapper: React.FC<ButtonRootProps> = (props) => {
     const { color, emphasis, variant } = props;
@@ -125,6 +133,7 @@ const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
         theme,
         useCustomColors,
         variant,
+        isLoading,
         ...forwardedProps
     } = props;
 
@@ -148,20 +157,33 @@ const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
             size,
             theme: emphasis === Emphasis.high && theme,
             variant,
+            isLoading,
         }),
         { [`${CSS_PREFIX}-custom-colors`]: useCustomColors },
+    );
+
+    const content = (
+        <>
+            {children}
+            {isLoading && <Progress theme={theme} variant={ProgressVariant.linear} useCustomColors />}
+        </>
     );
 
     if (!isEmpty(props.href)) {
         return (
             <a {...forwardedProps} ref={buttonRef as RefObject<HTMLAnchorElement>} className={buttonClassName}>
-                {children}
+                {content}
             </a>
         );
     }
     return (
-        <button {...forwardedProps} ref={buttonRef as RefObject<HTMLButtonElement>} className={buttonClassName}>
-            {children}
+        <button
+            disabled={isLoading}
+            {...forwardedProps}
+            ref={buttonRef as RefObject<HTMLButtonElement>}
+            className={buttonClassName}
+        >
+            {content}
         </button>
     );
 };


### PR DESCRIPTION
# General summary

This is a proposal. 
A button can be in loading state. This case is usefull to handle form loading and prevent the user to click multiple time on the button and create several items
This is the case for https://lumapps.atlassian.net/browse/LUM-10387?atlOrigin=eyJpIjoiMTljOGJkZjAwNmYzNGIyZDgzZjIwMmZiOTFiNjNmZmIiLCJwIjoiaiJ9

# Screenshots
![Capture d’écran 2020-06-27 à 16 55 21](https://user-images.githubusercontent.com/14941730/85925190-14fe3d00-b897-11ea-91a4-d6c9097b56b5.png)


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
