### PR TITLE
Chore/upgrade mdi 5.6.55

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1123,7 +1123,7 @@ module.exports = {
             },
         ],
         'import/first': 'error',
-        'import/group-exports': 'error',
+        'import/group-exports': 'off',
         'import/max-dependencies': [
             'warn',
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Upgrade to mdi v5.6.55 and handle backward compatibility.
+
 ## [0.25.16][] - 2020-09-16
 
 ### Added

--- a/packages/lumx-icons/font.scss
+++ b/packages/lumx-icons/font.scss
@@ -1,3 +1,52 @@
 $mdi-font-path: '~@mdi/font/fonts';
 
 @import '~@mdi/font/scss/materialdesignicons';
+
+.mdi-account-card-details {
+    @extend .mdi-card-account-details;
+}
+
+.mdi-account-card-details-outline {
+    @extend .mdi-card-account-details-outline;
+}
+
+.mdi-facebook-box {
+    @extend .mdi-facebook;
+}
+
+.mdi-file-document-box {
+    @extend .mdi-text-box;
+}
+
+.mdi-github-circle,
+.mdi-github-face {
+    @extend .mdi-github;
+}
+
+.mdi-google-pages {
+    @extend .mdi-format-list-bulleted;
+}
+
+.mdi-image-filter {
+    @extend .mdi-image-multiple-outline;
+}
+
+.mdi-library-books {
+    @extend .mdi-text-box-multiple;
+}
+
+.mdi-linkedin-box {
+    @extend .mdi-linkedin;
+}
+
+.mdi-mail-ru {
+    @extend .mdi-at;
+}
+
+.mdi-settings {
+    @extend .mdi-cog;
+}
+
+.mdi-twitter-box {
+    @extend .mdi-twitter;
+}

--- a/packages/lumx-icons/index.d.ts
+++ b/packages/lumx-icons/index.d.ts
@@ -1,1 +1,15 @@
 export * from '@mdi/js';
+
+export declare const mdiAccountCardDetails: string;
+export declare const mdiAccountCardDetailsOutline: string;
+export declare const mdiFacebookBox: string;
+export declare const mdiFileDocumentBox: string;
+export declare const mdiGithubCircle: string;
+export declare const mdiGithubFace: string;
+export declare const mdiGooglePages: string;
+export declare const mdiImageFilter: string;
+export declare const mdiLibraryBooks: string;
+export declare const mdiLinkedinBox: string;
+export declare const mdiMailRu: string;
+export declare const mdiSettings: string;
+export declare const mdiTwitterBox: string;

--- a/packages/lumx-icons/index.js
+++ b/packages/lumx-icons/index.js
@@ -1,1 +1,42 @@
+import {
+    mdiAt,
+    mdiCardAccountDetails,
+    mdiCardAccountDetailsOutline,
+    mdiCog,
+    mdiFacebook,
+    mdiFormatListBulleted,
+    mdiGithub,
+    mdiImageMultipleOutline,
+    mdiLinkedin,
+    mdiTextBox,
+    mdiTextBoxMultiple,
+    mdiTwitter,
+} from '@mdi/js';
+
 export * from '@mdi/js';
+
+export const mdiAccountCardDetails = mdiCardAccountDetails;
+
+export const mdiAccountCardDetailsOutline = mdiCardAccountDetailsOutline;
+
+export const mdiFacebookBox = mdiFacebook;
+
+export const mdiFileDocumentBox = mdiTextBox;
+
+export const mdiGithubCircle = mdiGithub;
+
+export const mdiGithubFace = mdiGithub;
+
+export const mdiGooglePages = mdiFormatListBulleted;
+
+export const mdiImageFilter = mdiImageMultipleOutline;
+
+export const mdiLibraryBooks = mdiTextBoxMultiple;
+
+export const mdiLinkedinBox = mdiLinkedin;
+
+export const mdiMailRu = mdiAt;
+
+export const mdiSettings = mdiCog;
+
+export const mdiTwitterBox = mdiTwitter;

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -4,8 +4,8 @@
         "url": "https://github.com/lumapps/design-system/issues"
     },
     "dependencies": {
-        "@mdi/font": "4.2.95",
-        "@mdi/js": "4.2.95"
+        "@mdi/font": "5.6.55",
+        "@mdi/js": "5.6.55"
     },
     "description": "LumX icons",
     "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,15 +3334,15 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mdi/font@4.2.95":
-  version "4.2.95"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-4.2.95.tgz#7fd524746979a37dc7c3fd7a9f9cea1bf58205ba"
-  integrity sha512-pCJ9hR8yQH1tMk6KTZYfJsZkI/XQ1rR9Fe/q50ATDDVUoDk7Wl7n9WqT6dYWn0mnCLgrTQl/WNjyrnTo5rKu+A==
+"@mdi/font@5.6.55":
+  version "5.6.55"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.6.55.tgz#3536d7a7671eda9d5d9ba191b9fb9aceccc0a07e"
+  integrity sha512-6wWrpTXiv2wBtoCL+EJ9Xxfy6Tv6Q1KxmrX54/M23tBNmdGmh417y1tn327oXQxO1nq7BiHGAKkWQZ/GQPLTCA==
 
-"@mdi/js@4.2.95":
-  version "4.2.95"
-  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-4.2.95.tgz#c920083f64873fe6cd721b15c23061c71d47811d"
-  integrity sha512-3qqOZx2HkrQEUc9fr5MiQWlokwmO8TK5bQZ2EP1Rg0q2Q507jy+fUeL8lb9ko2ossYqoPnugIr7jI0/O7uhlrA==
+"@mdi/js@5.6.55":
+  version "5.6.55"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-5.6.55.tgz#d1e99da22c8d462c17d4c5b530a7d1b77e668230"
+  integrity sha512-FphEd6PTivVSfsxjRB/Z5sJhxUmxA0jL/+nEQmqk8Ok1miSnw92ibj4p1SPAmgnR8OFTNCkHX23AvlU8YZQb5A==
 
 "@mdx-js/mdx@^0.15.5":
   version "0.15.7"


### PR DESCRIPTION
# General summary

Upgrade to mdi 5.6.55 and handle breaking changes.
To remember when upgrading into LumApps product:
- mdiFacebookBox (to remove from icon picker)
- mdiGithubFace (to remove from icon picker)
- mdiLinkedinBox (to remove from icon picker)
- mdiTwitterBox (to remove from icon picker)
- mdiGooglePlusBox (don't exists anymore)

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
