### PR TITLE
docs(docs): Add a way to render the props table specifying the props name

### DIFF
--- a/packages/lumx-react/src/components/button/Button.tsx
+++ b/packages/lumx-react/src/components/button/Button.tsx
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
 import { Emphasis, Icon, Size, Theme } from '@lumx/react';
+import { BaseButtonProps, ButtonRoot } from '@lumx/react/components/button/ButtonRoot';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { getBasicClass, getRootClassName } from '@lumx/react/utils';
-import { BaseButtonProps, ButtonRoot } from './ButtonRoot';
 
 /**
  * The authorized values for the `emphasis` prop.

--- a/packages/site-demo/content/product/components/button/index.mdx
+++ b/packages/site-demo/content/product/components/button/index.mdx
@@ -30,4 +30,5 @@ Use small size when space is a constraint.
 
 ### Properties
 
+<PropTable props="BaseButtonProps" />
 <PropTable component="Button" />

--- a/packages/site-demo/src/layout/PropTable.tsx
+++ b/packages/site-demo/src/layout/PropTable.tsx
@@ -6,7 +6,7 @@ import orderBy from 'lodash/orderBy';
 import { Alignment, Divider, ExpansionPanel, Grid, GridItem } from '@lumx/react';
 
 // @ts-ignore
-import { propsByComponent } from 'props-loader!';
+import { propsByComponent, propsByProps } from 'props-loader!';
 
 const renderTypeTableRow = ({ type, defaultValue }: Property): ReactElement => {
     let formattedType = <>{type}</>;
@@ -63,16 +63,21 @@ const PropTableRow: React.FC<PropTableRowProps> = ({ property }) => {
     );
 };
 
-const PropTable: React.FC<PropTableProps> = ({ component }) => {
+const PropTable: React.FC<PropTableProps> = ({ component, props }) => {
     const { engine } = useContext(EngineContext);
     if (engine === Engine.angularjs) {
         return <span>Could not load properties of the angular.js {component} component.</span>;
     }
 
-    const propertyList: Property[] = propsByComponent[component];
+    let propertyList: Property[] | undefined;
+    if (component) {
+        propertyList = propsByComponent[component];
+    } else if (props) {
+        propertyList = propsByProps[props];
+    }
 
     if (!propertyList) {
-        return <span>Could not load properties of the react {component} component.</span>;
+        return <span>Could not load properties of the react {component || props} component.</span>;
     }
 
     return (
@@ -104,7 +109,8 @@ interface PropTableRowProps {
 }
 
 interface PropTableProps {
-    component: string;
+    component?: string;
+    props?: string;
 }
 
 export { PropTable, Property };

--- a/packages/site-demo/webpack-loader/props-loader/index.js
+++ b/packages/site-demo/webpack-loader/props-loader/index.js
@@ -1,7 +1,7 @@
 const lodash = require('lodash');
 const typedoc = require('typedoc');
 
-const { convertToSimplePropsByComponent } = require('./convertPropTable');
+const { convertToSimplePropsByComponent, convertToSimplePropsByProps } = require('./convertPropTable');
 
 const inputFiles = ['../lumx-react'];
 const tsconfig = require('../../tsconfig.json');
@@ -32,5 +32,7 @@ module.exports = function propsLoader() {
     // Convert to simple props description.
     const propsByComponent = convertToSimplePropsByComponent(typeDocDef);
 
-    return `module.exports = ${JSON.stringify({ propsByComponent })}`;
+    const propsByProps = convertToSimplePropsByProps(typeDocDef);
+
+    return `module.exports = ${JSON.stringify({ propsByComponent, propsByProps })}`;
 };


### PR DESCRIPTION
The motivation for this PR was that some components inherit some props that are defined in differents files and so for instance the Button does not display those inherited props and in that case most of the button props comes from the first parent so not having them made it seems that there is not a lot a properties and hence customization possible. TLDR, some components needs to render inherited props for completeness sake and that PR aims to do it.

As a side note, I tried extracting inherited props from the _typedocRef_ at build time but it seems that typeDoc has some difficulties with inheritance from props defined in another file (or something like that ...) and in the _definitionById_ element (props-loader => convertPropTable => findComponentAndProps)  there was apparently no way to know what props are extended by a props or from what props a props inherit and so I decided to do something simpler but less elegant (we have two separated properties table in the doc and have to specify each props by hand) to work around that :) 

# General summary

Add a way to render the props table specifying the props name and not the component

# Screenshots

**Button props before**
![Capture d’écran de 2020-08-01 17-28-17](https://user-images.githubusercontent.com/45166587/89104861-bb041080-d41c-11ea-86d9-697a96ddac41.png)

**Button props after adding the BaseButtonProps Props Table in the demo**

```
<PropTable` props="BaseButtonProps" />
```


![Capture d’écran de 2020-08-01 17-28-28](https://user-images.githubusercontent.com/45166587/89104863-bc353d80-d41c-11ea-91e2-486111a686d6.png)


# Check list


-   [x] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

