### PR TITLE
chore: upgrade to mdi 5.8.55 and handle backward compatibility LUM-12974

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added component `SlideshowControls` to control a slideshow from the outside
 -   Add `linkAs` prop on `Button` and `IconButton` to customize the link component (can be used to inject the `Link` component from `react-router`).
+-   Make it possible to override `tabIndex` and `role` props of `ListItem.linkProps`.
+
+### Fixed
+
+-   Fixed page freeze when trying to use keyboard navigation on `List` component that has custom children.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ The alternative text is now required (`alt` prop in `Thumbnail`, `thumbnails[].alt` in `Mosaic`, `alt` in `ImageBlock`, `thumbnailProps.alt` in `PostBlock` and `thumbnailProps.alt` in `LinkPreview`).
 -   _[BREAKING]_ The title is now required in `ImageBlock`.
 -   _[BREAKING]_ Reworked Thumbnail CORS default. `crossOrigin` now default to `undefined` instead of `'anonymous'`. `isCrossOriginEnabled` prop was removed (use `crossOrigin={undefined}` instead).
+-   _[BREAKING]_ Upgrade to mdi v5.8.55 and handle backward compatibility (see [details]([./packages/lumx-icons/README-v4-to-v5-migration.md])).
 
 ### Removed
 
@@ -143,11 +144,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added component `SlideshowControls` to control a slideshow from the outside
 -   Add `linkAs` prop on `Button` and `IconButton` to customize the link component (can be used to inject the `Link` component from `react-router`).
--   Make it possible to override `tabIndex` and `role` props of `ListItem.linkProps`.
-
-### Fixed
-
--   Fixed page freeze when trying to use keyboard navigation on `List` component that has custom children.
 
 ### Changed
 

--- a/packages/lumx-icons/README-v4-to-v5-migration.md
+++ b/packages/lumx-icons/README-v4-to-v5-migration.md
@@ -1,0 +1,18 @@
+
+# @lumx/icons migration from @mdi v4 to v5
+
+Starting with LumX v1, the @lumx/icons lib now uses material design icon v5.
+To ease the migration, we managed to alias old icon names to new icon names when possible.
+
+However, some icons could not be aliases and seem to be very uncommon so can still encounter breaking change when
+updating to LumX v1.
+
+The list of deleted icons: `square-inc-cash`, `behance`, `slackware`, `quicktime`, `shopify`, `strava`, `houzz`, `glassdoor`,
+`beats`, `venmo`, `etsy`, `dribbble-box`, `accusoft`, `lyft`, `mixcloud`, `paypal`, `language-python-text`,
+`pinterest-box`, `wunderlist`, `vk-box`, `vk-circle`, `yelp`, `adchoices`, `mixer`, `tumblr-box`, `tumblr`, `uber`,
+`google-adwords`, `basecamp`, `google-physical-web`, `medium`, `meetup`, `flickr`, `mail-ru`, `houzz-box`, `itunes`,
+`instapaper`, `lastfm`, `amazon-drive`, `blackberry`, `dribbble`, `xing`, `xing-circle`, `steam-box`,
+`mastodon-variant`, `maxcdn`, `flattr`, `eventbrite`, `xda`, `google-pages`, `disqus-outline`,
+`android-head`, `pocket`, `periscope`, `xing-box`, `foursquare`
+
+The script used to generate the SCSS and JS icon aliases from V4 to V5: [mdi-v4-to-v5.js](https://gist.github.com/gcornut/5ffa16f1d09d00eedad1c9ab92c26d59)

--- a/packages/lumx-icons/font.scss
+++ b/packages/lumx-icons/font.scss
@@ -1,3 +1,4 @@
 $mdi-font-path: '~@mdi/font/fonts';
 
 @import '~@mdi/font/scss/materialdesignicons';
+@import './v4-to-v5-aliases';

--- a/packages/lumx-icons/index.d.ts
+++ b/packages/lumx-icons/index.d.ts
@@ -1,1 +1,3 @@
 export * from '@mdi/js';
+
+export * from './v4-to-v5-aliases';

--- a/packages/lumx-icons/index.js
+++ b/packages/lumx-icons/index.js
@@ -1,1 +1,3 @@
 export * from '@mdi/js';
+
+export * from './v4-to-v5-aliases';

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -4,8 +4,8 @@
         "url": "https://github.com/lumapps/design-system/issues"
     },
     "dependencies": {
-        "@mdi/font": "4.2.95",
-        "@mdi/js": "4.2.95"
+        "@mdi/font": "5.8.55",
+        "@mdi/js": "5.8.55"
     },
     "description": "LumX icons",
     "engines": {

--- a/packages/lumx-icons/v4-to-v5-aliases.d.ts
+++ b/packages/lumx-icons/v4-to-v5-aliases.d.ts
@@ -1,0 +1,262 @@
+export declare const mdiCowboy: string;
+
+export declare const mdiWorker: string;
+
+export declare const mdiArtist: string;
+
+export declare const mdiArtistOutline: string;
+
+export declare const mdiVoice: string;
+
+export declare const mdiAirplay: string;
+
+export declare const mdiAccountBadge: string;
+
+export declare const mdiAccountBadgeAlert: string;
+
+export declare const mdiAccountBadgeAlertOutline: string;
+
+export declare const mdiAccountBadgeHorizontal: string;
+
+export declare const mdiAccountBadgeHorizontalOutline: string;
+
+export declare const mdiAccountBadgeOutline: string;
+
+export declare const mdiHotel: string;
+
+export declare const mdiDictionary: string;
+
+export declare const mdiBible: string;
+
+export declare const mdiAudiobook: string;
+
+export declare const mdiBookOpenVariant: string;
+
+export declare const mdiSquareInc: string;
+
+export declare const mdiBowl: string;
+
+export declare const mdiCalendarRepeat: string;
+
+export declare const mdiCalendarRepeatOutline: string;
+
+export declare const mdiAccountCardDetails: string;
+
+export declare const mdiAccountCardDetailsOutline: string;
+
+export declare const mdiGithubBox: string;
+
+export declare const mdiGithubFace: string;
+
+export declare const mdiContactMail: string;
+
+export declare const mdiContactMailOutline: string;
+
+export declare const mdiContactPhone: string;
+
+export declare const mdiContactPhoneOutline: string;
+
+export declare const mdiCellphoneSettingsVariant: string;
+
+export declare const mdiCoins: string;
+
+export declare const mdiTor: string;
+
+export declare const mdiJson: string;
+
+export declare const mdiSettings: string;
+
+export declare const mdiSettingsBox: string;
+
+export declare const mdiSettingsOutline: string;
+
+export declare const mdiSettingsTransfer: string;
+
+export declare const mdiSettingsTransferOutline: string;
+
+export declare const mdiCoinOutline: string;
+
+export declare const mdiDatabaseRefresh: string;
+
+export declare const mdiFileSettingsVariant: string;
+
+export declare const mdiFileSettingsVariantOutline: string;
+
+export declare const mdiLibraryBooks: string;
+
+export declare const mdiLibraryMovie: string;
+
+export declare const mdiFolderSettingsVariant: string;
+
+export declare const mdiFolderSettingsVariantOutline: string;
+
+export declare const mdiTumblrReblog: string;
+
+export declare const mdiTextarea: string;
+
+export declare const mdiTextbox: string;
+
+export declare const mdiTextboxPassword: string;
+
+export declare const mdiGithubCircle: string;
+
+export declare const mdiNfcOff: string;
+
+export declare const mdiImageFilter: string;
+
+export declare const mdiMarkdown: string;
+
+export declare const mdiMarkdownOutline: string;
+
+export declare const mdiRuby: string;
+
+export declare const mdiXaml: string;
+
+export declare const mdiMessageSettingsVariant: string;
+
+export declare const mdiAzure: string;
+
+export declare const mdiAzureDevops: string;
+
+export declare const mdiBing: string;
+
+export declare const mdiMicrosoftDynamics: string;
+
+export declare const mdiEdge: string;
+
+export declare const mdiInternetExplorer: string;
+
+export declare const mdiOffice: string;
+
+export declare const mdiOnedrive: string;
+
+export declare const mdiOnenote: string;
+
+export declare const mdiOutlook: string;
+
+export declare const mdiVisualStudio: string;
+
+export declare const mdiVisualStudioCode: string;
+
+export declare const mdiWindows: string;
+
+export declare const mdiWindowsClassic: string;
+
+export declare const mdiXbox: string;
+
+export declare const mdiXboxController: string;
+
+export declare const mdiXboxControllerBatteryAlert: string;
+
+export declare const mdiXboxControllerBatteryCharging: string;
+
+export declare const mdiXboxControllerBatteryEmpty: string;
+
+export declare const mdiXboxControllerBatteryFull: string;
+
+export declare const mdiXboxControllerBatteryLow: string;
+
+export declare const mdiXboxControllerBatteryMedium: string;
+
+export declare const mdiXboxControllerBatteryUnknown: string;
+
+export declare const mdiXboxControllerMenu: string;
+
+export declare const mdiXboxControllerOff: string;
+
+export declare const mdiXboxControllerView: string;
+
+export declare const mdiYammer: string;
+
+export declare const mdiPeriodicTableCo2: string;
+
+export declare const mdiLibraryMusic: string;
+
+export declare const mdiLibraryMusicOutline: string;
+
+export declare const mdiWii: string;
+
+export declare const mdiWiiu: string;
+
+export declare const mdiFacebookBox: string;
+
+export declare const mdiGooglePlusBox: string;
+
+export declare const mdiNpmVariant: string;
+
+export declare const mdiNpmVariantOutline: string;
+
+export declare const mdiTwitterBox: string;
+
+export declare const mdiTwitterCircle: string;
+
+export declare const mdiLibraryVideo: string;
+
+export declare const mdiPot: string;
+
+export declare const mdiCiscoWebex: string;
+
+export declare const mdiNetworkRouter: string;
+
+export declare const mdiSailing: string;
+
+export declare const mdiCurrentAc: string;
+
+export declare const mdiPlaystation: string;
+
+export declare const mdiSortAlphabetical: string;
+
+export declare const mdiSortNumeric: string;
+
+export declare const mdiStarHalf: string;
+
+export declare const mdiSticker: string;
+
+export declare const mdiStorefront: string;
+
+export declare const mdiFileDocumentBox: string;
+
+export declare const mdiFileDocumentBoxCheck: string;
+
+export declare const mdiFileDocumentBoxCheckOutline: string;
+
+export declare const mdiFileDocumentBoxMinus: string;
+
+export declare const mdiFileDocumentBoxMinusOutline: string;
+
+export declare const mdiFileDocumentBoxMultiple: string;
+
+export declare const mdiFileDocumentBoxMultipleOutline: string;
+
+export declare const mdiFileDocumentBoxOutline: string;
+
+export declare const mdiFileDocumentBoxPlus: string;
+
+export declare const mdiFileDocumentBoxPlusOutline: string;
+
+export declare const mdiFileDocumentBoxRemove: string;
+
+export declare const mdiFileDocumentBoxRemoveOutline: string;
+
+export declare const mdiFileDocumentBoxSearch: string;
+
+export declare const mdiFileDocumentBoxSearchOutline: string;
+
+export declare const mdiTimerOff: string;
+
+export declare const mdiTimer: string;
+
+export declare const mdiTowing: string;
+
+export declare const mdiCamcorderBox: string;
+
+export declare const mdiCamcorderBoxOff: string;
+
+export declare const mdiWallSconceVariant: string;
+
+export declare const mdiHackernews: string;
+
+export declare const mdiYoutubeCreatorStudio: string;
+
+export declare const mdiLinkedinBox: string;
+

--- a/packages/lumx-icons/v4-to-v5-aliases.js
+++ b/packages/lumx-icons/v4-to-v5-aliases.js
@@ -1,0 +1,394 @@
+import {
+    mdiAccountCowboyHat,
+    mdiAccountHardHat,
+    mdiAccountMusic,
+    mdiAccountMusicOutline,
+    mdiAccountVoice,
+    mdiAppleAirplay,
+    mdiBadgeAccount,
+    mdiBadgeAccountAlert,
+    mdiBadgeAccountAlertOutline,
+    mdiBadgeAccountHorizontal,
+    mdiBadgeAccountHorizontalOutline,
+    mdiBadgeAccountOutline,
+    mdiBed,
+    mdiBookAlphabet,
+    mdiBookCross,
+    mdiBookMusic,
+    mdiBookOpenBlankVariant,
+    mdiBookRemoveMultipleOutline,
+    mdiBowlMix,
+    mdiCalendarSync,
+    mdiCalendarSyncOutline,
+    mdiCardAccountDetails,
+    mdiCardAccountDetailsOutline,
+    mdiCardAccountDetailsStar,
+    mdiCardAccountDetailsStarOutline,
+    mdiCardAccountMail,
+    mdiCardAccountMailOutline,
+    mdiCardAccountPhone,
+    mdiCardAccountPhoneOutline,
+    mdiCellphoneCog,
+    mdiCircleMultipleOutline,
+    mdiCloudRefresh,
+    mdiCodeJson,
+    mdiCog,
+    mdiCogBox,
+    mdiCogOutline,
+    mdiCogTransfer,
+    mdiCogTransferOutline,
+    mdiCurrencyUsdCircleOutline,
+    mdiDatabaseSync,
+    mdiFileCog,
+    mdiFileCogOutline,
+    mdiFilmstripBox,
+    mdiFilmstripBoxMultiple,
+    mdiFolderCog,
+    mdiFolderCogOutline,
+    mdiFolderRefreshOutline,
+    mdiFormTextarea,
+    mdiFormTextbox,
+    mdiFormTextboxPassword,
+    mdiGithub,
+    mdiIceCreamOff,
+    mdiImageMultipleOutline,
+    mdiLanguageMarkdown,
+    mdiLanguageMarkdownOutline,
+    mdiLanguageRuby,
+    mdiLanguageXaml,
+    mdiMessageCog,
+    mdiMicrosoftAzure,
+    mdiMicrosoftAzureDevops,
+    mdiMicrosoftBing,
+    mdiMicrosoftDynamics365,
+    mdiMicrosoftEdge,
+    mdiMicrosoftInternetExplorer,
+    mdiMicrosoftOffice,
+    mdiMicrosoftOnedrive,
+    mdiMicrosoftOnenote,
+    mdiMicrosoftOutlook,
+    mdiMicrosoftVisualStudio,
+    mdiMicrosoftVisualStudioCode,
+    mdiMicrosoftWindows,
+    mdiMicrosoftWindowsClassic,
+    mdiMicrosoftXbox,
+    mdiMicrosoftXboxController,
+    mdiMicrosoftXboxControllerBatteryAlert,
+    mdiMicrosoftXboxControllerBatteryCharging,
+    mdiMicrosoftXboxControllerBatteryEmpty,
+    mdiMicrosoftXboxControllerBatteryFull,
+    mdiMicrosoftXboxControllerBatteryLow,
+    mdiMicrosoftXboxControllerBatteryMedium,
+    mdiMicrosoftXboxControllerBatteryUnknown,
+    mdiMicrosoftXboxControllerMenu,
+    mdiMicrosoftXboxControllerOff,
+    mdiMicrosoftXboxControllerView,
+    mdiMicrosoftYammer,
+    mdiMoleculeCo2,
+    mdiMusicBoxMultiple,
+    mdiMusicBoxMultipleOutline,
+    mdiNintendoWii,
+    mdiNintendoWiiu,
+    mdiFacebook,
+    mdiGooglePlus,
+    mdiNpm,
+    mdiTwitter,
+    mdiPlayBoxMultiple,
+    mdiPotSteam,
+    mdiRollerSkateOff,
+    mdiRouterNetwork,
+    mdiSailBoat,
+    mdiSineWave,
+    mdiSonyPlaystation,
+    mdiSortAlphabeticalVariant,
+    mdiSortNumericVariant,
+    mdiStarHalfFull,
+    mdiStickerCircleOutline,
+    mdiStorefrontOutline,
+    mdiTextBox,
+    mdiTextBoxCheck,
+    mdiTextBoxCheckOutline,
+    mdiTextBoxMinus,
+    mdiTextBoxMinusOutline,
+    mdiTextBoxMultiple,
+    mdiTextBoxMultipleOutline,
+    mdiTextBoxOutline,
+    mdiTextBoxPlus,
+    mdiTextBoxPlusOutline,
+    mdiTextBoxRemove,
+    mdiTextBoxRemoveOutline,
+    mdiTextBoxSearch,
+    mdiTextBoxSearchOutline,
+    mdiTimerOffOutline,
+    mdiTimerOutline,
+    mdiTowTruck,
+    mdiVideoBox,
+    mdiVideoBoxOff,
+    mdiWallSconceRoundVariant,
+    mdiYCombinator,
+    mdiYoutubeStudio,
+    mdiLinkedin,
+} from '@mdi/js';
+
+export const mdiCowboy = mdiAccountCowboyHat;
+
+export const mdiWorker = mdiAccountHardHat;
+
+export const mdiArtist = mdiAccountMusic;
+
+export const mdiArtistOutline = mdiAccountMusicOutline;
+
+export const mdiVoice = mdiAccountVoice;
+
+export const mdiAirplay = mdiAppleAirplay;
+
+export const mdiAccountBadge = mdiBadgeAccount;
+
+export const mdiAccountBadgeAlert = mdiBadgeAccountAlert;
+
+export const mdiAccountBadgeAlertOutline = mdiBadgeAccountAlertOutline;
+
+export const mdiAccountBadgeHorizontal = mdiBadgeAccountHorizontal;
+
+export const mdiAccountBadgeHorizontalOutline = mdiBadgeAccountHorizontalOutline;
+
+export const mdiAccountBadgeOutline = mdiBadgeAccountOutline;
+
+export const mdiHotel = mdiBed;
+
+export const mdiDictionary = mdiBookAlphabet;
+
+export const mdiBible = mdiBookCross;
+
+export const mdiAudiobook = mdiBookMusic;
+
+export const mdiBookOpenVariant = mdiBookOpenBlankVariant;
+
+export const mdiSquareInc = mdiBookRemoveMultipleOutline;
+
+export const mdiBowl = mdiBowlMix;
+
+export const mdiCalendarRepeat = mdiCalendarSync;
+
+export const mdiCalendarRepeatOutline = mdiCalendarSyncOutline;
+
+export const mdiAccountCardDetails = mdiCardAccountDetails;
+
+export const mdiAccountCardDetailsOutline = mdiCardAccountDetailsOutline;
+
+export const mdiGithubBox = mdiCardAccountDetailsStar;
+
+export const mdiGithubFace = mdiCardAccountDetailsStarOutline;
+
+export const mdiContactMail = mdiCardAccountMail;
+
+export const mdiContactMailOutline = mdiCardAccountMailOutline;
+
+export const mdiContactPhone = mdiCardAccountPhone;
+
+export const mdiContactPhoneOutline = mdiCardAccountPhoneOutline;
+
+export const mdiCellphoneSettingsVariant = mdiCellphoneCog;
+
+export const mdiCoins = mdiCircleMultipleOutline;
+
+export const mdiTor = mdiCloudRefresh;
+
+export const mdiJson = mdiCodeJson;
+
+export const mdiSettings = mdiCog;
+
+export const mdiSettingsBox = mdiCogBox;
+
+export const mdiSettingsOutline = mdiCogOutline;
+
+export const mdiSettingsTransfer = mdiCogTransfer;
+
+export const mdiSettingsTransferOutline = mdiCogTransferOutline;
+
+export const mdiCoinOutline = mdiCurrencyUsdCircleOutline;
+
+export const mdiDatabaseRefresh = mdiDatabaseSync;
+
+export const mdiFileSettingsVariant = mdiFileCog;
+
+export const mdiFileSettingsVariantOutline = mdiFileCogOutline;
+
+export const mdiLibraryBooks = mdiFilmstripBox;
+
+export const mdiLibraryMovie = mdiFilmstripBoxMultiple;
+
+export const mdiFolderSettingsVariant = mdiFolderCog;
+
+export const mdiFolderSettingsVariantOutline = mdiFolderCogOutline;
+
+export const mdiTumblrReblog = mdiFolderRefreshOutline;
+
+export const mdiTextarea = mdiFormTextarea;
+
+export const mdiTextbox = mdiFormTextbox;
+
+export const mdiTextboxPassword = mdiFormTextboxPassword;
+
+export const mdiGithubCircle = mdiGithub;
+
+export const mdiNfcOff = mdiIceCreamOff;
+
+export const mdiImageFilter = mdiImageMultipleOutline;
+
+export const mdiMarkdown = mdiLanguageMarkdown;
+
+export const mdiMarkdownOutline = mdiLanguageMarkdownOutline;
+
+export const mdiRuby = mdiLanguageRuby;
+
+export const mdiXaml = mdiLanguageXaml;
+
+export const mdiMessageSettingsVariant = mdiMessageCog;
+
+export const mdiAzure = mdiMicrosoftAzure;
+
+export const mdiAzureDevops = mdiMicrosoftAzureDevops;
+
+export const mdiBing = mdiMicrosoftBing;
+
+export const mdiMicrosoftDynamics = mdiMicrosoftDynamics365;
+
+export const mdiEdge = mdiMicrosoftEdge;
+
+export const mdiInternetExplorer = mdiMicrosoftInternetExplorer;
+
+export const mdiOffice = mdiMicrosoftOffice;
+
+export const mdiOnedrive = mdiMicrosoftOnedrive;
+
+export const mdiOnenote = mdiMicrosoftOnenote;
+
+export const mdiOutlook = mdiMicrosoftOutlook;
+
+export const mdiVisualStudio = mdiMicrosoftVisualStudio;
+
+export const mdiVisualStudioCode = mdiMicrosoftVisualStudioCode;
+
+export const mdiWindows = mdiMicrosoftWindows;
+
+export const mdiWindowsClassic = mdiMicrosoftWindowsClassic;
+
+export const mdiXbox = mdiMicrosoftXbox;
+
+export const mdiXboxController = mdiMicrosoftXboxController;
+
+export const mdiXboxControllerBatteryAlert = mdiMicrosoftXboxControllerBatteryAlert;
+
+export const mdiXboxControllerBatteryCharging = mdiMicrosoftXboxControllerBatteryCharging;
+
+export const mdiXboxControllerBatteryEmpty = mdiMicrosoftXboxControllerBatteryEmpty;
+
+export const mdiXboxControllerBatteryFull = mdiMicrosoftXboxControllerBatteryFull;
+
+export const mdiXboxControllerBatteryLow = mdiMicrosoftXboxControllerBatteryLow;
+
+export const mdiXboxControllerBatteryMedium = mdiMicrosoftXboxControllerBatteryMedium;
+
+export const mdiXboxControllerBatteryUnknown = mdiMicrosoftXboxControllerBatteryUnknown;
+
+export const mdiXboxControllerMenu = mdiMicrosoftXboxControllerMenu;
+
+export const mdiXboxControllerOff = mdiMicrosoftXboxControllerOff;
+
+export const mdiXboxControllerView = mdiMicrosoftXboxControllerView;
+
+export const mdiYammer = mdiMicrosoftYammer;
+
+export const mdiPeriodicTableCo2 = mdiMoleculeCo2;
+
+export const mdiLibraryMusic = mdiMusicBoxMultiple;
+
+export const mdiLibraryMusicOutline = mdiMusicBoxMultipleOutline;
+
+export const mdiWii = mdiNintendoWii;
+
+export const mdiWiiu = mdiNintendoWiiu;
+
+export const mdiFacebookBox = mdiFacebook;
+
+export const mdiGooglePlusBox = mdiGooglePlus;
+
+export const mdiNpmVariant = mdiNpm;
+
+export const mdiNpmVariantOutline = mdiNpm;
+
+export const mdiTwitterBox = mdiTwitter;
+
+export const mdiTwitterCircle = mdiTwitter;
+
+export const mdiLibraryVideo = mdiPlayBoxMultiple;
+
+export const mdiPot = mdiPotSteam;
+
+export const mdiCiscoWebex = mdiRollerSkateOff;
+
+export const mdiNetworkRouter = mdiRouterNetwork;
+
+export const mdiSailing = mdiSailBoat;
+
+export const mdiCurrentAc = mdiSineWave;
+
+export const mdiPlaystation = mdiSonyPlaystation;
+
+export const mdiSortAlphabetical = mdiSortAlphabeticalVariant;
+
+export const mdiSortNumeric = mdiSortNumericVariant;
+
+export const mdiStarHalf = mdiStarHalfFull;
+
+export const mdiSticker = mdiStickerCircleOutline;
+
+export const mdiStorefront = mdiStorefrontOutline;
+
+export const mdiFileDocumentBox = mdiTextBox;
+
+export const mdiFileDocumentBoxCheck = mdiTextBoxCheck;
+
+export const mdiFileDocumentBoxCheckOutline = mdiTextBoxCheckOutline;
+
+export const mdiFileDocumentBoxMinus = mdiTextBoxMinus;
+
+export const mdiFileDocumentBoxMinusOutline = mdiTextBoxMinusOutline;
+
+export const mdiFileDocumentBoxMultiple = mdiTextBoxMultiple;
+
+export const mdiFileDocumentBoxMultipleOutline = mdiTextBoxMultipleOutline;
+
+export const mdiFileDocumentBoxOutline = mdiTextBoxOutline;
+
+export const mdiFileDocumentBoxPlus = mdiTextBoxPlus;
+
+export const mdiFileDocumentBoxPlusOutline = mdiTextBoxPlusOutline;
+
+export const mdiFileDocumentBoxRemove = mdiTextBoxRemove;
+
+export const mdiFileDocumentBoxRemoveOutline = mdiTextBoxRemoveOutline;
+
+export const mdiFileDocumentBoxSearch = mdiTextBoxSearch;
+
+export const mdiFileDocumentBoxSearchOutline = mdiTextBoxSearchOutline;
+
+export const mdiTimerOff = mdiTimerOffOutline;
+
+export const mdiTimer = mdiTimerOutline;
+
+export const mdiTowing = mdiTowTruck;
+
+export const mdiCamcorderBox = mdiVideoBox;
+
+export const mdiCamcorderBoxOff = mdiVideoBoxOff;
+
+export const mdiWallSconceVariant = mdiWallSconceRoundVariant;
+
+export const mdiHackernews = mdiYCombinator;
+
+export const mdiYoutubeCreatorStudio = mdiYoutubeStudio;
+
+export const mdiLinkedinBox = mdiLinkedin;
+

--- a/packages/lumx-icons/v4-to-v5-aliases.scss
+++ b/packages/lumx-icons/v4-to-v5-aliases.scss
@@ -1,0 +1,518 @@
+.mdi-cowboy {
+    @extend .mdi-account-cowboy-hat;
+}
+
+.mdi-worker {
+    @extend .mdi-account-hard-hat;
+}
+
+.mdi-artist {
+    @extend .mdi-account-music;
+}
+
+.mdi-artist-outline {
+    @extend .mdi-account-music-outline;
+}
+
+.mdi-voice {
+    @extend .mdi-account-voice;
+}
+
+.mdi-airplay {
+    @extend .mdi-apple-airplay;
+}
+
+.mdi-account-badge {
+    @extend .mdi-badge-account;
+}
+
+.mdi-account-badge-alert {
+    @extend .mdi-badge-account-alert;
+}
+
+.mdi-account-badge-alert-outline {
+    @extend .mdi-badge-account-alert-outline;
+}
+
+.mdi-account-badge-horizontal {
+    @extend .mdi-badge-account-horizontal;
+}
+
+.mdi-account-badge-horizontal-outline {
+    @extend .mdi-badge-account-horizontal-outline;
+}
+
+.mdi-account-badge-outline {
+    @extend .mdi-badge-account-outline;
+}
+
+.mdi-hotel {
+    @extend .mdi-bed;
+}
+
+.mdi-dictionary {
+    @extend .mdi-book-alphabet;
+}
+
+.mdi-bible {
+    @extend .mdi-book-cross;
+}
+
+.mdi-audiobook {
+    @extend .mdi-book-music;
+}
+
+.mdi-book-open-variant {
+    @extend .mdi-book-open-blank-variant;
+}
+
+.mdi-square-inc {
+    @extend .mdi-book-remove-multiple-outline;
+}
+
+.mdi-bowl {
+    @extend .mdi-bowl-mix;
+}
+
+.mdi-calendar-repeat {
+    @extend .mdi-calendar-sync;
+}
+
+.mdi-calendar-repeat-outline {
+    @extend .mdi-calendar-sync-outline;
+}
+
+.mdi-account-card-details {
+    @extend .mdi-card-account-details;
+}
+
+.mdi-account-card-details-outline {
+    @extend .mdi-card-account-details-outline;
+}
+
+.mdi-github-box {
+    @extend .mdi-card-account-details-star;
+}
+
+.mdi-github-face {
+    @extend .mdi-card-account-details-star-outline;
+}
+
+.mdi-contact-mail {
+    @extend .mdi-card-account-mail;
+}
+
+.mdi-contact-mail-outline {
+    @extend .mdi-card-account-mail-outline;
+}
+
+.mdi-contact-phone {
+    @extend .mdi-card-account-phone;
+}
+
+.mdi-contact-phone-outline {
+    @extend .mdi-card-account-phone-outline;
+}
+
+.mdi-cellphone-settings-variant {
+    @extend .mdi-cellphone-cog;
+}
+
+.mdi-coins {
+    @extend .mdi-circle-multiple-outline;
+}
+
+.mdi-tor {
+    @extend .mdi-cloud-refresh;
+}
+
+.mdi-json {
+    @extend .mdi-code-json;
+}
+
+.mdi-settings {
+    @extend .mdi-cog;
+}
+
+.mdi-settings-box {
+    @extend .mdi-cog-box;
+}
+
+.mdi-settings-outline {
+    @extend .mdi-cog-outline;
+}
+
+.mdi-settings-transfer {
+    @extend .mdi-cog-transfer;
+}
+
+.mdi-settings-transfer-outline {
+    @extend .mdi-cog-transfer-outline;
+}
+
+.mdi-coin-outline {
+    @extend .mdi-currency-usd-circle-outline;
+}
+
+.mdi-database-refresh {
+    @extend .mdi-database-sync;
+}
+
+.mdi-file-settings-variant {
+    @extend .mdi-file-cog;
+}
+
+.mdi-file-settings-variant-outline {
+    @extend .mdi-file-cog-outline;
+}
+
+.mdi-library-books {
+    @extend .mdi-filmstrip-box;
+}
+
+.mdi-library-movie {
+    @extend .mdi-filmstrip-box-multiple;
+}
+
+.mdi-folder-settings-variant {
+    @extend .mdi-folder-cog;
+}
+
+.mdi-folder-settings-variant-outline {
+    @extend .mdi-folder-cog-outline;
+}
+
+.mdi-tumblr-reblog {
+    @extend .mdi-folder-refresh-outline;
+}
+
+.mdi-textarea {
+    @extend .mdi-form-textarea;
+}
+
+.mdi-textbox {
+    @extend .mdi-form-textbox;
+}
+
+.mdi-textbox-password {
+    @extend .mdi-form-textbox-password;
+}
+
+.mdi-github-circle {
+    @extend .mdi-github;
+}
+
+.mdi-nfc-off {
+    @extend .mdi-ice-cream-off;
+}
+
+.mdi-image-filter {
+    @extend .mdi-image-multiple-outline;
+}
+
+.mdi-markdown {
+    @extend .mdi-language-markdown;
+}
+
+.mdi-markdown-outline {
+    @extend .mdi-language-markdown-outline;
+}
+
+.mdi-ruby {
+    @extend .mdi-language-ruby;
+}
+
+.mdi-xaml {
+    @extend .mdi-language-xaml;
+}
+
+.mdi-message-settings-variant {
+    @extend .mdi-message-cog;
+}
+
+.mdi-azure {
+    @extend .mdi-microsoft-azure;
+}
+
+.mdi-azure-devops {
+    @extend .mdi-microsoft-azure-devops;
+}
+
+.mdi-bing {
+    @extend .mdi-microsoft-bing;
+}
+
+.mdi-microsoft-dynamics {
+    @extend .mdi-microsoft-dynamics-365;
+}
+
+.mdi-edge {
+    @extend .mdi-microsoft-edge;
+}
+
+.mdi-internet-explorer {
+    @extend .mdi-microsoft-internet-explorer;
+}
+
+.mdi-office {
+    @extend .mdi-microsoft-office;
+}
+
+.mdi-onedrive {
+    @extend .mdi-microsoft-onedrive;
+}
+
+.mdi-onenote {
+    @extend .mdi-microsoft-onenote;
+}
+
+.mdi-outlook {
+    @extend .mdi-microsoft-outlook;
+}
+
+.mdi-visual-studio {
+    @extend .mdi-microsoft-visual-studio;
+}
+
+.mdi-visual-studio-code {
+    @extend .mdi-microsoft-visual-studio-code;
+}
+
+.mdi-windows {
+    @extend .mdi-microsoft-windows;
+}
+
+.mdi-windows-classic {
+    @extend .mdi-microsoft-windows-classic;
+}
+
+.mdi-xbox {
+    @extend .mdi-microsoft-xbox;
+}
+
+.mdi-xbox-controller {
+    @extend .mdi-microsoft-xbox-controller;
+}
+
+.mdi-xbox-controller-battery-alert {
+    @extend .mdi-microsoft-xbox-controller-battery-alert;
+}
+
+.mdi-xbox-controller-battery-charging {
+    @extend .mdi-microsoft-xbox-controller-battery-charging;
+}
+
+.mdi-xbox-controller-battery-empty {
+    @extend .mdi-microsoft-xbox-controller-battery-empty;
+}
+
+.mdi-xbox-controller-battery-full {
+    @extend .mdi-microsoft-xbox-controller-battery-full;
+}
+
+.mdi-xbox-controller-battery-low {
+    @extend .mdi-microsoft-xbox-controller-battery-low;
+}
+
+.mdi-xbox-controller-battery-medium {
+    @extend .mdi-microsoft-xbox-controller-battery-medium;
+}
+
+.mdi-xbox-controller-battery-unknown {
+    @extend .mdi-microsoft-xbox-controller-battery-unknown;
+}
+
+.mdi-xbox-controller-menu {
+    @extend .mdi-microsoft-xbox-controller-menu;
+}
+
+.mdi-xbox-controller-off {
+    @extend .mdi-microsoft-xbox-controller-off;
+}
+
+.mdi-xbox-controller-view {
+    @extend .mdi-microsoft-xbox-controller-view;
+}
+
+.mdi-yammer {
+    @extend .mdi-microsoft-yammer;
+}
+
+.mdi-periodic-table-co2 {
+    @extend .mdi-molecule-co2;
+}
+
+.mdi-library-music {
+    @extend .mdi-music-box-multiple;
+}
+
+.mdi-library-music-outline {
+    @extend .mdi-music-box-multiple-outline;
+}
+
+.mdi-wii {
+    @extend .mdi-nintendo-wii;
+}
+
+.mdi-wiiu {
+    @extend .mdi-nintendo-wiiu;
+}
+
+.mdi-facebook-box {
+    @extend .mdi-facebook;
+}
+
+.mdi-google-plus-box {
+    @extend .mdi-google-plus;
+}
+
+.mdi-npm-variant,
+.mdi-npm-variant-outline {
+    @extend .mdi-npm;
+}
+
+.mdi-twitter-box,
+.mdi-twitter-circle {
+    @extend .mdi-twitter;
+}
+
+.mdi-library-video {
+    @extend .mdi-play-box-multiple;
+}
+
+.mdi-pot {
+    @extend .mdi-pot-steam;
+}
+
+.mdi-cisco-webex {
+    @extend .mdi-roller-skate-off;
+}
+
+.mdi-network-router {
+    @extend .mdi-router-network;
+}
+
+.mdi-sailing {
+    @extend .mdi-sail-boat;
+}
+
+.mdi-current-ac {
+    @extend .mdi-sine-wave;
+}
+
+.mdi-playstation {
+    @extend .mdi-sony-playstation;
+}
+
+.mdi-sort-alphabetical {
+    @extend .mdi-sort-alphabetical-variant;
+}
+
+.mdi-sort-numeric {
+    @extend .mdi-sort-numeric-variant;
+}
+
+.mdi-star-half {
+    @extend .mdi-star-half-full;
+}
+
+.mdi-sticker {
+    @extend .mdi-sticker-circle-outline;
+}
+
+.mdi-storefront {
+    @extend .mdi-storefront-outline;
+}
+
+.mdi-file-document-box {
+    @extend .mdi-text-box;
+}
+
+.mdi-file-document-box-check {
+    @extend .mdi-text-box-check;
+}
+
+.mdi-file-document-box-check-outline {
+    @extend .mdi-text-box-check-outline;
+}
+
+.mdi-file-document-box-minus {
+    @extend .mdi-text-box-minus;
+}
+
+.mdi-file-document-box-minus-outline {
+    @extend .mdi-text-box-minus-outline;
+}
+
+.mdi-file-document-box-multiple {
+    @extend .mdi-text-box-multiple;
+}
+
+.mdi-file-document-box-multiple-outline {
+    @extend .mdi-text-box-multiple-outline;
+}
+
+.mdi-file-document-box-outline {
+    @extend .mdi-text-box-outline;
+}
+
+.mdi-file-document-box-plus {
+    @extend .mdi-text-box-plus;
+}
+
+.mdi-file-document-box-plus-outline {
+    @extend .mdi-text-box-plus-outline;
+}
+
+.mdi-file-document-box-remove {
+    @extend .mdi-text-box-remove;
+}
+
+.mdi-file-document-box-remove-outline {
+    @extend .mdi-text-box-remove-outline;
+}
+
+.mdi-file-document-box-search {
+    @extend .mdi-text-box-search;
+}
+
+.mdi-file-document-box-search-outline {
+    @extend .mdi-text-box-search-outline;
+}
+
+.mdi-timer-off {
+    @extend .mdi-timer-off-outline;
+}
+
+.mdi-timer {
+    @extend .mdi-timer-outline;
+}
+
+.mdi-towing {
+    @extend .mdi-tow-truck;
+}
+
+.mdi-camcorder-box {
+    @extend .mdi-video-box;
+}
+
+.mdi-camcorder-box-off {
+    @extend .mdi-video-box-off;
+}
+
+.mdi-wall-sconce-variant {
+    @extend .mdi-wall-sconce-round-variant;
+}
+
+.mdi-hackernews {
+    @extend .mdi-y-combinator;
+}
+
+.mdi-youtube-creator-studio {
+    @extend .mdi-youtube-studio;
+}
+
+.mdi-linkedin-box {
+    @extend .mdi-linkedin;
+}
+

--- a/packages/site-demo/content/product/components/uploader/react/default.tsx
+++ b/packages/site-demo/content/product/components/uploader/react/default.tsx
@@ -1,5 +1,5 @@
-import { mdiFileDocumentBoxPlus } from '@lumx/icons';
+import { mdiTextBoxPlus } from '@lumx/icons';
 import { Uploader } from '@lumx/react';
 import React from 'react';
 
-export const App = ({ theme }: any) => <Uploader icon={mdiFileDocumentBoxPlus} label="Add files" theme={theme} />;
+export const App = ({ theme }: any) => <Uploader icon={mdiTextBoxPlus} label="Add files" theme={theme} />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,15 +4423,15 @@
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.0.0.tgz#733a122382749d27e2e46ec38f8c71c9d53a9636"
   integrity sha512-ruuGHsnabmObBdeMg3vKdGRmh06Oog3eFpf/Tk6X0kDSJDpJTDCj2dqdp1+0VjzIUgHlFF9GBm7uFqfYhhdX9g==
 
-"@mdi/font@4.2.95":
-  version "4.2.95"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-4.2.95.tgz#7fd524746979a37dc7c3fd7a9f9cea1bf58205ba"
-  integrity sha512-pCJ9hR8yQH1tMk6KTZYfJsZkI/XQ1rR9Fe/q50ATDDVUoDk7Wl7n9WqT6dYWn0mnCLgrTQl/WNjyrnTo5rKu+A==
+"@mdi/font@5.8.55":
+  version "5.8.55"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.8.55.tgz#1464155bcbc8a6e4af6dffd611fe8e38e09af285"
+  integrity sha512-8mrwfFBsmj+D67ZiGQSe5TU/lcWCtDyli2eshQ2fvLCZGRPqFMM23YQp4+JMOTpk5yMZKTeAwNWIYfITy76OHA==
 
-"@mdi/js@4.2.95":
-  version "4.2.95"
-  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-4.2.95.tgz#c920083f64873fe6cd721b15c23061c71d47811d"
-  integrity sha512-3qqOZx2HkrQEUc9fr5MiQWlokwmO8TK5bQZ2EP1Rg0q2Q507jy+fUeL8lb9ko2ossYqoPnugIr7jI0/O7uhlrA==
+"@mdi/js@5.8.55":
+  version "5.8.55"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-5.8.55.tgz#630bc5fafd8b1d2f6e63489a9ab170177559e41b"
+  integrity sha512-2bvln56SW6V/nSDC/0/NTu1bMF/CgSyZox8mcWbAPWElBN3UYIrukKDUckEER8ifr8X2YJl1RLKQqi7T7qLzmg==
 
 "@mdx-js/mdx@^1.6.19":
   version "1.6.19"


### PR DESCRIPTION
# General summary

Upgrade `mdi` to 5.6.55 and handle backward compatibility.
`mdi` has been upgraded to v5x first in [v0.26.0](https://github.com/lumapps/design-system/releases/tag/v0.26.0) but then downgraded back to v4x in [v0.26.1](https://github.com/lumapps/design-system/releases/tag/v0.26.1) for stability purpose.

To remember when upgrading into LumApps product:

mdiFacebookBox (to remove from icon picker)
mdiGithubFace (to remove from icon picker)
mdiLinkedinBox (to remove from icon picker)
mdiTwitterBox (to remove from icon picker)
mdiGooglePlusBox (don't exists anymore)

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
