### PR TITLE
Fix SideNavigationItem split-actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Add `isCrossOriginEnabled` and `crossOrigin` missing props on `ImageBlock` component to forward them to `Thumbnail` component
+-   Add `onActionClick` on `SideNavigationItem` to have a dedicated action on the chevron icon and let the onClick on the link.
 
 ## [0.25.12][] - 2020-08-31
 

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
@@ -102,7 +102,6 @@ export const With3LevelsAndMultiActions = () => {
                     // tslint:disable-next-line: ter-no-script-url
                     linkProps={{ href: 'javascript:alert("Level 2")' }}
                     onActionClick={toggleL2}
-                    hasActionsSplitted
                 >
                     <SideNavigationItem
                         label="Level 3.1"

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
@@ -82,7 +82,7 @@ export const With3LevelsAndMultiActions = () => {
     const [l2IsOpen, setL2IsOpen] = React.useState(true);
     const toggleL1 = () => setL1IsOpen(!l1IsOpen);
     const toggleL2 = () => setL2IsOpen(!l2IsOpen);
-    const action3Click = () => alert('Level 3 chevron');
+    const alertMessage = (message: string) => () => alert(message);
 
     return (
         <SideNavigation>
@@ -92,8 +92,8 @@ export const With3LevelsAndMultiActions = () => {
                 isOpen={l1IsOpen}
                 // tslint:disable-next-line: ter-no-script-url
                 linkProps={{ href: 'javascript:alert("Level 1")' }}
-                onClick={toggleL1}
                 icon={mdiAccount}
+                onActionClick={toggleL1}
             >
                 <SideNavigationItem
                     label="Level 2"
@@ -101,21 +101,21 @@ export const With3LevelsAndMultiActions = () => {
                     isOpen={l2IsOpen}
                     // tslint:disable-next-line: ter-no-script-url
                     linkProps={{ href: 'javascript:alert("Level 2")' }}
-                    onClick={toggleL2}
+                    onActionClick={toggleL2}
+                    hasActionsSplitted
                 >
                     <SideNavigationItem
                         label="Level 3.1"
                         emphasis={Emphasis.low}
                         // tslint:disable-next-line: ter-no-script-url
-                        linkProps={{ href: 'javascript:alert("Level 3")' }}
-                        onClick={action3Click}
+                        linkProps={{ href: 'javascript:alert("Level 3.1 item is clicked")' }}
+                        onActionClick={alertMessage('Level 3.1 action is clicked')}
                     />
                     <SideNavigationItem
                         label="Level 3.2"
                         emphasis={Emphasis.low}
-                        // tslint:disable-next-line: ter-no-script-url
-                        linkProps={{ href: 'javascript:alert("Level 3")' }}
-                        onClick={action3Click}
+                        onClick={alertMessage('Level 3.2 item is clicked')}
+                        onActionClick={alertMessage('Level 3.2 action is clicked')}
                     />
                 </SideNavigationItem>
             </SideNavigationItem>

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -45,6 +45,9 @@ interface SideNavigationItemProps extends GenericProps {
 
     /** On click handler. */
     onClick?(evt: React.MouseEvent): void;
+
+    /** On the action button is clicked */
+    onActionClick?(evt: React.MouseEvent): void;
 }
 
 /**
@@ -75,14 +78,15 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
         icon,
         isOpen = DEFAULT_PROPS.isOpen,
         isSelected = DEFAULT_PROPS.isSelected,
-        onClick,
         linkProps,
+        onClick,
+        onActionClick,
         ...forwardedProps
     } = props;
 
     const content = children && Children.toArray(children).filter(isComponent(SideNavigationItem));
     const hasContent = !isEmpty(content);
-    const shouldSplitActions = Boolean(linkProps && onClick);
+    const shouldSplitActions = Boolean(onActionClick);
 
     return (
         <li
@@ -99,7 +103,7 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
         >
             {shouldSplitActions ? (
                 <div className={`${CLASSNAME}__wrapper`}>
-                    <a {...(linkProps || {})} className={`${CLASSNAME}__link`} tabIndex={0}>
+                    <a {...(linkProps || {})} className={`${CLASSNAME}__link`} onClick={onClick} tabIndex={0}>
                         {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />}
                         <span>{label}</span>
                     </a>
@@ -109,7 +113,7 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
                         icon={isOpen ? mdiChevronUp : mdiChevronDown}
                         size={Size.m}
                         emphasis={Emphasis.low}
-                        onClick={onClick}
+                        onClick={onActionClick}
                     />
                 </div>
             ) : (

--- a/packages/lumx-react/src/components/side-navigation/__snapshots__/SideNavigationItem.test.tsx.snap
+++ b/packages/lumx-react/src/components/side-navigation/__snapshots__/SideNavigationItem.test.tsx.snap
@@ -17,23 +17,14 @@ exports[`<SideNavigationItem> Snapshots and structure should render correctly wi
 <li
   className="lumx-side-navigation-item lumx-side-navigation-item--emphasis-high"
 >
-  <div
-    className="lumx-side-navigation-item__wrapper"
+  <a
+    className="lumx-side-navigation-item__link"
+    href="http://toto.com"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex={0}
   >
-    <a
-      className="lumx-side-navigation-item__link"
-      href="http://toto.com"
-      tabIndex={0}
-    >
-      <span />
-    </a>
-    <IconButton
-      className="lumx-side-navigation-item__toggle"
-      emphasis="low"
-      icon="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-      onClick={[Function]}
-      size="m"
-    />
-  </div>
+    <span />
+  </a>
 </li>
 `;


### PR DESCRIPTION
LUM-11702

# General summary

The goal of this PR is to provide a dedicated click on the `IconButton` and still have an onClick action on the item.

Why?

In the new react app, I need to have a `linkProps` in order to redirect the user to the proper page. AND also an `onClick` action to close the drawer. 
If in this scenario my item have children, I need an action to only open/close the children wrapper.


The new prop is called `onActionClick` but feel free to change the name.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
