### PR TITLE
docs(build): do not filter component based on name

### DIFF
--- a/packages/site-demo/content/product/components/button/index.mdx
+++ b/packages/site-demo/content/product/components/button/index.mdx
@@ -30,4 +30,9 @@ Use small size when space is a constraint.
 
 ### Properties
 
+#### Button
+<PropTable component="ButtonRoot" />
 <PropTable component="Button" />
+
+#### IconButton
+<PropTable component="IconButton" />

--- a/packages/site-demo/webpack-loader/props-loader/convertPropTable.js
+++ b/packages/site-demo/webpack-loader/props-loader/convertPropTable.js
@@ -32,11 +32,7 @@ function findComponentsAndProps(definitionById) {
         .map((def) => {
             const { id, kindString, signatures, name, sources, children } = def;
             // Component => Something that returns a react element.
-            if (
-                signatures &&
-                signatures.every((sign) => sign.type.name && sign.type.name.endsWith('Element')) &&
-                sources[0].fileName.includes(name)
-            ) {
+            if (signatures && signatures.every((sign) => sign.type.name) && sources[0].fileName.includes(name)) {
                 return {
                     name,
                     id,


### PR DESCRIPTION
# General summary

Do not filter components based on name in demo site build to have buttonRoot component available and be able to add it to the button doc as it contains most of the usefull button props.
Also add IconButton doc

Title in the button doc may have to be updated for clarity sake ?

# Screenshots

**Before**
![Capture d’écran de 2020-08-01 18-22-06](https://user-images.githubusercontent.com/45166587/89105728-0241cf80-d424-11ea-9431-12b5cd26213b.png)

**After**
![Capture d’écran de 2020-08-01 18-21-58](https://user-images.githubusercontent.com/45166587/89105729-040b9300-d424-11ea-80a7-b1f56a226343.png)

# Check list

-   [x] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
