### PR TITLE
fix: list controlled highlighted state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `ListItem` now properly keep the given `isHighligthed` prop value when controlled from a parent component. (Fixes
+    `Autocomplete` & `AutocompleteMultiple` keyboard arrow navigation in the completed suggestions)
+
 ## [0.25.3][] - 2020-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   `ListItem` now properly keep the given `isHighligthed` prop value when controlled from a parent component. (Fixes
-    `Autocomplete` & `AutocompleteMultiple` keyboard arrow navigation in the completed suggestions)
+-   `ListItem` now properly keep the given `isHighligthed` prop value when controlled from a parent component. Fixes `Autocomplete` & `AutocompleteMultiple` keyboard arrow navigation in the completed suggestions.
 
 ## [0.25.3][] - 2020-07-01
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.stories.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.stories.tsx
@@ -4,7 +4,7 @@ import { Autocomplete, List, ListItem, Size } from '@lumx/react';
 
 import { CITIES } from './__mockData__';
 
-export default { title: 'LumX components/Autocomplete' };
+export default { title: 'LumX components/autocomplete/Autocomplete' };
 
 const cityNames = CITIES.map((city) => city.text);
 

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.stories.tsx
@@ -4,7 +4,7 @@ import { AutocompleteMultiple, Chip, ChipGroup, Icon, List, ListItem, Size } fro
 
 import { mdiClose, mdiFlag } from '@lumx/icons';
 
-export default { title: 'LumX components/Autocomplete Multiple' };
+export default { title: 'LumX components/autocomplete/Autocomplete Multiple' };
 
 import { CITIES } from './__mockData__';
 

--- a/packages/lumx-react/src/components/autocomplete/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Demos.stories.tsx
@@ -1,0 +1,4 @@
+export default { title: 'LumX components/autocomplete/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as Multiple } from './demos/multiple';

--- a/packages/lumx-react/src/components/autocomplete/demos
+++ b/packages/lumx-react/src/components/autocomplete/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/autocomplete/react

--- a/packages/lumx-react/src/components/list/useInteractiveList.tsx
+++ b/packages/lumx-react/src/components/list/useInteractiveList.tsx
@@ -168,7 +168,7 @@ export const useInteractiveList: useInteractiveList = (options) => {
             // Clone list item: inject ref, add tab index and active state.
             return cloneElement<ListItemProps>(item, {
                 ...item.props,
-                isHighlighted,
+                isHighlighted: item.props.isHighlighted ?? isHighlighted,
                 linkRef: mergeRefs(item.props.linkRef, (element) => {
                     if (isHighlighted) {
                         element?.focus();

--- a/packages/site-demo/content/product/components/autocomplete/react/default.tsx
+++ b/packages/site-demo/content/product/components/autocomplete/react/default.tsx
@@ -107,23 +107,21 @@ const App = ({ theme }: any) => {
             onFocus={onFocus}
             inputRef={inputRef}
         >
-            {hasSuggestions && (
-                <List isClickable>
-                    {filteredCities.map((city, index) => {
-                        const onItemSelected = () => setSelectedCity(city);
-                        return (
-                            <ListItem
-                                size={Size.tiny}
-                                key={city.id}
-                                isHighlighted={index === activeItemIndex}
-                                onItemSelected={onItemSelected}
-                            >
-                                <div>{city.text}</div>
-                            </ListItem>
-                        );
-                    })}
-                </List>
-            )}
+            <List>
+                {filteredCities.map((city, index) => {
+                    const onItemSelected = () => setSelectedCity(city);
+                    return (
+                        <ListItem
+                            size={Size.tiny}
+                            key={city.id}
+                            isHighlighted={index === activeItemIndex}
+                            onItemSelected={onItemSelected}
+                        >
+                            <div>{city.text}</div>
+                        </ListItem>
+                    );
+                })}
+            </List>
         </Autocomplete>
     );
 };


### PR DESCRIPTION
# General summary

`ListItem` now properly keep the given `isHighligthed` prop value when controlled from a parent component. (Fixes `Autocomplete` & `AutocompleteMultiple` keyboard arrow navigation in the completed suggestions)

