### PR TITLE
docs(link-preview): added theme switcher on demo

### DIFF
--- a/packages/site-demo/content/product/components/link-preview/index.mdx
+++ b/packages/site-demo/content/product/components/link-preview/index.mdx
@@ -4,7 +4,7 @@
 
 ## Default
 
-<DemoBlock demo="default" />
+<DemoBlock demo="default" withThemeSwitcher />
 
 ### Properties
 


### PR DESCRIPTION
# General summary

Added the theme switcher on the demo block to see the dark themed link-preview.

# Screenshots

![Capture d’écran 2020-10-13 à 09 08 05](https://user-images.githubusercontent.com/15898440/95827140-9c32cc00-0d33-11eb-93d3-9e4551ff44d6.png)
