### PR TITLE
chore(site-demo): fix focus visible lib import

### DIFF
--- a/packages/site-demo/src/index.tsx
+++ b/packages/site-demo/src/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from 'react-dom';
 import { App } from './App';
 
+import 'focus-visible';
+
 import 'intersection-observer';
 
 import { reactAngularModule } from 'react-angular';


### PR DESCRIPTION
# General summary

Fix inclusion of the 'focus-visible' lib in the demo site.

