### PR TITLE
fix(material default border-radius): border radius in material design theme

### DIFF
--- a/packages/lumx-core/src/scss/core/border-radius/lumapps/_variables.scss
+++ b/packages/lumx-core/src/scss/core/border-radius/lumapps/_variables.scss
@@ -1,1 +1,1 @@
-$lumx-border-radius: 4px;
+$lumx-border-radius: 4px !default;


### PR DESCRIPTION
# General summary

In material design theme, default border radius should be 2px and was 4px

# Screenshots

Correct border radius (2px) shown on the button component 
<img width="852" alt="Capture d’écran 2020-07-20 à 10 57 08" src="https://user-images.githubusercontent.com/15898440/87919277-d9aaf480-ca77-11ea-8dab-893c446a5c86.png">


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if fix or feature) Add `need: test` label