### PR TITLE
fix(mosaic): fix missing CORS props for Thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `isCrossOriginEnabled` and `crossOrigin` props to the `MosaicElement` interface to be able to forward those props to the `Thumbnail` component inside the `Mosaic`component.
+
 ## [0.25.8][] - 2020-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Added `isCrossOriginEnabled` and `crossOrigin` props to the `MosaicElement` interface to be able to forward those props to the `Thumbnail` component inside the `Mosaic`component.
+-   Added `ThumbnailProps` props to the `MosaicElement` interface to be able to forward those props to the `Thumbnail` component inside the `Mosaic`component.
 
 ## [0.25.8][] - 2020-08-05
 

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 
-import { AspectRatio, FocusPoint, Theme, Thumbnail } from '@lumx/react';
+import { AspectRatio, CrossOrigin, FocusPoint, Theme, Thumbnail } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import take from 'lodash/take';
 
 interface MosaicElement {
-    url: string;
+    /**
+     * Allows images that are loaded from foreign origins
+     * to be used as if they had been loaded from the current origin.
+     */
+    crossOrigin?: CrossOrigin;
     focusPoint?: FocusPoint;
+    /** Active cross origin. */
+    isCrossOriginEnabled?: boolean;
+    url: string;
     onClick?(index: number): void;
 }
 
@@ -59,13 +66,15 @@ const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme,
                 return (
                     <div key={index} className={`${CLASSNAME}__thumbnail`}>
                         <Thumbnail
-                            tabIndex={thumbnail.onClick && '0'}
-                            onClick={handleClick}
                             aspectRatio={AspectRatio.free}
+                            crossOrigin={thumbnail.crossOrigin}
                             fillHeight
-                            image={thumbnail.url}
-                            theme={theme}
                             focusPoint={thumbnail.focusPoint}
+                            image={thumbnail.url}
+                            isCrossOriginEnabled={thumbnail.isCrossOriginEnabled}
+                            tabIndex={thumbnail.onClick && '0'}
+                            theme={theme}
+                            onClick={handleClick}
                         />
 
                         {thumbnails.length > 4 && index === 3 && (

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -6,7 +6,11 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 import classNames from 'classnames';
 import take from 'lodash/take';
 
-interface MosaicElement extends Exclude<ThumbnailProps, 'aspectRatio' | 'fillHeight'> {
+interface MosaicElement extends Omit<ThumbnailProps, 'aspectRatio' | 'fillHeight' | 'theme' | 'image'> {
+    /** @deprecated Use `image` instead. */
+    url: string;
+    /** @todo breaking change removing the `url` prop and making the `image` required. */
+    image?: ThumbnailProps['image'];
     onClick?(index: number): void;
 }
 
@@ -47,10 +51,10 @@ const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme,
         })}
     >
         <div className={`${CLASSNAME}__wrapper`}>
-            {take(thumbnails, 4).map((thumbnail, index) => {
+            {take(thumbnails, 4).map(({ url, image, onClick, ...thumbnail }, index) => {
                 const handleClick = () => {
-                    if (thumbnail.onClick) {
-                        thumbnail.onClick(index);
+                    if (onClick) {
+                        onClick(index);
                     }
                 };
 
@@ -58,9 +62,11 @@ const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme,
                     <div key={index} className={`${CLASSNAME}__thumbnail`}>
                         <Thumbnail
                             {...thumbnail}
+                            theme={theme}
+                            image={image ?? url}
                             aspectRatio={AspectRatio.free}
                             fillHeight
-                            tabIndex={thumbnail.onClick && '0'}
+                            tabIndex={onClick && '0'}
                             onClick={handleClick}
                         />
 

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
 
-import { AspectRatio, CrossOrigin, FocusPoint, Theme, Thumbnail } from '@lumx/react';
+import { AspectRatio, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import take from 'lodash/take';
 
-interface MosaicElement {
-    /**
-     * Allows images that are loaded from foreign origins
-     * to be used as if they had been loaded from the current origin.
-     */
-    crossOrigin?: CrossOrigin;
-    focusPoint?: FocusPoint;
-    /** Active cross origin. */
-    isCrossOriginEnabled?: boolean;
-    url: string;
+interface MosaicElement extends Exclude<ThumbnailProps, 'aspectRatio' | 'fillHeight'> {
     onClick?(index: number): void;
 }
 
@@ -66,14 +57,10 @@ const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme,
                 return (
                     <div key={index} className={`${CLASSNAME}__thumbnail`}>
                         <Thumbnail
+                            {...thumbnail}
                             aspectRatio={AspectRatio.free}
-                            crossOrigin={thumbnail.crossOrigin}
                             fillHeight
-                            focusPoint={thumbnail.focusPoint}
-                            image={thumbnail.url}
-                            isCrossOriginEnabled={thumbnail.isCrossOriginEnabled}
                             tabIndex={thumbnail.onClick && '0'}
-                            theme={theme}
                             onClick={handleClick}
                         />
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -208,21 +208,21 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
                     <img
                         {...(imgProps || {})}
                         ref={focusImageRef}
-                        className={`${CLASSNAME}__image`}
-                        src={image}
                         alt={alt}
+                        className={`${CLASSNAME}__image`}
                         loading={loading}
+                        src={image}
                     />
                 ) : (
                     <div className={`${CLASSNAME}__background`}>
                         <img
                             {...(imgProps || {})}
                             ref={focusImageRef}
+                            alt={alt}
                             className={`${CLASSNAME}__focused-image`}
                             crossOrigin={setCrossOrigin()}
-                            src={image}
-                            alt={alt}
                             loading={loading}
+                            src={image}
                         />
                     </div>
                 ))}


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Added `ThumbnailProps` props to the `MosaicElement` interface to be able to forward those props to the `Thumbnail` component inside the `Mosaic`component.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
