### PR TITLE
Tooltip a11y - display the tooltip on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added `ThumbnailProps` props to the `MosaicElement` interface to be able to forward those props to the `Thumbnail` component inside the `Mosaic`component.
 
+### Changed
+
+-   `Tooltip` are now displayed on `focus` in addition with `mouse` events.
+
 ## [0.25.8][] - 2020-08-05
 
 ### Fixed

--- a/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
+++ b/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
@@ -30,10 +30,14 @@ export function useTooltipOpen(delay: number, anchorElement: HTMLElement | null)
         };
 
         anchorElement.addEventListener('mouseenter', handleMouseEnter);
+        anchorElement.addEventListener('focusin', handleMouseEnter);
         anchorElement.addEventListener('mouseleave', handleMouseLeave);
+        anchorElement.addEventListener('focusout', handleMouseLeave);
         return () => {
             anchorElement.removeEventListener('mouseenter', handleMouseEnter);
+            anchorElement.removeEventListener('focusin', handleMouseEnter);
             anchorElement.removeEventListener('mouseleave', handleMouseLeave);
+            anchorElement.removeEventListener('focusout', handleMouseLeave);
 
             if (timer.current) {
                 clearTimeout(timer.current);


### PR DESCRIPTION
# General summary

In order to improve the accessibility, I propose to add this behavior.
When a keyboard user is focusing an icon, the tooltip is displayed.

# Screenshots


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
