### PR TITLE
chore(site-demo): display the lumx version on component demo pages

### DIFF
--- a/packages/site-demo/src/components/LumxVersion.tsx
+++ b/packages/site-demo/src/components/LumxVersion.tsx
@@ -1,0 +1,22 @@
+import { mdiTagOutline } from '@lumx/icons';
+import { Button, Emphasis, Size } from '@lumx/react';
+import React from 'react';
+
+declare global {
+    interface Window {
+        LUMX_VERSION: any;
+    }
+}
+
+export const LumxVersion: React.FC = () => (
+    <Button
+        className="lumx-spacing-margin-left"
+        emphasis={Emphasis.low}
+        size={Size.s}
+        leftIcon={mdiTagOutline}
+        href={`https://github.com/lumapps/design-system/blob/v${window.LUMX_VERSION}/CHANGELOG.md`}
+        target="_blank"
+    >
+        v{window.LUMX_VERSION}
+    </Button>
+);

--- a/packages/site-demo/src/components/layout/Main.tsx
+++ b/packages/site-demo/src/components/layout/Main.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { Redirect, Route, useHistory } from 'react-router-dom';
 
 import { ErrorBoundary } from '@lumx/demo/components/ErrorBoundary';
+import { LumxVersion } from '@lumx/demo/components/LumxVersion';
 import { EngineProvider } from '@lumx/demo/context/engine';
 import { GlobalThemeProvider } from '@lumx/demo/context/global-theme';
 import { Alignment, FlexBox, Orientation } from '@lumx/react';
@@ -28,17 +29,19 @@ export const Main: React.FC = (): ReactElement => {
                     <div className="main__wrapper">
                         <div className="main-header">
                             <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
-                                <FlexBox fillSpace>
-                                    <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
-                                        <span className="lumx-typography-overline lumx-spacing-margin-right-regular">
-                                            Theme
-                                        </span>
-                                        <ThemeSelector />
-                                    </FlexBox>
+                                <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
+                                    <span className="lumx-typography-overline lumx-spacing-margin-right-regular">
+                                        Theme
+                                    </span>
+                                    <ThemeSelector />
                                 </FlexBox>
-                                <Route path="/product/components*">
-                                    <EngineSelector />
-                                </Route>
+
+                                <FlexBox marginAuto={Alignment.left}>
+                                    <Route path="/product/components*">
+                                        <EngineSelector />
+                                        <LumxVersion />
+                                    </Route>
+                                </FlexBox>
                             </FlexBox>
                         </div>
 

--- a/packages/site-demo/src/index.html.ejs
+++ b/packages/site-demo/src/index.html.ejs
@@ -21,6 +21,7 @@
             <%
         }
         %>
+        <script type="text/javascript">window.LUMX_VERSION = '<%= LUMX_VERSION %>';</script>
     </head>
 
     <body>

--- a/packages/site-demo/webpack.config.js
+++ b/packages/site-demo/webpack.config.js
@@ -16,9 +16,11 @@ const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const WebpackBar = require('webpackbar');
+const webpack = require('webpack');
 const WebpackNotifierPlugin = require('webpack-notifier');
 
 const CONFIGS = require('../../configs');
+const LUMX_VERSION = require('../../lerna.json').version;
 
 const PKG_NAME = '@lumx/demo';
 const PKG_PATH = path.resolve(__dirname, './');
@@ -43,6 +45,9 @@ const plugins = [
         filename: `${filename}.css`,
     }),
 
+    new webpack.DefinePlugin({
+        LUMX_VERSION: JSON.stringify(LUMX_VERSION),
+    }),
     new HtmlWebpackPlugin({
         inject: false,
         template: `${SRC_PATH}/index.html.ejs`,


### PR DESCRIPTION

Add the lumx version on the component demo pages.
It also links to the CHANGELOG of this version on github.

![Capture d’écran de 2020-09-30 15-04-46](https://user-images.githubusercontent.com/939567/94688775-5555d700-032e-11eb-85c5-f36467ff3d1b.png)
