### PR TITLE
feat(tooltip): handle multiline and empty cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `Tooltip` can have a multiline `label` by putting `\n` character inside the string.
+
+### Changed
+
+-   `Tooltip` does not appear if the `label` is empty, `null` or `undefined`.
+
 ## [0.25.0][] - 2020-06-29
 
 ### Added

--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -29,3 +29,25 @@ export const InlineTooltip = () => (
         {' on one word.'}
     </>
 );
+
+export const MultilineTooltip = () => (
+    <>
+        <Tooltip label={'Only one sentence.'}>
+            <Button>One line</Button>
+        </Tooltip>
+        <Tooltip label={'First sentence.\nSecond sentence.\nThird sentence.\n'}>
+            <Button>Multiline</Button>
+        </Tooltip>
+    </>
+);
+
+export const EmptyTooltip = () => (
+    <>
+        <Tooltip label={''}>
+            <Button>Empty</Button>
+        </Tooltip>
+        <Tooltip label={false && 'tooltip'}>
+            <Button>Conditionnaly not displayed</Button>
+        </Tooltip>
+    </>
+);

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -35,7 +35,7 @@ interface OptionalTooltipProps extends GenericProps {
  */
 interface TooltipProps extends OptionalTooltipProps {
     /** Tooltip label. */
-    label: string;
+    label?: string | null | false;
 
     /** Tooltip anchor. */
     children: ReactNode;
@@ -82,6 +82,10 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
         forceOpen = DEFAULT_PROPS.forceOpen,
         ...forwardedProps
     } = props;
+    if (!label) {
+        return <>{children}</>;
+    }
+
     const id = useMemo(() => `tooltip-${uuid()}`, []);
     const [popperElement, setPopperElement] = useState<null | HTMLElement>(null);
     const anchorRef = useRef(null);
@@ -116,7 +120,11 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
                         {...attributes.popper}
                     >
                         <div className={`${CLASSNAME}__arrow`} />
-                        <div className={`${CLASSNAME}__inner`}>{label}</div>
+                        <div className={`${CLASSNAME}__inner`}>
+                            {label.indexOf('\n') !== -1
+                                ? label.split('\n').map((sentence) => <p key={sentence}>{sentence}</p>)
+                                : label}
+                        </div>
                     </div>,
                     document.body,
                 )}


### PR DESCRIPTION
# General summary
- Handle multiline in tooltip
- Tooltip with empty/undefined/null label is not displayed

# Screenshots
![Peek 29-06-2020 19-37](https://user-images.githubusercontent.com/2828353/86037728-20d93300-ba40-11ea-9729-47e590dc8a38.gif)


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
