### PR TITLE
chore: add component demos in storybook

### DIFF
--- a/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
@@ -6,7 +6,7 @@ import { Avatar } from './Avatar';
 
 import { select, text } from '@storybook/addon-knobs';
 
-export default { title: 'LumX components/Avatar' };
+export default { title: 'LumX components/avatar/Avatar' };
 
 /**
  * Avatar stories showing a simple Avatar with different sizes.

--- a/packages/lumx-react/src/components/avatar/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/avatar/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/avatar/demos
+++ b/packages/lumx-react/src/components/avatar/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/avatar/react

--- a/packages/lumx-react/src/components/badge/Badge.stories.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.stories.tsx
@@ -3,7 +3,7 @@ import { AspectRatio, Badge, ColorPalette, Icon, Size, Thumbnail, ThumbnailVaria
 import { select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
-export default { title: 'LumX components/Badge' };
+export default { title: 'LumX components/badge/Badge' };
 
 export const simpleBadgeWithValue = () => (
     <Badge color={select('Colors', ColorPalette, ColorPalette.blue)}>

--- a/packages/lumx-react/src/components/badge/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/badge/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/badge/Demos' };

--- a/packages/lumx-react/src/components/badge/demos
+++ b/packages/lumx-react/src/components/badge/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/badge/react

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_PROPS } from '@lumx/react/components/button/Button';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
-export default { title: 'LumX components/Button' };
+export default { title: 'LumX components/button/Button' };
 
 export const simpleButton = ({ theme }: any) => {
     return (

--- a/packages/lumx-react/src/components/button/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/button/Demos.stories.tsx
@@ -1,0 +1,6 @@
+export default { title: 'LumX components/button/Demos' };
+
+export { default as EmphasisHigh } from './demos/emphasis-high';
+export { default as EmphasisLow } from './demos/emphasis-low';
+export { default as EmphasisMedium } from './demos/emphasis-medium';
+export { default as Small } from './demos/small';

--- a/packages/lumx-react/src/components/button/demos
+++ b/packages/lumx-react/src/components/button/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/button/react

--- a/packages/lumx-react/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.stories.tsx
@@ -3,7 +3,7 @@ import { text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React, { useState } from 'react';
 
-export default { title: 'LumX components/Checkbox' };
+export default { title: 'LumX components/checkbox/Checkbox' };
 
 export const simpleSelect = ({ theme }: any) => {
     const [value, setValue] = useState(false);

--- a/packages/lumx-react/src/components/checkbox/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/checkbox/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/checkbox/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/checkbox/demos
+++ b/packages/lumx-react/src/components/checkbox/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/checkbox/react

--- a/packages/lumx-react/src/components/chip/Chip.stories.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { mdiClose, mdiViewList } from '@lumx/icons';
 import { Chip, Icon } from '@lumx/react';
 
-export default { title: 'LumX components/Chip' };
+export default { title: 'LumX components/chip/Chip' };
 
 export const simple = ({ theme }: any) => <Chip theme={theme}>The chip</Chip>;
 

--- a/packages/lumx-react/src/components/chip/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/chip/Demos.stories.tsx
@@ -1,0 +1,8 @@
+export default { title: 'LumX components/chip/Demos' };
+
+export { default as Choice } from './demos/choice';
+export { default as Default } from './demos/default';
+export { default as Dismissible } from './demos/dismissible';
+export { default as Filter } from './demos/filter';
+export { default as Group } from './demos/group';
+export { default as Small } from './demos/small';

--- a/packages/lumx-react/src/components/chip/demos
+++ b/packages/lumx-react/src/components/chip/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/chip/react

--- a/packages/lumx-react/src/components/comment-block/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/Demos.stories.tsx
@@ -1,0 +1,5 @@
+export default { title: 'LumX components/comment-block/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as Relevant } from './demos/relevant';
+export { default as Threaded } from './demos/threaded';

--- a/packages/lumx-react/src/components/comment-block/demos
+++ b/packages/lumx-react/src/components/comment-block/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/comment-block/react

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 
 import { DatePickerField, DatePickerProps } from '@lumx/react';
 
-export default { title: 'LumX components/DatePickerField' };
+export default { title: 'LumX components/date-picker/DatePickerField' };
 
 export const simple = ({ theme }: any) => {
     const [value, setValue] = React.useState<DatePickerProps['value']>();

--- a/packages/lumx-react/src/components/date-picker/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/date-picker/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/date-picker/Demos' };

--- a/packages/lumx-react/src/components/date-picker/demos
+++ b/packages/lumx-react/src/components/date-picker/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/date-picker/react

--- a/packages/lumx-react/src/components/dialog/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Demos.stories.tsx
@@ -1,0 +1,7 @@
+export default { title: 'LumX components/dialog/Demos' };
+
+export { default as Action } from './demos/action';
+export { default as Default } from './demos/default';
+export { default as PreventAutoDismiss } from './demos/prevent-auto-dismiss';
+export { default as Scrollable } from './demos/scrollable';
+export { default as Sizes } from './demos/sizes';

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -17,7 +17,7 @@ import { DialogSizes } from '@lumx/react/components/dialog/Dialog';
 import { select } from '@storybook/addon-knobs';
 import React, { RefObject, useRef, useState } from 'react';
 
-export default { title: 'LumX components/Dialog' };
+export default { title: 'LumX components/dialog/Dialog' };
 
 function useOpenButton(theme: Theme) {
     const buttonRef = useRef() as RefObject<HTMLButtonElement>;

--- a/packages/lumx-react/src/components/dialog/demos
+++ b/packages/lumx-react/src/components/dialog/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/dialog/react

--- a/packages/lumx-react/src/components/divider/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/divider/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/divider/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/divider/demos
+++ b/packages/lumx-react/src/components/divider/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/divider/react

--- a/packages/lumx-react/src/components/drag-handle/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/drag-handle/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/drag-handle/Demos' };

--- a/packages/lumx-react/src/components/drag-handle/demos
+++ b/packages/lumx-react/src/components/drag-handle/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/drag-handle/react

--- a/packages/lumx-react/src/components/expansion-panel/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/Demos.stories.tsx
@@ -1,0 +1,6 @@
+export default { title: 'LumX components/expansion-panel/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as DragHandle } from './demos/drag-handle';
+export { default as Examples } from './demos/examples';
+export { default as Trimmed } from './demos/trimmed';

--- a/packages/lumx-react/src/components/expansion-panel/demos
+++ b/packages/lumx-react/src/components/expansion-panel/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/expansion-panel/react

--- a/packages/lumx-react/src/components/flex-box/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/flex-box/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/flex-box/Demos' };

--- a/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
@@ -8,7 +8,7 @@ import isArray from 'lodash/isArray';
 import { DEFAULT_PROPS, FlexBox, FlexBoxProps } from './FlexBox';
 /*  tslint:disable object-literal-sort-keys */
 
-export default { title: 'LumX components/FlexBox' };
+export default { title: 'LumX components/flex-box/FlexBox' };
 
 type FlexBoxPropName = keyof FlexBoxProps;
 const flexViewKnobConfigs: Array<

--- a/packages/lumx-react/src/components/flex-box/demos
+++ b/packages/lumx-react/src/components/flex-box/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/flex-box/react

--- a/packages/lumx-react/src/components/grid/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/grid/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/grid/Demos' };

--- a/packages/lumx-react/src/components/grid/demos
+++ b/packages/lumx-react/src/components/grid/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/grid/react

--- a/packages/lumx-react/src/components/icon/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/icon/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/icon/Demos' };

--- a/packages/lumx-react/src/components/icon/Icon.stories.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.stories.tsx
@@ -4,7 +4,7 @@ import { mdiEmail } from '@lumx/icons';
 import { ColorPalette, FlexBox, Icon, IconSizes, Size } from '@lumx/react';
 import { Orientation } from '..';
 
-export default { title: 'LumX components/Icon' };
+export default { title: 'LumX components/icon/Icon' };
 
 const iconSizes: Array<IconSizes | undefined> = [
     undefined,

--- a/packages/lumx-react/src/components/icon/demos
+++ b/packages/lumx-react/src/components/icon/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/icon/react

--- a/packages/lumx-react/src/components/image-block/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/image-block/Demos.stories.tsx
@@ -1,0 +1,6 @@
+export default { title: 'LumX components/image-block/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as ImageBlockAlignment } from './demos/image-block-alignment';
+export { default as ImageBlockOver } from './demos/image-block-over';
+export { default as ImageBlockPadding } from './demos/image-block-padding';

--- a/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Alignment, AspectRatio, Chip, ChipGroup, ImageBlock, Size } from '@lumx/react';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
 
-export default { title: 'LumX components/Image Block' };
+export default { title: 'LumX components/image-block/Image Block' };
 
 const numberKnobOptions = {
     max: 1,

--- a/packages/lumx-react/src/components/image-block/demos
+++ b/packages/lumx-react/src/components/image-block/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/image-block/react

--- a/packages/lumx-react/src/components/input-helper/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/input-helper/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/input-helper/Demos' };

--- a/packages/lumx-react/src/components/input-helper/InputHelper.stories.tsx
+++ b/packages/lumx-react/src/components/input-helper/InputHelper.stories.tsx
@@ -2,7 +2,7 @@ import { InputHelper, Kind } from '@lumx/react';
 import { text } from '@storybook/addon-knobs';
 import React from 'react';
 
-export default { title: 'LumX components/Input Helper' };
+export default { title: 'LumX components/input-helper/Input Helper' };
 
 export const informationHelper = ({ theme }: any) => (
     <InputHelper kind={Kind.info} theme={theme}>

--- a/packages/lumx-react/src/components/input-helper/demos
+++ b/packages/lumx-react/src/components/input-helper/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/input-helper/react

--- a/packages/lumx-react/src/components/input-label/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/input-label/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/input-label/Demos' };

--- a/packages/lumx-react/src/components/input-label/InputLabel.stories.tsx
+++ b/packages/lumx-react/src/components/input-label/InputLabel.stories.tsx
@@ -4,6 +4,6 @@ import { text } from '@storybook/addon-knobs';
 
 import { InputLabel } from './InputLabel';
 
-export default { title: 'LumX components/Input Label' };
+export default { title: 'LumX components/input-label/Input Label' };
 
 export const simpleLabel = ({ theme }: any) => <InputLabel theme={theme}>{text('Label', 'The label')}</InputLabel>;

--- a/packages/lumx-react/src/components/input-label/demos
+++ b/packages/lumx-react/src/components/input-label/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/input-label/react

--- a/packages/lumx-react/src/components/lightbox/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/lightbox/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/lightbox/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/lightbox/demos
+++ b/packages/lumx-react/src/components/lightbox/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/lightbox/react

--- a/packages/lumx-react/src/components/link-preview/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/link-preview/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/link-preview/Demos' };

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.stories.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Size } from '..';
 import { LinkPreview } from './LinkPreview';
 
-export default { title: 'LumX components/Link preview' };
+export default { title: 'LumX components/link-preview/Link preview' };
 
 const LONG_LOREM_IPSUM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut quam sollicitudin, viverra quam eget, pretium tellus. Praesent sit amet augue in odio varius accumsan vitae quis nunc. Aliquam iaculis neque at augue laoreet, eu sagittis dolor tempus. Nullam sit amet bibendum velit, in pharetra lorem. Aliquam semper accumsan placerat. Sed felis risus, efficitur non eros non, rhoncus viverra lectus. Aliquam eget interdum tellus. Praesent non ex ut urna tempus facilisis. Sed tellus tortor, pharetra vel velit sit amet, aliquet condimentum quam. Sed dictum nibh eget nibh ullamcorper dignissim. Vestibulum elementum at mauris sit amet iaculis. Maecenas pretium luctus enim vel commodo. Cras accumsan sagittis eros, vel maximus sem molestie id. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 

--- a/packages/lumx-react/src/components/link-preview/demos
+++ b/packages/lumx-react/src/components/link-preview/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/link-preview/react

--- a/packages/lumx-react/src/components/link/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/link/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/link/Demos' };

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -2,7 +2,7 @@ import { ColorPalette, ColorVariant, Link } from '@lumx/react';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
-export default { title: 'LumX components/Link' };
+export default { title: 'LumX components/link/Link' };
 
 export const simpleLink = () => (
     <>

--- a/packages/lumx-react/src/components/link/demos
+++ b/packages/lumx-react/src/components/link/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/link/react

--- a/packages/lumx-react/src/components/list/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/list/Demos.stories.tsx
@@ -1,4 +1,4 @@
-export default { title: 'LumX components/List/Demos' };
+export default { title: 'LumX components/list/Demos' };
 
 export { default as tiny } from './demos/tiny';
 export { default as regular } from './demos/regular';

--- a/packages/lumx-react/src/components/list/List.stories.tsx
+++ b/packages/lumx-react/src/components/list/List.stories.tsx
@@ -9,7 +9,7 @@ import { select, text } from '@storybook/addon-knobs';
 import { List } from './List';
 import { ListItem } from './ListItem';
 
-export default { title: 'LumX components/List/List' };
+export default { title: 'LumX components/list/List' };
 
 export const KeyboardNavigation = () => {
     const listRef = useRef<any>();

--- a/packages/lumx-react/src/components/list/ListDivider.stories.tsx
+++ b/packages/lumx-react/src/components/list/ListDivider.stories.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 
 import { ListDivider } from './ListDivider';
 
-export default { title: 'LumX components/List/ListDivider' };
+export default { title: 'LumX components/list/ListDivider' };
 
 export const Default = () => <ListDivider />;

--- a/packages/lumx-react/src/components/list/ListItem.stories.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.stories.tsx
@@ -5,7 +5,7 @@ import { select, text } from '@storybook/addon-knobs';
 
 import { ListItem } from './ListItem';
 
-export default { title: 'LumX components/List/ListItem' };
+export default { title: 'LumX components/list/ListItem' };
 
 export const Default = ({ theme }: any) => <ListItem theme={theme}>{text('text', 'Text')}</ListItem>;
 

--- a/packages/lumx-react/src/components/list/ListSubheader.stories.tsx
+++ b/packages/lumx-react/src/components/list/ListSubheader.stories.tsx
@@ -3,6 +3,6 @@ import React from 'react';
 import { ListSubheader } from '@lumx/react';
 import { text } from '@storybook/addon-knobs';
 
-export default { title: 'LumX components/List/ListSubheader' };
+export default { title: 'LumX components/list/ListSubheader' };
 
 export const Default = () => <ListSubheader>{text('text', 'Text')}</ListSubheader>;

--- a/packages/lumx-react/src/components/message/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/message/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/message/Demos' };

--- a/packages/lumx-react/src/components/message/Message.stories.tsx
+++ b/packages/lumx-react/src/components/message/Message.stories.tsx
@@ -2,7 +2,7 @@ import { Message, MessageKind } from '@lumx/react';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
-export default { title: 'LumX components/Message' };
+export default { title: 'LumX components/message/Message' };
 
 export const message = () => (
     <Message

--- a/packages/lumx-react/src/components/message/demos
+++ b/packages/lumx-react/src/components/message/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/message/react

--- a/packages/lumx-react/src/components/mosaic/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/mosaic/Demos.stories.tsx
@@ -1,0 +1,1 @@
+export default { title: 'LumX components/mosaic/Demos' };

--- a/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { Alignment, ImageBlock, Lightbox, Slideshow, SlideshowItem, Theme } from '@lumx/react';
 import { Mosaic } from './Mosaic';
 
-export default { title: 'LumX components/Mosaic' };
+export default { title: 'LumX components/mosaic/Mosaic' };
 
 export const oneThumbnail = ({ theme }: any) => {
     const wrapperStyle = { width: 250 };

--- a/packages/lumx-react/src/components/mosaic/demos
+++ b/packages/lumx-react/src/components/mosaic/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/mosaic/react

--- a/packages/lumx-react/src/components/notification/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/notification/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/notification/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/notification/Notifications.stories.tsx
+++ b/packages/lumx-react/src/components/notification/Notifications.stories.tsx
@@ -4,7 +4,7 @@ import { Button, Notification, NotificationType } from '@lumx/react';
 
 import noop from 'lodash/noop';
 
-export default { title: 'LumX components/Notification' };
+export default { title: 'LumX components/notification/Notification' };
 
 const properties = {
     error: {

--- a/packages/lumx-react/src/components/notification/demos
+++ b/packages/lumx-react/src/components/notification/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/notification/react

--- a/packages/lumx-react/src/components/post-block/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/post-block/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/post-block/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/post-block/demos
+++ b/packages/lumx-react/src/components/post-block/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/post-block/react

--- a/packages/lumx-react/src/components/progress-tracker/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/Demos.stories.tsx
@@ -1,0 +1,8 @@
+export default { title: 'LumX components/progress-tracker/Demos' };
+
+export { default as Completed } from './demos/completed';
+export { default as Current } from './demos/current';
+export { default as Error } from './demos/error';
+export { default as Future } from './demos/future';
+export { default as Helper } from './demos/helper';
+export { default as States } from './demos/states';

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTracker.stories.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTracker.stories.tsx
@@ -3,7 +3,7 @@ import { text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React from 'react';
 
-export default { title: 'LumX components/Progress Tracker' };
+export default { title: 'LumX components/progress-tracker/Progress Tracker' };
 
 export const simpleSteps = ({ theme }: any) => (
     <ProgressTracker theme={theme}>

--- a/packages/lumx-react/src/components/progress-tracker/demos
+++ b/packages/lumx-react/src/components/progress-tracker/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/progress-tracker/react

--- a/packages/lumx-react/src/components/progress/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/progress/Demos.stories.tsx
@@ -1,0 +1,4 @@
+export default { title: 'LumX components/progress/Demos' };
+
+export { default as Circular } from './demos/circular';
+export { default as Linear } from './demos/linear';

--- a/packages/lumx-react/src/components/progress/demos
+++ b/packages/lumx-react/src/components/progress/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/progress/react

--- a/packages/lumx-react/src/components/radio-button/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/radio-button/Demos.stories.tsx
@@ -1,0 +1,4 @@
+export default { title: 'LumX components/radio-button/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as Helper } from './demos/helper';

--- a/packages/lumx-react/src/components/radio-button/RadioButton.stories.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.stories.tsx
@@ -3,7 +3,7 @@ import { text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React from 'react';
 
-export default { title: 'LumX components/Radio button' };
+export default { title: 'LumX components/radio-button/Radio button' };
 
 export const simpleRadioButton = ({ theme }: any) => (
     <RadioButton

--- a/packages/lumx-react/src/components/radio-button/RadioGroup.stories.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioGroup.stories.tsx
@@ -2,7 +2,7 @@ import { RadioButton, RadioGroup } from '@lumx/react';
 import noop from 'lodash/noop';
 import React from 'react';
 
-export default { title: 'LumX components/Radio Group' };
+export default { title: 'LumX components/radio-button/Radio Group' };
 
 export const radioGroup = ({ theme }: any) => (
     <RadioGroup>

--- a/packages/lumx-react/src/components/radio-button/demos
+++ b/packages/lumx-react/src/components/radio-button/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/radio-button/react

--- a/packages/lumx-react/src/components/select/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/select/Demos.stories.tsx
@@ -1,0 +1,9 @@
+export default { title: 'LumX components/select/Demos' };
+
+export { default as MultiSelectChip } from './demos/multi-select-chip';
+export { default as MultiSelectSearch } from './demos/multi-select-search';
+export { default as MultiSelect } from './demos/multi-select';
+export { default as SelectChip } from './demos/select-chip';
+export { default as SingleSelect } from './demos/single-select';
+export { default as ValidationInvalid } from './demos/validation-invalid';
+export { default as ValidationValid } from './demos/validation-valid';

--- a/packages/lumx-react/src/components/select/Select.stories.tsx
+++ b/packages/lumx-react/src/components/select/Select.stories.tsx
@@ -6,7 +6,7 @@ import range from 'lodash/range';
 import React, { SyntheticEvent, useState } from 'react';
 import { SelectVariant } from './constants';
 
-export default { title: 'LumX components/Select' };
+export default { title: 'LumX components/select/Select' };
 
 const CHOICES = ['First item', 'Second item', 'Third item'];
 

--- a/packages/lumx-react/src/components/select/SelectMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.stories.tsx
@@ -5,7 +5,7 @@ import noop from 'lodash/noop';
 import React, { SyntheticEvent } from 'react';
 import { SelectVariant } from './constants';
 
-export default { title: 'LumX components/Select Multiple' };
+export default { title: 'LumX components/select/Select Multiple' };
 
 const CHOICES = ['First item', 'Second item', 'Third item'];
 

--- a/packages/lumx-react/src/components/select/demos
+++ b/packages/lumx-react/src/components/select/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/select/react

--- a/packages/lumx-react/src/components/side-navigation/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/Demos.stories.tsx
@@ -1,0 +1,7 @@
+export default { title: 'LumX components/side-navigation/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as Emphasis } from './demos/emphasis';
+export { default as Nested } from './demos/nested';
+export { default as States } from './demos/states';
+export { default as WithIcon } from './demos/with-icon';

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Emphasis, SideNavigation, SideNavigationItem } from '@lumx/react';
 
-export default { title: 'LumX components/Side Navigation' };
+export default { title: 'LumX components/side-navigation/Side Navigation' };
 
 export const sideNavigation = () => (
     <SideNavigation>

--- a/packages/lumx-react/src/components/side-navigation/demos
+++ b/packages/lumx-react/src/components/side-navigation/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/side-navigation/react

--- a/packages/lumx-react/src/components/slider/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/slider/Demos.stories.tsx
@@ -1,0 +1,6 @@
+export default { title: 'LumX components/slider/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as Precision } from './demos/precision';
+export { default as Steps } from './demos/steps';
+export { default as WithoutMinMax } from './demos/without-min-max';

--- a/packages/lumx-react/src/components/slider/Slider.stories.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.stories.tsx
@@ -3,7 +3,7 @@ import { number, text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React from 'react';
 
-export default { title: 'LumX components/Slider' };
+export default { title: 'LumX components/slider/Slider' };
 
 export const defaultSlider = ({ theme }: any) => (
     <Slider

--- a/packages/lumx-react/src/components/slider/demos
+++ b/packages/lumx-react/src/components/slider/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/slider/react

--- a/packages/lumx-react/src/components/slideshow/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Demos.stories.tsx
@@ -1,0 +1,5 @@
+export default { title: 'LumX components/slideshow/Demos' };
+
+export { default as Auto } from './demos/auto';
+export { default as Default } from './demos/default';
+export { default as Group } from './demos/group';

--- a/packages/lumx-react/src/components/slideshow/demos
+++ b/packages/lumx-react/src/components/slideshow/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/slideshow/react

--- a/packages/lumx-react/src/components/switch/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/switch/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/switch/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/switch/Switch.stories.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.stories.tsx
@@ -3,7 +3,7 @@ import { text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React from 'react';
 
-export default { title: 'LumX components/Switch' };
+export default { title: 'LumX components/switch/Switch' };
 
 export const notCheckedSwitch = ({ theme }: any) => (
     <Switch checked={false} onToggle={noop} theme={theme}>

--- a/packages/lumx-react/src/components/switch/demos
+++ b/packages/lumx-react/src/components/switch/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/switch/react

--- a/packages/lumx-react/src/components/table/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/table/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/table/Demos' };
+
+export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/table/demos
+++ b/packages/lumx-react/src/components/table/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/table/react

--- a/packages/lumx-react/src/components/tabs/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/tabs/Demos.stories.tsx
@@ -1,0 +1,5 @@
+export default { title: 'LumX components/tabs/Demos' };
+
+export { default as Default } from './demos/default';
+export { default as IconTabs } from './demos/icon-tabs';
+export { default as LeftTabs } from './demos/left-tabs';

--- a/packages/lumx-react/src/components/tabs/demos
+++ b/packages/lumx-react/src/components/tabs/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/tabs/react

--- a/packages/lumx-react/src/components/text-field/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/Demos.stories.tsx
@@ -1,0 +1,15 @@
+export default { title: 'LumX components/text-field/Demos' };
+
+export { default as CharacterCounter } from './demos/character-counter';
+export { default as Clearable } from './demos/clearable';
+export { default as Default } from './demos/default';
+export { default as Disabled } from './demos/disabled';
+export { default as Helper } from './demos/helper';
+export { default as Icon } from './demos/icon';
+export { default as Invalid } from './demos/invalid';
+export { default as Placeholder } from './demos/placeholder';
+export { default as TextAreaInvalid } from './demos/text-area-invalid';
+export { default as TextArea } from './demos/text-area';
+export { default as TextAreaValid } from './demos/text-area-valid';
+export { default as Valid } from './demos/valid';
+export { default as WithChips } from './demos/with-chips';

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -3,7 +3,7 @@ import { number, text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React from 'react';
 
-export default { title: 'LumX components/TextField' };
+export default { title: 'LumX components/text-field/TextField' };
 
 /**
  * TextField story

--- a/packages/lumx-react/src/components/text-field/demos
+++ b/packages/lumx-react/src/components/text-field/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/text-field/react

--- a/packages/lumx-react/src/components/thumbnail/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Demos.stories.tsx
@@ -1,0 +1,6 @@
+export default { title: 'LumX components/thumbnail/Demos' };
+
+export { default as Combined } from './demos/combined';
+export { default as Ratios } from './demos/ratios';
+export { default as Sizes } from './demos/sizes';
+export { default as Variants } from './demos/variants';

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -2,7 +2,7 @@ import { Alignment, AspectRatio, CrossOrigin, Size, Theme, Thumbnail, ThumbnailV
 import { boolean, number, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
-export default { title: 'LumX components/Thumbnail' };
+export default { title: 'LumX components/thumbnail/Thumbnail' };
 
 const numberKnobOtions = {
     max: 1,

--- a/packages/lumx-react/src/components/thumbnail/demos
+++ b/packages/lumx-react/src/components/thumbnail/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/thumbnail/react

--- a/packages/lumx-react/src/components/toolbar/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/toolbar/Demos.stories.tsx
@@ -1,0 +1,6 @@
+export default { title: 'LumX components/toolbar/Demos' };
+
+export { default as Back } from './demos/back';
+export { default as Default } from './demos/default';
+export { default as Dialog } from './demos/dialog';
+export { default as MediaPicker } from './demos/media-picker';

--- a/packages/lumx-react/src/components/toolbar/demos
+++ b/packages/lumx-react/src/components/toolbar/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/toolbar/react

--- a/packages/lumx-react/src/components/uploader/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/uploader/Demos.stories.tsx
@@ -1,0 +1,5 @@
+export default { title: 'LumX components/uploader/Demos' };
+
+export { default as Avatar } from './demos/avatar';
+export { default as Default } from './demos/default';
+export { default as Thumbnail } from './demos/thumbnail';

--- a/packages/lumx-react/src/components/uploader/demos
+++ b/packages/lumx-react/src/components/uploader/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/uploader/react

--- a/packages/lumx-react/src/components/user-block/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/Demos.stories.tsx
@@ -1,0 +1,7 @@
+export default { title: 'LumX components/user-block/Demos' };
+
+export { default as Extended } from './demos/extended';
+export { default as SizeL } from './demos/size-l';
+export { default as SizeM } from './demos/size-m';
+export { default as SizeS } from './demos/size-s';
+export { default as Vertical } from './demos/vertical';

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -3,7 +3,7 @@ import { Badge, ColorPalette, Icon, List, ListItem, Size } from '@lumx/react';
 import React from 'react';
 import { UserBlock } from './UserBlock';
 
-export default { title: 'LumX components/UserBlock' };
+export default { title: 'LumX components/user-block/UserBlock' };
 
 export const s = () => {
     // tslint:disable-next-line:no-console

--- a/packages/lumx-react/src/components/user-block/demos
+++ b/packages/lumx-react/src/components/user-block/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/user-block/react


### PR DESCRIPTION
# General summary

Add symbolic link from react demos to storybook to have all the react demos listed inside storybook.

# Screenshots


![2020-08-04-140837_249x402_scrot](https://user-images.githubusercontent.com/939567/89292180-3a335780-d65c-11ea-8e55-31acb1346b9b.png)
