### PR TITLE
refactor(components): harmonize jsdoc and props

### DIFF
--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, RefObject, SyntheticEvent, useRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Dropdown, DropdownProps, Offset, PopoverProps, TextField, Theme } from '@lumx/react';
+import { Dropdown, Offset, Placement, TextField, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
@@ -14,161 +14,142 @@ import { useFocus } from '@lumx/react/hooks/useFocus';
  */
 interface AutocompleteProps extends GenericProps {
     /**
-     * Whether the suggestions list should display anchored to the input
-     * If false, it will be anchored to the text field wrapper.
+     * Whether the suggestions list should display anchored to the input or to the wrapper.
+     * @see {@link DropdownProps#anchorToInput}
      */
     anchorToInput?: boolean;
-
-    /** A ref that will be passed to the input or textarea element. */
-    inputRef?: RefObject<HTMLInputElement>;
-
     /**
-     * Vertical and/or horizontal offsets that will be applied to the Dropdown position.
+     * The reference passed to the <input> or <textarea> element.
+     * @see {@link TextFieldProps#inputRef}
+     */
+    inputRef?: RefObject<HTMLInputElement>;
+    /**
+     * The offset that will be applied to the Dropdown position.
      * @see {@link DropdownProps#offset}
      */
     offset?: Offset;
-
     /**
      * The preferred Dropdown location against the anchor element.
      * @see {@link DropdownProps#placement}
      */
-    placement?: DropdownProps['placement'];
-
+    placement?: Placement;
     /**
-     * Whether the dropdown should fit to the anchor width
-     * @see {@link DropdownProps#hasError}
+     * Whether the dropdown should fit to the anchor width or not.
+     * @see {@link DropdownProps#fitToAnchorWidth}
      */
     fitToAnchorWidth?: boolean;
-
-    /** The error related to the component */
+    /**
+     * The error related to the component.
+     * @see {@link TextFieldProps#error}
+     */
     error?: string | ReactNode;
-
     /**
      * Whether the text field is displayed with error style or not.
      * @see {@link TextFieldProps#hasError}
      */
     hasError?: boolean;
-
     /**
-     * Whether the text box should be focused upon closing the suggestions
+     * Whether the text box should be focused upon closing the suggestions or not.
      */
     shouldFocusOnClose?: boolean;
-
     /**
      * Whether the text field displays a clear button or not.
-     * @see {@link TextFieldProps#hasError}
+     * @see {@link TextFieldProps#isClearable}
      */
     isClearable?: boolean;
-
     /**
-     * Text field helper message.
+     * The helper message of the text field.
      * @see {@link TextFieldProps#helper}
      */
     helper?: string;
-
     /**
-     * Text field icon (SVG path)
+     * The icon of the text field (SVG path).
      * @see {@link TextFieldProps#icon}
      */
     icon?: string;
-
     /**
-     * Whether the text field is disabled or not.
+     * Whether the component is disabled or not.
      * @see {@link TextFieldProps#isDisabled}
      */
     isDisabled?: boolean;
-
     /**
      * Whether the text field is displayed with valid style or not.
      * @see {@link TextFieldProps#isValid}
      */
     isValid?: boolean;
-
     /**
-     * Text field label displayed in a label tag.
+     * The label of the text field displayed in a label tag.
      * @see {@link TextFieldProps#label}
      */
     label?: string;
-
     /**
-     * Text field placeholder message.
+     * The placeholder message of the text field.
      * @see {@link TextFieldProps#placeholder}
      */
     placeholder?: string;
-
-    /** Theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-
-    /**
-     * Children of the Autocomplete. This should be a list of the different
-     * suggestions that
-     */
+    /** The children elements to be transcluded into the component. Should be a list of suggestions. */
     children: React.ReactNode;
-
     /**
-     * List of chips to be displayed before the text field input.
+     * The list of chips to be displayed before the text field input.
      */
     chips?: React.ReactNode;
-
     /**
-     * Text field value.
-     * @see {@link TextFieldProps#onChange}
+     * The value of the text field.
+     * @see {@link TextFieldProps#value}
      */
     value: string;
-
     /**
      * Whether the suggestions from the autocomplete should be displayed or not.
-     * Useful to control when the suggestions are displayed from outside the component
+     * @see {@link DropdownProps#isOpen}
      */
     isOpen: boolean;
-
-    /** Native input name. */
-    name?: string;
-
     /**
-     * Whether a click in the Autocomplete dropdown would close it
+     * The native input name property.
+     * @see {@link TextFieldProps#name}
+     */
+    name?: string;
+    /**
+     * Whether a click in the Autocomplete dropdown would close it or not.
      * @see {@link DropdownProps#closeOnClick}
      */
-    closeOnClick?: DropdownProps['closeOnClick'];
-
+    closeOnClick?: boolean;
     /**
-     * Whether a click anywhere out of the Autocomplete would close it
-     * @see {@link PopoverProps#closeOnClickAway}
+     * Whether a click anywhere out of the Autocomplete would close it or not.
+     * @see {@link DropdownProps#closeOnClickAway}
      */
-    closeOnClickAway?: PopoverProps['closeOnClickAway'];
-
+    closeOnClickAway?: boolean;
     /**
-     * Whether an escape key press would close the Autocomplete.
-     * @see {@link PopoverProps#closeOnEscape}
+     * Whether an escape key press would close the Autocomplete or not.
+     * @see {@link DropdownProps#closeOnEscape}
      */
-    closeOnEscape?: PopoverProps['closeOnEscape'];
-
+    closeOnEscape?: boolean;
     /**
-     * The function to be called when the user clicks away or Escape is pressed
-     * @see {@link PopoverProps#onClose}
-     */
-    onClose?: PopoverProps['onClose'];
-
-    /**
-     * The callback function called when the bottom of the dropdown is reached.
-     * @see {@link DropdownProps#onInfiniteScroll}
-     */
-    onInfiniteScroll?: VoidFunction;
-
-    /** Handle onChange event. */
-    onChange(value: string, name?: string, event?: SyntheticEvent): void;
-
-    /**
-     * Text field focus change handler.
-     * @see {@link TextFieldProps#onFocus}
-     */
-    onFocus?(event: React.FocusEvent): void;
-
-    /**
-     * Text field blur change handler.
+     * The function called on blur.
      * @see {@link TextFieldProps#onBlur}
      */
     onBlur?(event: React.FocusEvent): void;
+    /**
+     * The function called on change.
+     * @see {@link TextFieldProps#onChange}
+     */
+    onChange(value: string, name?: string, event?: SyntheticEvent): void;
+    /**
+     * The function called on close.
+     * @see {@link DropdownProps#onClose}
+     */
+    onClose?(): void;
+    /**
+     * The function called on focus.
+     * @see {@link TextFieldProps#onFocus}
+     */
+    onFocus?(event: React.FocusEvent): void;
+    /**
+     * The function called when the bottom of the dropdown is reached.
+     * @see {@link DropdownProps#onInfiniteScroll}
+     */
+    onInfiniteScroll?(): void;
 }
 
 /**
@@ -186,55 +167,46 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: Partial<AutocompleteProps> = {
     anchorToInput: false,
+    closeOnClick: false,
     closeOnClickAway: true,
     closeOnEscape: true,
-    isOpen: undefined,
     shouldFocusOnClose: false,
 };
 
-/**
- * This component allows to make the connection between a Text Field and a Dropdown,
- * displaying a list of suggestions from the text entered on the text field.
- *
- * @param  props The component props
- * @return The component.
- */
-const Autocomplete: React.FC<AutocompleteProps> = (props) => {
-    const {
-        anchorToInput = DEFAULT_PROPS.anchorToInput,
-        className,
-        children,
-        chips,
-        value,
-        onBlur,
-        onChange,
-        onFocus,
-        isOpen,
-        closeOnClick,
-        closeOnClickAway,
-        closeOnEscape,
-        error,
-        hasError,
-        helper,
-        icon,
-        disabled,
-        isDisabled = disabled,
-        isClearable,
-        isValid,
-        label,
-        placeholder,
-        theme,
-        onClose,
-        offset,
-        shouldFocusOnClose = DEFAULT_PROPS.shouldFocusOnClose,
-        placement,
-        inputRef = useRef(null),
-        fitToAnchorWidth,
-        onInfiniteScroll,
-        name,
-        ...forwardedProps
-    } = props;
-
+const Autocomplete: React.FC<AutocompleteProps> = ({
+    anchorToInput = DEFAULT_PROPS.anchorToInput,
+    children,
+    chips,
+    className,
+    closeOnClick = DEFAULT_PROPS.closeOnClick,
+    closeOnClickAway = DEFAULT_PROPS.closeOnClickAway,
+    closeOnEscape = DEFAULT_PROPS.closeOnEscape,
+    disabled,
+    error,
+    fitToAnchorWidth,
+    hasError,
+    helper,
+    icon,
+    inputRef = useRef(null),
+    isClearable,
+    isDisabled = disabled,
+    isOpen,
+    isValid,
+    label,
+    name,
+    offset,
+    onBlur,
+    onChange,
+    onClose,
+    onFocus,
+    onInfiniteScroll,
+    placeholder,
+    placement,
+    shouldFocusOnClose = DEFAULT_PROPS.shouldFocusOnClose,
+    theme,
+    value,
+    ...forwardedProps
+}) => {
     const textFieldRef = useRef(null);
     useFocus(inputRef.current, !isOpen && shouldFocusOnClose);
 
@@ -249,38 +221,38 @@ const Autocomplete: React.FC<AutocompleteProps> = (props) => {
             )}
         >
             <TextField
-                value={value}
-                name={name}
-                onChange={onChange}
                 chips={chips}
-                textFieldRef={textFieldRef}
-                inputRef={inputRef}
-                isClearable={isClearable}
-                onBlur={onBlur}
-                onFocus={onFocus}
-                hasError={hasError}
                 error={error}
+                hasError={hasError}
                 helper={helper}
                 icon={icon}
+                inputRef={inputRef}
+                isClearable={isClearable}
                 isDisabled={isDisabled}
                 isValid={isValid}
                 label={label}
+                name={name}
+                onBlur={onBlur}
+                onChange={onChange}
+                onFocus={onFocus}
                 placeholder={placeholder}
+                textFieldRef={textFieldRef}
                 theme={theme}
+                value={value}
             />
             <Dropdown
                 anchorRef={anchorToInput ? inputRef : textFieldRef}
-                isOpen={isOpen}
                 closeOnClick={closeOnClick}
                 closeOnClickAway={closeOnClickAway}
                 closeOnEscape={closeOnEscape}
-                onClose={onClose}
-                offset={offset}
-                placement={placement}
                 fitToAnchorWidth={fitToAnchorWidth}
+                isOpen={isOpen}
+                offset={offset}
+                onClose={onClose}
                 onInfiniteScroll={onInfiniteScroll}
-                theme={theme}
+                placement={placement}
                 shouldFocusOnOpen={false}
+                theme={theme}
             >
                 {children}
             </Dropdown>

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
@@ -48,10 +48,8 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: Partial<AutocompleteMultipleProps> = {
-    closeOnClick: false,
     closeOnClickAway: true,
     closeOnEscape: true,
-    isOpen: undefined,
     selectedChipRender(choice, index, onClear, isDisabled) {
         const onClick = (event: React.MouseEvent) => onClear && onClear(event, choice);
         return (
@@ -70,98 +68,87 @@ const DEFAULT_PROPS: Partial<AutocompleteMultipleProps> = {
     values: [],
 };
 
-/**
- * This component allows to create a multiple autocomplete, allowing the user to select multiple values from a
- * list that can be filtered.
- *
- * @param  props The component props.
- * @return The component.
- */
-const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props) => {
-    const {
-        anchorToInput,
-        className,
-        children,
-        chipsAlignment,
-        value,
-        values = DEFAULT_PROPS.values,
-        onBlur,
-        onChange,
-        onFocus,
-        onKeyDown,
-        isOpen,
-        closeOnClickAway,
-        closeOnEscape,
-        hasError,
-        helper,
-        icon,
-        inputRef,
-        isDisabled,
-        isClearable,
-        isValid,
-        label,
-        placeholder,
-        theme,
-        type,
-        onClose,
-        onClear,
-        offset,
-        placement,
-        fitToAnchorWidth,
-        shouldFocusOnClose,
-        onInfiniteScroll,
-        selectedChipRender = DEFAULT_PROPS.selectedChipRender,
-        name,
-        ...forwardedProps
-    } = props;
-
-    return (
-        <Autocomplete
-            {...forwardedProps}
-            anchorToInput={anchorToInput}
-            className={classNames(
-                className,
-                handleBasicClasses({
-                    prefix: CLASSNAME,
-                }),
-            )}
-            name={name}
-            value={value}
-            onChange={onChange}
-            onKeyDown={onKeyDown}
-            onBlur={onBlur}
-            shouldFocusOnClose={shouldFocusOnClose}
-            onFocus={onFocus}
-            hasError={hasError}
-            helper={helper}
-            icon={icon}
-            inputRef={inputRef}
-            chips={
-                <ChipGroup align={chipsAlignment}>
-                    {values!.map((chip: object, index: number) => selectedChipRender!(chip, index, onClear))}
-                </ChipGroup>
-            }
-            isDisabled={isDisabled}
-            isClearable={isClearable}
-            isValid={isValid}
-            label={label}
-            placeholder={placeholder}
-            theme={theme}
-            type={type}
-            isOpen={isOpen}
-            closeOnClick={false}
-            closeOnClickAway={closeOnClickAway}
-            closeOnEscape={closeOnEscape}
-            onClose={onClose}
-            offset={offset}
-            placement={placement}
-            fitToAnchorWidth={fitToAnchorWidth}
-            onInfiniteScroll={onInfiniteScroll}
-        >
-            {children}
-        </Autocomplete>
-    );
-};
+const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = ({
+    anchorToInput,
+    children,
+    chipsAlignment,
+    className,
+    closeOnClickAway = DEFAULT_PROPS.closeOnClickAway,
+    closeOnEscape = DEFAULT_PROPS.closeOnEscape,
+    fitToAnchorWidth,
+    hasError,
+    helper,
+    icon,
+    inputRef,
+    isClearable,
+    isDisabled,
+    isOpen,
+    isValid,
+    label,
+    name,
+    offset,
+    onBlur,
+    onChange,
+    onClear,
+    onClose,
+    onFocus,
+    onInfiniteScroll,
+    onKeyDown,
+    placeholder,
+    placement,
+    selectedChipRender = DEFAULT_PROPS.selectedChipRender,
+    shouldFocusOnClose,
+    theme,
+    type,
+    value,
+    values = DEFAULT_PROPS.values,
+    ...forwardedProps
+}) => (
+    <Autocomplete
+        {...forwardedProps}
+        anchorToInput={anchorToInput}
+        className={classNames(
+            className,
+            handleBasicClasses({
+                prefix: CLASSNAME,
+            }),
+        )}
+        name={name}
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+        shouldFocusOnClose={shouldFocusOnClose}
+        onFocus={onFocus}
+        hasError={hasError}
+        helper={helper}
+        icon={icon}
+        inputRef={inputRef}
+        chips={
+            <ChipGroup align={chipsAlignment}>
+                {values!.map((chip: object, index: number) => selectedChipRender!(chip, index, onClear))}
+            </ChipGroup>
+        }
+        isDisabled={isDisabled}
+        isClearable={isClearable}
+        isValid={isValid}
+        label={label}
+        placeholder={placeholder}
+        theme={theme}
+        type={type}
+        isOpen={isOpen}
+        closeOnClick={false}
+        closeOnClickAway={closeOnClickAway}
+        closeOnEscape={closeOnEscape}
+        onClose={onClose}
+        offset={offset}
+        placement={placement}
+        fitToAnchorWidth={fitToAnchorWidth}
+        onInfiniteScroll={onInfiniteScroll}
+    >
+        {children}
+    </Autocomplete>
+);
 AutocompleteMultiple.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, DEFAULT_PROPS, AutocompleteMultiple, AutocompleteMultipleProps };

--- a/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -24,6 +24,9 @@ exports[`<Autocomplete> Props should render correctly when the dropdown is close
         "current": null,
       }
     }
+    closeOnClick={false}
+    closeOnClickAway={true}
+    closeOnEscape={true}
     isOpen={false}
     shouldFocusOnOpen={false}
   >
@@ -123,6 +126,9 @@ exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
         "current": null,
       }
     }
+    closeOnClick={false}
+    closeOnClickAway={true}
+    closeOnEscape={true}
     isOpen={true}
     shouldFocusOnOpen={false}
   >

--- a/packages/lumx-react/src/components/autocomplete/__snapshots__/AutocompleteMultiple.test.tsx.snap
+++ b/packages/lumx-react/src/components/autocomplete/__snapshots__/AutocompleteMultiple.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`<AutocompleteMultiple> Snapshots and structure should render correctly 
   chips={<ChipGroup />}
   className="lumx-autocomplete-multiple"
   closeOnClick={false}
+  closeOnClickAway={true}
+  closeOnEscape={true}
   isOpen={true}
   onChange={[MockFunction]}
   value=""

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -18,22 +18,17 @@ type AvatarSize = Size.xs | Size.s | Size.m | Size.l | Size.xl | Size.xxl;
  * Defines the props of the component.
  */
 interface AvatarProps extends GenericProps {
-    /** Actions elements to be transcluded into the component */
+    /** The action elements to be transcluded into the component. */
     actions?: HTMLElement | ReactNode;
-    /** Avatar badge */
+    /** The optional avatar badge. */
     badge?: ReactElement;
-    /** Size. */
-    size?: AvatarSize;
-    /** Theme. */
-    theme?: Theme;
-    /** Avatar image */
+    /** The avatar image URL. */
     image: string;
+    /** The size variant of the component. */
+    size?: AvatarSize;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<AvatarProps> {}
 
 /**
  * The display name of the component.
@@ -48,25 +43,18 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    actions: undefined,
-    badge: undefined,
+const DEFAULT_PROPS: Partial<AvatarProps> = {
     size: Size.m,
     theme: Theme.light,
 };
 
-/**
- * Simple component used to identify user.
- *
- * @return The component.
- */
 const Avatar: React.FC<AvatarProps> = ({
-    actions = DEFAULT_PROPS.actions,
-    badge = DEFAULT_PROPS.badge,
+    actions,
+    badge,
     className,
+    image,
     size = DEFAULT_PROPS.size,
     theme = DEFAULT_PROPS.theme,
-    image,
     ...forwardedProps
 }) => {
     const style: CSSProperties = {

--- a/packages/lumx-react/src/components/badge/Badge.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.tsx
@@ -8,14 +8,9 @@ import React, { ReactNode } from 'react';
  * Defines the props of the component.
  */
 interface BadgeProps extends GenericProps {
-    /**
-     * Badge content.
-     */
+    /** The children elements to be transcluded into the component. */
     children?: ReactNode;
-
-    /**
-     * The badge color.
-     */
+    /** The color variant of the component. */
     color?: Color;
 }
 
@@ -32,14 +27,14 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: BadgeProps = {
+const DEFAULT_PROPS: Partial<BadgeProps> = {
     color: ColorPalette.primary,
 };
 
-const Badge: React.FC<BadgeProps> = ({ color = DEFAULT_PROPS.color, className, ...forwardedProps }) => {
+const Badge: React.FC<BadgeProps> = ({ children, className, color = DEFAULT_PROPS.color, ...forwardedProps }) => {
     return (
         <div {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color }))}>
-            {forwardedProps.children}
+            {children}
         </div>
     );
 };

--- a/packages/lumx-react/src/components/button/Button.tsx
+++ b/packages/lumx-react/src/components/button/Button.tsx
@@ -18,28 +18,19 @@ const ButtonEmphasis = Emphasis;
  * Defines the props of the component.
  */
 interface ButtonProps extends BaseButtonProps {
-    /**
-     * Button content.
-     */
+    /** The children elements to be transcluded into the component. */
     children?: ReactNode;
-
     /**
-     * Adds an icon to the left of the button label.
+     * The icon name to place at the left of the button label.
      * @see {@link IconProps#icon}
      */
     leftIcon?: string;
-
     /**
-     * Adds an icon to the right of the button label.
+     * The icon name to place at the right of the button label.
      * @see {@link IconProps#icon}
      */
     rightIcon?: string;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ButtonProps> {}
 
 /**
  * The display name of the component.
@@ -54,23 +45,16 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ButtonProps> = {
     emphasis: Emphasis.high,
     size: Size.m,
     theme: Theme.light,
 };
 
-/**
- * Displays a button.
- * If the `href` property is set, it will display a `<a>` HTML tag. If not, it will use a `<button>` HTML tag instead.
- *
- * @param  props The component props.
- * @return The component.
- */
 const Button: React.FC<ButtonProps> = (props) => {
     const {
-        className,
         children,
+        className,
         emphasis = DEFAULT_PROPS.emphasis,
         leftIcon,
         rightIcon,

--- a/packages/lumx-react/src/components/button/ButtonGroup.tsx
+++ b/packages/lumx-react/src/components/button/ButtonGroup.tsx
@@ -8,14 +8,9 @@ import { GenericProps, getRootClassName } from '@lumx/react/utils';
  * Defines the props of the component
  */
 interface ButtonGroupProps extends GenericProps {
-    /** Ref passed to the wrapper. */
+    /** The reference passed to the wrapper. */
     buttonGroupRef?: Ref<HTMLDivElement>;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ButtonGroupProps> {}
 
 /**
  * The display name of the component.
@@ -30,16 +25,9 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<ButtonGroupProps> = {};
 
-/**
- * Displays a group of <Button>s.
- *
- * @see {@link Button} for more information on <Button>.
- *
- * @return The component.
- */
-const ButtonGroup: React.FC<ButtonGroupProps> = ({ children, className, buttonGroupRef, ...forwardedProps }) => (
+const ButtonGroup: React.FC<ButtonGroupProps> = ({ buttonGroupRef, children, className, ...forwardedProps }) => (
     <div {...forwardedProps} className={classNames(className, CLASSNAME)} ref={buttonGroupRef}>
         {children}
     </div>

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -14,62 +14,29 @@ import { GenericProps, handleBasicClasses } from '@lumx/react/utils';
 export type ButtonSize = Size.s | Size.m;
 
 interface BaseButtonProps extends GenericProps {
-    /**
-     * Reference on the `<a>` or `<button>` button HTML element.
-     */
+    /** The reference passed to the <a> or <button> element. */
     buttonRef?: RefObject<HTMLButtonElement> | RefObject<HTMLAnchorElement>;
-
-    /**
-     * Use this property to add a background color to the button in low emphasis.
-     */
-    hasBackground?: boolean;
-
-    /**
-     * Use this property to create a link button pointing to the given URL.
-     */
-    href?: string;
-
-    /**
-     * Button selected state.
-     */
-    isSelected?: boolean;
-
-    /**
-     * Button disabled state.
-     */
-    isDisabled?: boolean;
-
-    /**
-     * Use this property if you specified a URL in the `href` property and you want to customize the link button target property.
-     */
-    target?: '_self' | '_blank' | '_parent' | '_top';
-
-    /**
-     * Button color.
-     */
+    /** The color variant of the component. */
     color?: Color;
-
-    /**
-     * Button emphasis.
-     */
+    /** The emphasis variant of the component. */
     emphasis?: Emphasis;
-
-    /**
-     * Button size.
-     */
-    size?: ButtonSize;
-
-    /**
-     * Theme.
-     */
-    theme?: Theme;
-
-    /** Native input name. */
+    /** Whether or not the button has a background color in low emphasis. */
+    hasBackground?: boolean;
+    /** The native anchor href property. It determines whether the Button will be a <button> or an <a>. */
+    href?: string;
+    /** Whether the component is disabled or not. */
+    isDisabled?: boolean;
+    /** Whether the component is selected or not. */
+    isSelected?: boolean;
+    /** The native input name property. */
     name?: string;
-
-    /**
-     * Whether custom colors are applied to this component.
-     */
+    /** The size variant of the component. */
+    size?: ButtonSize;
+    /** The native anchor target property. */
+    target?: '_self' | '_blank' | '_parent' | '_top';
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
 }
 
@@ -113,33 +80,23 @@ const renderButtonWrapper: React.FC<ButtonRootProps> = (props) => {
     );
 };
 
-/**
- * A generic button component used to implement the Button and IconButton components.
- * To use internally.
- *
- * Renders a <a> anchor if an `href` is provided or a <button> otherwise.
- * Wraps the element in a wrapper if the `hasBackground` param is set to true.
- *
- * @param  props Component props.
- * @return React element.
- */
 const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
     const {
         buttonRef,
-        emphasis,
+        children,
+        className,
+        color,
         disabled,
+        emphasis,
+        hasBackground,
+        href,
         isDisabled = disabled,
         isSelected,
+        name,
         size,
-        color,
-        className,
-        hasBackground,
-        children,
         theme,
         useCustomColors,
         variant,
-        name,
-        href,
         ...forwardedProps
     } = props;
 

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -10,16 +10,11 @@ import { getRootClassName } from '@lumx/react/utils';
  */
 interface IconButtonProps extends BaseButtonProps {
     /**
-     * The icon used as the button label.
+     * The icon name to use as the button label.
      * @see {@link IconProps#icon}
      */
     icon: string;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<IconButtonProps> {}
 
 /**
  * The display name of the component.
@@ -34,18 +29,12 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<IconButtonProps> = {
     emphasis: Emphasis.high,
     size: Size.m,
     theme: Theme.light,
 };
 
-/**
- * Displays an icon button.
- *
- * @param  props The component props.
- * @return The component.
- */
 const IconButton: React.FC<IconButtonProps> = (props) => {
     const {
         emphasis = DEFAULT_PROPS.emphasis,

--- a/packages/lumx-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.tsx
@@ -14,32 +14,27 @@ import uniqueId from 'lodash/uniqueId';
  * Defines the props of the component.
  */
 interface CheckboxProps extends GenericProps {
+    /** The helper of the checkbox. */
+    helper?: string;
+    /** The native input id property. */
+    id?: string;
     /** Whether it is checked or not. */
     isChecked?: boolean;
-    /** Is checkbox disabled */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-    /** Helper */
-    helper?: string;
-    /** Native input id */
-    id?: string;
-    /** Label */
+    /** The label of the checkbox. */
     label?: ReactNode;
-    /** Native input name. */
+    /** The native input name property. */
     name?: string;
-    /** Component theme */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-    /** Native input value. */
+    /** The native input value property. */
     value?: string;
-    /** Handle onChange event. */
+    /** The function called on change. */
     onChange?(isChecked: boolean, value?: string, name?: string, event?: SyntheticEvent): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<CheckboxProps> {}
 
 /**
  * The display name of the component.
@@ -54,7 +49,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<CheckboxProps> = {
     theme: Theme.light,
 };
 

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -18,38 +18,33 @@ type ChipSize = Size.s | Size.m;
  * Defines the props of the component.
  */
 interface ChipProps extends GenericProps {
-    /** A component to be rendered after the main label area. */
+    /** A component to be rendered after the content. */
     after?: ReactNode;
-    /** A component to be rendered before the main label area. */
+    /** A component to be rendered before the content. */
     before?: ReactNode;
-    /** The component color variant. */
+    /** The reference passed to the <a> element. */
+    chipRef?: Ref<HTMLAnchorElement>;
+    /** The color variant of the component. */
     color?: Color;
-    /** Whether the chip has pointer on hover. */
+    /** Whether the component is clickable or not. */
     isClickable?: boolean;
-    /** Indicates if the chip is currently in an active state or not. */
-    isSelected?: boolean;
-    /** Indicates if the chip is currently disabled or not. */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-    /** Indicates if the chip is currently in a highlighted state or not. */
+    /** Whether the chip is currently in a highlighted state or not. */
     isHighlighted?: boolean;
-    /** The size of the chip. */
+    /** Whether the component is selected or not. */
+    isSelected?: boolean;
+    /** The size variant of the component. */
     size?: ChipSize;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-    /** A ref that will be passed to the wrapper element. */
-    chipRef?: Ref<HTMLAnchorElement>;
-    /** A function to be executed when the after element is clicked. */
+    /** The function called when the "after" element is clicked. */
     onAfterClick?: MouseEventHandler;
-    /** A function to be executed when the before element is clicked. */
+    /** The function called when the "before" element is clicked. */
     onBeforeClick?: MouseEventHandler;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ChipProps> {}
 
 /**
  * The display name of the component.
@@ -64,7 +59,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ChipProps> = {
     size: Size.m,
     theme: Theme.light,
 };
@@ -88,30 +83,24 @@ function useStopPropagation(handler?: MouseEventHandler): MouseEventHandler {
     );
 }
 
-/**
- * Displays information or allow an action on a compact element.
- * This is the base component for all variations of the chips see https://material.io/design/components/chips.html.
- *
- * @return The Chip component.
- */
 const Chip: React.FC<ChipProps> = ({
-    after = DEFAULT_PROPS.after,
-    before = DEFAULT_PROPS.before,
-    className,
+    after,
+    before,
     children,
+    chipRef,
+    className,
     color,
-    isClickable,
-    isSelected,
     disabled,
+    isClickable,
     isDisabled = disabled,
     isHighlighted,
+    isSelected,
     onAfterClick,
     onBeforeClick,
     onClick,
     size = DEFAULT_PROPS.size,
     theme = DEFAULT_PROPS.theme,
     useCustomColors,
-    chipRef,
     ...forwardedProps
 }) => {
     const hasAfterClick = isFunction(onAfterClick);

--- a/packages/lumx-react/src/components/chip/ChipGroup.tsx
+++ b/packages/lumx-react/src/components/chip/ChipGroup.tsx
@@ -12,22 +12,16 @@ import { useChipGroupNavigation, useChipGroupNavigationType } from '@lumx/react/
  * Defines the props of the component.
  */
 interface ChipGroupProps extends GenericProps {
-    /** Children of the ChipGroup. This should be a list of Chips */
-    children: React.ReactNode;
-
-    /** Chip group alignment */
+    /** The alignment of the component. */
     align?: string;
+    /** The children elements to be transcluded into the component. Should be a list of Chip. */
+    children: React.ReactNode;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ChipGroupProps> {}
 
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ChipGroupProps> = {
     align: 'left',
 };
 
@@ -50,9 +44,9 @@ interface ChipGroup {
  * @return The Chip Group component.
  */
 const ChipGroup: React.FC<ChipGroupProps> & ChipGroup = ({
-    className,
     align = DEFAULT_PROPS.align,
     children,
+    className,
     ...forwardedProps
 }) => {
     const chipGroupClassName = handleBasicClasses({

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -13,44 +13,42 @@ import { AvatarProps } from '../avatar/Avatar';
  * Defines the props of the component.
  */
 interface CommentBlockProps extends GenericProps {
-    /* Actions elements to be transcluded into the component */
+    /** The action elements to be transcluded into the component. */
     actions?: HTMLElement | ReactNode;
-    /* The url of the avatar picture we want to display */
+    /**
+     * The url of the avatar picture we want to display.
+     * @see {@link AvatarProps#image}
+     */
     avatar: string;
     /** The props to pass to the avatar, minus those already set by the CommentBlock props. */
     avatarProps?: Omit<AvatarProps, 'image' | 'size' | 'tabIndex' | 'onClick' | 'onKeyPress'>;
-    /* Children elements to be transcluded into the component */
+    /** The children elements to be transcluded into the component. */
     children?: HTMLElement | ReactNode;
-    /* Comment timestamp */
+    /** The timestamp of the component. */
     date: string;
-    /* Where the component has actions to display */
+    /** Whether the component has actions to display or not. */
     hasActions?: boolean;
-    /* Whether the component has children blocks to display */
+    /** Whether the component has children blocks to display or not. */
     hasChildren?: boolean;
-    /* Whether the component children are indented below parent */
+    /** Whether the component children are indented below parent or not. */
     hasIndentedChildren?: boolean;
-    /* Whether the children blocks are shown*/
+    /** Whether the component is open or not. */
     isOpen?: boolean;
-    /* Whether the comment is relevant */
+    /** Whether the comment is relevant or not. */
     isRelevant?: boolean;
-    /* Username display */
+    /** The name of the comment author. */
     name: string;
-    /* Content to be displayed */
+    /** The content of the comment. */
     text: HTMLElement | string;
-    /* Component theme */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /* Callback for the click event. */
+    /** The function called on click. */
     onClick?(): void;
-    /* Callback for the mouseEnter event. */
+    /** The function called when the cursor enters the component. */
     onMouseEnter?(): void;
-    /* Callback for the mouseEnter event. */
+    /** The function called when the cursor exists the component. */
     onMouseLeave?(): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<CommentBlockProps> {}
 
 /**
  * The display name of the component.
@@ -65,27 +63,22 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<CommentBlockProps> = {
     hasActions: false,
     hasChildren: false,
     hasIndentedChildren: false,
     isOpen: false,
     isRelevant: false,
     theme: Theme.light,
-    avatarProps: undefined,
 };
 
-/**
- * [Enter the description of the component here].
- *
- * @return The component.
- */
 const CommentBlock: React.FC<CommentBlockProps> = ({
     actions,
     avatar,
+    avatarProps,
     children,
     date,
-    hasActions,
+    hasActions = DEFAULT_PROPS.hasActions,
     hasChildren = DEFAULT_PROPS.hasChildren,
     hasIndentedChildren = DEFAULT_PROPS.hasIndentedChildren,
     isOpen = DEFAULT_PROPS.isOpen,
@@ -96,7 +89,6 @@ const CommentBlock: React.FC<CommentBlockProps> = ({
     onMouseLeave,
     text,
     theme = DEFAULT_PROPS.theme,
-    avatarProps = DEFAULT_PROPS.avatarProps,
 }: CommentBlockProps): React.ReactElement => {
     const enterKeyPress: KeyboardEventHandler<HTMLElement> = (evt: KeyboardEvent<HTMLElement>) => {
         if (evt.which === ENTER_KEY_CODE && isFunction(onClick)) {

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -15,25 +15,19 @@ import DatePickerValueProp from './DatePickerValueProp';
  */
 
 interface DatePickerProps extends GenericProps {
-    /** Locale. */
-    locale: string;
-
-    /** Max date. */
-    maxDate?: Date;
-
-    /** Min date. */
-    minDate?: Date;
-
-    /** Today or selected date Ref */
-    todayOrSelectedDateRef?: RefObject<HTMLButtonElement>;
-
-    /** Value. */
-    value: DatePickerValueProp;
-
-    /** Month to display by default */
+    /** The month to display by default. */
     defaultMonth?: DatePickerValueProp;
-
-    /** On change. */
+    /** The locale (language or region) to use. */
+    locale: string;
+    /** The date after which no date can be selected. */
+    maxDate?: Date;
+    /** The date before which no date can be selected. */
+    minDate?: Date;
+    /** The reference passed to the <button> element if it corresponds to the current date or the selected date. */
+    todayOrSelectedDateRef?: RefObject<HTMLButtonElement>;
+    /** The current value of the text field. */
+    value: DatePickerValueProp;
+    /** The function called on change. */
     onChange(value?: moment.Moment): void;
 }
 
@@ -50,20 +44,10 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: Partial<DatePickerProps> = {
-    maxDate: undefined,
-    minDate: undefined,
-};
+const DEFAULT_PROPS: Partial<DatePickerProps> = {};
 
-/**
- * Simple component used to pick a date (semi-controlled implementation).
- * @param props See DatePickerProps.
- *
- * @return The component.
- */
-const DatePicker = (props: DatePickerProps) => {
+const DatePicker: React.FC<DatePickerProps> = ({ defaultMonth, locale, value, ...forwaredProps }) => {
     let castedValue;
-    const { value, defaultMonth } = props;
     if (value) {
         castedValue = moment(value);
     } else if (defaultMonth) {
@@ -80,12 +64,15 @@ const DatePicker = (props: DatePickerProps) => {
     const setNextMonth = () => setMonthOffset(monthOffset + 1);
 
     const selectedMonth = moment(today)
-        .locale(props.locale)
+        .locale(locale)
         .add(monthOffset, 'months');
 
     return (
         <DatePickerControlled
-            {...props}
+            {...forwaredProps}
+            defaultMonth={defaultMonth}
+            locale={locale}
+            value={value}
             onPrevMonthChange={setPrevMonth}
             onNextMonthChange={setNextMonth}
             selectedMonth={selectedMonth}

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -10,7 +10,7 @@ import { mdiChevronLeft, mdiChevronRight } from '@lumx/icons';
 
 import { getAnnotatedMonthCalendar, getWeekDays } from '@lumx/core/js/date-picker';
 
-import { CLASSNAME, DEFAULT_PROPS, DatePickerProps } from './DatePicker';
+import { CLASSNAME, DatePickerProps } from './DatePicker';
 
 /**
  * Defines the props of the component.
@@ -19,11 +19,9 @@ import { CLASSNAME, DEFAULT_PROPS, DatePickerProps } from './DatePicker';
 type DatePickerControlledProps = DatePickerProps & {
     /** The selected month to display. */
     selectedMonth: moment.Moment;
-
-    /** Changing to previous month. */
+    /** The function called when switching to previous month. */
     onPrevMonthChange(): void;
-
-    /** Changing to next month. */
+    /** The function called when switching to next month. */
     onNextMonthChange(): void;
 };
 
@@ -32,18 +30,13 @@ type DatePickerControlledProps = DatePickerProps & {
  */
 const COMPONENT_NAME = 'DatePickerControlled';
 
-/**
- * Simple component used to pick a date (controlled implementation).
- *
- * @return The component.
- */
 const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
     locale,
-    maxDate = DEFAULT_PROPS.maxDate,
-    minDate = DEFAULT_PROPS.minDate,
+    maxDate,
+    minDate,
     onChange,
-    onPrevMonthChange,
     onNextMonthChange,
+    onPrevMonthChange,
     selectedMonth,
     todayOrSelectedDateRef,
     value,

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -16,28 +16,21 @@ import { GenericProps } from '@lumx/react/utils';
  * Defines the props of the component.
  */
 interface DatePickerFieldProps extends GenericProps {
-    /** Locale. */
-    locale: string;
-
-    /** Max date. */
-    maxDate?: Date;
-
-    /** Min date. */
-    minDate?: Date;
-
-    /** Value. */
-    value: DatePickerValueProp;
-
-    /** Month to display by default */
+    /** The month to display by default. */
     defaultMonth?: DatePickerValueProp;
-
-    /** Native input name. */
-    name?: string;
-
-    /** Disabled state. */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-
-    /** On change. */
+    /** The locale (language or region) to use. */
+    locale: string;
+    /** The date after which no date can be selected. */
+    maxDate?: Date;
+    /** The date before which no date can be selected. */
+    minDate?: Date;
+    /** The native input name property. */
+    name?: string;
+    /** The current value of the text field. */
+    value: DatePickerValueProp;
+    /** The function called on change. */
     onChange(value?: moment.Moment, name?: string, event?: SyntheticEvent): void;
 }
 
@@ -46,20 +39,15 @@ interface DatePickerFieldProps extends GenericProps {
  */
 const COMPONENT_NAME = 'DatePickerField';
 
-/**
- * Simple component used to pick a date (ready-to-use wrapped implementation).
- *
- * @return The component.
- */
 const DatePickerField = ({
-    value,
-    locale,
-    minDate,
-    maxDate,
     defaultMonth,
-    onChange,
     disabled,
     isDisabled = disabled,
+    locale,
+    maxDate,
+    minDate,
+    onChange,
+    value,
     ...textFieldProps
 }: DatePickerFieldProps) => {
     const wrapperRef = useRef(null);

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -21,70 +21,31 @@ import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
  * Defines the props of the component.
  */
 interface DialogProps extends GenericProps {
-    /**
-     * Element(s) to display in the footer part.
-     */
+    /** The elements to display in the footer part. */
     footer?: ReactNode;
-
-    /**
-     * Force divider between the dialog content and the footer (instead of showing it on scroll)
-     */
+    /** Whether the divider between the dialog content and the footer is always displayed (instead of showing it on scroll). */
     forceFooterDivider?: boolean;
-
-    /**
-     * Element(s) to display in the header part.
-     */
+    /** The elements to display in the header part. */
     header?: ReactNode;
-
-    /**
-     * Force divider between the dialog content and the header (instead of showing it on scroll)
-     */
+    /** Whether the divider between the dialog content and the footer is always displayed (instead of showing it on scroll). */
     forceHeaderDivider?: boolean;
-
-    /**
-     * Display an indefinite progress indicator over the dialog content when activated.
-     */
+    /** Whether the indefinite progress indicator over the dialog content is displayed or not. */
     isLoading?: boolean;
-
-    /**
-     * Controls the visibility of the dialog.
-     */
+    /** Whether the component is open or not. */
     isOpen?: boolean;
-
-    /**
-     * Ref of element that triggered modal opening to set focus on.
-     */
+    /** The reference of the element that triggered modal opening to set focus on. */
     parentElement?: RefObject<HTMLElement>;
-
-    /**
-     * Ref of content section of the Dialog.
-     */
+    /** The reference passed to the content. */
     contentRef?: RefObject<HTMLDivElement>;
-
-    /**
-     * Ref of the element that should get the focus when the dialogs opens.
-     * By default, the first child will take focus.
-     */
+    /** The reference of the element that should get the focus when the dialogs opens. By default, the first child will take focus. */
     focusElement?: RefObject<HTMLElement>;
-
-    /**
-     * Prevent clickaway and escape to dismiss the dialog
-     */
+    /** Whether to keep the dialog open on clickaway or escape press. */
     preventAutoClose?: boolean;
-
-    /**
-     * Size of the dialog
-     */
+    /** The size variant of the component. */
     size?: DialogSizes;
-
-    /**
-     * The z-axis position.
-     */
+    /** The z-axis position. */
     zIndex?: number;
-
-    /**
-     * Callback called when the dialog is closing.
-     */
+    /** The function called on close. */
     onClose?(): void;
 }
 
@@ -114,32 +75,24 @@ const DEFAULT_PROPS: Partial<DialogProps> = {
     size: Size.big,
 };
 
-/**
- * Dialog component.
- *
- * @param props Component props.
- * @return The component.
- */
-const Dialog: React.FC<DialogProps> = (props) => {
-    const {
-        children,
-        className,
-        header,
-        focusElement,
-        forceFooterDivider = DEFAULT_PROPS.forceFooterDivider,
-        forceHeaderDivider = DEFAULT_PROPS.forceHeaderDivider,
-        footer,
-        isLoading,
-        isOpen = DEFAULT_PROPS.isOpen,
-        onClose,
-        parentElement,
-        contentRef,
-        preventAutoClose = DEFAULT_PROPS.preventAutoClose,
-        size = DEFAULT_PROPS.size,
-        zIndex,
-        ...forwardedProps
-    } = props;
-
+const Dialog: React.FC<DialogProps> = ({
+    children,
+    className,
+    contentRef,
+    focusElement,
+    footer,
+    forceFooterDivider = DEFAULT_PROPS.forceFooterDivider,
+    forceHeaderDivider = DEFAULT_PROPS.forceHeaderDivider,
+    header,
+    isLoading,
+    isOpen = DEFAULT_PROPS.isOpen,
+    onClose,
+    parentElement,
+    preventAutoClose = DEFAULT_PROPS.preventAutoClose,
+    size = DEFAULT_PROPS.size,
+    zIndex,
+    ...forwardedProps
+}) => {
     useCallbackOnEscape(onClose, isOpen && !preventAutoClose);
 
     const wrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/lumx-react/src/components/divider/Divider.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.tsx
@@ -10,16 +10,9 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface DividerProps extends GenericProps {
-    /**
-     * The <Divider> theme.
-     */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<DividerProps> {}
 
 /**
  * The display name of the component.
@@ -34,21 +27,13 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<DividerProps> = {
     theme: Theme.light,
 };
 
-/**
- * Displays a divider.
- * This simply wraps a <hr> element.
- *
- * @return The component.
- */
-const Divider: React.FC<DividerProps> = ({ className, theme = DEFAULT_PROPS.theme, ...forwardedProps }) => {
-    return (
-        <hr {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))} />
-    );
-};
+const Divider: React.FC<DividerProps> = ({ className, theme = DEFAULT_PROPS.theme, ...forwardedProps }) => (
+    <hr {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))} />
+);
 Divider.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, DEFAULT_PROPS, Divider, DividerProps };

--- a/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
+++ b/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
@@ -12,6 +12,7 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface DragHandleProps extends GenericProps {
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
 }
 
@@ -25,15 +26,11 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}DragHandle`;
  */
 const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
-const DragHandle: React.FC<DragHandleProps> = (props) => {
-    const { className, theme, ...forwardedProps } = props;
-
-    return (
-        <div {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))}>
-            <Icon icon={mdiDragVertical} color={theme === Theme.dark ? ColorPalette.light : undefined} size={Size.xs} />
-        </div>
-    );
-};
+const DragHandle: React.FC<DragHandleProps> = ({ className, theme, ...forwardedProps }) => (
+    <div {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))}>
+        <Icon icon={mdiDragVertical} color={theme === Theme.dark ? ColorPalette.light : undefined} size={Size.xs} />
+    </div>
+);
 DragHandle.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, DragHandle, DragHandleProps };

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -3,7 +3,7 @@ import React, { cloneElement, useMemo, useRef } from 'react';
 import classNames from 'classnames';
 
 import { List, ListProps } from '@lumx/react/components/list/List';
-import { Offset, Placement, Popover, PopoverProps } from '@lumx/react/components/popover/Popover';
+import { Offset, Placement, Popover } from '@lumx/react/components/popover/Popover';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { useInfiniteScroll } from '@lumx/react/hooks/useInfiniteScroll';
 import { GenericProps, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
@@ -12,36 +12,65 @@ import { GenericProps, getRootClassName, handleBasicClasses, isComponent } from 
  * Defines the props of the component.
  */
 interface DropdownProps extends GenericProps {
-    /** The reference of the DOM element used to set the position of the Dropdown. */
-    anchorRef: React.RefObject<HTMLElement>;
-    /** Children of the Dropdown. */
-    children: React.ReactNode;
-    /** Whether a click anywhere out of the Dropdown would close it. */
-    closeOnClickAway?: boolean;
-    /** Whether an escape key press would close the Dropdown. */
-    closeOnEscape?: boolean;
-    /** Whether to close the Dropdown when clicking in it. */
-    closeOnClick?: boolean;
-    /** Whether the dropdown should fit to the anchor width (if dropdown is smaller). */
-    fitToAnchorWidth?: boolean;
-    /** Whether the dropdown should shrink to fit within the viewport height. */
-    fitWithinViewportHeight?: PopoverProps['fitWithinViewportHeight'];
-    /** Vertical and/or horizontal offsets that will be applied to the Dropdown position. */
-    offset?: Offset;
-    /** The preferred Dropdown location against the anchor element. */
-    placement?: Placement;
-    /** Whether the focus should be set on the list when the dropdown is open. */
-    shouldFocusOnOpen?: boolean;
-    /** Whether the dropdown should be displayed or not. Useful to control the Dropdown from outside the component. */
-    isOpen: boolean;
-    /** The z-axis position. */
-    zIndex?: number;
-    /** The function to be called when the user clicks away or Escape is pressed */
-    onClose?: VoidFunction;
-    /**
-     * The callback function called when the bottom of the dropdown is reached.
+    /** The reference of the DOM element used to set the position of the popover.
+     * @see {@link PopoverProps#anchorRef}
      */
-    onInfiniteScroll?: VoidFunction;
+    anchorRef: React.RefObject<HTMLElement>;
+    /** The children elements to be transcluded into the component. */
+    children: React.ReactNode;
+    /**
+     * Whether a click anywhere out of the Dropdown would close it or not.
+     * @see {@link PopoverProps#closeOnClickAway}
+     */
+    closeOnClickAway?: boolean;
+    /**
+     * Whether to close the Dropdown when clicking in it or not.
+     */
+    closeOnClick?: boolean;
+    /**
+     * Whether an escape key press would close the Dropdown or not.
+     * @see {@link PopoverProps#closeOnEscape}
+     */
+    closeOnEscape?: boolean;
+    /**
+     * Whether the dropdown should fit to the anchor width (if dropdown is smaller) or not.
+     * @see {@link PopoverProps#fitToAnchorWidth}
+     */
+    fitToAnchorWidth?: boolean;
+    /**
+     * Whether the dropdown should shrink to fit within the viewport height or not.
+     * @see {@link PopoverProps#fitWithinViewportHeight}
+     */
+    fitWithinViewportHeight?: boolean;
+    /**
+     * Whether the dropdown should be displayed or not. Useful to control the Dropdown from outside the component.
+     * @see {@link PopoverProps#isOpen}
+     */
+    isOpen: boolean;
+    /**
+     * The offset that will be applied to the Dropdown position.
+     * @see {@link PopoverProps#offset}
+     */
+    offset?: Offset;
+    /**
+     * The preferred Dropdown location against the anchor element.
+     * @see {@link PopoverProps#placement}
+     */
+    placement?: Placement;
+    /** Whether the focus should be set on the list when the dropdown is open or not. */
+    shouldFocusOnOpen?: boolean;
+    /**
+     * The z-axis position.
+     * @see {@link PopoverProps#zIndex}
+     */
+    zIndex?: number;
+    /**
+     * The function called on close.
+     * @see {@link PopoverProps#onClose}
+     */
+    onClose?(): void;
+    /** The callback function called when the bottom of the dropdown is reached. */
+    onInfiniteScroll?(): void;
 }
 
 /**
@@ -63,17 +92,11 @@ const DEFAULT_PROPS: Partial<DropdownProps> = {
     closeOnEscape: true,
     fitToAnchorWidth: true,
     fitWithinViewportHeight: true,
+    isOpen: false,
     placement: Placement.BOTTOM_START,
     shouldFocusOnOpen: true,
-    isOpen: undefined,
 };
 
-/**
- * Displays a dropdown.
- *
- * @param  props The component props.
- * @return The component.
- */
 const Dropdown: React.FC<DropdownProps> = (props) => {
     const {
         anchorRef,
@@ -84,13 +107,13 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
         closeOnEscape = DEFAULT_PROPS.closeOnEscape,
         fitToAnchorWidth = DEFAULT_PROPS.fitToAnchorWidth,
         fitWithinViewportHeight = DEFAULT_PROPS.fitWithinViewportHeight,
+        isOpen = DEFAULT_PROPS.isOpen,
         offset,
-        placement = DEFAULT_PROPS.placement,
-        shouldFocusOnOpen = DEFAULT_PROPS.shouldFocusOnOpen,
-        isOpen,
-        zIndex,
         onClose,
         onInfiniteScroll,
+        placement = DEFAULT_PROPS.placement,
+        shouldFocusOnOpen = DEFAULT_PROPS.shouldFocusOnOpen,
+        zIndex,
         ...forwardedProps
     } = props;
     const popoverRef = useRef<HTMLDivElement>(null);
@@ -118,19 +141,19 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
     return isOpen ? (
         <Popover
             {...forwardedProps}
-            className={classNames(className, `${CLASSNAME}__menu`, handleBasicClasses({ prefix: CLASSNAME }))}
             anchorRef={anchorRef}
-            popoverRef={popoverRef}
-            placement={placement}
-            offset={offset}
-            zIndex={zIndex}
-            fitToAnchorWidth={fitToAnchorWidth}
-            fitWithinViewportHeight={fitWithinViewportHeight}
-            isOpen={isOpen}
-            onClose={onClose}
+            className={classNames(className, `${CLASSNAME}__menu`, handleBasicClasses({ prefix: CLASSNAME }))}
             closeOnClickAway={closeOnClickAway}
             closeOnEscape={closeOnEscape}
+            fitToAnchorWidth={fitToAnchorWidth}
+            fitWithinViewportHeight={fitWithinViewportHeight}
             focusElement={shouldFocusOnOpen ? listElement : undefined}
+            isOpen={isOpen}
+            offset={offset}
+            onClose={onClose}
+            placement={placement}
+            popoverRef={popoverRef}
+            zIndex={zIndex}
         >
             {popperElement}
         </Popover>

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -23,27 +23,20 @@ import {
  * Defines the props of the component.
  */
 interface ExpansionPanelProps extends GenericProps {
-    /** The color theme. */
-    theme?: Theme;
-
-    /** The label text used when no `<header>` was provided in the children. */
-    label?: string;
-
     /** Whether the hexpansion panel has a background. */
     hasBackground?: boolean;
-
     /** Whether the header has a divider. */
     hasHeaderDivider?: boolean;
-
-    /** Set panel open or not. */
+    /** Whether the component is open or not. */
     isOpen?: boolean;
-
+    /** The label text used when no `<header>` was provided in the children. */
+    label?: string;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
     /** The function called on open. */
     onOpen?: Callback;
-
     /** The function called on close. */
     onClose?: Callback;
-
     /** The function called on open or close. */
     onToggleOpen?(shouldOpen: boolean): void;
 }
@@ -71,15 +64,15 @@ const isFooter = isComponent('footer');
 
 const ExpansionPanel: React.FC<ExpansionPanelProps> = (props) => {
     const {
-        label,
-        theme = DEFAULT_PROPS.theme,
+        className,
         hasBackground,
         hasHeaderDivider,
         isOpen,
-        className,
-        onOpen,
+        label,
         onClose,
+        onOpen,
         onToggleOpen,
+        theme = DEFAULT_PROPS.theme,
         ...forwardedProps
     } = props;
 

--- a/packages/lumx-react/src/components/flex-box/FlexBox.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.tsx
@@ -11,37 +11,21 @@ export type MarginAutoAlignment = Alignment.top | Alignment.bottom | Alignment.r
  * Defines the props of the component.
  */
 interface FlexBoxProps extends GenericProps {
-    /**
-     * Flex direction.
-     */
+    /** The flex direction. */
     orientation?: Orientation;
-    /**
-     * Enable/Disable flex wrap.
-     */
+    /** Whether the "flex wrap" is enabled or not. */
     wrap?: boolean;
-    /**
-     * Flex vertical alignment.
-     */
+    /** The flex vertical alignment. */
     vAlign?: Alignment.left | Alignment.center | Alignment.right;
-    /**
-     * Flex horizontal alignment.
-     */
+    /** The flex horizontal alignment. */
     hAlign?: Alignment.top | Alignment.center | Alignment.bottom;
-    /**
-     * Enable/Disable content filling space.
-     */
+    /** Whether the "content filling space" is enabled or not. */
     fillSpace?: boolean;
-    /**
-     * Enable/Disable content shrink.
-     */
+    /** Whether the "content shrink" is disabled or not. */
     noShrink?: boolean;
-    /**
-     * Enable/Disable auto margin all around.
-     */
+    /** Whether the "auto margin" is enabled all around or not. */
     marginAuto?: MarginAutoAlignment | MarginAutoAlignment[];
-    /**
-     * Content on which to apply a flex layout.
-     */
+    /** The children elements to be transcluded into the component. */
     children?: ReactNode;
 }
 
@@ -64,13 +48,13 @@ const DEFAULT_PROPS: Partial<FlexBoxProps> = {
 const FlexBox: React.FC<FlexBoxProps> = ({
     children,
     className,
-    orientation,
-    wrap = DEFAULT_PROPS.wrap,
-    vAlign,
-    hAlign,
     fillSpace = DEFAULT_PROPS.fillSpace,
-    noShrink = DEFAULT_PROPS.noShrink,
+    hAlign,
     marginAuto,
+    noShrink = DEFAULT_PROPS.noShrink,
+    orientation,
+    vAlign,
+    wrap = DEFAULT_PROPS.wrap,
     ...forwardedProps
 }) => (
     <div

--- a/packages/lumx-react/src/components/grid/Grid.tsx
+++ b/packages/lumx-react/src/components/grid/Grid.tsx
@@ -11,21 +11,17 @@ type GridGutterSize = Size.regular | Size.big | Size.huge;
  * Defines the props of the component.
  */
 interface GridProps extends GenericProps {
+    /** The grid orientation. */
     orientation?: Orientation;
-    /* Should children wrap */
+    /** Whether the children are wrapped or not. */
     wrap?: string;
-    /* How we should vertically align the children */
+    /** The grid vertical alignment. */
     vAlign?: Alignment;
-    /* How we should horizontally align the children */
+    /** The grid horizontal alignment. */
     hAlign?: Alignment;
-    /* Grid gutters */
+    /** The grid gutter size. */
     gutter?: GridGutterSize;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<GridProps> {}
 
 /**
  * The display name of the component.
@@ -43,16 +39,11 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  *
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<GridProps> = {
     orientation: Orientation.horizontal,
     wrap: 'nowrap',
 };
 
-/**
- * Grid layout component.
- *
- * @return The component.
- */
 const Grid: React.FC<GridProps> = ({
     children,
     className,

--- a/packages/lumx-react/src/components/grid/GridItem.tsx
+++ b/packages/lumx-react/src/components/grid/GridItem.tsx
@@ -10,18 +10,13 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface GridItemProps extends GenericProps {
-    /* How the item should self align */
+    /** The alignment of the grid item. */
     align?: Alignment;
-    /* Order */
+    /** The order of the grid item. */
     order?: string;
-    /* Weight of the item in the grid*/
+    /** The width of the grid item. */
     width?: string;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<GridItemProps> {}
 
 /**
  * The display name of the component.
@@ -39,13 +34,8 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  *
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<GridItemProps> = {};
 
-/**
- * [Enter the description of the component here].
- *
- * @return The component.
- */
 const GridItem: React.FC<GridItemProps> = ({
     children,
     className,

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -12,35 +12,24 @@ type IconSizes = Size.xxs | Size.xs | Size.s | Size.m | Size.l | Size.xl | Size.
  * Defines the props of the component.
  */
 interface IconProps extends GenericProps {
+    /** The color of the icon. */
+    color?: Color;
+    /** The degree of lightness and darkness of the selected icon color. */
+    colorVariant?: ColorVariant;
+    /** Whether the icon has a shape. */
+    hasShape?: boolean;
     /**
      * The icon SVG path draw code (`d` property of the `<path>` SVG element).
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths}
      */
     icon: string;
-
-    /** Reference on the `<i>` icon HTML element. */
+    /** The reference passed to the <i> element. */
     iconRef?: React.RefObject<HTMLElement>;
-
-    /** The icon color. */
-    color?: Color;
-
-    /** Whether the icon has shape. */
-    hasShape?: boolean;
-
-    /** The icon color variant. */
-    colorVariant?: ColorVariant;
-
-    /** The icon size. */
+    /** The size variant of the component. */
     size?: IconSizes;
-
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<IconProps> {}
 
 /**
  * The display name of the component.
@@ -55,24 +44,18 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<IconProps> = {
     color: ColorPalette.dark,
-    iconRef: undefined,
     size: Size.m,
 };
 
-/**
- * Displays an icon in the form of a HTML <svg> tag with the wanted icon path.
- *
- * @return The component
- */
 const Icon: React.FC<IconProps> = ({
     className,
     color,
     colorVariant,
     hasShape,
     icon,
-    iconRef = DEFAULT_PROPS.iconRef,
+    iconRef,
     size,
     theme,
     ...forwardedProps

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -27,30 +27,41 @@ type ImageBlockSize = Size.xl | Size.xxl;
  * Defines the props of the component.
  */
 interface ImageBlockProps extends GenericProps {
-    /** The caption wrapper alignment. */
+    /**
+     * The caption wrapper alignment.
+     * @see {@link ThumbnailProps#align}
+     */
     align?: Alignment;
-    /** The aspect ratio the image will get. */
+    /**
+     * The aspect ratio the image will get.
+     * @see {@link ThumbnailProps#aspectRatio}
+     */
     aspectRatio?: AspectRatio;
-    /** Caption position. */
+    /** The position of the caption. */
     captionPosition?: ImageBlockCaptionPosition;
     /** The style to apply to the caption section. */
     captionStyle?: CSSProperties;
     /**
-     * Allows images that are loaded from foreign origins
-     * to be used as if they had been loaded from the current origin.
+     * Allows images that are loaded from foreign origins to be used as if they had been loaded from the current origin.
+     * @see {@link ThumbnailProps#crossOrigin}
      */
     crossOrigin?: CrossOrigin;
     /** The image description. Can be either a string, or sanitized html. */
-    description?:
-        | string
-        | {
-              __html: string;
-          };
-    /** Whether the image has to fill its container's height. */
+    description?: string | { __html: string };
+    /**
+     * Whether the image has to fill its container's height.
+     * @see {@link ThumbnailProps#fillHeight}
+     */
     fillHeight?: boolean;
-    /** Focal Point coordinates. */
+    /**
+     * The focal point coordinates.
+     * @see {@link ThumbnailProps#focusPoint}
+     */
     focusPoint?: FocusPoint;
-    /** The url of the image we want to display in the image-block. */
+    /**
+     * The url of the image we want to display.
+     * @see {@link ThumbnailProps#image}
+     */
     image: string;
     /** The props to pass to the thumbnail, minus those already set by the ImageBlock props. */
     thumbnailProps?: Omit<
@@ -66,22 +77,28 @@ interface ImageBlockProps extends GenericProps {
         | 'theme'
         | 'onClick'
     >;
-    /** Enable cross origin attribute. */
+    /**
+     * Whether the cross origin attribute is enabled.
+     * @see {@link ThumbnailProps#isCrossOriginEnabled}
+     */
     isCrossOriginEnabled?: boolean;
-    /** The image block size. */
+    /**
+     * The size variant of the component.
+     * @see {@link ThumbnailProps#size}
+     */
     size?: ImageBlockSize;
     /** Tags elements to be transcluded into the component */
     tags?: HTMLElement | ReactNode;
-    /** The theme to use to display the image-block. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
     /** The image title to display in the caption. */
     title?: string;
+    /**
+     * The function called on click.
+     * @see {@link ThumbnailProps#onClick}
+     */
+    onClick?(): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ImageBlockProps> {}
 
 /**
  * The display name of the component.
@@ -96,49 +113,36 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    actions: undefined,
+const DEFAULT_PROPS: Partial<ImageBlockProps> = {
     align: Alignment.left,
     aspectRatio: AspectRatio.original,
     captionPosition: ImageBlockCaptionPosition.below,
     captionStyle: {},
-    description: undefined,
     fillHeight: false,
-    focusPoint: undefined,
-    size: undefined,
-    tags: undefined,
     theme: Theme.light,
-    title: undefined,
-    thumbnailProps: undefined,
 };
 
-/**
- * Displays an properly structured image block.
- *
- * @return The component.
- */
 const ImageBlock: React.FC<ImageBlockProps> = ({
-    actions = DEFAULT_PROPS.actions,
+    actions,
     align = DEFAULT_PROPS.align,
     aspectRatio = DEFAULT_PROPS.aspectRatio,
-    className,
     captionPosition = DEFAULT_PROPS.captionPosition,
     captionStyle = DEFAULT_PROPS.captionStyle,
+    className,
     crossOrigin,
-    description = DEFAULT_PROPS.description,
+    description,
     fillHeight = DEFAULT_PROPS.fillHeight,
-    focusPoint = DEFAULT_PROPS.focusPoint,
+    focusPoint,
     image,
     isCrossOriginEnabled,
-    size = DEFAULT_PROPS.size,
-    tags = DEFAULT_PROPS.tags,
+    onClick,
+    size,
+    tags,
     theme = DEFAULT_PROPS.theme,
-    title = DEFAULT_PROPS.title,
-    thumbnailProps = DEFAULT_PROPS.thumbnailProps,
-    ...props
+    thumbnailProps,
+    title,
+    ...forwardedProps
 }) => {
-    const { onClick = null, ...forwardedProps } = props;
-
     return (
         <div
             {...forwardedProps}
@@ -169,9 +173,9 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
                 focusPoint={focusPoint}
                 image={image}
                 isCrossOriginEnabled={isCrossOriginEnabled}
+                onClick={onClick}
                 size={size}
                 theme={theme}
-                onClick={onClick}
             />
             {(title || description || tags) && (
                 <div className={`${CLASSNAME}__wrapper`} style={captionStyle}>

--- a/packages/lumx-react/src/components/input-helper/InputHelper.tsx
+++ b/packages/lumx-react/src/components/input-helper/InputHelper.tsx
@@ -10,12 +10,13 @@ import { INPUT_HELPER_CONFIGURATION } from './constants';
  * Defines the props of the component.
  */
 interface InputHelperProps extends GenericProps {
+    /** The children elements to be transcluded into the component. */
     children: string | ReactNode;
+    /** The kind of helper (error or sucess for exemple). */
     kind?: Kind;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
 }
-
-interface DefaultPropsType extends Partial<InputHelperProps> {}
 
 /**
  * The display name of the component.
@@ -30,7 +31,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<InputHelperProps> = {
     kind: Kind.info,
     theme: Theme.light,
 };

--- a/packages/lumx-react/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-react/src/components/input-label/InputLabel.tsx
@@ -8,12 +8,13 @@ import React, { ReactNode } from 'react';
  * Defines the props of the component.
  */
 interface InputLabelProps extends GenericProps {
-    isRequired?: boolean;
-    theme?: Theme;
+    /** The children elements to be transcluded into the component. */
     children: string | ReactNode;
+    /** Whether the component is required or not. */
+    isRequired?: boolean;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
 }
-
-interface DefaultPropsType extends Partial<InputLabelProps> {}
 
 /**
  * The display name of the component.
@@ -28,16 +29,16 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<InputLabelProps> = {
     isRequired: false,
     theme: Theme.light,
 };
 
 const InputLabel: React.FC<InputLabelProps> = ({
+    children,
     className,
     isRequired = DEFAULT_PROPS.isRequired,
     theme = DEFAULT_PROPS.theme,
-    children,
     ...forwardedProps
 }) => (
     <label

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -19,28 +19,23 @@ const _TRANSITION_DURATION = 400;
  * Defines the props of the component.
  */
 interface LightboxProps extends GenericProps {
-    /** Label for accessibility assistive devices. */
+    /** The label for accessibility assistive devices. */
     ariaLabel?: string;
-    /** should the close button be visible - default true */
+    /** Whether the closing button should be visible or not. */
     isCloseButtonVisible?: boolean;
-    /** Status of lightbox. */
+    /** Whether the component is open or not. */
     isOpen?: boolean;
-    /** Ref of element that triggered modal opening to set focus on. */
+    /** The reference of the element that triggered modal opening to set focus on. */
     parentElement: RefObject<any>;
-    /** Prevent clickaway and escape to dismiss the lightbox */
+    /** Whether to keep the dialog open on clickaway or escape press. */
     preventAutoClose?: boolean;
-    /** Theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
     /** The z-axis position. */
     zIndex?: number;
-    /** Callback called when lightbox is closing. */
+    /** The function called on close. */
     onClose?(): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<LightboxProps> {}
 
 /**
  * The display name of the component.
@@ -55,7 +50,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<LightboxProps> = {
     ariaLabel: 'Lightbox',
     isCloseButtonVisible: true,
     isOpen: false,

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
@@ -21,32 +21,29 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface LinkPreviewProps extends GenericProps {
-    /** The url of the link. */
+    /** The text of the link. Can be either a string, or sanitized html. */
+    description?: string | { __html: string };
+    /**
+     * The url of the link.
+     * @see {@link LinkProps#image}
+     */
     link: string;
-    /** Content text. Can be either a string, or sanitized html. */
-    description?:
-        | string
-        | {
-              __html: string;
-          };
-    /** The size variant of the web bookmark. */
+    /** The props to pass to the link, minus those already set by the LinkPreview props. */
+    linkProps?: Omit<LinkProps, 'color' | 'colorVariant' | 'href' | 'target'>;
+    /** The size variant of the component. */
     size?: Size.regular | Size.big;
-    /** Theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** Thumbnail image source */
+    /**
+     * The image URL of the Thumbnail.
+     * @see {@link ThumbnailProps#image}
+     */
     thumbnail?: string;
     /** The props to pass to the thumbnail, minus those already set by the LinkPreview props. */
     thumbnailProps?: Omit<ThumbnailProps, 'aspectRatio' | 'fillHeight' | 'image' | 'onClick' | 'role' | 'tabIndex'>;
-    /** The props to pass to the link, minus those already set by the LinkPreview props. */
-    linkProps?: Omit<LinkProps, 'color' | 'colorVariant' | 'href' | 'target'>;
-    /** Link title */
+    /** The title of the link. */
     title?: string;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<LinkPreviewProps> {}
 
 /**
  * The display name of the component.
@@ -61,28 +58,21 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<LinkPreviewProps> = {
     size: Size.regular,
     theme: Theme.light,
-    thumbnailProps: undefined,
-    linkProps: undefined,
 };
 
-/**
- * LinkPreview Element that display a Lumapps post
- *
- * @return The component.
- */
 const LinkPreview: React.FC<LinkPreviewProps> = ({
     className,
-    title,
     description,
     link,
+    linkProps,
     size = DEFAULT_PROPS.size,
     theme = DEFAULT_PROPS.theme,
     thumbnail = '',
-    thumbnailProps = DEFAULT_PROPS.thumbnailProps,
-    linkProps = DEFAULT_PROPS.linkProps,
+    thumbnailProps,
+    title,
     ...forwardedProps
 }) => {
     const goToUrl = useCallback(() => window.open(link, '_blank'), [link]);

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -10,13 +10,11 @@ import { getRootClassName, handleBasicClasses } from '@lumx/react/utils';
  * Defines the props of the component.
  */
 interface LinkProps extends React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> {
-    /** The icon color. */
+    /** The color of the icon. */
     color?: Color;
-
-    /** The icon color variant. */
+    /** The degree of lightness and darkness of the selected icon color. */
     colorVariant?: ColorVariant;
-
-    /** Ref to the native HTML anchor element. */
+    /** The reference passed to the <a> element. */
     linkRef?: Ref<HTMLAnchorElement>;
 }
 
@@ -30,22 +28,15 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Link`;
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
-/**
- * Link component.
- *
- * @return The component.
- */
-const Link: React.FC<LinkProps> = ({ children, className, linkRef, color, colorVariant, ...forwardedProps }) => {
-    return (
-        <a
-            {...forwardedProps}
-            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }))}
-            ref={linkRef}
-        >
-            {children}
-        </a>
-    );
-};
+const Link: React.FC<LinkProps> = ({ children, className, color, colorVariant, linkRef, ...forwardedProps }) => (
+    <a
+        {...forwardedProps}
+        className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }))}
+        ref={linkRef}
+    >
+        {children}
+    </a>
+);
 Link.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, COMPONENT_NAME, Link, LinkProps };

--- a/packages/lumx-react/src/components/list/List.tsx
+++ b/packages/lumx-react/src/components/list/List.tsx
@@ -14,30 +14,20 @@ import { useInteractiveList } from './useInteractiveList';
  * Defines the props of the component.
  */
 interface ListProps extends GenericProps {
-    /** List content (should use `<ListItem>`, `<ListSubheader>` or `<ListDivider>`) */
+    /** The children elements to be transcluded into the component. Should be ListItem, ListSubheader or ListDivider. */
     children: ReactNode;
-
     /**
      * Whether the list items are clickable.
      * @deprecated not needed anymore.
      */
     isClickable?: boolean;
-
-    /** Item padding size. */
+    /** The item padding size. */
     itemPadding?: Size.big | Size.huge;
-
-    /** The ref passed to the ul element. */
+    /** The reference passed to the <ul> element. */
     listElementRef?: Ref<HTMLUListElement>;
-
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-
-    /**
-     * Callback used to retrieved the select entry.
-     *
-     * @param key   React key of the selected item.
-     * @param index Index of the selected item among the sibling items.
-     */
+    /** The function called when a list item is selected. */
     onListItemSelected?(key: Key, index: number): void;
 }
 
@@ -55,23 +45,16 @@ interface List {
     useKeyboardListNavigation: useKeyboardListNavigationType;
 }
 
-/**
- * List component - Use vertical layout to display elements
- *
- * @param  props The component props.
- * @return The component.
- */
-const List: React.FC<ListProps> & List = (props) => {
-    const {
-        className,
-        isClickable,
-        itemPadding,
-        listElementRef,
-        onListItemSelected,
-        useCustomColors,
-        children,
-        ...forwardedProps
-    } = props;
+const List: React.FC<ListProps> & List = ({
+    children,
+    className,
+    isClickable,
+    itemPadding,
+    listElementRef,
+    onListItemSelected,
+    useCustomColors,
+    ...forwardedProps
+}) => {
     const ref = useRef<HTMLUListElement>(null);
 
     const { items, hasClickableItem } = useInteractiveList({

--- a/packages/lumx-react/src/components/list/ListDivider.tsx
+++ b/packages/lumx-react/src/components/list/ListDivider.tsx
@@ -21,14 +21,9 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}ListDivider`;
  */
 const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
-/**
- * Renders a thin line that will acts as a divider in List
- *
- * @return The component.
- */
-const ListDivider: React.FC<ListDividerProps> = ({ className, ...forwardedProps }) => {
-    return <li {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} />;
-};
+const ListDivider: React.FC<ListDividerProps> = ({ className, ...forwardedProps }) => (
+    <li {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))} />
+);
 ListDivider.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, ListDivider, ListDividerProps };

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, Ref, useMemo } from 'react';
+import React, { ReactNode, Ref, useMemo } from 'react';
 
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
@@ -25,34 +25,25 @@ type ListItemSizes = Size.tiny | Size.regular | Size.big | Size.huge;
  * Defines the props of the component.
  */
 interface ListItemProps extends GenericProps {
-    /** After content element */
-    after?: ReactElement;
-
-    /** Before content element. */
-    before?: ReactElement;
-
-    /** List item content. */
+    /** A component to be rendered after the content. */
+    after?: ReactNode;
+    /** A component to be rendered before the content. */
+    before?: ReactNode;
+    /** The children elements to be transcluded into the component. */
     children: string | ReactNode;
-
-    /** Whether the list item should be highlighted. */
+    /** Whether the list item should be highlighted or not. */
     isHighlighted?: boolean;
-
-    /** Whether the list item is selected or not. */
+    /** Whether the component is selected or not. */
     isSelected?: boolean;
-
-    /** List item size. */
-    size?: ListItemSizes;
-
-    /** List item reference. */
+    /** The reference passed to the <li> element. */
     listItemRef?: Ref<HTMLLIElement>;
-
     /** props that will be passed on to the Link */
     linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
-
-    /** Link element reference (use with {@link linkProps} prop). */
+    /** The reference passed to the <a> element. */
     linkRef?: Ref<HTMLAnchorElement>;
-
-    /** Callback used to retrieved the selected entry. */
+    /** The size variant of the component. */
+    size?: ListItemSizes;
+    /** The function called when an item is selected. */
     onItemSelected?(): void;
 }
 
@@ -77,31 +68,24 @@ const DEFAULT_PROPS: Partial<ListProps> = {
  * Check if the list item is clickable.
  * @return `true` if the list item is clickable; `false` otherwise.
  */
-function isClickable({ linkProps, onItemSelected }: ListItemProps): boolean {
+function isClickable({ linkProps, onItemSelected }: Partial<ListItemProps>): boolean {
     return !isEmpty(linkProps?.href) || !!onItemSelected;
 }
 
-/**
- * Component used in List element.
- *
- * @param  props The component props.
- * @return The component.
- */
-const ListItem: React.FC<ListItemProps> = (props) => {
-    const {
-        after,
-        children,
-        className,
-        isHighlighted,
-        isSelected,
-        size = DEFAULT_PROPS.size,
-        onItemSelected,
-        before,
-        linkProps = {},
-        linkRef,
-        listItemRef,
-        ...forwardedProps
-    } = props;
+const ListItem: React.FC<ListItemProps> = ({
+    after,
+    before,
+    children,
+    className,
+    isHighlighted,
+    isSelected,
+    linkProps = {},
+    linkRef,
+    listItemRef,
+    onItemSelected,
+    size = DEFAULT_PROPS.size,
+    ...forwardedProps
+}) => {
     const onKeyDown = useMemo(() => (onItemSelected ? onEnterPressed(onItemSelected) : undefined), [onItemSelected]);
 
     const content = (
@@ -124,7 +108,7 @@ const ListItem: React.FC<ListItemProps> = (props) => {
                 }),
             )}
         >
-            {isClickable(props) ? (
+            {isClickable({ linkProps, onItemSelected }) ? (
                 /* Clickable list item */
                 <a
                     {...linkProps}

--- a/packages/lumx-react/src/components/list/ListSubheader.tsx
+++ b/packages/lumx-react/src/components/list/ListSubheader.tsx
@@ -10,7 +10,7 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface ListSubheaderProps extends GenericProps {
-    /** List sub header content. */
+    /** The children elements to be transcluded into the component. */
     children: string | ReactNode;
 }
 
@@ -24,18 +24,11 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}ListSubheader`;
  */
 const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
-/**
- * Component used in List to display some separator / title section.
- *
- * @return The component.
- */
-const ListSubheader: React.FC<ListSubheaderProps> = ({ children, className, ...forwardedProps }) => {
-    return (
-        <li {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}>
-            {children}
-        </li>
-    );
-};
+const ListSubheader: React.FC<ListSubheaderProps> = ({ children, className, ...forwardedProps }) => (
+    <li {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}>
+        {children}
+    </li>
+);
 ListSubheader.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, ListSubheader, ListSubheaderProps };

--- a/packages/lumx-react/src/components/message/Message.tsx
+++ b/packages/lumx-react/src/components/message/Message.tsx
@@ -16,20 +16,12 @@ enum MessageKind {
  * Defines the props of the component.
  */
 interface MessageProps extends GenericProps {
-    /**
-     * Message content.
-     */
+    /** The children elements to be transcluded into the component. */
     children?: ReactNode;
-
-    /**
-     * The kind of message.
-     */
-    kind?: MessageKind;
-
-    /**
-     * Put a background to the message
-     */
+    /** Whether the message has a background or not. */
     hasBackground?: boolean;
+    /** The kind of helper (error or sucess for exemple). */
+    kind?: MessageKind;
 }
 
 /**
@@ -69,14 +61,7 @@ const KIND_ICON = {
     [MessageKind.warning]: mdiAlertCircle,
 };
 
-/**
- * Component used to display a message, with an icon and possibly a background
- *
- * @param  props The component props.
- * @return The component.
- */
-const Message: React.FC<MessageProps> = (props) => {
-    const { children, className, kind, hasBackground, ...forwardedProps } = props;
+const Message: React.FC<MessageProps> = ({ children, className, hasBackground, kind, ...forwardedProps }) => {
     const icon = kind ? KIND_ICON[kind] : null;
 
     const color = kind ? KIND_COLOR[kind] : DEFAULT_PROPS.color;

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -14,11 +14,11 @@ interface ClickableThumbnailProps
     onClick?(index: number): void;
 }
 interface MosaicProps extends GenericProps {
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
+    /** The list of thumbnails. */
     thumbnails: ClickableThumbnailProps[];
 }
-
-interface DefaultPropsType extends Partial<MosaicProps> {}
 
 /**
  * The display name of the component.
@@ -33,9 +33,10 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<MosaicProps> = {
     theme: Theme.light,
 };
+
 const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme, thumbnails, ...forwardedProps }) => (
     <div
         {...forwardedProps}

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -29,35 +29,23 @@ enum NotificationType {
  * Defines the props of the component.
  */
 interface NotificationProps extends GenericProps {
-    /** Label for action button. */
+    /** The label of the action button. */
     actionLabel?: string;
-
-    /** Content of notification. */
+    /** The content of the notification. */
     content?: React.ReactNode;
-
-    /** Whether notification is open or not. */
+    /** Whether the component is open or not. */
     isOpen?: boolean;
-
-    /** Theme */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-
-    /** Type of notification (info, success, warning, error). */
+    /** The type of notification (error or success for example). */
     type?: NotificationType;
-
     /** The z-axis position. */
     zIndex?: number;
-
-    /** Callback function for action button. */
+    /** The function called on click on the action button. */
     onActionClick?(): void;
-
-    /** Function to handle click on the notification. */
+    /** The function called on click on the component. */
     onClick?(): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<NotificationProps> {}
 
 /**
  * The display name of the component.
@@ -72,7 +60,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<NotificationProps> = {
     content: '',
     theme: Theme.light,
     zIndex: 9999,
@@ -84,12 +72,12 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return The notification component.
  */
 const Notification: React.FC<NotificationProps> = ({
-    onActionClick,
     actionLabel,
-    content = DEFAULT_PROPS.content,
     className,
-    onClick,
+    content = DEFAULT_PROPS.content,
     isOpen = false,
+    onActionClick,
+    onClick,
     theme = DEFAULT_PROPS.theme,
     type,
     zIndex = DEFAULT_PROPS.zIndex,

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -63,36 +63,36 @@ const OFFSET = 8;
  * Defines the props of the component.
  */
 interface PopoverProps extends GenericProps {
-    /** The reference of the anchor. */
+    /** The reference of the DOM element used to set the position of the popover. */
     anchorRef: React.RefObject<HTMLElement>;
-    /** Children element displayed inside popover. */
+    /** The children elements to be transcluded into the component. */
     children: ReactNode;
-    /** Whether the popover is open */
-    isOpen: boolean;
-    /** The reference of the popover. */
-    popoverRef?: React.RefObject<HTMLDivElement>;
-    /** The desired placement */
-    placement?: Placement;
-    /** The desired offset */
-    offset?: Offset;
-    /** How high the component is flying */
-    elevation?: Elevation;
-    /** The z-axis position. */
-    zIndex?: number;
-    /** Whether the dropdown should fit to the anchor width (if dropdown is smaller). */
-    fitToAnchorWidth?: boolean;
-    /** Shrink popover if even after flipping there is not enough space */
-    fitWithinViewportHeight?: boolean;
     /** Whether a click anywhere out of the popover would close it. */
     closeOnClickAway?: boolean;
     /** Whether an escape key press would close the popover. */
     closeOnEscape?: boolean;
-    /** Whether we put an arrow or not. */
-    hasArrow?: boolean;
+    /** How high the component is flying. */
+    elevation?: Elevation;
+    /** Whether the dropdown should fit to the anchor width (if dropdown is smaller). */
+    fitToAnchorWidth?: boolean;
+    /** Shrink popover if even after flipping there is not enough space. */
+    fitWithinViewportHeight?: boolean;
     /** Element to focus when opening the popover. */
     focusElement?: RefObject<HTMLElement>;
-    /** The function to be called when the user clicks away or Escape is pressed */
-    onClose?: VoidFunction;
+    /** Whether we put an arrow or not. */
+    hasArrow?: boolean;
+    /** Whether the popover is open or not. */
+    isOpen: boolean;
+    /** The desired offset. */
+    offset?: Offset;
+    /** The desired placement. */
+    placement?: Placement;
+    /** The reference of the popover. */
+    popoverRef?: React.RefObject<HTMLDivElement>;
+    /** The z-axis position. */
+    zIndex?: number;
+    /** The function to be called when the user clicks away or Escape is pressed. */
+    onClose?(): void;
 }
 
 /**
@@ -109,14 +109,14 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: Partial<PopoverProps> = {
-    elevation: 3,
-    placement: Placement.AUTO,
-    zIndex: 9999,
-    fitToAnchorWidth: false,
-    fitWithinViewportHeight: false,
     closeOnClickAway: false,
     closeOnEscape: false,
+    elevation: 3,
+    fitToAnchorWidth: false,
+    fitWithinViewportHeight: false,
     hasArrow: false,
+    placement: Placement.AUTO,
+    zIndex: 9999,
 };
 
 /**
@@ -174,32 +174,25 @@ const applyMaxHeight = {
     },
 };
 
-/**
- * Popover.
- *
- * @param  props The component props.
- * @return The component.
- */
-const Popover: React.FC<PopoverProps> = (props) => {
-    const {
-        anchorRef,
-        popoverRef,
-        placement,
-        isOpen,
-        children,
-        fitToAnchorWidth = DEFAULT_PROPS.fitToAnchorWidth,
-        fitWithinViewportHeight = DEFAULT_PROPS.fitWithinViewportHeight,
-        offset,
-        elevation = DEFAULT_PROPS.elevation,
-        zIndex = DEFAULT_PROPS.zIndex,
-        closeOnClickAway = DEFAULT_PROPS.closeOnClickAway,
-        closeOnEscape = DEFAULT_PROPS.closeOnEscape,
-        hasArrow = DEFAULT_PROPS.hasArrow,
-        focusElement,
-        className,
-        onClose,
-        ...forwardedProps
-    } = props;
+const Popover: React.FC<PopoverProps> = ({
+    anchorRef,
+    children,
+    className,
+    closeOnClickAway = DEFAULT_PROPS.closeOnClickAway,
+    closeOnEscape = DEFAULT_PROPS.closeOnEscape,
+    elevation = DEFAULT_PROPS.elevation,
+    fitToAnchorWidth = DEFAULT_PROPS.fitToAnchorWidth,
+    fitWithinViewportHeight = DEFAULT_PROPS.fitWithinViewportHeight,
+    focusElement,
+    hasArrow = DEFAULT_PROPS.hasArrow,
+    isOpen,
+    offset,
+    onClose,
+    placement = DEFAULT_PROPS.placement,
+    popoverRef,
+    zIndex = DEFAULT_PROPS.zIndex,
+    ...forwardedProps
+}) => {
     const [popperElement, setPopperElement] = useState<null | HTMLElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);
 

--- a/packages/lumx-react/src/components/post-block/PostBlock.tsx
+++ b/packages/lumx-react/src/components/post-block/PostBlock.tsx
@@ -13,40 +13,34 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface PostBlockProps extends GenericProps {
-    /* Actions elements to be transcluded into the component */
+    /** The action elements to be transcluded into the component. */
     actions?: ReactNode;
-    /* Atachments elements to be transcluded into the component */
+    /** The attachment elements to be transcluded into the component. */
     attachments?: ReactNode;
-    /* Author element to be transcluded into the component */
+    /** The author element to be transcluded into the component. */
     author?: ReactNode;
-    /* Meta elements to be transcluded into the component */
+    /** The meta elements to be transcluded into the component. */
     meta?: ReactNode;
-    /* Orientation. */
+    /** The orientation. */
     orientation?: Orientation;
-    /* Tags elements to be transcluded into the component */
+    /** The tag elements to be transcluded into the component. */
     tags?: ReactNode;
-    /* Content text. Can be either a string, or sanitized html. */
-    text?:
-        | string
-        | {
-              __html: string;
-          };
-    /** Thumbnail image source */
+    /** Content text. Can be either a string, or sanitized html. */
+    text?: string | { __html: string };
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
+    /**
+     * The url of the image we want to display.
+     * @see {@link ThumbnailProps#image}
+     */
     thumbnail?: string;
     /** The props to pass to the thumbnail, minus those already set by the PostBlock props. */
     thumbnailProps?: Omit<ThumbnailProps, 'image' | 'theme' | 'onClick' | 'variant' | 'tabIndex'>;
-    /* Post title */
+    /** The title of the post. */
     title: string;
-    /* Theme. */
-    theme?: Theme;
-    /* Callback for the click event. */
+    /** The function called on click. */
     onClick?(): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<PostBlockProps> {}
 
 /**
  * The display name of the component.
@@ -61,18 +55,11 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<PostBlockProps> = {
     orientation: Orientation.horizontal,
-    text: undefined,
     theme: Theme.light,
-    thumbnailProps: undefined,
 };
 
-/**
- * PostBlock Element that display a Lumapps post
- *
- * @return The component.
- */
 const PostBlock: React.FC<PostBlockProps> = ({
     actions,
     attachments,
@@ -82,11 +69,11 @@ const PostBlock: React.FC<PostBlockProps> = ({
     onClick,
     orientation = DEFAULT_PROPS.orientation,
     tags,
-    text = DEFAULT_PROPS.text,
-    thumbnail,
-    thumbnailProps = DEFAULT_PROPS.thumbnailProps,
-    title,
+    text,
     theme = DEFAULT_PROPS.theme,
+    thumbnail,
+    thumbnailProps,
+    title,
 }) => {
     return (
         <div className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, orientation, theme }))}>

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
@@ -10,15 +10,10 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 /**
  * Defines the props of the component.
  */
-interface ProgressTrackerProps extends GenericProps {}
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ProgressTrackerProps> {
+interface ProgressTrackerProps extends GenericProps {
     /** The active step index. */
     activeStep: number;
-    /** The current component theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
 }
 
@@ -35,21 +30,13 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ProgressTrackerProps> = {
     activeStep: 0,
     theme: Theme.light,
 };
 
-/**
- * Displays a track of steps.
- *
- * Each step can have multiple attributes defining their current state to keep the user
- * aware of it's position in the process.
- *
- * @return The component.
- */
 const ProgressTracker: React.FC<ProgressTrackerProps> = ({
-    activeStep = DEFAULT_PROPS.activeStep,
+    activeStep = DEFAULT_PROPS.activeStep as number,
     children,
     className,
     theme = DEFAULT_PROPS.theme,

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.tsx
@@ -14,28 +14,18 @@ import { mdiAlertCircle, mdiCheckCircle, mdiRadioboxBlank, mdiRadioboxMarked } f
 /**
  * Defines the props of the component.
  */
-interface ProgressTrackerStepProps extends GenericProps {}
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ProgressTrackerStepProps> {
+interface ProgressTrackerStepProps extends GenericProps {
     /** Whether the step should be in error state or not. */
     hasError?: boolean;
-
-    /** The step's helper text. */
+    /** The helper of the step. */
     helper?: string | null;
-
-    /** Whether the current step is active. */
-    isActive: boolean;
-
-    /** Whether the current step is completed. */
-    isComplete: boolean;
-
-    /** The step's label. */
+    /** Whether the current step is active or not. */
+    isActive?: boolean;
+    /** Whether the current step is completed or not. */
+    isComplete?: boolean;
+    /** The label of the step. */
     label: string | null;
-
-    /** The component theme to apply. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
 }
 
@@ -52,7 +42,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ProgressTrackerStepProps> = {
     hasError: false,
     helper: null,
     isActive: false,
@@ -74,10 +64,9 @@ const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
     isComplete = DEFAULT_PROPS.isComplete,
     label = DEFAULT_PROPS.label,
     theme = DEFAULT_PROPS.theme,
-    ...props
+    onClick = null,
+    ...forwardedProps
 }) => {
-    const { onClick = null, ...forwardedProps }: ProgressTrackerStepProps = props;
-
     const isClickable: boolean = isFunction(onClick);
 
     /**

--- a/packages/lumx-react/src/components/progress/Progress.tsx
+++ b/packages/lumx-react/src/components/progress/Progress.tsx
@@ -21,16 +21,11 @@ enum ProgressVariant {
 interface ProgressProps extends GenericProps {
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-    /* Type of progress */
+    /** The component variant. */
     variant?: ProgressVariant;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ProgressProps> {}
 
 /**
  * The display name of the component.
@@ -45,16 +40,11 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ProgressProps> = {
     theme: Theme.light,
     variant: ProgressVariant.circular,
 };
 
-/**
- * Simple Progress component that can be displayed as a linear or circular element
- *
- * @return The component.
- */
 const Progress: React.FC<ProgressProps> = ({
     className,
     theme = DEFAULT_PROPS.theme,

--- a/packages/lumx-react/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.tsx
@@ -13,41 +13,27 @@ import uniqueId from 'lodash/uniqueId';
  * Defines the props of the component.
  */
 interface RadioButtonProps extends GenericProps {
+    /** The helper of the radio button. */
+    helper?: string;
+    /** The native input id property. */
+    id?: string;
     /** Whether it is checked or not. */
     isChecked?: boolean;
-
-    /**  Whether or not the radio button is disabled. */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-
-    /** Radio button helper. */
-    helper?: string;
-
-    /** Native radio input id. */
-    id?: string;
-
-    /** Radio button label. */
+    /** The label of the radio button. */
     label?: ReactNode;
-
-    /** Native input name. */
+    /** The native input name property. */
     name?: string;
-
-    /** Theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-
-    /** Native input value. */
+    /** The native input value property. */
     value?: string;
-
-    /** Handle onChange event. */
+    /** The function called on change. */
     onChange?(value?: string, name?: string, event?: SyntheticEvent): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<RadioButtonProps> {}
 
 /**
  * The display name of the component.
@@ -62,33 +48,26 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<RadioButtonProps> = {
     theme: Theme.light,
 };
 
-/**
- * Defines a radio button.
- *
- * @param  props The component props.
- * @return The component.
- */
-const RadioButton: React.FC<RadioButtonProps> = (props) => {
-    const {
-        className,
-        checked,
-        isChecked = checked,
-        disabled,
-        isDisabled = disabled,
-        helper,
-        id,
-        label,
-        name,
-        theme = DEFAULT_PROPS.theme,
-        useCustomColors,
-        value,
-        onChange,
-        ...forwardedProps
-    } = props;
+const RadioButton: React.FC<RadioButtonProps> = ({
+    checked,
+    className,
+    disabled,
+    helper,
+    id,
+    isChecked = checked,
+    isDisabled = disabled,
+    label,
+    name,
+    onChange,
+    theme = DEFAULT_PROPS.theme,
+    useCustomColors,
+    value,
+    ...forwardedProps
+}) => {
     const radioButtonId: string = id || uniqueId(`${CLASSNAME.toLowerCase()}-`);
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {

--- a/packages/lumx-react/src/components/radio-button/RadioGroup.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioGroup.tsx
@@ -9,9 +9,7 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface RadioGroupProps extends GenericProps {
-    /**
-     * List of radio buttons in the group (should use <RadioButton>).
-     */
+    /** The children elements to be transcluded into the component. Should use RadioButton. */
     children: ReactNode;
 }
 
@@ -25,29 +23,19 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}RadioGroup`;
  */
 const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
-/**
- * Radio group component.
- *
- * @param  props The component props.
- * @return The component.
- */
-const RadioGroup: React.FC<RadioGroupProps> = (props) => {
-    const { className, children, ...forwardedProps } = props;
-
-    return (
-        <div
-            {...forwardedProps}
-            className={classNames(
-                className,
-                handleBasicClasses({
-                    prefix: CLASSNAME,
-                }),
-            )}
-        >
-            {children}
-        </div>
-    );
-};
+const RadioGroup: React.FC<RadioGroupProps> = ({ children, className, ...forwardedProps }) => (
+    <div
+        {...forwardedProps}
+        className={classNames(
+            className,
+            handleBasicClasses({
+                prefix: CLASSNAME,
+            }),
+        )}
+    >
+        {children}
+    </div>
+);
 RadioGroup.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, RadioGroup, RadioGroupProps };

--- a/packages/lumx-react/src/components/select/Select.tsx
+++ b/packages/lumx-react/src/components/select/Select.tsx
@@ -24,9 +24,6 @@ interface SelectProps extends CoreSelectProps {
     value: string;
 }
 
-/** Define the types of the default props. */
-interface DefaultPropsType extends Partial<SelectProps> {}
-
 /** The display name of the component. */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 
@@ -34,9 +31,8 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /** The default value of props. */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SelectProps> = {
     hasError: false,
-    isOpen: false,
     isValid: false,
     selectedValueRender: (choice) => choice,
 };
@@ -49,23 +45,23 @@ const stopPropagation = (evt: Event) => evt.stopPropagation();
  * @return The component.
  */
 const SelectField: React.FC<SelectProps> = ({
-    variant,
-    label,
-    value,
+    anchorRef,
+    handleKeyboardNav,
+    hasError = DEFAULT_PROPS.hasError,
+    hasInputClear,
+    isDisabled,
     isEmpty,
-    isValid,
-    hasError,
+    isRequired,
+    isValid = DEFAULT_PROPS.isValid,
+    label,
     onClear,
     onInputClick,
-    theme,
     placeholder,
-    handleKeyboardNav,
-    targetUuid,
-    anchorRef,
-    isRequired,
-    isDisabled,
-    hasInputClear,
     selectedValueRender = DEFAULT_PROPS.selectedValueRender,
+    targetUuid,
+    theme,
+    value,
+    variant,
 }) => {
     return (
         <>

--- a/packages/lumx-react/src/components/select/SelectMultiple.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.tsx
@@ -21,8 +21,7 @@ import { CoreSelectProps, SelectVariant } from './constants';
 interface SelectMultipleProps extends CoreSelectProps {
     /** The list of selected values. */
     value: string[];
-
-    /** The function called to render a selected value when `isMultiple` is true. Default: Renders the value inside of a Chip */
+    /** The function called to render a selected value when `isMultiple` is true. Default: Renders the value inside of a Chip. */
     selectedChipRender?(
         choice: string,
         index: number,
@@ -32,9 +31,6 @@ interface SelectMultipleProps extends CoreSelectProps {
     ): ReactNode | string;
 }
 
-/** Define the types of the default props. */
-interface DefaultPropsType extends Partial<SelectMultipleProps> {}
-
 /** The display name of the component. */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 
@@ -42,9 +38,8 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /** The default value of props. */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SelectMultipleProps> = {
     hasError: false,
-    isOpen: false,
     isValid: false,
     selectedChipRender(choice, index, onClear, isDisabled?, theme?) {
         const onClick = (event: React.MouseEvent) => onClear && onClear(event, choice);
@@ -65,115 +60,108 @@ const DEFAULT_PROPS: DefaultPropsType = {
     selectedValueRender: (choice) => choice,
 };
 
-/**
- * Select Multiple component.
- *
- * @return The component.
- */
 const SelectMultipleField: React.FC<SelectMultipleProps> = ({
-    variant,
-    label,
-    value,
+    anchorRef,
+    handleKeyboardNav,
+    hasError = DEFAULT_PROPS.hasError,
+    isDisabled,
     isEmpty,
-    isValid,
-    hasError,
+    isRequired,
+    isValid = DEFAULT_PROPS.isValid,
+    label,
     onClear,
     onInputClick,
-    theme,
     placeholder,
-    handleKeyboardNav,
-    targetUuid,
-    anchorRef,
-    isRequired,
-    isDisabled,
     selectedChipRender = DEFAULT_PROPS.selectedChipRender,
     selectedValueRender = DEFAULT_PROPS.selectedValueRender,
-}) => {
-    return (
-        <>
-            {variant === SelectVariant.input && (
-                <>
-                    {label && (
-                        <div className={`${CLASSNAME}__header`}>
-                            <InputLabel
-                                htmlFor={targetUuid}
-                                className={`${CLASSNAME}__label`}
-                                isRequired={isRequired}
-                                theme={theme}
-                            >
-                                {label}
-                            </InputLabel>
-                        </div>
-                    )}
-
-                    <div
-                        ref={anchorRef as RefObject<HTMLDivElement>}
-                        id={targetUuid}
-                        className={`${CLASSNAME}__wrapper`}
-                        onClick={onInputClick}
-                        onKeyDown={handleKeyboardNav}
-                        tabIndex={isDisabled ? undefined : 0}
-                        aria-disabled={isDisabled || undefined}
-                    >
-                        <div className={`${CLASSNAME}__chips`}>
-                            {!isEmpty && (
-                                <ChipGroup theme={theme}>
-                                    {value.map((val: string, index: number) =>
-                                        selectedChipRender!(val, index, onClear, isDisabled, theme),
-                                    )}
-                                </ChipGroup>
-                            )}
-                        </div>
-
-                        {isEmpty && placeholder && (
-                            <div
-                                className={classNames([
-                                    `${CLASSNAME}__input-native`,
-                                    `${CLASSNAME}__input-native--placeholder`,
-                                ])}
-                            >
-                                <span>{placeholder}</span>
-                            </div>
-                        )}
-
-                        {(isValid || hasError) && (
-                            <div className={`${CLASSNAME}__input-validity`}>
-                                <Icon icon={isValid ? mdiCheckCircle : mdiAlertCircle} size={Size.xxs} />
-                            </div>
-                        )}
-
-                        <div className={`${CLASSNAME}__input-indicator`}>
-                            <Icon icon={mdiMenuDown} size={Size.s} />
-                        </div>
+    targetUuid,
+    theme,
+    value,
+    variant,
+}) => (
+    <>
+        {variant === SelectVariant.input && (
+            <>
+                {label && (
+                    <div className={`${CLASSNAME}__header`}>
+                        <InputLabel
+                            htmlFor={targetUuid}
+                            className={`${CLASSNAME}__label`}
+                            isRequired={isRequired}
+                            theme={theme}
+                        >
+                            {label}
+                        </InputLabel>
                     </div>
-                </>
-            )}
+                )}
 
-            {variant === SelectVariant.chip && (
-                <Chip
+                <div
+                    ref={anchorRef as RefObject<HTMLDivElement>}
                     id={targetUuid}
-                    isSelected={!isEmpty}
-                    isDisabled={isDisabled}
-                    after={<Icon icon={isEmpty ? mdiMenuDown : mdiCloseCircle} />}
-                    onAfterClick={isEmpty ? onInputClick : onClear}
+                    className={`${CLASSNAME}__wrapper`}
                     onClick={onInputClick}
-                    chipRef={anchorRef as RefObject<HTMLAnchorElement>}
-                    theme={theme}
+                    onKeyDown={handleKeyboardNav}
+                    tabIndex={isDisabled ? undefined : 0}
+                    aria-disabled={isDisabled || undefined}
                 >
-                    {isEmpty && <span>{label}</span>}
+                    <div className={`${CLASSNAME}__chips`}>
+                        {!isEmpty && (
+                            <ChipGroup theme={theme}>
+                                {value.map((val: string, index: number) =>
+                                    selectedChipRender!(val, index, onClear, isDisabled, theme),
+                                )}
+                            </ChipGroup>
+                        )}
+                    </div>
 
-                    {!isEmpty && (
-                        <span>
-                            <span>{selectedValueRender!(value[0])}</span>
-
-                            {value.length > 1 && <span>&nbsp;+{value.length - 1}</span>}
-                        </span>
+                    {isEmpty && placeholder && (
+                        <div
+                            className={classNames([
+                                `${CLASSNAME}__input-native`,
+                                `${CLASSNAME}__input-native--placeholder`,
+                            ])}
+                        >
+                            <span>{placeholder}</span>
+                        </div>
                     )}
-                </Chip>
-            )}
-        </>
-    );
-};
+
+                    {(isValid || hasError) && (
+                        <div className={`${CLASSNAME}__input-validity`}>
+                            <Icon icon={isValid ? mdiCheckCircle : mdiAlertCircle} size={Size.xxs} />
+                        </div>
+                    )}
+
+                    <div className={`${CLASSNAME}__input-indicator`}>
+                        <Icon icon={mdiMenuDown} size={Size.s} />
+                    </div>
+                </div>
+            </>
+        )}
+
+        {variant === SelectVariant.chip && (
+            <Chip
+                id={targetUuid}
+                isSelected={!isEmpty}
+                isDisabled={isDisabled}
+                after={<Icon icon={isEmpty ? mdiMenuDown : mdiCloseCircle} />}
+                onAfterClick={isEmpty ? onInputClick : onClear}
+                onClick={onInputClick}
+                chipRef={anchorRef as RefObject<HTMLAnchorElement>}
+                theme={theme}
+            >
+                {isEmpty && <span>{label}</span>}
+
+                {!isEmpty && (
+                    <span>
+                        <span>{selectedValueRender!(value[0])}</span>
+
+                        {value.length > 1 && <span>&nbsp;+{value.length - 1}</span>}
+                    </span>
+                )}
+            </Chip>
+        )}
+    </>
+);
 
 const SelectMultiple = (props: any) =>
     withSelectContext(SelectMultipleField, {

--- a/packages/lumx-react/src/components/select/WithSelectContext.tsx
+++ b/packages/lumx-react/src/components/select/WithSelectContext.tsx
@@ -16,9 +16,6 @@ import { CoreSelectProps, SelectVariant } from './constants';
 /** Defines the props of the component. */
 interface SelectProps extends CoreSelectProps {}
 
-/** Define the types of the default props. */
-interface DefaultPropsType extends Partial<SelectProps> {}
-
 /** The display name of the component. */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 
@@ -26,7 +23,7 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /** The default value of props. */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SelectProps> = {
     hasError: false,
     isOpen: false,
     isValid: false,

--- a/packages/lumx-react/src/components/select/constants.ts
+++ b/packages/lumx-react/src/components/select/constants.ts
@@ -13,58 +13,40 @@ enum SelectVariant {
 interface CoreSelectProps extends GenericProps {
     /** Whether the select (input variant) is displayed with error style or not. */
     hasError?: boolean;
-
-    /** The error related to the component */
+    /** The error related to the component. */
     error?: string | ReactNode;
-
     /** The helper to display within the popover (last position). */
     helper?: string;
-
-    /** Whether the select is disabled or not. */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-
-    /** Whether the select is required or not. */
+    /** Whether the component is required or not. */
     isRequired?: boolean;
-
-    /** Whether the select is opened or not. */
+    /** Whether the component is open or not. */
     isOpen?: boolean;
-
     /** Whether the select (input variant) is displayed with valid style or not. */
     isValid?: boolean;
-
     /** The select label. */
     label?: string;
-
     /** The select placeholder (input variant). */
     placeholder?: string;
-
-    /** The theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-
     /** The selected choices area style. */
     variant?: SelectVariant;
-
-    /** The callback function called when the clear button is clicked. NB: if not specified, clear buttons won't be displayed. */
+    /** The function called when the clear button is clicked. NB: if not specified, clear buttons won't be displayed. */
     onClear?(event: SyntheticEvent, value?: string): void;
-
-    /** The callback function called when the select field is blurred */
+    /** The function called when the select field is blurred. */
     onBlur?(): void;
-
-    /** The callback function called on integrated search field change (500ms debounce). */
+    /** The function called on integrated search field change (500ms debounce). */
     onFilter?(): void;
-
-    /** The callback function called when the select input is clicked, can be used for dropdown toggle. */
+    /** The function called when the select input is clicked, can be used for dropdown toggle. */
     onInputClick?(): void;
-
-    /** The callback function called when the dropdown is closed. */
+    /** The function called when the dropdown is closed. */
     onDropdownClose?(): void;
-
-    /** The callback function called when the bottom of the dropdown is reached. */
+    /** The function called when the bottom of the dropdown is reached. */
     onInfiniteScroll?(): void;
-
     /** The function called to render the selected value. Default: Renders the value as a string. */
     selectedValueRender?(choice: string): ReactNode | string;
 }

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
@@ -11,13 +11,11 @@ import { GenericProps, getRootClassName, handleBasicClasses, isComponent } from 
  * Defines the props of the component.
  */
 interface SideNavigationProps extends GenericProps {
-    /**  Side navigation content (should use `<SideNavigationItem>`). */
+    /** The children elements to be transcluded into the component. Should use SideNavigationItem. */
     children: ReactNode;
-
-    /** Theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
 }
 
@@ -31,9 +29,13 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}SideNavigation`;
  */
 const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
-const SideNavigation: React.FC<SideNavigationProps> = (props) => {
-    const { className, theme, children, useCustomColors, ...forwardedProps } = props;
-
+const SideNavigation: React.FC<SideNavigationProps> = ({
+    children,
+    className,
+    theme,
+    useCustomColors,
+    ...forwardedProps
+}) => {
     const content = Children.toArray(children).filter(isComponent(SideNavigationItem));
     return (
         <ul

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -22,32 +22,24 @@ import { IconButton } from '../button/IconButton';
  * Defines the props of the component.
  */
 interface SideNavigationItemProps extends GenericProps {
-    /** Side navigation item content (should use `<SideNavigationItem>`). */
+    /** The children elements to be transcluded into the component. Should use SideNavigationItem. */
     children?: ReactNode;
-
-    /** Menu item emphasis. */
+    /** The emphasis variant of the component. */
     emphasis?: Emphasis;
-
-    /** Menu item label. */
+    /** The label of the menu item. */
     label: string | ReactNode;
-
-    /** Menu item icon (SVG path code). */
+    /** The icon the menu item (SVG path code). */
     icon?: string;
-
-    /** Whether or not the menu is open. */
+    /** Whether the component is open or not. */
     isOpen?: boolean;
-
-    /** Whether or not the menu is selected. */
+    /** Whether the component is selected or not. */
     isSelected?: boolean;
-
-    /** props that will be passed on to the Link */
+    /** The props to pass to the link, minus those already set by the SideNavigationItem props. */
     linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
-
-    /** On click handler. */
-    onClick?(evt: React.MouseEvent): void;
-
-    /** On the action button is clicked */
+    /** The function called on click on the action button. */
     onActionClick?(evt: React.MouseEvent): void;
+    /** The function called on click on the component. */
+    onClick?(evt: React.MouseEvent): void;
 }
 
 /**
@@ -69,21 +61,19 @@ const DEFAULT_PROPS: Partial<SideNavigationItemProps> = {
     isSelected: false,
 };
 
-const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
-    const {
-        children,
-        className,
-        emphasis = DEFAULT_PROPS.emphasis,
-        label,
-        icon,
-        isOpen = DEFAULT_PROPS.isOpen,
-        isSelected = DEFAULT_PROPS.isSelected,
-        linkProps,
-        onClick,
-        onActionClick,
-        ...forwardedProps
-    } = props;
-
+const SideNavigationItem: React.FC<SideNavigationItemProps> = ({
+    children,
+    className,
+    emphasis = DEFAULT_PROPS.emphasis,
+    icon,
+    isOpen = DEFAULT_PROPS.isOpen,
+    isSelected = DEFAULT_PROPS.isSelected,
+    label,
+    linkProps,
+    onActionClick,
+    onClick,
+    ...forwardedProps
+}) => {
     const content = children && Children.toArray(children).filter(isComponent(SideNavigationItem));
     const hasContent = !isEmpty(content);
     const shouldSplitActions = Boolean(onActionClick);

--- a/packages/lumx-react/src/components/slider/Slider.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.tsx
@@ -14,40 +14,32 @@ import uuid from 'uuid/v4';
  * Defines the props of the component.
  */
 interface SliderProps extends GenericProps {
-    /** Deactivate the component */
-    isDisabled?: boolean;
-    /** Label */
-    label?: string;
-    /** Helper message */
+    /** The helper message of the slider. */
     helper?: string;
-    /** Should the min and max labels be hidden */
+    /** Whether the min and max labels should be hidden or not. */
     hideMinMaxLabel?: boolean;
-    /** Maximum value */
+    /** Whether the component is disabled or not. */
+    isDisabled?: boolean;
+    /** The label of the slider. */
+    label?: string;
+    /** The maximum value of the slider range. */
     max: number;
-    /** Minimum value */
+    /** The minimum value of the slider range. */
     min: number;
-    /**  Number of figures used for the fractional part of the value */
-    precision?: number;
-    /** Value between 2 steps */
-    steps?: number;
-    /** Value */
-    value: number;
-    /** Native input name. */
+    /** The native input name property. */
     name?: string;
-    /** Handle onChange event. */
-    onChange(value: number, name?: string, event?: SyntheticEvent): void;
-    /** Callback function invoked when the component is clicked */
-    onMouseDown?(event: React.SyntheticEvent): void;
-}
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<SliderProps> {
-    /**
-     * The theme.
-     */
+    /** The number of figures used for the fractional part of the value. */
+    precision?: number;
+    /** The value between two steps. */
+    steps?: number;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
+    /** The current selected value of the slider. */
+    value: number;
+    /** The function called on change. */
+    onChange(value: number, name?: string, event?: SyntheticEvent): void;
+    /** The function called on click. */
+    onMouseDown?(event: React.SyntheticEvent): void;
 }
 
 /**
@@ -66,7 +58,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  *
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SliderProps> = {
     hideMinMaxLabel: false,
     precision: 0,
     steps: 0,
@@ -106,28 +98,23 @@ const computeValueFromPercent = (percent: number, min: number, max: number, prec
 const computePercentFromValue = (value: number, min: number, max: number): number =>
     Number((value - min) / (max - min));
 
-/**
- * Slider component.
- *
- * @return The component.
- */
 const Slider: React.FC<SliderProps> = ({
     className,
-    label,
+    disabled,
     helper,
+    hideMinMaxLabel = DEFAULT_PROPS.hideMinMaxLabel,
     id,
+    isDisabled = disabled,
+    label,
     max,
     min,
-    onMouseDown,
-    onChange,
-    steps,
-    precision = DEFAULT_PROPS.precision,
-    hideMinMaxLabel = DEFAULT_PROPS.hideMinMaxLabel,
-    value = DEFAULT_PROPS.value!,
-    disabled,
-    isDisabled = disabled,
-    theme = DEFAULT_PROPS.theme,
     name,
+    onChange,
+    onMouseDown,
+    precision = DEFAULT_PROPS.precision,
+    steps,
+    theme = DEFAULT_PROPS.theme,
+    value = DEFAULT_PROPS.value!,
     ...forwardedProps
 }) => {
     const sliderId = useMemo(() => id || `slider-${uuid()}`, [id]);

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -15,28 +15,23 @@ import { SlideshowControls } from './SlideshowControls';
  * Defines the props of the component.
  */
 interface SlideshowProps extends GenericProps {
-    /** Index of the current slide */
+    /** The index of the current slide. */
     activeIndex?: number;
-    /** Enable/disable automatic rotation of slideshow */
+    /** Whether the automatic rotation of the slideshow is enabled or not. */
     autoPlay?: boolean;
-    /** Whether the image has to fill its container's height. */
+    /** Whether the image has to fill its container height or not. */
     fillHeight?: boolean;
-    /** Enable grouping of slides */
+    /** The number of slides to group together. */
     groupBy?: number;
-    /** Enable/disable controls for slideshow */
+    /** Whether slideshow has controls or not. */
     hasControls?: boolean;
-    /** Interval between each slide when automatic rotation is enabled */
+    /** The interval between each slide when automatic rotation is enabled. */
     interval?: number;
-    /** Theme */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<SlideshowProps> {}
 
 /**
  * The display name of the component.
@@ -51,7 +46,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SlideshowProps> = {
     activeIndex: 0,
     autoPlay: false,
     fillHeight: false,
@@ -61,11 +56,6 @@ const DEFAULT_PROPS: DefaultPropsType = {
     theme: Theme.light,
 };
 
-/**
- * Displays a slideshow.
- *
- * @return The component.
- */
 const Slideshow: React.FC<SlideshowProps> = ({
     activeIndex = DEFAULT_PROPS.activeIndex as number,
     autoPlay = DEFAULT_PROPS.autoPlay,

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -19,12 +19,19 @@ import noop from 'lodash/noop';
  * Defines the props of the component.
  */
 interface SlideshowControlsProps extends GenericProps {
+    /** The index of the current slide. */
     activeIndex?: number;
+    /** The reference of the parent element. */
     parentRef: RefObject<HTMLDivElement>;
+    /** The number of slides. */
     slidesCount: number;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    onPaginationClick?(index: number): void;
+    /** The function called on click on the "next" arrow */
     onNextClick?(): void;
+    /** The function called on click on a navigation item */
+    onPaginationClick?(index: number): void;
+    /** The function called on click on the "previous" arrow */
     onPreviousClick?(): void;
 }
 
@@ -62,28 +69,14 @@ const DEFAULT_PROPS: DefaultPropsType = {
     theme: Theme.light,
 };
 
-/**
- * Controls for the slideshow component.
- *
- * @param  props The component props.
- * @return The component.
- */
 const SlideshowControls: React.FC<SlideshowControlsProps> = ({
-    /** Index of the current slide */
     activeIndex = DEFAULT_PROPS.activeIndex,
-    /** Css class */
     className,
-    /** Reference of parent element */
-    parentRef,
-    /** Number of slides */
-    slidesCount,
-    /** Callback for the click on a navigation item */
-    onPaginationClick = DEFAULT_PROPS.onPaginationClick,
-    /** Callback for the click on the "next" arrow */
     onNextClick = DEFAULT_PROPS.onNextClick,
-    /** Callback for the click on the "previous" arrow */
+    onPaginationClick = DEFAULT_PROPS.onPaginationClick,
     onPreviousClick = DEFAULT_PROPS.onPreviousClick,
-    /** Theme */
+    parentRef,
+    slidesCount,
     theme = DEFAULT_PROPS.theme,
     ...forwardedProps
 }) => {

--- a/packages/lumx-react/src/components/switch/Switch.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.tsx
@@ -19,44 +19,25 @@ enum SwitchPosition {
  * Defines the props of the component.
  */
 interface SwitchProps extends GenericProps {
+    /** The helper of the switch. */
+    helper?: string;
     /** Whether it is checked or not. */
     isChecked?: boolean;
-
-    /** Switch disabled state. */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-
-    /**
-     * A small help to display below.
-     */
-    helper?: string;
-
-    /** Native input name. */
+    /** The native input name property. */
     name?: string;
-
-    /**
-     * The position of the toggle regarding the label.
-     */
+    /** The position of the toggle regarding the label. */
     position?: SwitchPosition;
-
-    /**
-     * The theme.
-     */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-
-    /** Native input value. */
+    /** The native input value property. */
     value?: string;
-
-    /** Handle onChange event. */
+    /** The function called on change. */
     onChange?(isChecked: boolean, value?: string, name?: string, event?: SyntheticEvent): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<SwitchProps> {}
 
 /**
  * The display name of the component.
@@ -71,25 +52,20 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SwitchProps> = {
     position: SwitchPosition.left,
     theme: Theme.light,
 };
 
-/**
- * [Enter the description of the component here].
- *
- * @return The component.
- */
 const Switch: React.FC<SwitchProps> = ({
-    className,
-    id,
-    children,
     checked,
-    isChecked = checked,
+    children,
+    className,
     disabled,
-    isDisabled = disabled,
     helper,
+    id,
+    isChecked = checked,
+    isDisabled = disabled,
     name,
     onChange,
     position = DEFAULT_PROPS.position,

--- a/packages/lumx-react/src/components/table/Table.tsx
+++ b/packages/lumx-react/src/components/table/Table.tsx
@@ -11,24 +11,13 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface TableProps extends GenericProps {
-    /**
-     * Whether the table has checkbox or thumbnail on first cell.
-     */
+    /** Whether the table has checkbox or thumbnail on first cell or not. */
     hasBefore?: boolean;
-    /**
-     * Whether the table has dividers.
-     */
+    /** Whether the table has dividers or not. */
     hasDividers?: boolean;
-    /**
-     * The theme.
-     */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableProps> {}
 
 /**
  * The display name of the component.
@@ -43,7 +32,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<TableProps> = {
     hasBefore: false,
     hasDividers: false,
     theme: Theme.light,
@@ -57,8 +46,8 @@ const DEFAULT_PROPS: DefaultPropsType = {
 const Table: React.FC<TableProps> = ({
     children,
     className,
-    hasBefore,
-    hasDividers,
+    hasBefore = DEFAULT_PROPS.hasBefore,
+    hasDividers = DEFAULT_PROPS.hasDividers,
     theme = DEFAULT_PROPS.theme,
     ...forwardedProps
 }) => (

--- a/packages/lumx-react/src/components/table/TableBody.tsx
+++ b/packages/lumx-react/src/components/table/TableBody.tsx
@@ -11,11 +11,6 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 interface TableBodyProps extends GenericProps {}
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableBodyProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}TableBody`;
@@ -28,13 +23,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<TableBodyProps> = {};
 
-/**
- * The TableBody component displays an HTML Table Body, composed TableBody-cells in TableBody Rows.
- *
- * @return The component.
- */
 const TableBody: React.FC<TableBodyProps> = ({ children, className, ...forwardedProps }) => (
     <tbody {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}>
         {children}

--- a/packages/lumx-react/src/components/table/TableCell.tsx
+++ b/packages/lumx-react/src/components/table/TableCell.tsx
@@ -38,42 +38,18 @@ enum TableCellVariant {
  * Defines the props of the component.
  */
 interface TableCellProps extends GenericProps {
-    /**
-     * The mdi name of the icon (thead only).
-     */
+    /** The name of the icon (thead only). */
     icon?: string;
-
-    /**
-     * Whether the column is sortable or not (thead only).
-     */
+    /** Whether the column is sortable or not (thead only). */
     isSortable?: boolean;
-
-    /**
-     * The scope of the thead.
-     */
+    /** The scope of the thead. */
     scope?: ThScope;
-
-    /**
-     * The initial sort order (sortable thead only).
-     */
+    /** The initial sort order (sortable thead only). */
     sortOrder?: ThOrder;
-
-    /**
-     * The variant of the cell.
-     */
+    /** The variant of the cell. */
     variant?: TableCellVariant;
-
-    /**
-     * The function to call when we click on an order button.
-     */
+    /** The function called on click on header. */
     onHeaderClick?(): void;
-}
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableCellProps> {
-    variant: TableCellVariant;
 }
 
 /**
@@ -89,16 +65,11 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<TableCellProps> = {
     onHeaderClick: undefined,
     variant: TableCellVariant.body,
 };
 
-/**
- * The TableCell component displays an HTML Table Header Cell.
- *
- * @return The component.
- */
 const TableCell: React.FC<TableCellProps> = ({
     children,
     className,

--- a/packages/lumx-react/src/components/table/TableHeader.tsx
+++ b/packages/lumx-react/src/components/table/TableHeader.tsx
@@ -11,11 +11,6 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 interface TableHeaderProps extends GenericProps {}
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableHeaderProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}TableHeader`;
@@ -28,13 +23,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<TableHeaderProps> = {};
 
-/**
- * The TableHeader component displays an HTML Table Head, composed TableHeader-cells in TableHeader Rows.
- *
- * @return The component.
- */
 const TableHeader: React.FC<TableHeaderProps> = ({ children, className, ...forwardedProps }) => (
     <thead {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}>
         {children}

--- a/packages/lumx-react/src/components/table/TableRow.tsx
+++ b/packages/lumx-react/src/components/table/TableRow.tsx
@@ -9,17 +9,11 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface TableRowProps extends GenericProps {
-    /**
-     * Whether the table row is clickable.
-     */
+    /** Whether the component is clickable or not. */
     isClickable?: boolean;
-    /**
-     * Whether the table row is disabled.
-     */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-    /**
-     * Whether the table row is selected.
-     */
+    /** Whether the component is selected or not. */
     isSelected?: boolean;
 }
 
@@ -33,16 +27,11 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}TableRow`;
  */
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 
-/**
- * The TableRow component displays an HTML Table Row, which contains table cells.
- *
- * @return The component.
- */
 const TableRow: React.FC<TableRowProps> = ({
     children,
     className,
-    isClickable,
     disabled,
+    isClickable,
     isDisabled = disabled,
     isSelected,
     ...forwardedProps

--- a/packages/lumx-react/src/components/tabs/Tab.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.tsx
@@ -10,17 +10,17 @@ import { GenericProps, handleBasicClasses } from '@lumx/react/utils';
  * Defines the props of the component.
  */
 interface TabProps extends GenericProps {
-    /** Tab index */
-    index?: number;
-    /** Tab icon */
+    /** The icon of the tab. */
     icon?: IconProps['icon'];
-    /** Is tab active */
+    /** The index of the tab. */
+    index?: number;
+    /** Whether the tab is active or not. */
     isActive?: boolean;
-    /** Is tab disabled */
+    /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-    /** Tab label */
+    /** The label of the tab. */
     label?: string | ReactNode;
-    /** Function to trigger on tab click */
+    /** The function called on click. */
     onTabClick?(e: { event: SyntheticEvent; index?: number }): void;
 }
 
@@ -34,17 +34,12 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Tab`;
  */
 const CLASSNAME = `${CSS_PREFIX}-tabs__link`;
 
-/**
- * Define a single Tab for Tabs component.
- *
- * @return The component.
- */
 const Tab: React.FC<TabProps> = ({
     className,
+    disabled,
     icon,
     index,
     isActive,
-    disabled,
     isDisabled = disabled,
     label,
     onTabClick,

--- a/packages/lumx-react/src/components/tabs/Tabs.tsx
+++ b/packages/lumx-react/src/components/tabs/Tabs.tsx
@@ -21,26 +21,21 @@ enum TabsPosition {
  * Defines the props of the component.
  */
 interface TabsProps extends GenericProps {
-    /** Active tab */
+    /** The active tab. */
     activeTab?: number;
-    /** Component tabs */
+    /** The children elements to be transcluded into the component. */
     children: ReactNode;
-    /** Tabs Layout */
+    /** The layout of the tabs. */
     layout?: TabsLayout;
-    /** Function to trigger on tab click */
-    onTabClick: TabProps['onTabClick'];
-    /** Tabs Position */
+    /** The position of the tabs. */
     position?: TabsPosition;
-    /** Component theme */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** Whether custom colors are applied to this component. */
+    /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
+    /** The function called on click. */
+    onTabClick: TabProps['onTabClick'];
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TabsProps> {}
 
 /**
  * The display name of the component.
@@ -55,7 +50,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<TabsProps> = {
     activeTab: 0,
     children: [],
     layout: TabsLayout.fixed,
@@ -63,14 +58,9 @@ const DEFAULT_PROPS: DefaultPropsType = {
     theme: Theme.light,
 };
 
-/**
- * Defines a Tabs component.
- *
- * @return The component.
- */
 const Tabs: React.FC<TabsProps> = ({
     activeTab = DEFAULT_PROPS.activeTab,
-    children,
+    children = DEFAULT_PROPS.children,
     className,
     layout = DEFAULT_PROPS.layout,
     onTabClick,

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -13,80 +13,56 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface TextFieldProps extends GenericProps {
-    /** A Chip Group to be rendered before the main text input */
+    /** A Chip Group to be rendered before the main text input. */
     chips?: HTMLElement | ReactNode;
-
-    /** The error related to the TextField */
+    /** The error related to the TextField. */
     error?: string | ReactNode;
-
-    /** Whether we force the focus style */
+    /** Whether we force the focus style or not. */
     forceFocusStyle?: boolean;
-
     /** Whether the text field is displayed with error style or not. */
     hasError?: boolean;
-
-    /** The helper related to the TextField */
+    /** The helper related to the TextField. */
     helper?: string | ReactNode;
-
-    /** The max length the input accepts. If set, a character counter will be displayed. */
-    maxLength?: number;
-
     /** Text field icon (SVG path). */
     icon?: string;
-
-    /** Id that will be passed to input element. An id is generated (uuid) if no id is provided. */
+    /** The id that will be passed to input element. An id is generated (uuid) if no id is provided. */
     id?: string;
-
-    /** Whether the text field is disabled or not. */
-    isDisabled?: boolean;
-
-    /** Whether the text field is required or not. */
-    isRequired?: boolean;
-
-    /** Whether the text field is displayed with valid style or not. */
-    isValid?: boolean;
-
+    /** The reference passed to the <input> or <textarea> element. */
+    inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
     /** Whether the text field shows a cross to clear its content or not. */
     isClearable?: boolean;
-
-    /** Text field label displayed in a label tag. */
+    /** Whether the component is disabled or not. */
+    isDisabled?: boolean;
+    /** Whether the component is required or not. */
+    isRequired?: boolean;
+    /** Whether the text field is displayed with valid style or not. */
+    isValid?: boolean;
+    /** The label of the text field. */
     label?: string;
-
-    /** Text field placeholder message. */
-    placeholder?: string;
-
-    /** Theme. */
-    theme?: Theme;
-
-    /** Whether custom colors are applied to this component. */
-    useCustomColors?: boolean;
-
-    /** Switches the input to a textarea. */
-    multiline?: boolean;
-
-    /** Minimum rows to be displayed (requires multiline to be enabled). */
+    /** The max length the input accepts. If set, a character counter will be displayed. */
+    maxLength?: number;
+    /** The minimum rows to be displayed (requires multiline to be enabled). */
     minimumRows?: number;
-
-    /** A ref that will be passed to the input or text area element. */
-    inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
-
-    /** Native input name. */
+    /** Whether the text field is a textarea or an input. */
+    multiline?: boolean;
+    /** The native input name property. */
     name?: string;
-
-    /** Text field value. */
-    value?: string;
-
-    /** A ref that will be passed to the wrapper element. */
+    /** The placeholder message of the text field. */
+    placeholder?: string;
+    /** The reference passed to the wrapper. */
     textFieldRef?: RefObject<HTMLDivElement>;
-
-    /** Handle onChange event. */
-    onChange(value: string, name?: string, event?: SyntheticEvent): void;
-
-    /** Text field focus change handler. */
-    onFocus?(event: React.FocusEvent): void;
-
-    /** Text field blur change handler. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
+    /** Whether custom colors are applied to this component or not. */
+    useCustomColors?: boolean;
+    /** The value of the text field. */
+    value?: string;
+    /** The function called on blur. */
     onBlur?(event: React.FocusEvent): void;
+    /** The function called on change. */
+    onChange(value: string, name?: string, event?: SyntheticEvent): void;
+    /** The function called on focus. */
+    onFocus?(event: React.FocusEvent): void;
 }
 
 /**
@@ -119,6 +95,7 @@ const DEFAULT_PROPS: Partial<TextFieldProps> = {
     theme: Theme.light,
     type: 'text',
 };
+
 /**
  * Hook that allows to calculate the number of rows needed for a text area.
  * @param minimumRows Minimum number of rows that we want to display.
@@ -265,45 +242,37 @@ const renderInputNative: React.FC<InputNativeProps> = (props) => {
     );
 };
 
-/**
- * Text field.
- *
- * @param  props Text field props.
- * @return The component.
- */
-const TextField: React.FC<TextFieldProps> = (props) => {
-    const {
-        chips,
-        className,
-        error,
-        forceFocusStyle = DEFAULT_PROPS.forceFocusStyle,
-        hasError,
-        helper,
-        icon,
-        id,
-        disabled,
-        isDisabled = disabled,
-        isRequired,
-        isClearable = DEFAULT_PROPS.isClearable,
-        isValid,
-        label,
-        maxLength,
-        onChange,
-        onFocus,
-        onBlur,
-        placeholder,
-        minimumRows = DEFAULT_PROPS.minimumRows as number,
-        inputRef = React.useRef(null),
-        theme = DEFAULT_PROPS.theme,
-        multiline = DEFAULT_PROPS.multiline,
-        useCustomColors,
-        textFieldRef,
-        type = DEFAULT_PROPS.type,
-        value,
-        name,
-        ...forwardedProps
-    } = props;
-
+const TextField: React.FC<TextFieldProps> = ({
+    chips,
+    className,
+    disabled,
+    error,
+    forceFocusStyle = DEFAULT_PROPS.forceFocusStyle,
+    hasError,
+    helper,
+    icon,
+    id,
+    inputRef = React.useRef(null),
+    isClearable = DEFAULT_PROPS.isClearable,
+    isDisabled = disabled,
+    isRequired,
+    isValid,
+    label,
+    maxLength,
+    minimumRows = DEFAULT_PROPS.minimumRows as number,
+    multiline = DEFAULT_PROPS.multiline,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    placeholder,
+    textFieldRef,
+    theme = DEFAULT_PROPS.theme,
+    type = DEFAULT_PROPS.type,
+    useCustomColors,
+    value,
+    ...forwardedProps
+}) => {
     const textFieldId = useMemo(() => id || `text-field-${uuid()}`, [id]);
     const [isFocus, setFocus] = useState(false);
     const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(minimumRows);

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 export default { title: 'LumX components/thumbnail/Thumbnail' };
 
 interface StoryProps {
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme: Theme;
 }
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -75,41 +75,36 @@ interface ThumbnailProps extends GenericProps {
     align?: Alignment;
     /** The image aspect ratio. */
     aspectRatio?: AspectRatio;
-    /** Enable cross origin attribute. */
-    isCrossOriginEnabled?: boolean;
     /**
      * Allows images that are loaded from foreign origins
      * to be used as if they had been loaded from the current origin.
      */
     crossOrigin?: CrossOrigin;
-    /** Whether the image has to fill its container's height. */
-    fillHeight?: boolean;
-    /** Avatar image. */
-    image: string;
-    /** Size. */
-    size?: ThumbnailSize;
-    /** Image Loading mode */
-    loading?: ImageLoading;
-    /** Theme. */
-    theme?: Theme;
-    /** Variant. */
-    variant?: ThumbnailVariant;
-    /** Focal Point coordinates. */
-    focusPoint?: FocusPoint;
-    /** Allows to re-center the image according to the focal point after after window resizing */
-    isFollowingWindowSize?: boolean;
-    /** Time before recalculating focal point if isFollowingWindowSize is activated */
-    resizeDebounceTime?: number;
-    /** props that will be passed directly to the `img` tag */
-    imgProps?: ImgHTMLAttributes<HTMLImageElement>;
-    /** Fallback svg or react node. */
+    /** The fallback svg or react node. */
     fallback?: string | ReactNode;
+    /** Whether the image has to fill its container height or not. */
+    fillHeight?: boolean;
+    /** The focal Point coordinates. */
+    focusPoint?: FocusPoint;
+    /** The avatar image. */
+    image: string;
+    /** The props that will be passed directly to the <img> element. */
+    imgProps?: ImgHTMLAttributes<HTMLImageElement>;
+    /** Whether cross origin is enabled or not. */
+    isCrossOriginEnabled?: boolean;
+    /** Whether the image has to be centered according to the focal point after a window resize. */
+    isFollowingWindowSize?: boolean;
+    /** The size variant of the component. */
+    size?: ThumbnailSize;
+    /** The image loading mode. */
+    loading?: ImageLoading;
+    /** The time before recalculating focal point if isFollowingWindowSize is activated. */
+    resizeDebounceTime?: number;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
+    /** The variant of the component. */
+    variant?: ThumbnailVariant;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ThumbnailProps> {}
 
 /**
  * The display name of the component.
@@ -124,49 +119,41 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ThumbnailProps> = {
     align: Alignment.left,
-    crossOrigin: CrossOrigin.anonymous,
     aspectRatio: AspectRatio.original,
+    crossOrigin: CrossOrigin.anonymous,
     fallback: mdiImageBrokenVariant,
     fillHeight: false,
     focusPoint: { x: 0, y: 0 },
     isCrossOriginEnabled: true,
+    isFollowingWindowSize: true,
     loading: ImageLoading.lazy,
+    resizeDebounceTime: 20,
     size: undefined,
     theme: Theme.light,
     variant: ThumbnailVariant.squared,
-    resizeDebounceTime: 20,
-    isFollowingWindowSize: true,
 };
 
-/**
- * Simple component used to display image with square or round shape.
- * Convenient to display image previews or user avatar.
- * Has a fallback image when the source image is in error.
- *
- * @return The component.
- */
 const Thumbnail: React.FC<ThumbnailProps> = ({
-    className,
-    // tslint:disable-next-line: no-unused
-    isCrossOriginEnabled = DEFAULT_PROPS.isCrossOriginEnabled,
-    crossOrigin = DEFAULT_PROPS.crossOrigin,
-    resizeDebounceTime = DEFAULT_PROPS.resizeDebounceTime,
-    isFollowingWindowSize = DEFAULT_PROPS.isFollowingWindowSize,
     align = DEFAULT_PROPS.align,
+    alt = 'Thumbnail',
     aspectRatio = DEFAULT_PROPS.aspectRatio,
+    className,
+    crossOrigin = DEFAULT_PROPS.crossOrigin,
     fallback = DEFAULT_PROPS.fallback,
     fillHeight = DEFAULT_PROPS.fillHeight,
+    focusPoint = DEFAULT_PROPS.focusPoint,
+    image,
+    imgProps,
+    isCrossOriginEnabled = DEFAULT_PROPS.isCrossOriginEnabled,
+    isFollowingWindowSize = DEFAULT_PROPS.isFollowingWindowSize,
     loading = DEFAULT_PROPS.loading,
+    onClick = null,
+    resizeDebounceTime = DEFAULT_PROPS.resizeDebounceTime,
     size = DEFAULT_PROPS.size,
     theme = DEFAULT_PROPS.theme,
     variant = DEFAULT_PROPS.variant,
-    image,
-    alt = 'Thumbnail',
-    onClick = null,
-    focusPoint = DEFAULT_PROPS.focusPoint,
-    imgProps,
     ...forwardedProps
 }: ThumbnailProps): ReactElement => {
     const [thumbnailState, setThumbnailState] = useState<ThumbnailStates>('isLoading');

--- a/packages/lumx-react/src/components/toolbar/Toolbar.tsx
+++ b/packages/lumx-react/src/components/toolbar/Toolbar.tsx
@@ -10,18 +10,13 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
  * Defines the props of the component.
  */
 interface ToolbarProps extends GenericProps {
-    /* Slot for the right element. */
+    /** A component to be rendered after the content. */
     after?: ReactNode;
-    /* Slot for the left element. */
+    /** A component to be rendered before the content. */
     before?: ReactNode;
-    /* Slot fo the main title element. */
+    /** The label of the toolbar. */
     label?: ReactNode;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ToolbarProps> {}
 
 /**
  * The display name of the component.
@@ -36,33 +31,26 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<ToolbarProps> = {};
 
-/**
- * Toolbar component.
- *
- * @return The component.
- */
-const Toolbar: React.FC<ToolbarProps> = ({ after, before, className, label, ...forwardedProps }) => {
-    return (
-        <div
-            {...forwardedProps}
-            className={classNames(
-                className,
-                handleBasicClasses({
-                    hasAfter: Boolean(after),
-                    hasBefore: Boolean(before),
-                    hasLabel: Boolean(label),
-                    prefix: CLASSNAME,
-                }),
-            )}
-        >
-            {before && <div className={`${CLASSNAME}__before`}>{before}</div>}
-            {label && <div className={`${CLASSNAME}__label`}>{label}</div>}
-            {after && <div className={`${CLASSNAME}__after`}>{after}</div>}
-        </div>
-    );
-};
+const Toolbar: React.FC<ToolbarProps> = ({ after, before, className, label, ...forwardedProps }) => (
+    <div
+        {...forwardedProps}
+        className={classNames(
+            className,
+            handleBasicClasses({
+                hasAfter: Boolean(after),
+                hasBefore: Boolean(before),
+                hasLabel: Boolean(label),
+                prefix: CLASSNAME,
+            }),
+        )}
+    >
+        {before && <div className={`${CLASSNAME}__before`}>{before}</div>}
+        {label && <div className={`${CLASSNAME}__label`}>{label}</div>}
+        {after && <div className={`${CLASSNAME}__after`}>{after}</div>}
+    </div>
+);
 Toolbar.displayName = COMPONENT_NAME;
 
 export { CLASSNAME, DEFAULT_PROPS, Toolbar, ToolbarProps };

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -18,28 +18,19 @@ import { useTooltipOpen } from './useTooltipOpen';
 type TooltipPlacement = Placement.TOP | Placement.RIGHT | Placement.BOTTOM | Placement.LEFT;
 
 /**
- * Defines the optional props of the component.
- */
-interface OptionalTooltipProps extends GenericProps {
-    /** Delay in ms before closing the tooltip . */
-    delay?: number;
-
-    /** Placement of tooltip relative to the anchor element. */
-    placement?: TooltipPlacement;
-
-    /** Force tooltip to show even without the mouse over the anchor. */
-    forceOpen?: boolean;
-}
-
-/**
  * Defines the props of the component.
  */
-interface TooltipProps extends OptionalTooltipProps {
-    /** Tooltip label. */
-    label?: string | null | false;
-
-    /** Tooltip anchor. */
+interface TooltipProps extends GenericProps {
+    /** The children elements to be transcluded into the component. Will act as the tooltip anchor. */
     children: ReactNode;
+    /** The delay (in ms) before closing the tooltip. */
+    delay?: number;
+    /** Whether the tooltip is displayed even without the mouse hovering the anchor. */
+    forceOpen?: boolean;
+    /** The label of the tooltip. */
+    label?: string | null | false;
+    /** The placement of the tooltip based on the anchor element placement. */
+    placement?: TooltipPlacement;
 }
 
 /**
@@ -55,10 +46,10 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: Required<OptionalTooltipProps> = {
+const DEFAULT_PROPS: Partial<TooltipProps> = {
     delay: 500,
-    placement: Placement.BOTTOM,
     forceOpen: false,
+    placement: Placement.BOTTOM,
 };
 
 /**
@@ -66,23 +57,15 @@ const DEFAULT_PROPS: Required<OptionalTooltipProps> = {
  */
 const OFFSET = 8;
 
-/**
- * Tooltip.
- *
- * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#tooltip
- * @param  props The component props.
- * @return The component.
- */
-const Tooltip: React.FC<TooltipProps> = (props) => {
-    const {
-        label,
-        children,
-        className,
-        delay = DEFAULT_PROPS.delay,
-        placement = DEFAULT_PROPS.placement,
-        forceOpen = DEFAULT_PROPS.forceOpen,
-        ...forwardedProps
-    } = props;
+const Tooltip: React.FC<TooltipProps> = ({
+    children,
+    className,
+    delay = DEFAULT_PROPS.delay as number,
+    forceOpen = DEFAULT_PROPS.forceOpen as boolean,
+    label,
+    placement = DEFAULT_PROPS.placement,
+    ...forwardedProps
+}) => {
     if (!label) {
         return <>{children}</>;
     }

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -18,33 +18,19 @@ type UploaderSize = Size.xl | Size.xxl;
  * Defines the props of the component.
  */
 interface UploaderProps extends GenericProps {
-    /**
-     * Aspect ratio
-     */
+    /** The aspect ratio the image will get. */
     aspectRatio?: AspectRatio;
-    /**
-     * Icon
-     */
+    /** The icon of the uploader. */
     icon?: string;
-    /**
-     * Label
-     */
+    /** The label of the uploader. */
     label?: string;
-    /**
-     * Size
-     */
+    /** The size variant of the component. */
     size?: UploaderSize;
-    /**
-     * Theme
-     */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /**
-     * Uploader variant
-     */
+    /** The variant of the component. */
     variant?: UploaderVariant;
-    /**
-     * On click handler
-     */
+    /** The function called on click. */
     onClick?: MouseEventHandler<HTMLDivElement>;
 }
 
@@ -68,24 +54,16 @@ const DEFAULT_PROPS: Partial<UploaderProps> = {
     variant: UploaderVariant.square,
 };
 
-/**
- * [Enter the description of the component here].
- *
- * @param  props The component props.
- * @return The component.
- */
-const Uploader: React.FC<UploaderProps> = (props) => {
-    const {
-        aspectRatio = DEFAULT_PROPS.aspectRatio,
-        className,
-        label,
-        icon,
-        size = DEFAULT_PROPS.size,
-        theme = DEFAULT_PROPS.theme,
-        variant = DEFAULT_PROPS.variant,
-        ...forwardedProps
-    } = props;
-
+const Uploader: React.FC<UploaderProps> = ({
+    aspectRatio = DEFAULT_PROPS.aspectRatio,
+    className,
+    label,
+    icon,
+    size = DEFAULT_PROPS.size,
+    theme = DEFAULT_PROPS.theme,
+    variant = DEFAULT_PROPS.variant,
+    ...forwardedProps
+}) => {
     // Adjust to square aspect ratio when using circle variants.
     const adjustedAspectRatio = variant === UploaderVariant.circle ? AspectRatio.square : aspectRatio;
 

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -18,38 +18,36 @@ type UserBlockSize = Size.s | Size.m | Size.l;
  * Defines the props of the component.
  */
 interface UserBlockProps extends GenericProps {
-    /* The url of the avatar picture we want to display */
+    /**
+     * The url of the avatar picture we want to display.
+     * @see {@link AvatarProps#image}
+     */
     avatar?: string;
     /** The props to pass to the avatar, minus those already set by the UserBlock props. */
     avatarProps?: Omit<AvatarProps, 'image' | 'size' | 'onClick' | 'tabIndex' | 'theme'>;
-    /** Simple Action block. */
+    /** The single action element to be transcluded into the component. */
     simpleAction?: ReactNode;
-    /** Multiple Actions block. */
+    /** The group of action elements to be transcluded into the component. */
     multipleActions?: ReactNode;
-    /** Additional fields used to describe the use. */
+    /** The additional fields used to describe the user. */
     fields?: string[];
-    /** User name. */
+    /** The name of the user.. */
     name?: string;
-    /** Orientation. */
+    /** The orientation of the user block. */
     orientation?: Orientation;
-    /** Size. */
+    /** The size variant of the component. */
     size?: UserBlockSize;
-    /** Theme. */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** Reference passed to the wrapper. */
+    /** The reference passed to the wrapper. */
     userBlockRef?: Ref<HTMLDivElement>;
-    /** Callback for the click event. */
+    /** The function called on click. */
     onClick?(): void;
-    /** Callback for the mouseEnter event. */
+    /** The function called when the cursor enters the component. */
     onMouseEnter?(): void;
-    /** Callback for the mouseEnter event. */
+    /** The function called when the cursor exits the component. */
     onMouseLeave?(): void;
 }
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<UserBlockProps> {}
 
 /**
  * The display name of the component.
@@ -64,33 +62,28 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<UserBlockProps> = {
+    avatarProps: undefined,
     orientation: Orientation.horizontal,
     size: Size.m,
     theme: Theme.light,
-    avatarProps: undefined,
 };
 
-/**
- * Render a user information as a card if orientation is vertical or no action user info block if horizontal.
- *
- * @return The component.
- */
 const UserBlock: React.FC<UserBlockProps> = ({
     avatar,
-    theme = DEFAULT_PROPS.theme,
-    orientation = DEFAULT_PROPS.orientation,
+    avatarProps = DEFAULT_PROPS.avatarProps,
+    className,
     fields,
+    multipleActions,
     name,
     onClick,
     onMouseEnter,
     onMouseLeave,
-    className,
+    orientation = DEFAULT_PROPS.orientation,
     simpleAction,
-    multipleActions,
     size = DEFAULT_PROPS.size,
+    theme = DEFAULT_PROPS.theme,
     userBlockRef,
-    avatarProps = DEFAULT_PROPS.avatarProps,
     ...forwardedProps
 }) => {
     let componentSize = size;

--- a/packages/site-demo/src/components/DemoColor.tsx
+++ b/packages/site-demo/src/components/DemoColor.tsx
@@ -5,6 +5,7 @@ import { useThemeColorVariants } from '@lumx/demo/hooks/useThemeColorVariants';
 import { Theme } from '@lumx/react';
 
 interface DemoColorProps {
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme: Theme;
     color: string;
 }

--- a/packages/site-demo/src/components/design-tokens/ColorVariantsDesignTokenGroup.tsx
+++ b/packages/site-demo/src/components/design-tokens/ColorVariantsDesignTokenGroup.tsx
@@ -10,7 +10,7 @@ import { DesignTokenGroup } from './DesignTokenGroup';
 interface Props {
     /** The color name (blue, red, dark, etc.). */
     color: string;
-    /** Theme */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme: Theme;
 }
 

--- a/packages/site-demo/src/components/design-tokens/DesignToken.tsx
+++ b/packages/site-demo/src/components/design-tokens/DesignToken.tsx
@@ -20,9 +20,7 @@ interface DesignTokenProps {
      * From which version the design token is available.
      */
     version?: string;
-    /**
-     * The design token theme.
-     */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
     /**
      * The design token demo.

--- a/packages/site-demo/src/components/design-tokens/DesignTokenGroup.tsx
+++ b/packages/site-demo/src/components/design-tokens/DesignTokenGroup.tsx
@@ -4,9 +4,7 @@ import React, { ReactNode } from 'react';
 import { Theme } from '@lumx/react';
 
 interface DesignTokenGroupProps {
-    /**
-     * The design token group theme.
-     */
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
     /**
      * The design tokens.


### PR DESCRIPTION
# General summary

Harmonization of Jsdoc and props definition.

- [x] Fix jsdoc format for each props (no `/* */` anymore, only `/** */`)
- [x] Same sentence format for every prop (`The ... .` for a standard prop and `Whether ... or not.` for a boolean prop)
- [x] Harmonize jsdoc for common props like:
  - `theme`
  - reference
  - `name`
  - `label`
  - `helper`
  - event method
  - `isDisabled`
  - `isSelected`
  - `size`
  - `color`
  - ...
- [x] Fix and/or add `@see {@link}` when necessary
- [x] Remove extraneous typing like `interface DefaultPropsType extends Partial<IconButtonProps> {}`
- [x] Remove unnecessary (and often not incorrectly copy/paste) component jsdoc
- [x] Sort props:
  - In interface definition
  - in default props definition
  - in props destructuration