### PR TITLE
docs(link): updated text and demo blocks

### DIFF
--- a/packages/site-demo/content/product/components/link/index.mdx
+++ b/packages/site-demo/content/product/components/link/index.mdx
@@ -1,14 +1,22 @@
 # Link
 
-**Display simple hyperlink**
+**Display simple hyperlinks**
 
 ## Default
 
+By default, links are in primary color. They can have an optional icon.
+
 <DemoBlock demo="default" withThemeSwitcher />
+
+## Styles and sizes
+
+Use text styles and icon sizes so that the icon height doesn’t exceed the text line height.
+
+<DemoBlock demo="sizes" withThemeSwitcher />
 
 ## Implicit
 
-Link can also be more subtle and appear as normal text (ex: articles titles in contents list widget, User name in [user-block](../user-block))
+Links can also be more subtle and appear as normal text (ex: articles titles in contents list widget, User name in [user-block](../user-block))
 
 <DemoBlock demo="implicit" withThemeSwitcher />
 

--- a/packages/site-demo/content/product/components/link/index.mdx
+++ b/packages/site-demo/content/product/components/link/index.mdx
@@ -1,4 +1,4 @@
-# Link
+# Link <ReactStabilityFlag status="unstable" />
 
 **Display simple hyperlinks**
 

--- a/packages/site-demo/content/product/components/link/react/default.tsx
+++ b/packages/site-demo/content/product/components/link/react/default.tsx
@@ -5,21 +5,15 @@ import { Alignment, ColorPalette, FlexBox, Icon, Link, Orientation, Size, Theme 
 
 const App = ({ theme }: any) => (
     <>
-        <div className="lumx-spacing-margin-bottom">
+        <div className="lumx-spacing-margin-bottom-big">
             <Link color={theme === Theme.light ? ColorPalette.primary : ColorPalette.light}>Default link</Link>
         </div>
 
-        <div className="lumx-spacing-margin-bottom">
-            <Link color={theme === Theme.light ? ColorPalette.primary : ColorPalette.light}>
-                <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
-                    <Icon icon={mdiPencil} size={Size.xs} className="lumx-spacing-margin-right-tiny" />
-                    <span>Link with an icon</span>
-                </FlexBox>
-            </Link>
-        </div>
-
         <Link color={theme === Theme.light ? ColorPalette.primary : ColorPalette.light}>
-            <span className="lumx-typography-title">Link with Title typography</span>
+            <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
+                <Icon icon={mdiPencil} size={Size.xs} className="lumx-spacing-margin-right-tiny" />
+                <span>Link with an icon</span>
+            </FlexBox>
         </Link>
     </>
 );

--- a/packages/site-demo/content/product/components/link/react/implicit.tsx
+++ b/packages/site-demo/content/product/components/link/react/implicit.tsx
@@ -5,11 +5,11 @@ import { Alignment, ColorPalette, FlexBox, Icon, Link, Orientation, Size, Theme 
 
 const App = ({ theme }: any) => (
     <>
-        <div className="lumx-spacing-margin-bottom">
+        <div className="lumx-spacing-margin-bottom-big">
             <Link color={theme === Theme.light ? ColorPalette.dark : ColorPalette.light}>Default link</Link>
         </div>
 
-        <div className="lumx-spacing-margin-bottom">
+        <div className="lumx-spacing-margin-bottom-big">
             <Link color={theme === Theme.light ? ColorPalette.dark : ColorPalette.light}>
                 <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
                     <Icon icon={mdiPencil} size={Size.xs} className="lumx-spacing-margin-right-tiny" />

--- a/packages/site-demo/content/product/components/link/react/sizes.tsx
+++ b/packages/site-demo/content/product/components/link/react/sizes.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { mdiPencil } from '@lumx/icons';
+import { Alignment, ColorPalette, FlexBox, Icon, Link, Orientation, Size, Theme } from '@lumx/react';
+
+const App = ({ theme }: any) => (
+    <>
+        <div className="lumx-spacing-margin-bottom-big">
+            <Link color={theme === Theme.light ? ColorPalette.primary : ColorPalette.light}>
+                <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
+                    <Icon icon={mdiPencil} size={Size.s} className="lumx-spacing-margin-right-tiny" />
+                    <span className="lumx-typography-title">Link with Title typography</span>
+                </FlexBox>
+            </Link>
+        </div>
+
+        <div className="lumx-spacing-margin-bottom-big">
+            <Link color={theme === Theme.light ? ColorPalette.primary : ColorPalette.light}>
+                <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
+                    <Icon icon={mdiPencil} size={Size.s} className="lumx-spacing-margin-right-tiny" />
+                    <span className="lumx-typography-subtitle2">Link with Subtitle 2 typography</span>
+                </FlexBox>
+            </Link>
+        </div>
+
+        <div className="lumx-spacing-margin-bottom-big">
+            <Link color={theme === Theme.light ? ColorPalette.primary : ColorPalette.light}>
+                <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
+                    <Icon icon={mdiPencil} size={Size.xs} className="lumx-spacing-margin-right-tiny" />
+                    <span className="lumx-typography-body1">Link with Body 1 typography</span>
+                </FlexBox>
+            </Link>
+        </div>
+
+        <Link color={theme === Theme.light ? ColorPalette.primary : ColorPalette.light}>
+            <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
+                <Icon icon={mdiPencil} size={Size.xxs} className="lumx-spacing-margin-right-tiny" />
+                <span className="lumx-typography-caption">Link with Caption typography</span>
+            </FlexBox>
+        </Link>
+    </>
+);
+
+export default App;


### PR DESCRIPTION
# General summary

Fixed text, added icon size explanation

# Screenshots

![Capture d’écran 2020-10-13 à 18 04 15](https://user-images.githubusercontent.com/15898440/95886190-90b8c280-0d7e-11eb-8ab8-eeee351d32b7.png)
