### PR TITLE
fix(thumbnail): remove useless object

### DIFF
--- a/packages/lumx-react/src/components/thumbnail/FocusedImage.ts
+++ b/packages/lumx-react/src/components/thumbnail/FocusedImage.ts
@@ -22,19 +22,6 @@ const IMG_STYLES = {
     minWidth: '100%',
 };
 
-const RESIZE_LISTENER_OBJECT_STYLES = {
-    height: '100%',
-    width: '100%',
-    border: 'none',
-
-    // set these styles to emulate "visibility: hidden"
-    // can't use visibility because it breaks the object
-    // events in Firefox
-    opacity: 0,
-    zIndex: -1,
-    pointerEvents: 'none',
-};
-
 export interface LumHTMLImageElement extends HTMLImageElement {
     __focused_image_instance__: FocusedImage;
 }
@@ -134,19 +121,6 @@ export class FocusedImage {
         if (this.options.updateOnWindowResize) {
             window.addEventListener('resize', this.debounceApplyShift);
         }
-        const object = document.createElement('object');
-        Object.assign(object.style, RESIZE_LISTENER_OBJECT_STYLES, ABSOLUTE_STYLES);
-        // Use load event callback because contentDocument doesn't exist
-        // until this fires in Firefox
-        object.addEventListener('load', () =>
-            object.contentDocument?.defaultView?.addEventListener('resize', () => this.debounceApplyShift()),
-        );
-        object.type = 'text/html';
-        object.setAttribute('aria-hidden', 'true');
-        object.tabIndex = -1;
-        this.container.appendChild(object);
-        object.data = 'about:blank';
-        this.resizeListenerObject = object;
     }
 
     public stopListening() {


### PR DESCRIPTION
# General summary

Remove useless code which create `<object>` when you set `aspectRatio` props on `Thumbnail` component

# Screenshots

<img width="1308" alt="Screenshot 2020-09-25 at 10 54 30" src="https://user-images.githubusercontent.com/6178321/94255730-fad10b00-ff28-11ea-9aa9-f6419f0b6efb.png">


# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
