### PR TITLE
docs(link-preview): added big size docs

### DIFF
--- a/packages/site-demo/content/product/components/link-preview/index.mdx
+++ b/packages/site-demo/content/product/components/link-preview/index.mdx
@@ -1,13 +1,15 @@
-# Link preview
+# Link preview <ReactStabilityFlag status="unstable" />
 
 **Link previews display an hyperlink related info and image.**
 
 ## Regular size
+
 Use `regular` size by default.
 
 <DemoBlock demo="default" withThemeSwitcher />
 
 ## Big size
+
 Use `big` size to give more emphasis to the displayed hyperlink, make sure to have a good quality image.
 
 <DemoBlock demo="big" withThemeSwitcher />

--- a/packages/site-demo/content/product/components/link-preview/index.mdx
+++ b/packages/site-demo/content/product/components/link-preview/index.mdx
@@ -2,9 +2,15 @@
 
 **Link previews display an hyperlink related info and image.**
 
-## Default
+## Regular size
+Use `regular` size by default.
 
 <DemoBlock demo="default" withThemeSwitcher />
+
+## Big size
+Use `big` size to give more emphasis to the displayed hyperlink, make sure to have a good quality image.
+
+<DemoBlock demo="big" withThemeSwitcher />
 
 ### Properties
 

--- a/packages/site-demo/content/product/components/link-preview/react/big.tsx
+++ b/packages/site-demo/content/product/components/link-preview/react/big.tsx
@@ -4,14 +4,16 @@ import { LinkPreview, Size } from '@lumx/react';
 
 const App = ({ theme }: any) => {
     return (
-        <LinkPreview
-            title={'Link title'}
-            description={'Description'}
-            url={'https://google.com'}
-            size={Size.big}
-            theme={theme}
-            thumbnail={'https://picsum.photos/320/240'}
-        />
+        <div style={{ width: 350, margin: '0 auto' }}>
+            <LinkPreview
+                title={'Link title'}
+                description={'Description'}
+                url={'https://google.com'}
+                size={Size.big}
+                theme={theme}
+                thumbnail={'https://picsum.photos/320/240'}
+            />
+        </div>
     );
 };
 

--- a/packages/site-demo/content/product/components/link-preview/react/big.tsx
+++ b/packages/site-demo/content/product/components/link-preview/react/big.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { LinkPreview, Size } from '@lumx/react';
+
+const App = ({ theme }: any) => {
+    return (
+        <LinkPreview
+            title={'Link title'}
+            description={'Description'}
+            url={'https://google.com'}
+            size={Size.big}
+            theme={theme}
+            thumbnail={'https://picsum.photos/320/240'}
+        />
+    );
+};
+
+export default App;


### PR DESCRIPTION
# General summary

Changed text and added demo for the size `big`

# Screenshots

<img width="548" alt="Capture d’écran 2020-10-14 à 16 59 02" src="https://user-images.githubusercontent.com/15898440/96007256-970e7380-0e3e-11eb-8230-dcae626ac8fc.png">
