### PR TITLE
fix demo site script to render props correctly

### DIFF
--- a/packages/site-demo/webpack-loader/props-loader/convertPropTable.js
+++ b/packages/site-demo/webpack-loader/props-loader/convertPropTable.js
@@ -34,7 +34,7 @@ function findComponentsAndProps(definitionById) {
             // Component => Something that returns a react element.
             if (
                 signatures &&
-                signatures.every((sign) => sign.type.name && sign.type.name.endsWith('ReactElement')) &&
+                signatures.every((sign) => sign.type.name && sign.type.name.endsWith('Element')) &&
                 sources[0].fileName.includes(name)
             ) {
                 return {


### PR DESCRIPTION
# General summary

A little fix to render the components props on the demo site 

# Screenshots

**Before**
![Capture d’écran de 2020-07-29 21-39-58](https://user-images.githubusercontent.com/45166587/88845210-1ac3a700-d1e4-11ea-9b8c-c1dca58e7a1e.png)

****
**After**
![Capture d’écran de 2020-07-29 21-39-58](https://user-images.githubusercontent.com/45166587/88845135-02538c80-d1e4-11ea-8b44-f6f9d9d2b57f.png)


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
