### PR TITLE
chore(site-demo): allow alternative site root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add `gap` property to `FlexBox` component.
 -   Add has divider helper.
+-   Add `linkAs` prop on `SideNavigationItem`, `ListItem` and `Link` to customize the link component (can be used to inject the `Link` component from `react-router`).
 
 ### Changed
 

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -30,3 +30,8 @@ export const simpleLink = () => (
         </Link>
     </>
 );
+
+const CustomLink: React.FC = ({ children, ...props }) =>
+    React.createElement('a', { ...props, style: { color: 'red' } }, children);
+
+export const withCustomLink = () => <Link linkAs={CustomLink}>My link text</Link>;

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 
 import { Color, ColorVariant } from '@lumx/react';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { renderLink } from '@lumx/react/utils/renderLink';
 
 /**
  * Defines the props of the component.
@@ -15,6 +16,9 @@ interface LinkProps extends React.DetailedHTMLProps<React.AnchorHTMLAttributes<H
 
     /** The icon color variant. */
     colorVariant?: ColorVariant;
+
+    /** Sets a custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
 
     /** Ref to the native HTML anchor element. */
     linkRef?: Ref<HTMLAnchorElement>;
@@ -35,15 +39,23 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  *
  * @return The component.
  */
-const Link: React.FC<LinkProps> = ({ children, className, linkRef, color, colorVariant, ...forwardedProps }) => {
-    return (
-        <a
-            {...forwardedProps}
-            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }))}
-            ref={linkRef}
-        >
-            {children}
-        </a>
+const Link: React.FC<LinkProps> = ({
+    children,
+    className,
+    linkAs,
+    linkRef,
+    color,
+    colorVariant,
+    ...forwardedProps
+}) => {
+    return renderLink(
+        {
+            linkAs,
+            ...forwardedProps,
+            className: classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant })),
+            ref: linkRef,
+        },
+        children,
     );
 };
 Link.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/list/ListItem.stories.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.stories.tsx
@@ -26,3 +26,12 @@ export const Sizes = ({ theme }: any) => (
         {text('text', 'Text')}
     </ListItem>
 );
+
+const CustomLink: React.FC = ({ children, ...props }) =>
+    React.createElement('a', { ...props, style: { color: 'red' } }, children);
+
+export const WithCustomLink = ({ theme }: any) => (
+    <ListItem theme={theme} linkAs={CustomLink} linkProps={{ href: 'http://google.com' }}>
+        My custom link
+    </ListItem>
+);

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -7,6 +7,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
 import { ListProps, Size } from '@lumx/react';
 import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { renderLink } from '@lumx/react/utils/renderLink';
 
 /**
  *  Authorized size values.
@@ -45,6 +46,9 @@ interface ListItemProps extends GenericProps {
 
     /** List item reference. */
     listItemRef?: Ref<HTMLLIElement>;
+
+    /** Sets a custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
 
     /** props that will be passed on to the Link */
     linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
@@ -97,6 +101,7 @@ const ListItem: React.FC<ListItemProps> = (props) => {
         size = DEFAULT_PROPS.size,
         onItemSelected,
         before,
+        linkAs,
         linkProps = {},
         linkRef,
         listItemRef,
@@ -126,23 +131,25 @@ const ListItem: React.FC<ListItemProps> = (props) => {
         >
             {isClickable(props) ? (
                 /* Clickable list item */
-                <a
-                    {...linkProps}
-                    className={classNames(
-                        handleBasicClasses({
-                            prefix: `${CLASSNAME}__link`,
-                            isHighlighted,
-                            isSelected,
-                        }),
-                    )}
-                    onClick={onItemSelected}
-                    onKeyDown={onKeyDown}
-                    ref={linkRef}
-                    role={onItemSelected ? 'button' : undefined}
-                    tabIndex={0}
-                >
-                    {content}
-                </a>
+                renderLink(
+                    {
+                        linkAs,
+                        ...linkProps,
+                        className: classNames(
+                            handleBasicClasses({
+                                prefix: `${CLASSNAME}__link`,
+                                isHighlighted,
+                                isSelected,
+                            }),
+                        ),
+                        onClick: onItemSelected,
+                        onKeyDown,
+                        ref: linkRef,
+                        role: onItemSelected ? 'button' : undefined,
+                        tabIndex: 0,
+                    },
+                    content,
+                )
             ) : (
                 /* Non clickable list item */
                 <div className={`${CLASSNAME}__wrapper`}>{content}</div>

--- a/packages/lumx-react/src/components/list/__snapshots__/ListItem.test.tsx.snap
+++ b/packages/lumx-react/src/components/list/__snapshots__/ListItem.test.tsx.snap
@@ -67,3 +67,21 @@ exports[`<ListItem> Snapshots and structure should render story Sizes 1`] = `
   </div>
 </li>
 `;
+
+exports[`<ListItem> Snapshots and structure should render story WithCustomLink 1`] = `
+<li
+  className="lumx-list-item lumx-list-item--size-regular"
+>
+  <CustomLink
+    className="lumx-list-item__link"
+    href="http://google.com"
+    tabIndex={0}
+  >
+    <div
+      className="lumx-list-item__content"
+    >
+      My custom link
+    </div>
+  </CustomLink>
+</li>
+`;

--- a/packages/lumx-react/src/components/post-block/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/post-block/Demos.stories.tsx
@@ -1,3 +1,0 @@
-export default { title: 'LumX components/post-block/Demos' };
-
-export { default as Default } from './demos/default';

--- a/packages/lumx-react/src/components/select/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/select/Demos.stories.tsx
@@ -1,9 +1,10 @@
 export default { title: 'LumX components/select/Demos' };
 
+export { default as MultiSelect } from './demos/multi-select';
 export { default as MultiSelectChip } from './demos/multi-select-chip';
 export { default as MultiSelectSearch } from './demos/multi-select-search';
-export { default as MultiSelect } from './demos/multi-select';
 export { default as SelectChip } from './demos/select-chip';
 export { default as SingleSelect } from './demos/single-select';
-export { default as ValidationInvalid } from './demos/validation-invalid';
-export { default as ValidationValid } from './demos/validation-valid';
+export { default as StateDisabled } from './demos/state-disabled';
+export { default as StateInvalid } from './demos/state-invalid';
+export { default as ValidationValid } from './demos/state-valid';

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
@@ -5,6 +5,9 @@ import { Emphasis, SideNavigation, SideNavigationItem } from '@lumx/react';
 
 export default { title: 'LumX components/side-navigation/Side Navigation' };
 
+const CustomLink: React.FC = ({ children, ...props }) =>
+    React.createElement('a', { ...props, style: { color: 'red' } }, children);
+
 export const sideNavigation = () => (
     <SideNavigation>
         <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
@@ -21,8 +24,9 @@ export const sideNavigation = () => (
             linkProps={{ href: 'https://www.google.com/not-visited' }}
         />
         <SideNavigationItem
-            label="Navigation item"
+            label="Navigation item (custom link)"
             emphasis={Emphasis.low}
+            linkAs={CustomLink}
             linkProps={{ href: 'https://www.google.com/not-visited-1' }}
         />
         <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -16,6 +16,8 @@ import {
     isComponent,
     onEnterPressed,
 } from '@lumx/react/utils';
+import { renderLink } from '@lumx/react/utils/renderLink';
+
 import { IconButton } from '../button/IconButton';
 
 /**
@@ -39,6 +41,9 @@ interface SideNavigationItemProps extends GenericProps {
 
     /** Whether or not the menu is selected. */
     isSelected?: boolean;
+
+    /** Sets a custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
 
     /** props that will be passed on to the Link */
     linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
@@ -78,6 +83,7 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
         icon,
         isOpen = DEFAULT_PROPS.isOpen,
         isSelected = DEFAULT_PROPS.isSelected,
+        linkAs,
         linkProps,
         onClick,
         onActionClick,
@@ -103,10 +109,17 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
         >
             {shouldSplitActions ? (
                 <div className={`${CLASSNAME}__wrapper`}>
-                    <a {...(linkProps || {})} className={`${CLASSNAME}__link`} onClick={onClick} tabIndex={0}>
-                        {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />}
-                        <span>{label}</span>
-                    </a>
+                    {renderLink(
+                        {
+                            linkAs,
+                            ...linkProps,
+                            className: `${CLASSNAME}__link`,
+                            onClick,
+                            tabIndex: 0,
+                        },
+                        icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />,
+                        <span>{label}</span>,
+                    )}
 
                     <IconButton
                         className={`${CLASSNAME}__toggle`}
@@ -117,23 +130,25 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
                     />
                 </div>
             ) : (
-                <a
-                    {...(linkProps || {})}
-                    className={`${CLASSNAME}__link`}
-                    tabIndex={0}
-                    onClick={onClick}
-                    onKeyDown={onClick ? onEnterPressed(onClick as Callback) : undefined}
-                >
-                    {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />}
-                    <span>{label}</span>
-                    {hasContent && (
+                renderLink(
+                    {
+                        linkAs,
+                        ...linkProps,
+                        className: `${CLASSNAME}__link`,
+                        tabIndex: 0,
+                        onClick,
+                        onKeyDown: onClick ? onEnterPressed(onClick as Callback) : undefined,
+                    },
+                    icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />,
+                    <span>{label}</span>,
+                    hasContent && (
                         <Icon
                             className={`${CLASSNAME}__chevron`}
                             icon={isOpen ? mdiChevronUp : mdiChevronDown}
                             size={Size.xs}
                         />
-                    )}
-                </a>
+                    ),
+                )
             )}
 
             {hasContent && isOpen && <ul className={`${CLASSNAME}__children`}>{content}</ul>}

--- a/packages/lumx-react/src/utils/renderLink.tsx
+++ b/packages/lumx-react/src/utils/renderLink.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * Render link with default <a> HTML component or a custom one provided by `linkAs`.
+ *
+ * Can be used to inject the `Link` component from `react-router` and provide better a11y on LumX components.
+ *
+ * @param linkAs    Custom link component.
+ * @param children  Link children.
+ * @return          A link.
+ */
+export const renderLink = ({ linkAs, ...forwardedProps }: any, ...children: any) =>
+    React.createElement(linkAs || 'a', forwardedProps, ...children);

--- a/packages/site-demo/content/menu.yml
+++ b/packages/site-demo/content/menu.yml
@@ -1,0 +1,53 @@
+-   Product:
+        -   Foundations:
+                - Color
+                - Iconography
+                - Typography
+        -   Components:
+                - Autocomplete
+                - Avatar
+                - Badge
+                - Button
+                - Checkbox
+                - Chip
+                - Comment block
+                - Date picker
+                - Dialog
+                - Divider
+                - Dropdown
+                - Expansion panel
+                - Image block
+                - Lightbox
+                - Link
+                - Link preview
+                - List
+                - Message
+                - Notification
+                - Popover
+                - Progress
+                - Progress tracker
+                - Radio button
+                - Select
+                - Side navigation
+                - Slider
+                - Slideshow
+                - Switch
+                - Table
+                - Tabs
+                - Text field
+                - Thumbnail
+                - Toolbar
+                - Tooltip
+                - Uploader
+                - User block
+        -   Patterns:
+                - Filter and sort
+        -   Utilities:
+                - Color
+                - Spacing
+                - Typography
+        -   Design Tokens:
+                - Color
+                - Size
+- Brand
+- Partners

--- a/packages/site-demo/content/product/components/avatar/angularjs/controller.js
+++ b/packages/site-demo/content/product/components/avatar/angularjs/controller.js
@@ -19,6 +19,6 @@ function DemoController() {
     };
 }
 
-angular.module('design-system').controller('DemoController', DemoController);
+//angular.module('design-system').controller('DemoController', DemoController);
 
 export { DemoController };

--- a/packages/site-demo/package.json
+++ b/packages/site-demo/package.json
@@ -64,7 +64,9 @@
         "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.11.0",
         "webpack-notifier": "^1.8.0",
-        "webpackbar": "^4.0.0"
+        "webpackbar": "^4.0.0",
+        "yaml-loader": "^0.6.0",
+        "yargs": "^16.0.3"
     },
     "description": "The official LumApps Design System (LumX) demo site",
     "engines": {

--- a/packages/site-demo/src/App.tsx
+++ b/packages/site-demo/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Main } from './components/layout/Main';
@@ -12,9 +12,10 @@ import { MainNav } from './components/layout/MainNav';
  */
 const App: React.FC = (): ReactElement => {
     return (
-        <Router>
-            <MainNav />
-
+        <Router basename={window.PUBLIC_PATH}>
+            <Route path="/:path*">
+                <MainNav />
+            </Route>
             <ErrorBoundary>
                 <Main />
             </ErrorBoundary>

--- a/packages/site-demo/src/components/DemoBlock/index.tsx
+++ b/packages/site-demo/src/components/DemoBlock/index.tsx
@@ -1,14 +1,13 @@
+import { Code, DemoModule, useLoadDemo } from '@lumx/demo/components/DemoBlock/useLoadDemo';
 import { useHighlightedCode } from '@lumx/demo/components/layout/utils/useHighlightedCode';
-import { Engine, EngineContext } from '@lumx/demo/context/engine';
+import { EngineContext } from '@lumx/demo/context/engine';
 
 import { mdiCodeTags } from '@lumx/icons';
 import { Button, Emphasis, Switch, SwitchPosition, Theme } from '@lumx/react';
 
 import classNames from 'classnames';
 import get from 'lodash/get';
-import React, { ReactNode, useContext, useEffect, useState } from 'react';
-
-import AngularTemplate from 'react-angular';
+import React, { ReactNode, useContext, useState } from 'react';
 
 interface DemoBlockProps {
     children?: ReactNode;
@@ -17,90 +16,6 @@ interface DemoBlockProps {
     code?: Code;
     withThemeSwitcher?: boolean;
 }
-
-interface HasTheme {
-    theme: Theme;
-}
-
-// tslint:disable-next-line:interface-over-type-literal
-type Module = {};
-
-type NullModule = Module;
-
-type DemoModule = Module & {
-    default: React.FC<HasTheme>;
-};
-
-type AngularControllerModule = Module & {
-    DemoController(): void;
-};
-
-type Code =
-    | undefined
-    | {
-          react?: {
-              demo?: DemoModule | NullModule;
-              code?: string;
-          };
-          angularjs?: {
-              demo?: {
-                  controller?: AngularControllerModule | NullModule;
-                  template?: string | NullModule;
-              };
-              code?: string;
-          };
-      };
-
-function loadReactDemo(code: Code): DemoModule | null {
-    const demo = code?.react?.demo;
-    if (!demo || !('default' in demo)) {
-        return null;
-    }
-    return demo;
-}
-
-function loadAngularjsDemo(code: Code): DemoModule | null {
-    const controllerModule = code?.angularjs?.demo?.controller;
-    const template = code?.angularjs?.demo?.template;
-    if (!template || !(typeof template === 'string') || !controllerModule || !('DemoController' in controllerModule)) {
-        return null;
-    }
-
-    return {
-        default({ theme }: HasTheme) {
-            let container: any;
-
-            useEffect(() => {
-                if (!container) {
-                    return;
-                }
-
-                container.$scope.theme = theme;
-                container.$scope.$apply();
-            }, [container, theme]);
-
-            return (
-                <AngularTemplate
-                    ref={(c: any) => (container = c)}
-                    template={template}
-                    controller={controllerModule.DemoController}
-                    controllerAs="vm"
-                    scope={{ theme }}
-                />
-            );
-        },
-    };
-}
-
-const useLoadDemo = (code: Code, engine: string): DemoModule | null => {
-    const [demo, setDemo] = useState<DemoModule | null>(null);
-
-    useEffect(() => {
-        setDemo(engine === Engine.react ? loadReactDemo(code) : loadAngularjsDemo(code));
-    }, [engine]);
-
-    return demo;
-};
 
 function renderDemo(demo: DemoModule | null, theme: Theme, engine: string) {
     if (!demo) {
@@ -113,7 +28,12 @@ function renderDemo(demo: DemoModule | null, theme: Theme, engine: string) {
     return <demo.default theme={theme} />;
 }
 
-const DemoBlock: React.FC<DemoBlockProps> = ({ children, code, engine: propEngine, withThemeSwitcher = false }) => {
+export const DemoBlock: React.FC<DemoBlockProps> = ({
+    children,
+    code,
+    engine: propEngine,
+    withThemeSwitcher = false,
+}) => {
     const contextEngine = useContext(EngineContext).engine;
     const engine = propEngine || contextEngine;
 
@@ -168,5 +88,3 @@ const DemoBlock: React.FC<DemoBlockProps> = ({ children, code, engine: propEngin
         </div>
     );
 };
-
-export { DemoBlock };

--- a/packages/site-demo/src/components/DemoBlock/loadAngularjs.ts
+++ b/packages/site-demo/src/components/DemoBlock/loadAngularjs.ts
@@ -1,0 +1,48 @@
+function loadScript(url: string, integrity?: string, crossOrigin = 'anonymous') {
+    return new Promise((resolve, reject) => {
+        const head = document.getElementsByTagName('head')[0];
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        if (integrity) {
+            script.integrity = integrity;
+        }
+        script.crossOrigin = crossOrigin;
+
+        const onLoad = (...args: any) => resolve([script, ...args]);
+        script.addEventListener('load', onLoad);
+        const onError = (...args: any) => reject([script, ...args]);
+        script.addEventListener('error', onError);
+        script.src = url;
+        head.appendChild(script);
+    });
+}
+
+async function loadDependencies() {
+    await Promise.all([
+        loadScript(
+            'https://code.jquery.com/jquery-3.4.1.js',
+            //'https://code.jquery.com/jquery-3.4.1.min.js',
+            //'sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=',
+        ),
+        loadScript(
+            'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular.js',
+            //'https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular.min.js',
+            //'sha384-TBbVc3SDLcWU5RloNEsoiDVvRK9iYkBNMm1OsAcOIVEASb7zzMWB0aMobj6CzKUw',
+        ),
+    ]);
+    const [reactAngular] = await Promise.all([import('react-angular'), import('@lumx/angularjs')]);
+
+    // @ts-ignore
+    window.angular.module('design-system', ['lumx', reactAngular.reactAngularModule(false).name]);
+    console.debug('ok');
+
+    return reactAngular.default;
+}
+
+let ReactAngular: Promise<any>;
+export async function loadAngularjs() {
+    if (!ReactAngular) {
+        ReactAngular = loadDependencies();
+    }
+    return ReactAngular;
+}

--- a/packages/site-demo/src/components/DemoBlock/useLoadDemo.tsx
+++ b/packages/site-demo/src/components/DemoBlock/useLoadDemo.tsx
@@ -1,0 +1,90 @@
+import { loadAngularjs } from '@lumx/demo/components/DemoBlock/loadAngularjs';
+import { Engine } from '@lumx/demo/context/engine';
+import { Theme } from '@lumx/react';
+import React, { useEffect, useState } from 'react';
+
+interface Module {}
+type NullModule = Module;
+interface HasTheme {
+    theme: Theme;
+}
+
+export type DemoModule = Module & {
+    default: React.FC<HasTheme>;
+};
+type AngularControllerModule = Module & {
+    DemoController(): void;
+};
+export type Code =
+    | undefined
+    | {
+          react?: {
+              demo?: DemoModule | NullModule;
+              code?: string;
+          };
+          angularjs?: {
+              demo?: {
+                  controller?: AngularControllerModule | NullModule;
+                  template?: string | NullModule;
+              };
+              code?: string;
+          };
+      };
+
+function loadReactDemo(code: Code): DemoModule | null {
+    const demo = code?.react?.demo;
+    if (!demo || !('default' in demo)) {
+        return null;
+    }
+    return demo;
+}
+
+async function loadAngularjsDemo(code: Code): Promise<DemoModule | null> {
+    const controllerModule = code?.angularjs?.demo?.controller;
+    const template = code?.angularjs?.demo?.template;
+    if (!template || !(typeof template === 'string') || !controllerModule || !('DemoController' in controllerModule)) {
+        return null;
+    }
+    const AngularTemplate = await loadAngularjs();
+
+    // @ts-ignore
+    window.angular.module('design-system').controller('DemoController', controllerModule.DemoController);
+    return {
+        default({ theme }: HasTheme) {
+            let container: any;
+
+            useEffect(() => {
+                if (!container) {
+                    return;
+                }
+
+                container.$scope.theme = theme;
+                container.$scope.$apply();
+            }, [container, theme]);
+
+            return (
+                <AngularTemplate
+                    ref={(c: any) => (container = c)}
+                    template={template}
+                    controller={controllerModule.DemoController}
+                    controllerAs="vm"
+                    scope={{ theme }}
+                />
+            );
+        },
+    };
+}
+
+export const useLoadDemo = (code: Code, engine: string): DemoModule | null => {
+    const [demo, setDemo] = useState<DemoModule | null>(null);
+
+    useEffect(() => {
+        if (engine === Engine.angularjs) {
+            loadAngularjsDemo(code).then(setDemo);
+        } else {
+            setDemo(loadReactDemo(code));
+        }
+    }, [engine]);
+
+    return demo;
+};

--- a/packages/site-demo/src/components/layout/Main.tsx
+++ b/packages/site-demo/src/components/layout/Main.tsx
@@ -45,7 +45,7 @@ export const Main: React.FC = (): ReactElement => {
                             </FlexBox>
                         </div>
 
-                        <Route path="*">
+                        <Route path="/:path*">
                             <ErrorBoundary>
                                 <MainContent />
                             </ErrorBoundary>

--- a/packages/site-demo/src/components/layout/MainContent.tsx
+++ b/packages/site-demo/src/components/layout/MainContent.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { LoadingContent } from '@lumx/demo/components/layout/LoadingContent';
 import { EngineContext } from '@lumx/demo/context/engine';
 import classNames from 'classnames';
-import { useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 type Content = ReactElement | null | undefined;
 
@@ -16,7 +16,7 @@ const useLoadContent = (path: string): Content => {
             try {
                 const loadedContent = await import(
                     /* webpackChunkName: "content/[request]" */
-                    `content/${path.replace(/^\//, '')}`
+                    `content/${path}`
                 );
                 setContent(React.createElement(loadedContent.default, {}, null));
             } catch (exception) {
@@ -34,8 +34,8 @@ const useLoadContent = (path: string): Content => {
  * @return The main content component.
  */
 export const MainContent: React.FC = () => {
-    const { location } = useHistory();
-    const content = useLoadContent(location.pathname);
+    const { path = '' } = useParams();
+    const content = useLoadContent(path);
     const { engine } = useContext(EngineContext);
 
     return (
@@ -43,9 +43,9 @@ export const MainContent: React.FC = () => {
             <div className="main-content__wrapper">
                 {content === undefined && <LoadingContent />}
                 {content === null && (
-                    <span>
-                        Could not load content for <code>{location.pathname}</code>
-                    </span>
+                    <p>
+                        Could not load content for <code>{path}</code>
+                    </p>
                 )}
                 {content ? content : null}
             </div>

--- a/packages/site-demo/src/index.html.ejs
+++ b/packages/site-demo/src/index.html.ejs
@@ -9,29 +9,32 @@
 
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,500,700" />
 
+        <base href="/" />
+
+        <script type="text/javascript">
+            window.LUMX_VERSION = '<%= LUMX_VERSION %>';
+            window.PUBLIC_PATH = window.location.pathname.match(/(^\/(lumapps-[^\/]+\/?)?)/)[0];
+            if (!window.PUBLIC_PATH.match(/\/$/)) {
+                window.location.href += '/';
+            }
+            document.querySelector('base').attributes.href.value = window.PUBLIC_PATH;
+        </script>
+
         <%
         // CSS assets.
         for (const key of Object.keys(htmlWebpackPlugin.files.css)) {
             const href = htmlWebpackPlugin.files.css[key];
             const id = href.split('.')[0].replace(/^\//, '');
-            const rel = id === 'theme-material' ? 'preload' : 'stylesheet';
+            const rel = id === 'theme-material' ? 'rel="preload" as="style"' : 'rel="stylesheet"';
 
             %>
-            <link href="<%= href %>" id="<%= id %>" rel="<%= rel %>" />
+            <link href="<%= href %>" id="<%= id %>" <%= rel %> />
             <%
         }
         %>
-        <script type="text/javascript">window.LUMX_VERSION = '<%= LUMX_VERSION %>';</script>
     </head>
 
     <body>
-        <script src="https://code.jquery.com/jquery-3.4.1.min.js"
-                integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
-                crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.7.8/angular.min.js"
-                integrity="sha384-TBbVc3SDLcWU5RloNEsoiDVvRK9iYkBNMm1OsAcOIVEASb7zzMWB0aMobj6CzKUw"
-                crossorigin="anonymous"></script>
-
         <div class="app" id="root"></div>
 
         <%

--- a/packages/site-demo/src/index.tsx
+++ b/packages/site-demo/src/index.tsx
@@ -6,11 +6,4 @@ import 'focus-visible';
 
 import 'intersection-observer';
 
-import { reactAngularModule } from 'react-angular';
-
-import '@lumx/angularjs';
-
-// @ts-ignore
-angular.module('design-system', ['lumx', reactAngularModule(false).name]);
-
 render(<App />, document.getElementById('root'));

--- a/packages/site-demo/src/style/layout/main-nav/_main-nav.scss
+++ b/packages/site-demo/src/style/layout/main-nav/_main-nav.scss
@@ -17,7 +17,8 @@ $main-nav-width: 300px;
         display: flex;
         align-items: center;
         margin-bottom: $lumx-spacing-unit * 4;
-        cursor: pointer;
+        color: lumx-color-variant(dark, N);
+        text-decoration: none;
 
         img {
             height: map-get($lumx-sizes, s);

--- a/packages/site-demo/src/style/layout/main/_main.scss
+++ b/packages/site-demo/src/style/layout/main/_main.scss
@@ -53,8 +53,7 @@
             @include lumx-link('primary');
         }
 
-        /* stylelint-disable-next-line selector-type-no-unknown */
-        inlinecode {
+        p code {
             padding: 0 $lumx-spacing-unit-tiny;
             background-color: $lumx-color-dark-L5;
             color: $lumx-color-dark-N;

--- a/packages/site-demo/src/untypped-modules.d.ts
+++ b/packages/site-demo/src/untypped-modules.d.ts
@@ -4,3 +4,4 @@
 declare module 'prismjs';
 declare module 'react-angular';
 declare module '*.svg';
+declare module 'content/menu.yml';

--- a/packages/site-demo/src/utils.ts
+++ b/packages/site-demo/src/utils.ts
@@ -6,7 +6,7 @@ import { GlobalTheme } from '@lumx/core/js/types';
  *
  * @param theme The theme to apply the custom color palette on.
  */
-function setDemoCustomColors(theme: GlobalTheme) {
+export function setDemoCustomColors(theme: GlobalTheme) {
     const styleTag = document.createElement('style');
     document.head.appendChild(styleTag);
 
@@ -38,4 +38,11 @@ function setDemoCustomColors(theme: GlobalTheme) {
     });
 }
 
-export { setDemoCustomColors };
+declare global {
+    interface Window {
+        /**
+         * App root path ('/', '/lumapps-prod/', 'lumapps-foo', etc.).
+         */
+        PUBLIC_PATH: string;
+    }
+}

--- a/packages/site-demo/webpack-loader/mdx-loader/index.js
+++ b/packages/site-demo/webpack-loader/mdx-loader/index.js
@@ -2,6 +2,7 @@ const mdx = require('@mdx-js/mdx');
 
 const mdxBreakLine = require('./mdx-break-line');
 const mdxDemoCodeExtractor = require('./mdx-demo-code-extractor');
+const mdxInlineCode = require('./mdx-inline-code');
 
 // Imports needed in generated code.
 const IMPORT_REACT_FRAGMENT = 'import React, { Fragment } from "react"';
@@ -33,7 +34,7 @@ module.exports = async function mdxLoader(source) {
     // MDX to JSX.
     const jsx = await mdx(source, {
         remarkPlugins: [mdxDemoCodeExtractor(this.resourcePath)],
-        rehypePlugins: [mdxBreakLine],
+        rehypePlugins: [mdxBreakLine, mdxInlineCode],
         preserveNewlines: true,
     });
 

--- a/packages/site-demo/webpack-loader/mdx-loader/mdx-demo-code-extractor.js
+++ b/packages/site-demo/webpack-loader/mdx-loader/mdx-demo-code-extractor.js
@@ -110,7 +110,7 @@ const isPreImport = (node) =>
     node.type === 'element' && node.tagName === 'pre' && get(node, ['children', 0, 'properties', 'import']);
 const isImport = (node) => isJSXImport(node) || isPreImport(node);
 
-const ADDITIONAL_IMPORT = `
+const COMP_DEMO_ADDITIONAL_IMPORT = `
 import { DemoBlock } from '@lumx/demo/components/DemoBlock';
 import { PropTable } from '@lumx/demo/components/PropTable';
 import { ReactStabilityFlag } from '@lumx/demo/components/ReactStabilityFlag';
@@ -159,11 +159,12 @@ module.exports = (resourcePath) => () => {
 
         if (contentHasDemo) {
             importStatement += `\n${importController}`;
+            importStatement += COMP_DEMO_ADDITIONAL_IMPORT;
         }
 
         tree.children = [
             // Group all imports at the top with demo block import.
-            { type: 'import', value: ADDITIONAL_IMPORT + importStatement },
+            { type: 'import', value: importStatement },
 
             // Transformed content.
             ...content,

--- a/packages/site-demo/webpack-loader/mdx-loader/mdx-inline-code.js
+++ b/packages/site-demo/webpack-loader/mdx-loader/mdx-inline-code.js
@@ -1,0 +1,16 @@
+/**
+ * Replace inlineCode elements with code elements
+ */
+function replaceInlineCode(node) {
+    if (node.tagName === 'inlineCode') {
+        return { ...node, tagName: 'code' };
+    }
+    if (node.children) {
+        return { ...node, children: node.children.map(replaceInlineCode) };
+    }
+    return node;
+}
+
+module.exports = () => (tree) => {
+    tree.children = tree.children.map(replaceInlineCode);
+};

--- a/packages/site-demo/webpack.config.js
+++ b/packages/site-demo/webpack.config.js
@@ -7,7 +7,6 @@ const path = require('path');
 
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlMinifierPlugin = require('html-minifier-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const IS_CI = require('is-ci');
@@ -45,6 +44,7 @@ const plugins = [
         filename: `${filename}.css`,
     }),
 
+    // Define LumX version variable to inject in the HTML.
     new webpack.DefinePlugin({
         LUMX_VERSION: JSON.stringify(LUMX_VERSION),
     }),
@@ -52,8 +52,6 @@ const plugins = [
         inject: false,
         template: `${SRC_PATH}/index.html.ejs`,
     }),
-
-    new ForkTsCheckerWebpackPlugin(),
 ];
 
 const cssLoaders = [
@@ -178,6 +176,11 @@ module.exports = {
                 },
             },
             {
+                test: /\.ya?ml$/,
+                type: 'json',
+                use: 'yaml-loader',
+            },
+            {
                 test: /\.mdx?$/,
                 use: [
                     {
@@ -199,7 +202,6 @@ module.exports = {
     output: {
         filename: `${filename}.js`,
         path: DIST_PATH,
-        publicPath: '/',
     },
 
     node: {
@@ -231,7 +233,7 @@ if (isDev) {
             'Access-Control-Allow-Origin': '*',
         },
         historyApiFallback: {
-            index: '/',
+            index: '/lumapps-prod/',
         },
         host: '0.0.0.0',
         hot: true,
@@ -239,6 +241,7 @@ if (isDev) {
         overlay: true,
         port: 4000,
         quiet: true,
+        publicPath: '/lumapps-prod/',
     };
 
     module.exports.watch = true;


### PR DESCRIPTION
- [x] Use relative path in HTML
- [x] Detect root path (`/` or `lumapps-preview` or `lumapps-prod`)
- [x] Set HTML base path to root path
- [x] Set react router base name to root path
- [x] Fix MainNav links 
- [ ] Fix MDX paths (image src or link href)

Bonus: Make MDX import `DemoBlock`, `PropTable` and `ReactStabilityFlag` only on demo component page
Bonus: Fix preload stylesheet (for theme switcher)