### PR TITLE
chore(link-a11y): add `linkAs` prop on component with links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add `gap` property to `FlexBox` component.
 -   Add has divider helper.
 -   Add optional `closeOnClick` property to `Select` component.
+-   Add `linkAs` prop on `SideNavigationItem`, `ListItem` and `Link` to customize the link component (can be used to inject the `Link` component from `react-router`).
 
 ### Changed
 

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -30,3 +30,8 @@ export const simpleLink = () => (
         </Link>
     </>
 );
+
+const CustomLink: React.FC = ({ children, ...props }) =>
+    React.createElement('a', { ...props, style: { color: 'red' } }, children);
+
+export const withCustomLink = () => <Link linkAs={CustomLink}>My link text</Link>;

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 
 import { Color, ColorVariant } from '@lumx/react';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { renderLink } from '@lumx/react/utils/renderLink';
 
 /**
  * Defines the props of the component.
@@ -15,6 +16,9 @@ interface LinkProps extends React.DetailedHTMLProps<React.AnchorHTMLAttributes<H
 
     /** The icon color variant. */
     colorVariant?: ColorVariant;
+
+    /** Sets a custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
 
     /** Ref to the native HTML anchor element. */
     linkRef?: Ref<HTMLAnchorElement>;
@@ -35,15 +39,23 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  *
  * @return The component.
  */
-const Link: React.FC<LinkProps> = ({ children, className, linkRef, color, colorVariant, ...forwardedProps }) => {
-    return (
-        <a
-            {...forwardedProps}
-            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }))}
-            ref={linkRef}
-        >
-            {children}
-        </a>
+const Link: React.FC<LinkProps> = ({
+    children,
+    className,
+    linkAs,
+    linkRef,
+    color,
+    colorVariant,
+    ...forwardedProps
+}) => {
+    return renderLink(
+        {
+            linkAs,
+            ...forwardedProps,
+            className: classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant })),
+            ref: linkRef,
+        },
+        children,
     );
 };
 Link.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/list/ListItem.stories.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.stories.tsx
@@ -26,3 +26,12 @@ export const Sizes = ({ theme }: any) => (
         {text('text', 'Text')}
     </ListItem>
 );
+
+const CustomLink: React.FC = ({ children, ...props }) =>
+    React.createElement('a', { ...props, style: { color: 'red' } }, children);
+
+export const WithCustomLink = ({ theme }: any) => (
+    <ListItem theme={theme} linkAs={CustomLink} linkProps={{ href: 'http://google.com' }}>
+        My custom link
+    </ListItem>
+);

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -7,6 +7,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
 import { ListProps, Size } from '@lumx/react';
 import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { renderLink } from '@lumx/react/utils/renderLink';
 
 /**
  *  Authorized size values.
@@ -45,6 +46,9 @@ interface ListItemProps extends GenericProps {
 
     /** List item reference. */
     listItemRef?: Ref<HTMLLIElement>;
+
+    /** Sets a custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
 
     /** props that will be passed on to the Link */
     linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
@@ -97,6 +101,7 @@ const ListItem: React.FC<ListItemProps> = (props) => {
         size = DEFAULT_PROPS.size,
         onItemSelected,
         before,
+        linkAs,
         linkProps = {},
         linkRef,
         listItemRef,
@@ -126,23 +131,25 @@ const ListItem: React.FC<ListItemProps> = (props) => {
         >
             {isClickable(props) ? (
                 /* Clickable list item */
-                <a
-                    {...linkProps}
-                    className={classNames(
-                        handleBasicClasses({
-                            prefix: `${CLASSNAME}__link`,
-                            isHighlighted,
-                            isSelected,
-                        }),
-                    )}
-                    onClick={onItemSelected}
-                    onKeyDown={onKeyDown}
-                    ref={linkRef}
-                    role={onItemSelected ? 'button' : undefined}
-                    tabIndex={0}
-                >
-                    {content}
-                </a>
+                renderLink(
+                    {
+                        linkAs,
+                        ...linkProps,
+                        className: classNames(
+                            handleBasicClasses({
+                                prefix: `${CLASSNAME}__link`,
+                                isHighlighted,
+                                isSelected,
+                            }),
+                        ),
+                        onClick: onItemSelected,
+                        onKeyDown,
+                        ref: linkRef,
+                        role: onItemSelected ? 'button' : undefined,
+                        tabIndex: 0,
+                    },
+                    content,
+                )
             ) : (
                 /* Non clickable list item */
                 <div className={`${CLASSNAME}__wrapper`}>{content}</div>

--- a/packages/lumx-react/src/components/list/__snapshots__/ListItem.test.tsx.snap
+++ b/packages/lumx-react/src/components/list/__snapshots__/ListItem.test.tsx.snap
@@ -67,3 +67,21 @@ exports[`<ListItem> Snapshots and structure should render story Sizes 1`] = `
   </div>
 </li>
 `;
+
+exports[`<ListItem> Snapshots and structure should render story WithCustomLink 1`] = `
+<li
+  className="lumx-list-item lumx-list-item--size-regular"
+>
+  <CustomLink
+    className="lumx-list-item__link"
+    href="http://google.com"
+    tabIndex={0}
+  >
+    <div
+      className="lumx-list-item__content"
+    >
+      My custom link
+    </div>
+  </CustomLink>
+</li>
+`;

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
@@ -5,6 +5,9 @@ import { Emphasis, SideNavigation, SideNavigationItem } from '@lumx/react';
 
 export default { title: 'LumX components/side-navigation/Side Navigation' };
 
+const CustomLink: React.FC = ({ children, ...props }) =>
+    React.createElement('a', { ...props, style: { color: 'red' } }, children);
+
 export const sideNavigation = () => (
     <SideNavigation>
         <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
@@ -21,8 +24,9 @@ export const sideNavigation = () => (
             linkProps={{ href: 'https://www.google.com/not-visited' }}
         />
         <SideNavigationItem
-            label="Navigation item"
+            label="Navigation item (custom link)"
             emphasis={Emphasis.low}
+            linkAs={CustomLink}
             linkProps={{ href: 'https://www.google.com/not-visited-1' }}
         />
         <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -16,6 +16,8 @@ import {
     isComponent,
     onEnterPressed,
 } from '@lumx/react/utils';
+import { renderLink } from '@lumx/react/utils/renderLink';
+
 import { IconButton } from '../button/IconButton';
 
 /**
@@ -39,6 +41,9 @@ interface SideNavigationItemProps extends GenericProps {
 
     /** Whether or not the menu is selected. */
     isSelected?: boolean;
+
+    /** Sets a custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
 
     /** props that will be passed on to the Link */
     linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
@@ -78,6 +83,7 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
         icon,
         isOpen = DEFAULT_PROPS.isOpen,
         isSelected = DEFAULT_PROPS.isSelected,
+        linkAs,
         linkProps,
         onClick,
         onActionClick,
@@ -103,10 +109,17 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
         >
             {shouldSplitActions ? (
                 <div className={`${CLASSNAME}__wrapper`}>
-                    <a {...(linkProps || {})} className={`${CLASSNAME}__link`} onClick={onClick} tabIndex={0}>
-                        {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />}
-                        <span>{label}</span>
-                    </a>
+                    {renderLink(
+                        {
+                            linkAs,
+                            ...linkProps,
+                            className: `${CLASSNAME}__link`,
+                            onClick,
+                            tabIndex: 0,
+                        },
+                        icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />,
+                        <span>{label}</span>,
+                    )}
 
                     <IconButton
                         className={`${CLASSNAME}__toggle`}
@@ -117,23 +130,25 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
                     />
                 </div>
             ) : (
-                <a
-                    {...(linkProps || {})}
-                    className={`${CLASSNAME}__link`}
-                    tabIndex={0}
-                    onClick={onClick}
-                    onKeyDown={onClick ? onEnterPressed(onClick as Callback) : undefined}
-                >
-                    {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />}
-                    <span>{label}</span>
-                    {hasContent && (
+                renderLink(
+                    {
+                        linkAs,
+                        ...linkProps,
+                        className: `${CLASSNAME}__link`,
+                        tabIndex: 0,
+                        onClick,
+                        onKeyDown: onClick ? onEnterPressed(onClick as Callback) : undefined,
+                    },
+                    icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />,
+                    <span>{label}</span>,
+                    hasContent && (
                         <Icon
                             className={`${CLASSNAME}__chevron`}
                             icon={isOpen ? mdiChevronUp : mdiChevronDown}
                             size={Size.xs}
                         />
-                    )}
-                </a>
+                    ),
+                )
             )}
 
             {hasContent && isOpen && <ul className={`${CLASSNAME}__children`}>{content}</ul>}

--- a/packages/lumx-react/src/utils/renderLink.tsx
+++ b/packages/lumx-react/src/utils/renderLink.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * Render link with default <a> HTML component or a custom one provided by `linkAs`.
+ *
+ * Can be used to inject the `Link` component from `react-router` and provide better a11y on LumX components.
+ *
+ * @param linkAs    Custom link component.
+ * @param children  Link children.
+ * @return          A link.
+ */
+export const renderLink = ({ linkAs, ...forwardedProps }: any, ...children: any) =>
+    React.createElement(linkAs || 'a', forwardedProps, ...children);


### PR DESCRIPTION
Having `<a>` internallized in our components makes it difficult to implement good a11y with frontend routed link (i.e. using `Link` component from `react-router`).

This PR adds a `linkAs` prop on `SideNavigationItem`, `ListItem` and `Link` to customize the link component.

This can be used with `react-router` like this:
```jsx
<Link linkAs={ReactRouter.Link} to="/" ... >
<ListItem linkAs={ReactRouter.Link} linkProps={{ to: '/' }} ... >
<SubNavigationItem linkAs={ReactRouter.Link} linkProps={{ to: '/' }} ... >
```