### PR TITLE
fix(mosaic): add contain mode in some cases for mosaic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Upgrade to mdi v5.6.55 and handle backward compatibility.
+-   On `Mosaic` component, change the default behavior for vertical images when at first position to contain mode instead of cover.
 -   _[BREAKING]_ `lumx-has-divider` mixin now accepts a position constant as second parameter (`lumx-base-const('position', 'TOP|RIGHT|BOTTOM|LEFT')`).
 
 ## [0.25.16][] - 2020-09-16

--- a/packages/lumx-core/src/scss/components/mosaic/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/mosaic/lumapps/_index.scss
@@ -16,8 +16,8 @@
         bottom: -1px;
         left: -1px;
         display: grid;
-        /* Safari hack to make the mosaic fit the height of the parent */
-        height: stretch;
+        height: 100%;
+        background-color: lumx-color-variant('dark', 'L6');
 
         #{$self}--has-1-thumbnail & {
             grid-template-areas: 'b';
@@ -99,6 +99,15 @@
 
             &:nth-child(4) {
                 grid-area: s43;
+            }
+        }
+
+        &--is-contain-mode {
+            img {
+                top: 0 !important;
+                min-width: auto !important;
+                height: 100% !important;
+                margin: auto;
             }
         }
     }

--- a/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
@@ -15,6 +15,16 @@ export const oneThumbnail = ({ theme }: any) => {
     );
 };
 
+export const oneVerticalThumbnail = ({ theme }: any) => {
+    const wrapperStyle = { width: 250 };
+
+    return (
+        <div style={wrapperStyle}>
+            <Mosaic theme={theme} thumbnails={[{ url: 'https://picsum.photos/100/150' }]} />
+        </div>
+    );
+};
+
 export const twoThumbnails = ({ theme }: any) => {
     const wrapperStyle = { width: 250 };
 
@@ -28,6 +38,18 @@ export const twoThumbnails = ({ theme }: any) => {
     );
 };
 
+export const twoVerticalThumbnails = ({ theme }: any) => {
+    const wrapperStyle = { width: 250 };
+
+    return (
+        <div style={wrapperStyle}>
+            <Mosaic
+                theme={theme}
+                thumbnails={[{ url: 'https://picsum.photos/100/150' }, { url: 'https://picsum.photos/100/160' }]}
+            />
+        </div>
+    );
+};
 export const threeThumbnails = ({ theme }: any) => {
     const wrapperStyle = { width: 250 };
 
@@ -39,6 +61,23 @@ export const threeThumbnails = ({ theme }: any) => {
                     { url: 'https://picsum.photos/200' },
                     { url: 'https://picsum.photos/210' },
                     { url: 'https://picsum.photos/220' },
+                ]}
+            />
+        </div>
+    );
+};
+
+export const threeVerticalThumbnails = ({ theme }: any) => {
+    const wrapperStyle = { width: 250 };
+
+    return (
+        <div style={wrapperStyle}>
+            <Mosaic
+                theme={theme}
+                thumbnails={[
+                    { url: 'https://picsum.photos/100/150' },
+                    { url: 'https://picsum.photos/100/160' },
+                    { url: 'https://picsum.photos/100/170' },
                 ]}
             />
         </div>
@@ -57,6 +96,24 @@ export const fourThumbnails = ({ theme }: any) => {
                     { url: 'https://picsum.photos/210' },
                     { url: 'https://picsum.photos/220' },
                     { url: 'https://picsum.photos/230' },
+                ]}
+            />
+        </div>
+    );
+};
+
+export const fourVerticalThumbnails = ({ theme }: any) => {
+    const wrapperStyle = { width: 250 };
+
+    return (
+        <div style={wrapperStyle}>
+            <Mosaic
+                theme={theme}
+                thumbnails={[
+                    { url: 'https://picsum.photos/100/150' },
+                    { url: 'https://picsum.photos/100/160' },
+                    { url: 'https://picsum.photos/100/170' },
+                    { url: 'https://picsum.photos/100/180' },
                 ]}
             />
         </div>

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { AspectRatio, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
+import { useBooleanState } from '@lumx/react/hooks';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import take from 'lodash/take';
@@ -40,47 +41,67 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 const DEFAULT_PROPS: DefaultPropsType = {
     theme: Theme.light,
 };
-const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme, thumbnails, ...forwardedProps }) => (
-    <div
-        {...forwardedProps}
-        className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }), {
-            [`${CLASSNAME}--has-1-thumbnail`]: thumbnails?.length === 1,
-            [`${CLASSNAME}--has-2-thumbnails`]: thumbnails?.length === 2,
-            [`${CLASSNAME}--has-3-thumbnails`]: thumbnails?.length === 3,
-            [`${CLASSNAME}--has-4-thumbnails`]: thumbnails?.length >= 4,
-        })}
-    >
-        <div className={`${CLASSNAME}__wrapper`}>
-            {take(thumbnails, 4).map(({ url, image, onClick, ...thumbnail }, index) => {
-                const handleClick = () => {
-                    if (onClick) {
-                        onClick(index);
-                    }
-                };
 
-                return (
-                    <div key={index} className={`${CLASSNAME}__thumbnail`}>
-                        <Thumbnail
-                            {...thumbnail}
-                            theme={theme}
-                            image={image ?? url}
-                            aspectRatio={AspectRatio.free}
-                            fillHeight
-                            tabIndex={onClick && '0'}
-                            onClick={handleClick}
-                        />
-
-                        {thumbnails.length > 4 && index === 3 && (
-                            <div className={`${CLASSNAME}__overlay`}>
-                                <span>+{thumbnails.length - 4}</span>
-                            </div>
-                        )}
-                    </div>
-                );
+const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme, thumbnails, ...forwardedProps }) => {
+    return (
+        <div
+            {...forwardedProps}
+            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }), {
+                [`${CLASSNAME}--has-1-thumbnail`]: thumbnails?.length === 1,
+                [`${CLASSNAME}--has-2-thumbnails`]: thumbnails?.length === 2,
+                [`${CLASSNAME}--has-3-thumbnails`]: thumbnails?.length === 3,
+                [`${CLASSNAME}--has-4-thumbnails`]: thumbnails?.length >= 4,
             })}
+        >
+            <div className={`${CLASSNAME}__wrapper`}>
+                {take(thumbnails, 4).map(({ url, image, onClick, ...thumbnail }, index) => {
+                    const handleClick = () => {
+                        if (onClick) {
+                            onClick(index);
+                        }
+                    };
+                    const [isVertical, setNotVertical, setVertical] = useBooleanState(true);
+                    const shouldBeInContainMode =
+                        isVertical && (index === 0 || (index === 1 && thumbnails.length === 2));
+
+                    return (
+                        <div
+                            key={index}
+                            className={classNames(`${CLASSNAME}__thumbnail`, {
+                                [`${CLASSNAME}__thumbnail--is-contain-mode`]: shouldBeInContainMode,
+                            })}
+                        >
+                            <Thumbnail
+                                {...thumbnail}
+                                theme={theme}
+                                image={image ?? url}
+                                aspectRatio={AspectRatio.free}
+                                fillHeight
+                                tabIndex={onClick && '0'}
+                                onClick={handleClick}
+                                imgProps={{
+                                    onLoad: (e) => {
+                                        if (e.currentTarget.height > e.currentTarget.width) {
+                                            setVertical();
+                                        } else {
+                                            setNotVertical();
+                                        }
+                                    },
+                                }}
+                            />
+
+                            {thumbnails.length > 4 && index === 3 && (
+                                <div className={`${CLASSNAME}__overlay`}>
+                                    <span>+{thumbnails.length - 4}</span>
+                                </div>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 Mosaic.displayName = COMPONENT_NAME;
 

--- a/packages/lumx-react/src/components/mosaic/__snapshots__/Mosaic.test.tsx.snap
+++ b/packages/lumx-react/src/components/mosaic/__snapshots__/Mosaic.test.tsx.snap
@@ -8,13 +8,18 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
     className="lumx-mosaic__wrapper"
   >
     <div
-      className="lumx-mosaic__thumbnail"
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
       key="0"
     >
       <Thumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/200"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -28,6 +33,11 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/210"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -41,6 +51,11 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/220"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -54,6 +69,11 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/230"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -71,13 +91,18 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
     className="lumx-mosaic__wrapper"
   >
     <div
-      className="lumx-mosaic__thumbnail"
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
       key="0"
     >
       <Thumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/200"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -90,6 +115,11 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/210"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -102,6 +132,11 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/220"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -114,6 +149,90 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/230"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Mosaic> Snapshots and structure should render story fourVerticalThumbnails 1`] = `
+<div
+  className="lumx-mosaic lumx-mosaic--theme-light lumx-mosaic--has-4-thumbnails"
+>
+  <div
+    className="lumx-mosaic__wrapper"
+  >
+    <div
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
+      key="0"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/150"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="1"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/160"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="2"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/170"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="3"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/180"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -130,13 +249,46 @@ exports[`<Mosaic> Snapshots and structure should render story oneThumbnail 1`] =
     className="lumx-mosaic__wrapper"
   >
     <div
-      className="lumx-mosaic__thumbnail"
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
       key="0"
     >
       <Thumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/200"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Mosaic> Snapshots and structure should render story oneVerticalThumbnail 1`] = `
+<div
+  className="lumx-mosaic lumx-mosaic--theme-light lumx-mosaic--has-1-thumbnail"
+>
+  <div
+    className="lumx-mosaic__wrapper"
+  >
+    <div
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
+      key="0"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/150"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -153,13 +305,18 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
     className="lumx-mosaic__wrapper"
   >
     <div
-      className="lumx-mosaic__thumbnail"
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
       key="0"
     >
       <Thumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/640/480/?image=24"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -173,6 +330,11 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/640/480/?image=25"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -186,6 +348,11 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/640/480/?image=26"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -199,6 +366,11 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/640/480/?image=27"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         tabIndex="0"
         theme="light"
@@ -224,13 +396,18 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
     className="lumx-mosaic__wrapper"
   >
     <div
-      className="lumx-mosaic__thumbnail"
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
       key="0"
     >
       <Thumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/200"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -243,6 +420,11 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/210"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -255,6 +437,73 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/220"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Mosaic> Snapshots and structure should render story threeVerticalThumbnails 1`] = `
+<div
+  className="lumx-mosaic lumx-mosaic--theme-light lumx-mosaic--has-3-thumbnails"
+>
+  <div
+    className="lumx-mosaic__wrapper"
+  >
+    <div
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
+      key="0"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/150"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="1"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/160"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail"
+      key="2"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/170"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
@@ -271,25 +520,80 @@ exports[`<Mosaic> Snapshots and structure should render story twoThumbnails 1`] 
     className="lumx-mosaic__wrapper"
   >
     <div
-      className="lumx-mosaic__thumbnail"
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
       key="0"
     >
       <Thumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/200"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />
     </div>
     <div
-      className="lumx-mosaic__thumbnail"
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
       key="1"
     >
       <Thumbnail
         aspectRatio="free"
         fillHeight={true}
         image="https://picsum.photos/210"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Mosaic> Snapshots and structure should render story twoVerticalThumbnails 1`] = `
+<div
+  className="lumx-mosaic lumx-mosaic--theme-light lumx-mosaic--has-2-thumbnails"
+>
+  <div
+    className="lumx-mosaic__wrapper"
+  >
+    <div
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
+      key="0"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/150"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
+        onClick={[Function]}
+        theme="light"
+      />
+    </div>
+    <div
+      className="lumx-mosaic__thumbnail lumx-mosaic__thumbnail--is-contain-mode"
+      key="1"
+    >
+      <Thumbnail
+        aspectRatio="free"
+        fillHeight={true}
+        image="https://picsum.photos/100/160"
+        imgProps={
+          Object {
+            "onLoad": [Function],
+          }
+        }
         onClick={[Function]}
         theme="light"
       />


### PR DESCRIPTION
# General summary
Vertical images were cropped in mosaic, we decided to display the first image of a mosaic IF it's vertical, in contain mode. Same for the second image in a 2 thumbnails mosaic. If more than 2 thumbnails, then only the first image is concerned.

Linked to this ticket : https://lumapps.atlassian.net/browse/LUM-12096
<!-- Please describe the PR content -->

# Screenshots
One thumbnail of a vertical image (thumbnail in contain mode):
![image](https://user-images.githubusercontent.com/10506209/95767185-ae215a00-0cb4-11eb-8dcd-89898160c5aa.png)
Two thumbnails of vertical images (the two thumbnails are in contain mode) :
![image](https://user-images.githubusercontent.com/10506209/95767277-d01adc80-0cb4-11eb-91bc-88f5f07013f1.png)
Three thumbnails of vertical images (only first thumbnail in contain mode) :
![image](https://user-images.githubusercontent.com/10506209/95767448-107a5a80-0cb5-11eb-8404-4d8a651ff542.png)
Four thumbnails of vertical images (only first thumbnail in contain mode) :
![image](https://user-images.githubusercontent.com/10506209/95767510-238d2a80-0cb5-11eb-9a4b-28975024a18e.png)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
