### PR TITLE
refactor(default-props): use native React `defaultProps` system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `Link` prop type is now more permissive to accommodate for alternative components injected in `linkAs`.
 -   Add `linkAs` prop on `Button` and `IconButton` to customize the link component (can be used to inject the `Link` component from `react-router`).
+-   Expose component default props in React's `Component.defaultProps`
 
 ## [0.26.1][] - 2020-10-14
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -188,7 +188,6 @@ const DEFAULT_PROPS: Partial<AutocompleteProps> = {
     anchorToInput: false,
     closeOnClickAway: true,
     closeOnEscape: true,
-    isOpen: undefined,
     shouldFocusOnClose: false,
 };
 
@@ -201,7 +200,7 @@ const DEFAULT_PROPS: Partial<AutocompleteProps> = {
  */
 const Autocomplete: React.FC<AutocompleteProps> = (props) => {
     const {
-        anchorToInput = DEFAULT_PROPS.anchorToInput,
+        anchorToInput,
         className,
         children,
         chips,
@@ -225,7 +224,7 @@ const Autocomplete: React.FC<AutocompleteProps> = (props) => {
         theme,
         onClose,
         offset,
-        shouldFocusOnClose = DEFAULT_PROPS.shouldFocusOnClose,
+        shouldFocusOnClose,
         placement,
         inputRef = useRef(null),
         fitToAnchorWidth,
@@ -285,5 +284,6 @@ const Autocomplete: React.FC<AutocompleteProps> = (props) => {
     );
 };
 Autocomplete.displayName = COMPONENT_NAME;
+Autocomplete.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Autocomplete, AutocompleteProps };
+export { CLASSNAME, Autocomplete, AutocompleteProps };

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
@@ -84,7 +84,7 @@ const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props) => {
         children,
         chipsAlignment,
         value,
-        values = DEFAULT_PROPS.values,
+        values,
         onBlur,
         onChange,
         onFocus,
@@ -110,7 +110,7 @@ const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props) => {
         fitToAnchorWidth,
         shouldFocusOnClose,
         onInfiniteScroll,
-        selectedChipRender = DEFAULT_PROPS.selectedChipRender,
+        selectedChipRender,
         ...forwardedProps
     } = props;
 
@@ -161,5 +161,6 @@ const AutocompleteMultiple: React.FC<AutocompleteMultipleProps> = (props) => {
     );
 };
 AutocompleteMultiple.displayName = COMPONENT_NAME;
+AutocompleteMultiple.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, AutocompleteMultiple, AutocompleteMultipleProps };
+export { CLASSNAME, AutocompleteMultiple, AutocompleteMultipleProps };

--- a/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -16,6 +16,8 @@ exports[`<Autocomplete> Props should render correctly when the dropdown is close
         "current": null,
       }
     }
+    theme="light"
+    type="text"
     value=""
   />
   <Dropdown
@@ -24,7 +26,13 @@ exports[`<Autocomplete> Props should render correctly when the dropdown is close
         "current": null,
       }
     }
+    closeOnClick={true}
+    closeOnClickAway={true}
+    closeOnEscape={true}
+    fitToAnchorWidth={true}
+    fitWithinViewportHeight={true}
     isOpen={false}
+    placement="bottom-start"
     shouldFocusOnOpen={false}
   >
     <List
@@ -115,6 +123,8 @@ exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
         "current": null,
       }
     }
+    theme="light"
+    type="text"
     value=""
   />
   <Dropdown
@@ -123,7 +133,13 @@ exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
         "current": null,
       }
     }
+    closeOnClick={true}
+    closeOnClickAway={true}
+    closeOnEscape={true}
+    fitToAnchorWidth={true}
+    fitWithinViewportHeight={true}
     isOpen={true}
+    placement="bottom-start"
     shouldFocusOnOpen={false}
   >
     <List

--- a/packages/lumx-react/src/components/autocomplete/__snapshots__/AutocompleteMultiple.test.tsx.snap
+++ b/packages/lumx-react/src/components/autocomplete/__snapshots__/AutocompleteMultiple.test.tsx.snap
@@ -2,11 +2,19 @@
 
 exports[`<AutocompleteMultiple> Snapshots and structure should render correctly 1`] = `
 <Autocomplete
-  chips={<ChipGroup />}
+  anchorToInput={false}
+  chips={
+    <ChipGroup
+      align="left"
+    />
+  }
   className="lumx-autocomplete-multiple"
   closeOnClick={false}
+  closeOnClickAway={true}
+  closeOnEscape={true}
   isOpen={true}
   onChange={[MockFunction]}
+  shouldFocusOnClose={false}
   value=""
 >
   <List

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -31,11 +31,6 @@ interface AvatarProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<AvatarProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Avatar`;
@@ -48,9 +43,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    actions: undefined,
-    badge: undefined,
+const DEFAULT_PROPS: Partial<AvatarProps> = {
     size: Size.m,
     theme: Theme.light,
 };
@@ -60,15 +53,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
  *
  * @return The component.
  */
-const Avatar: React.FC<AvatarProps> = ({
-    actions = DEFAULT_PROPS.actions,
-    badge = DEFAULT_PROPS.badge,
-    className,
-    size = DEFAULT_PROPS.size,
-    theme = DEFAULT_PROPS.theme,
-    image,
-    ...forwardedProps
-}) => {
+const Avatar: React.FC<AvatarProps> = ({ actions, badge, className, size, theme, image, ...forwardedProps }) => {
     const style: CSSProperties = {
         backgroundImage: `url(${image})`,
     };
@@ -87,5 +72,6 @@ const Avatar: React.FC<AvatarProps> = ({
     );
 };
 Avatar.displayName = COMPONENT_NAME;
+Avatar.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Avatar, AvatarProps, AvatarSize };
+export { CLASSNAME, Avatar, AvatarProps, AvatarSize };

--- a/packages/lumx-react/src/components/avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/lumx-react/src/components/avatar/__snapshots__/Avatar.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`<Avatar> Snapshots and structure should render story avatarWithActions 
           hasBackground={true}
           icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
           size="s"
+          theme="light"
         />
       </div>
       <div
@@ -40,6 +41,7 @@ exports[`<Avatar> Snapshots and structure should render story avatarWithActions 
           hasBackground={true}
           icon="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
           size="s"
+          theme="light"
         />
       </div>
       <div>
@@ -49,6 +51,7 @@ exports[`<Avatar> Snapshots and structure should render story avatarWithActions 
           hasBackground={true}
           icon="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"
           size="s"
+          theme="light"
         />
       </div>
     </div>

--- a/packages/lumx-react/src/components/badge/Badge.test.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.test.tsx
@@ -7,7 +7,9 @@ import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/util
 import { getBasicClass } from '@lumx/react/utils';
 
 import { Theme } from '@lumx/react';
-import { Badge, BadgeProps, CLASSNAME, DEFAULT_PROPS } from './Badge';
+import { Badge, BadgeProps, CLASSNAME } from './Badge';
+
+const DEFAULT_PROPS = Badge.defaultProps as any;
 
 /**
  * Defines what the `setup` function will return.

--- a/packages/lumx-react/src/components/badge/Badge.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.tsx
@@ -36,7 +36,7 @@ const DEFAULT_PROPS: BadgeProps = {
     color: ColorPalette.light,
 };
 
-const Badge: React.FC<BadgeProps> = ({ color = DEFAULT_PROPS.color, className, ...forwardedProps }) => {
+const Badge: React.FC<BadgeProps> = ({ color, className, ...forwardedProps }) => {
     return (
         <div {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color }))}>
             {forwardedProps.children}
@@ -45,5 +45,6 @@ const Badge: React.FC<BadgeProps> = ({ color = DEFAULT_PROPS.color, className, .
 };
 
 Badge.displayName = COMPONENT_NAME;
+Badge.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Badge, BadgeProps };
+export { CLASSNAME, Badge, BadgeProps };

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -1,11 +1,12 @@
 import { mdiSend } from '@lumx/icons';
 
 import { Button, ColorPalette, Emphasis, Size } from '@lumx/react';
-import { DEFAULT_PROPS } from '@lumx/react/components/button/Button';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
 export default { title: 'LumX components/button/Button' };
+
+const DEFAULT_PROPS = Button.defaultProps as any;
 
 export const simpleButton = ({ theme }: any) => {
     return (

--- a/packages/lumx-react/src/components/button/Button.test.tsx
+++ b/packages/lumx-react/src/components/button/Button.test.tsx
@@ -6,7 +6,9 @@ import 'jest-enzyme';
 import { mdiCheck, mdiChevronDown, mdiPlus } from '@lumx/icons';
 import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
 import { getBasicClass } from '@lumx/react/utils';
-import { Button, ButtonProps, CLASSNAME, DEFAULT_PROPS } from './Button';
+import { Button, ButtonProps, CLASSNAME } from './Button';
+
+const DEFAULT_PROPS = Button.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/button/Button.tsx
+++ b/packages/lumx-react/src/components/button/Button.tsx
@@ -37,11 +37,6 @@ interface ButtonProps extends BaseButtonProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ButtonProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Button`;
@@ -54,7 +49,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ButtonProps> = {
     emphasis: Emphasis.high,
     size: Size.m,
     theme: Theme.light,
@@ -68,16 +63,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return The component.
  */
 const Button: React.FC<ButtonProps> = (props) => {
-    const {
-        className,
-        children,
-        emphasis = DEFAULT_PROPS.emphasis,
-        leftIcon,
-        rightIcon,
-        size = DEFAULT_PROPS.size,
-        theme = DEFAULT_PROPS.theme,
-        ...forwardedProps
-    } = props;
+    const { className, children, emphasis, leftIcon, rightIcon, size, theme, ...forwardedProps } = props;
 
     const buttonClassName = classNames(
         className,
@@ -94,5 +80,6 @@ const Button: React.FC<ButtonProps> = (props) => {
     );
 };
 Button.displayName = COMPONENT_NAME;
+Button.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, ButtonEmphasis, Button, ButtonProps };
+export { CLASSNAME, ButtonEmphasis, Button, ButtonProps };

--- a/packages/lumx-react/src/components/button/ButtonGroup.tsx
+++ b/packages/lumx-react/src/components/button/ButtonGroup.tsx
@@ -13,11 +13,6 @@ interface ButtonGroupProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ButtonGroupProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}ButtonGroup`;
@@ -30,7 +25,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<ButtonGroupProps> = {};
 
 /**
  * Displays a group of <Button>s.
@@ -45,5 +40,6 @@ const ButtonGroup: React.FC<ButtonGroupProps> = ({ children, className, buttonGr
     </div>
 );
 ButtonGroup.displayName = COMPONENT_NAME;
+ButtonGroup.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, ButtonGroup, ButtonGroupProps };
+export { CLASSNAME, ButtonGroup, ButtonGroupProps };

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -181,5 +181,6 @@ const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
     );
 };
 ButtonRoot.displayName = COMPONENT_NAME;
+ButtonRoot.defaultProps = {};
 
 export { BUTTON_CLASSNAME, BUTTON_WRAPPER_CLASSNAME, BaseButtonProps, ButtonRootProps, ButtonRoot };

--- a/packages/lumx-react/src/components/button/IconButton.test.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.test.tsx
@@ -4,7 +4,9 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
-import { CLASSNAME, DEFAULT_PROPS, IconButton, IconButtonProps } from './IconButton';
+import { CLASSNAME, IconButton, IconButtonProps } from './IconButton';
+
+const DEFAULT_PROPS = IconButton.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -17,11 +17,6 @@ interface IconButtonProps extends BaseButtonProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<IconButtonProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}IconButton`;
@@ -34,7 +29,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<IconButtonProps> = {
     emphasis: Emphasis.high,
     size: Size.m,
     theme: Theme.light,
@@ -47,13 +42,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return The component.
  */
 const IconButton: React.FC<IconButtonProps> = (props) => {
-    const {
-        emphasis = DEFAULT_PROPS.emphasis,
-        icon,
-        size = DEFAULT_PROPS.size,
-        theme = DEFAULT_PROPS.theme,
-        ...forwardedProps
-    } = props;
+    const { emphasis, icon, size, theme, ...forwardedProps } = props;
 
     return (
         <ButtonRoot {...{ emphasis, size, theme, ...forwardedProps }} variant="icon">
@@ -62,5 +51,6 @@ const IconButton: React.FC<IconButtonProps> = (props) => {
     );
 };
 IconButton.displayName = COMPONENT_NAME;
+IconButton.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, IconButton, IconButtonProps };
+export { CLASSNAME, IconButton, IconButtonProps };

--- a/packages/lumx-react/src/components/button/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/ButtonGroup.test.tsx.snap
@@ -4,11 +4,18 @@ exports[`<ButtonGroup> Snapshots and structure should render correctly a group b
 <div
   className="lumx-button-group"
 >
-  <Button>
+  <Button
+    emphasis="high"
+    size="m"
+    theme="light"
+  >
     Label
   </Button>
   <IconButton
+    emphasis="high"
     icon="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+    size="m"
+    theme="light"
   />
 </div>
 `;

--- a/packages/lumx-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.tsx
@@ -36,11 +36,6 @@ interface CheckboxProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<CheckboxProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Checkbox`;
@@ -53,8 +48,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    disabled: false,
+const DEFAULT_PROPS: Partial<CheckboxProps> = {
     theme: Theme.light,
     value: false,
 };
@@ -66,14 +60,14 @@ const DEFAULT_PROPS: DefaultPropsType = {
  */
 const Checkbox: React.FC<CheckboxProps> = ({
     className,
-    disabled = DEFAULT_PROPS.disabled,
+    disabled,
     helper,
     id,
     label,
     onChange,
-    theme = DEFAULT_PROPS.theme,
+    theme,
     useCustomColors,
-    value = DEFAULT_PROPS.value,
+    value,
     ...forwardedProps
 }) => {
     const inputId = id || uniqueId(`${CLASSNAME.toLowerCase()}-`);
@@ -131,5 +125,6 @@ const Checkbox: React.FC<CheckboxProps> = ({
     );
 };
 Checkbox.displayName = COMPONENT_NAME;
+Checkbox.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Checkbox, CheckboxProps };
+export { CLASSNAME, Checkbox, CheckboxProps };

--- a/packages/lumx-react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/lumx-react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`<Checkbox> Props should use the given props 1`] = `
     </InputLabel>
     <InputHelper
       className="lumx-checkbox__helper"
+      kind="info"
       theme="light"
     >
       Test helper

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -47,11 +47,6 @@ interface ChipProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ChipProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Chip`;
@@ -64,11 +59,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    isClickable: false,
-    isDisabled: false,
-    isHighlighted: false,
-    isSelected: false,
+const DEFAULT_PROPS: Partial<ChipProps> = {
     size: Size.m,
     theme: Theme.light,
 };
@@ -111,8 +102,8 @@ const Chip: React.FC<ChipProps> = ({
     onAfterClick,
     onBeforeClick,
     onClick,
-    size = DEFAULT_PROPS.size,
-    theme = DEFAULT_PROPS.theme,
+    size,
+    theme,
     useCustomColors,
     chipRef,
     ...forwardedProps
@@ -180,5 +171,6 @@ const Chip: React.FC<ChipProps> = ({
 };
 
 Chip.displayName = COMPONENT_NAME;
+Chip.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Chip, ChipProps };
+export { CLASSNAME, Chip, ChipProps };

--- a/packages/lumx-react/src/components/chip/ChipGroup.tsx
+++ b/packages/lumx-react/src/components/chip/ChipGroup.tsx
@@ -1,3 +1,4 @@
+import { Alignment } from '@lumx/react/components';
 import React from 'react';
 
 import classNames from 'classnames';
@@ -20,15 +21,10 @@ interface ChipGroupProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ChipGroupProps> {}
-
-/**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    align: 'left',
+const DEFAULT_PROPS: Partial<ChipGroupProps> = {
+    align: Alignment.left,
 };
 
 /**
@@ -49,12 +45,7 @@ interface ChipGroup {
  * Displays a list of Chips in a grouped fashion.
  * @return The Chip Group component.
  */
-const ChipGroup: React.FC<ChipGroupProps> & ChipGroup = ({
-    className,
-    align = DEFAULT_PROPS.align,
-    children,
-    ...forwardedProps
-}) => {
+const ChipGroup: React.FC<ChipGroupProps> & ChipGroup = ({ className, align, children, ...forwardedProps }) => {
     const chipGroupClassName = handleBasicClasses({
         align,
         prefix: CLASSNAME,
@@ -68,6 +59,7 @@ const ChipGroup: React.FC<ChipGroupProps> & ChipGroup = ({
 };
 
 ChipGroup.displayName = COMPONENT_NAME;
+ChipGroup.defaultProps = DEFAULT_PROPS;
 ChipGroup.useChipGroupNavigation = useChipGroupNavigation;
 
 export { CLASSNAME, ChipGroup, ChipGroupProps };

--- a/packages/lumx-react/src/components/chip/__snapshots__/ChipGroup.test.tsx.snap
+++ b/packages/lumx-react/src/components/chip/__snapshots__/ChipGroup.test.tsx.snap
@@ -6,16 +6,22 @@ exports[`<ChipGroup /> Snapshot should render correctly Chip Group component 1`]
 >
   <Chip
     key="1"
+    size="m"
+    theme="light"
   >
     Chip 1
   </Chip>
   <Chip
     key="2"
+    size="m"
+    theme="light"
   >
     Chip 2
   </Chip>
   <Chip
     key="3"
+    size="m"
+    theme="light"
   >
     Chip 3
   </Chip>

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -45,11 +45,6 @@ interface CommentBlockProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<CommentBlockProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}CommentBlock`;
@@ -62,12 +57,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    hasActions: false,
-    hasChildren: false,
-    hasIndentedChildren: false,
-    isOpen: false,
-    isRelevant: false,
+const DEFAULT_PROPS: Partial<CommentBlockProps> = {
     theme: Theme.light,
 };
 
@@ -82,16 +72,16 @@ const CommentBlock: React.FC<CommentBlockProps> = ({
     children,
     date,
     hasActions,
-    hasChildren = DEFAULT_PROPS.hasChildren,
-    hasIndentedChildren = DEFAULT_PROPS.hasIndentedChildren,
-    isOpen = DEFAULT_PROPS.isOpen,
-    isRelevant = DEFAULT_PROPS.isRelevant,
+    hasChildren,
+    hasIndentedChildren,
+    isOpen,
+    isRelevant,
     name,
     onClick,
     onMouseEnter,
     onMouseLeave,
     text,
-    theme = DEFAULT_PROPS.theme,
+    theme,
 }: CommentBlockProps): React.ReactElement => {
     const enterKeyPress: KeyboardEventHandler<HTMLElement> = (evt: KeyboardEvent<HTMLElement>) => {
         if (evt.which === ENTER_KEY_CODE && isFunction(onClick)) {
@@ -151,5 +141,6 @@ const CommentBlock: React.FC<CommentBlockProps> = ({
     );
 };
 CommentBlock.displayName = COMPONENT_NAME;
+CommentBlock.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, CommentBlock, CommentBlockProps };
+export { CLASSNAME, CommentBlock, CommentBlockProps };

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -50,10 +50,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: Partial<DatePickerProps> = {
-    maxDate: undefined,
-    minDate: undefined,
-};
+const DEFAULT_PROPS: Partial<DatePickerProps> = {};
 
 /**
  * Simple component used to pick a date (semi-controlled implementation).
@@ -93,5 +90,6 @@ const DatePicker = (props: DatePickerProps) => {
     );
 };
 DatePicker.displayName = COMPONENT_NAME;
+DatePicker.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, COMPONENT_NAME, DEFAULT_PROPS, DatePicker, DatePickerProps };
+export { CLASSNAME, COMPONENT_NAME, DatePicker, DatePickerProps };

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -10,7 +10,7 @@ import { mdiChevronLeft, mdiChevronRight } from '@lumx/icons';
 
 import { getAnnotatedMonthCalendar, getWeekDays } from '@lumx/core/js/date-picker';
 
-import { CLASSNAME, DEFAULT_PROPS, DatePickerProps } from './DatePicker';
+import { CLASSNAME, DatePickerProps } from './DatePicker';
 
 /**
  * Defines the props of the component.
@@ -39,8 +39,8 @@ const COMPONENT_NAME = 'DatePickerControlled';
  */
 const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
     locale,
-    maxDate = DEFAULT_PROPS.maxDate,
-    minDate = DEFAULT_PROPS.minDate,
+    maxDate,
+    minDate,
     onChange,
     onPrevMonthChange,
     onNextMonthChange,

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
@@ -10,6 +10,8 @@ exports[`<DatePickerControlled> Snapshots and structure should render correctly 
         emphasis="low"
         icon="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
         onClick={[MockFunction]}
+        size="m"
+        theme="light"
       />
     }
     before={
@@ -17,6 +19,8 @@ exports[`<DatePickerControlled> Snapshots and structure should render correctly 
         emphasis="low"
         icon="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
         onClick={[MockFunction]}
+        size="m"
+        theme="light"
       />
     }
     className="lumx-date-picker__toolbar"

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
@@ -14,6 +14,8 @@ exports[`<DatePickerField> Snapshots and structure should render correctly 1`] =
         "current": null,
       }
     }
+    theme="light"
+    type="text"
     value="18 janvier 1970"
   />
 </Fragment>
@@ -33,6 +35,8 @@ exports[`<DatePickerField> Snapshots and structure should render correctly when 
         "current": null,
       }
     }
+    theme="light"
+    type="text"
     value="18 janvier 1970"
   />
 </Fragment>
@@ -52,6 +56,8 @@ exports[`<DatePickerField> Snapshots and structure should render correctly when 
         "current": null,
       }
     }
+    theme="light"
+    type="text"
     value="18 janvier 1970"
   />
 </Fragment>
@@ -71,6 +77,8 @@ exports[`<DatePickerField> Snapshots and structure should render without selecte
         "current": null,
       }
     }
+    theme="light"
+    type="text"
     value=""
   />
 </Fragment>

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -112,10 +112,6 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: Partial<DialogProps> = {
-    forceFooterDivider: false,
-    forceHeaderDivider: false,
-    isOpen: false,
-    preventAutoClose: false,
     size: Size.big,
 };
 
@@ -131,17 +127,17 @@ const Dialog: React.FC<DialogProps> = (props) => {
         className,
         header,
         focusElement,
-        forceFooterDivider = DEFAULT_PROPS.forceFooterDivider,
-        forceHeaderDivider = DEFAULT_PROPS.forceHeaderDivider,
+        forceFooterDivider,
+        forceHeaderDivider,
         footer,
         isLoading,
-        isOpen = DEFAULT_PROPS.isOpen,
+        isOpen,
         onOpen,
         onClose,
         parentElement,
         contentRef,
-        preventAutoClose = DEFAULT_PROPS.preventAutoClose,
-        size = DEFAULT_PROPS.size,
+        preventAutoClose,
+        size,
         zIndex,
         ...forwardedProps
     } = props;
@@ -262,5 +258,6 @@ const Dialog: React.FC<DialogProps> = (props) => {
         : null;
 };
 Dialog.displayName = COMPONENT_NAME;
+Dialog.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Dialog, DialogProps, DialogSizes };
+export { CLASSNAME, Dialog, DialogProps, DialogSizes };

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -8,7 +8,10 @@ exports[`<Dialog> Snapshots and structure should render story dialogSizes 1`] = 
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -95,7 +98,10 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithFocusabl
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -112,6 +118,7 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithFocusabl
         "current": undefined,
       }
     }
+    size="big"
   >
     <header>
       <Toolbar
@@ -120,6 +127,8 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithFocusabl
             emphasis="low"
             icon="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
             onClick={[Function]}
+            size="m"
+            theme="light"
           />
         }
         label={
@@ -149,12 +158,15 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithFocusabl
         label="Text input"
         maxLength={10}
         onChange={[Function]}
+        theme="light"
+        type="text"
         value="value"
       />
       <Checkbox
         className="lumx-spacing-margin-bottom-huge"
         label="Checkbox input"
         onChange={[Function]}
+        theme="light"
         value={false}
       />
       <Select
@@ -163,6 +175,7 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithFocusabl
         label="Select label"
         onDropdownClose={[Function]}
         onInputClick={[Function]}
+        selectedValueRender={[Function]}
         value=""
       >
         <List
@@ -212,7 +225,10 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -226,6 +242,7 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    size="big"
   >
     <header
       className="lumx-spacing-padding lumx-typography-title"
@@ -267,7 +284,10 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -279,6 +299,7 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    size="big"
   >
     <header
       className="lumx-spacing-padding lumx-typography-title"
@@ -320,7 +341,10 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -334,6 +358,7 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    size="big"
   >
     <div
       className="lumx-spacing-padding"
@@ -365,7 +390,10 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -379,6 +407,7 @@ exports[`<Dialog> Snapshots and structure should render story dialogWithHeaderFo
         "current": undefined,
       }
     }
+    size="big"
   >
     <header
       className="lumx-spacing-padding lumx-typography-title"
@@ -420,7 +449,10 @@ exports[`<Dialog> Snapshots and structure should render story loadingDialog 1`] 
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -433,6 +465,7 @@ exports[`<Dialog> Snapshots and structure should render story loadingDialog 1`] 
         "current": undefined,
       }
     }
+    size="big"
   >
     <div
       className="lumx-spacing-padding"
@@ -464,7 +497,10 @@ exports[`<Dialog> Snapshots and structure should render story preventDialogAutoC
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -477,6 +513,7 @@ exports[`<Dialog> Snapshots and structure should render story preventDialogAutoC
       }
     }
     preventAutoClose={true}
+    size="big"
   >
     <div
       className="lumx-spacing-padding"
@@ -502,6 +539,8 @@ tertiam. Cras mattis iudicium purus sit amet fermentum
           <Button
             emphasis="low"
             onClick={[Function]}
+            size="m"
+            theme="light"
           >
             Close
           </Button>
@@ -520,7 +559,10 @@ exports[`<Dialog> Snapshots and structure should render story scrollableDialog 1
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -606,7 +648,10 @@ exports[`<Dialog> Snapshots and structure should render story scrollableDialogWi
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -618,6 +663,7 @@ exports[`<Dialog> Snapshots and structure should render story scrollableDialogWi
         "current": undefined,
       }
     }
+    size="big"
   >
     <header
       className="lumx-spacing-padding lumx-typography-title"
@@ -701,7 +747,10 @@ exports[`<Dialog> Snapshots and structure should render story simpleDialog 1`] =
         "current": undefined,
       }
     }
+    emphasis="high"
     onClick={[Function]}
+    size="m"
+    theme="light"
   >
     Open dialog
   </Button>
@@ -713,6 +762,7 @@ exports[`<Dialog> Snapshots and structure should render story simpleDialog 1`] =
         "current": undefined,
       }
     }
+    size="big"
   >
     <div
       className="lumx-spacing-padding"

--- a/packages/lumx-react/src/components/divider/Divider.test.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.test.tsx
@@ -7,7 +7,9 @@ import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/util
 import { getBasicClass } from '@lumx/react/utils';
 
 import { Theme } from '@lumx/react';
-import { CLASSNAME, DEFAULT_PROPS, Divider, DividerProps } from './Divider';
+import { CLASSNAME, Divider, DividerProps } from './Divider';
+
+const DEFAULT_PROPS = Divider.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/divider/Divider.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.tsx
@@ -17,11 +17,6 @@ interface DividerProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<DividerProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Divider`;
@@ -34,7 +29,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<DividerProps> = {
     theme: Theme.light,
 };
 
@@ -44,11 +39,12 @@ const DEFAULT_PROPS: DefaultPropsType = {
  *
  * @return The component.
  */
-const Divider: React.FC<DividerProps> = ({ className, theme = DEFAULT_PROPS.theme, ...forwardedProps }) => {
+const Divider: React.FC<DividerProps> = ({ className, theme, ...forwardedProps }) => {
     return (
         <hr {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))} />
     );
 };
 Divider.displayName = COMPONENT_NAME;
+Divider.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Divider, DividerProps };
+export { CLASSNAME, Divider, DividerProps };

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -65,7 +65,6 @@ const DEFAULT_PROPS: Partial<DropdownProps> = {
     fitWithinViewportHeight: true,
     placement: Placement.BOTTOM_START,
     shouldFocusOnOpen: true,
-    isOpen: undefined,
 };
 
 /**
@@ -79,14 +78,14 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
         anchorRef,
         children,
         className,
-        closeOnClick = DEFAULT_PROPS.closeOnClick,
-        closeOnClickAway = DEFAULT_PROPS.closeOnClickAway,
-        closeOnEscape = DEFAULT_PROPS.closeOnEscape,
-        fitToAnchorWidth = DEFAULT_PROPS.fitToAnchorWidth,
-        fitWithinViewportHeight = DEFAULT_PROPS.fitWithinViewportHeight,
+        closeOnClick,
+        closeOnClickAway,
+        closeOnEscape,
+        fitToAnchorWidth,
+        fitWithinViewportHeight,
         offset,
-        placement = DEFAULT_PROPS.placement,
-        shouldFocusOnOpen = DEFAULT_PROPS.shouldFocusOnOpen,
+        placement,
+        shouldFocusOnOpen,
         isOpen,
         zIndex,
         onClose,
@@ -137,5 +136,6 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
     ) : null;
 };
 Dropdown.displayName = COMPONENT_NAME;
+Dropdown.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Dropdown, DropdownProps };
+export { CLASSNAME, Dropdown, DropdownProps };

--- a/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<Dropdown> Snapshots and structure should render correctly 1`] = `
   className="lumx-dropdown__menu lumx-dropdown"
   closeOnClickAway={true}
   closeOnEscape={true}
+  elevation={3}
   fitToAnchorWidth={true}
   fitWithinViewportHeight={true}
   focusElement={
@@ -24,6 +25,7 @@ exports[`<Dropdown> Snapshots and structure should render correctly 1`] = `
       "current": null,
     }
   }
+  zIndex={9999}
 >
   <div>
     This is the content of the dropdown

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
@@ -8,7 +8,9 @@ import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/util
 import { getBasicClass } from '@lumx/react/utils';
 
 import { Theme } from '@lumx/react';
-import { CLASSNAME, DEFAULT_PROPS, ExpansionPanel, ExpansionPanelProps } from './ExpansionPanel';
+import { CLASSNAME, ExpansionPanel, ExpansionPanelProps } from './ExpansionPanel';
+
+const DEFAULT_PROPS = ExpansionPanel.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -72,7 +72,7 @@ const isFooter = isComponent('footer');
 const ExpansionPanel: React.FC<ExpansionPanelProps> = (props) => {
     const {
         label,
-        theme = DEFAULT_PROPS.theme,
+        theme,
         hasBackground,
         hasHeaderDivider,
         isOpen,
@@ -162,5 +162,6 @@ const ExpansionPanel: React.FC<ExpansionPanelProps> = (props) => {
     );
 };
 ExpansionPanel.displayName = COMPONENT_NAME;
+ExpansionPanel.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, ExpansionPanel, ExpansionPanelProps };
+export { CLASSNAME, ExpansionPanel, ExpansionPanelProps };

--- a/packages/lumx-react/src/components/expansion-panel/__snapshots__/ExpansionPanel.test.tsx.snap
+++ b/packages/lumx-react/src/components/expansion-panel/__snapshots__/ExpansionPanel.test.tsx.snap
@@ -22,6 +22,8 @@ exports[`<ExpansionPanel> Snapshots and structure should render correctly 1`] = 
         color="dark"
         emphasis="low"
         icon="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+        size="m"
+        theme="light"
       />
     </div>
   </header>

--- a/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
@@ -5,10 +5,12 @@ import fromPairs from 'lodash/fromPairs';
 import React from 'react';
 
 import isArray from 'lodash/isArray';
-import { DEFAULT_PROPS, FlexBox, FlexBoxProps } from './FlexBox';
+import { FlexBox, FlexBoxProps } from './FlexBox';
 /*  tslint:disable object-literal-sort-keys */
 
 export default { title: 'LumX components/flex-box/FlexBox' };
+
+const DEFAULT_PROPS = FlexBox.defaultProps as any;
 
 type FlexBoxPropName = keyof FlexBoxProps;
 const flexViewKnobConfigs: Array<

--- a/packages/lumx-react/src/components/flex-box/FlexBox.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.tsx
@@ -61,21 +61,17 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}FlexBox`;
  */
 const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
-const DEFAULT_PROPS: Partial<FlexBoxProps> = {
-    fillSpace: false,
-    noShrink: false,
-    wrap: false,
-};
+const DEFAULT_PROPS: Partial<FlexBoxProps> = {};
 
 const FlexBox: React.FC<FlexBoxProps> = ({
     children,
     className,
     orientation,
-    wrap = DEFAULT_PROPS.wrap,
+    wrap,
     vAlign,
     hAlign,
-    fillSpace = DEFAULT_PROPS.fillSpace,
-    noShrink = DEFAULT_PROPS.noShrink,
+    fillSpace,
+    noShrink,
     marginAuto,
     gap,
     ...forwardedProps
@@ -101,5 +97,6 @@ const FlexBox: React.FC<FlexBoxProps> = ({
     </div>
 );
 FlexBox.displayName = COMPONENT_NAME;
+FlexBox.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, FlexBox, FlexBoxProps };
+export { CLASSNAME, FlexBox, FlexBoxProps };

--- a/packages/lumx-react/src/components/flex-box/__snapshots__/FlexBox.test.tsx.snap
+++ b/packages/lumx-react/src/components/flex-box/__snapshots__/FlexBox.test.tsx.snap
@@ -6,11 +6,14 @@ Array [
     className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--v-align-center lumx-flex-box--h-align-center"
   >
     <Button
+      emphasis="high"
+      size="m"
       style={
         Object {
           "height": 200,
         }
       }
+      theme="light"
     >
       Button
     </Button>
@@ -42,25 +45,20 @@ Array [
   <div
     className="lumx-flex-box"
   >
-    <FlexBox
-      fillSpace={false}
-      noShrink={false}
-    >
+    <FlexBox>
       <Icon
         icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
       />
     </FlexBox>
-    <FlexBox
-      fillSpace={false}
-      noShrink={false}
-    >
+    <FlexBox>
       Some text in a div
     </FlexBox>
-    <FlexBox
-      fillSpace={false}
-      noShrink={false}
-    >
-      <Button>
+    <FlexBox>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         OK
       </Button>
     </FlexBox>
@@ -80,7 +78,11 @@ Array [
   <div
     className="lumx-flex-box"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       OK
     </Button>
   </div>,
@@ -98,13 +100,21 @@ Array [
       }
     }
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Default
     </Button>
     <FlexBox
       hAlign="top"
     >
-      <Button>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         Top
       </Button>
     </FlexBox>
@@ -113,14 +123,22 @@ Array [
       hAlign="center"
       vAlign="center"
     >
-      <Button>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         Center button
       </Button>
     </FlexBox>
     <FlexBox
       hAlign="bottom"
     >
-      <Button>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         Bottom
       </Button>
     </FlexBox>
@@ -128,21 +146,33 @@ Array [
   <div
     className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--h-align-top"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Top
     </Button>
   </div>,
   <div
     className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--v-align-center lumx-flex-box--h-align-center lumx-flex-box--fill-space"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Center button
     </Button>
   </div>,
   <div
     className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--h-align-bottom"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Bottom
     </Button>
   </div>,
@@ -160,7 +190,11 @@ Array [
       }
     }
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Button
     </Button>
     <FlexBox
@@ -168,7 +202,11 @@ Array [
     >
       Some long text
     </FlexBox>
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Button
     </Button>
   </div>,
@@ -191,13 +229,21 @@ Array [
       }
     }
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Default
     </Button>
     <FlexBox
       vAlign="left"
     >
-      <Button>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         Left
       </Button>
     </FlexBox>
@@ -206,14 +252,22 @@ Array [
       hAlign="center"
       vAlign="center"
     >
-      <Button>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         Center button
       </Button>
     </FlexBox>
     <FlexBox
       vAlign="right"
     >
-      <Button>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         Right
       </Button>
     </FlexBox>
@@ -221,21 +275,33 @@ Array [
   <div
     className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--v-align-left"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Left
     </Button>
   </div>,
   <div
     className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--v-align-center lumx-flex-box--h-align-center lumx-flex-box--fill-space"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Center button
     </Button>
   </div>,
   <div
     className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--v-align-right"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Right
     </Button>
   </div>,
@@ -257,21 +323,37 @@ Array [
       fillSpace={true}
       orientation="vertical"
     >
-      <Button>
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
         Button
       </Button>
     </FlexBox>
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Button
     </Button>
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Button
     </Button>
   </div>,
   <div
     className="lumx-flex-box lumx-flex-box--orientation-vertical lumx-flex-box--fill-space"
   >
-    <Button>
+    <Button
+      emphasis="high"
+      size="m"
+      theme="light"
+    >
       Button
     </Button>
   </div>,

--- a/packages/lumx-react/src/components/grid/Grid.tsx
+++ b/packages/lumx-react/src/components/grid/Grid.tsx
@@ -23,11 +23,6 @@ interface GridProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<GridProps> {}
-
-/**
  * The display name of the component.
  *
  */
@@ -43,7 +38,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  *
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<GridProps> = {
     orientation: Orientation.horizontal,
     wrap: 'nowrap',
 };
@@ -58,11 +53,11 @@ const Grid: React.FC<GridProps> = ({
     className,
     gutter,
     hAlign,
-    orientation = DEFAULT_PROPS.orientation,
+    orientation,
     vAlign,
-    wrap = DEFAULT_PROPS.wrap,
+    wrap,
     ...forwardedProps
-}: GridProps): React.ReactElement => {
+}) => {
     return (
         <div
             {...forwardedProps}
@@ -79,5 +74,6 @@ const Grid: React.FC<GridProps> = ({
     );
 };
 Grid.displayName = COMPONENT_NAME;
+Grid.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Grid, GridProps };
+export { CLASSNAME, Grid, GridProps };

--- a/packages/lumx-react/src/components/grid/GridItem.tsx
+++ b/packages/lumx-react/src/components/grid/GridItem.tsx
@@ -19,11 +19,6 @@ interface GridItemProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<GridItemProps> {}
-
-/**
  * The display name of the component.
  *
  */
@@ -39,7 +34,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  *
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<GridItemProps> = {};
 
 /**
  * [Enter the description of the component here].
@@ -64,5 +59,6 @@ const GridItem: React.FC<GridItemProps> = ({
     );
 };
 GridItem.displayName = COMPONENT_NAME;
+GridItem.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, GridItem, GridItemProps };
+export { CLASSNAME, GridItem, GridItemProps };

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -38,11 +38,6 @@ interface IconProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<IconProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Icon`;
@@ -55,11 +50,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    color: ColorPalette.dark,
-    iconRef: undefined,
-    size: Size.m,
-};
+const DEFAULT_PROPS: Partial<IconProps> = {};
 
 /**
  * Displays an icon in the form of a HTML <svg> tag with the wanted icon path.
@@ -72,7 +63,7 @@ const Icon: React.FC<IconProps> = ({
     colorVariant,
     hasShape,
     icon,
-    iconRef = DEFAULT_PROPS.iconRef,
+    iconRef,
     size,
     theme,
     ...forwardedProps
@@ -83,7 +74,7 @@ const Icon: React.FC<IconProps> = ({
     } else if (theme) {
         iconColor = theme === Theme.light ? ColorPalette.dark : ColorPalette.light;
     } else if (hasShape) {
-        iconColor = DEFAULT_PROPS.color;
+        iconColor = ColorPalette.dark;
     }
 
     let iconSize;
@@ -100,7 +91,7 @@ const Icon: React.FC<IconProps> = ({
             iconSize = size;
         }
     } else if (hasShape) {
-        iconSize = DEFAULT_PROPS.size;
+        iconSize = Size.m;
     }
 
     return (
@@ -133,5 +124,6 @@ const Icon: React.FC<IconProps> = ({
     );
 };
 Icon.displayName = COMPONENT_NAME;
+Icon.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Icon, IconProps, IconSizes };
+export { CLASSNAME, Icon, IconProps, IconSizes };

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -79,11 +79,6 @@ interface ImageBlockProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ImageBlockProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}ImageBlock`;
@@ -96,20 +91,11 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    actions: undefined,
+const DEFAULT_PROPS: Partial<ImageBlockProps> = {
     align: Alignment.left,
     aspectRatio: AspectRatio.original,
     captionPosition: ImageBlockCaptionPosition.below,
-    captionStyle: {},
-    description: undefined,
-    fillHeight: false,
-    focusPoint: undefined,
-    size: undefined,
-    tags: undefined,
     theme: Theme.light,
-    title: undefined,
-    thumbnailProps: undefined,
 };
 
 /**
@@ -118,23 +104,23 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return The component.
  */
 const ImageBlock: React.FC<ImageBlockProps> = ({
-    actions = DEFAULT_PROPS.actions,
-    align = DEFAULT_PROPS.align,
-    aspectRatio = DEFAULT_PROPS.aspectRatio,
+    actions,
+    align,
+    aspectRatio,
     className,
-    captionPosition = DEFAULT_PROPS.captionPosition,
-    captionStyle = DEFAULT_PROPS.captionStyle,
+    captionPosition,
+    captionStyle,
     crossOrigin,
-    description = DEFAULT_PROPS.description,
-    fillHeight = DEFAULT_PROPS.fillHeight,
-    focusPoint = DEFAULT_PROPS.focusPoint,
+    description,
+    fillHeight,
+    focusPoint,
     image,
     isCrossOriginEnabled,
-    size = DEFAULT_PROPS.size,
-    tags = DEFAULT_PROPS.tags,
-    theme = DEFAULT_PROPS.theme,
-    title = DEFAULT_PROPS.title,
-    thumbnailProps = DEFAULT_PROPS.thumbnailProps,
+    size,
+    tags,
+    theme,
+    title,
+    thumbnailProps,
     ...props
 }) => {
     const { onClick = null, ...forwardedProps } = props;
@@ -195,5 +181,6 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
     );
 };
 ImageBlock.displayName = COMPONENT_NAME;
+ImageBlock.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, ImageBlockCaptionPosition, ImageBlock, ImageBlockProps };
+export { CLASSNAME, ImageBlockCaptionPosition, ImageBlock, ImageBlockProps };

--- a/packages/lumx-react/src/components/input-helper/InputHelper.tsx
+++ b/packages/lumx-react/src/components/input-helper/InputHelper.tsx
@@ -15,8 +15,6 @@ interface InputHelperProps extends GenericProps {
     theme?: Theme;
 }
 
-interface DefaultPropsType extends Partial<InputHelperProps> {}
-
 /**
  * The display name of the component.
  */
@@ -30,19 +28,13 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<InputHelperProps> = {
     kind: Kind.info,
     theme: Theme.light,
 };
 
-const InputHelper: React.FC<InputHelperProps> = ({
-    children,
-    className,
-    kind = DEFAULT_PROPS.kind as Kind,
-    theme = DEFAULT_PROPS.theme,
-    ...forwardedProps
-}) => {
-    const { color } = INPUT_HELPER_CONFIGURATION[kind] || {};
+const InputHelper: React.FC<InputHelperProps> = ({ children, className, kind, theme, ...forwardedProps }) => {
+    const { color } = INPUT_HELPER_CONFIGURATION[kind as any] || {};
 
     return (
         <span
@@ -55,5 +47,6 @@ const InputHelper: React.FC<InputHelperProps> = ({
 };
 
 InputHelper.displayName = COMPONENT_NAME;
+InputHelper.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, InputHelper, InputHelperProps };
+export { CLASSNAME, InputHelper, InputHelperProps };

--- a/packages/lumx-react/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-react/src/components/input-label/InputLabel.tsx
@@ -13,8 +13,6 @@ interface InputLabelProps extends GenericProps {
     children: string | ReactNode;
 }
 
-interface DefaultPropsType extends Partial<InputLabelProps> {}
-
 /**
  * The display name of the component.
  */
@@ -28,18 +26,11 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    isRequired: false,
+const DEFAULT_PROPS: Partial<InputLabelProps> = {
     theme: Theme.light,
 };
 
-const InputLabel: React.FC<InputLabelProps> = ({
-    className,
-    isRequired = DEFAULT_PROPS.isRequired,
-    theme = DEFAULT_PROPS.theme,
-    children,
-    ...forwardedProps
-}) => (
+const InputLabel: React.FC<InputLabelProps> = ({ className, isRequired, theme, children, ...forwardedProps }) => (
     <label
         {...forwardedProps}
         className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, isRequired, theme }))}
@@ -49,5 +40,6 @@ const InputLabel: React.FC<InputLabelProps> = ({
 );
 
 InputLabel.displayName = COMPONENT_NAME;
+InputLabel.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, InputLabel, InputLabelProps };
+export { CLASSNAME, InputLabel, InputLabelProps };

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -11,7 +11,6 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import isFunction from 'lodash/isFunction';
-import noop from 'lodash/noop';
 
 const _TRANSITION_DURATION = 400;
 
@@ -47,11 +46,6 @@ interface LightboxProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<LightboxProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Lightbox`;
@@ -64,14 +58,9 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<LightboxProps> = {
     ariaLabel: 'Lightbox',
     isCloseButtonVisible: true,
-    isOpen: false,
-    noWrapper: false,
-    onClose: noop,
-    onOpen: noop,
-    preventAutoClose: false,
     role: 'dialog',
     theme: Theme.light,
 };
@@ -82,18 +71,18 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return Lightbox.
  */
 const Lightbox: React.FC<LightboxProps> = ({
-    ariaLabel = DEFAULT_PROPS.ariaLabel,
+    ariaLabel,
     children,
     className,
-    isCloseButtonVisible = DEFAULT_PROPS.isCloseButtonVisible,
-    isOpen = DEFAULT_PROPS.isOpen,
-    noWrapper = DEFAULT_PROPS.noWrapper,
-    onClose = DEFAULT_PROPS.onClose,
-    onOpen = DEFAULT_PROPS.onOpen,
+    isCloseButtonVisible,
+    isOpen,
+    noWrapper,
+    onClose,
+    onOpen,
     parentElement,
-    preventAutoClose = DEFAULT_PROPS.preventAutoClose,
-    role = DEFAULT_PROPS.role,
-    theme = DEFAULT_PROPS.theme,
+    preventAutoClose,
+    role,
+    theme,
     zIndex,
 }) => {
     const buttonRef: React.RefObject<HTMLButtonElement> = useRef(null);
@@ -236,5 +225,6 @@ const Lightbox: React.FC<LightboxProps> = ({
     );
 };
 Lightbox.displayName = COMPONENT_NAME;
+Lightbox.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Lightbox, LightboxProps };
+export { CLASSNAME, Lightbox, LightboxProps };

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.test.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.test.tsx
@@ -7,7 +7,9 @@ import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/util
 import { getBasicClass } from '@lumx/react/utils';
 
 import { Size, Theme } from '..';
-import { CLASSNAME, DEFAULT_PROPS, LinkPreview, LinkPreviewProps } from './LinkPreview';
+import { CLASSNAME, LinkPreview, LinkPreviewProps } from './LinkPreview';
+
+const DEFAULT_PROPS = LinkPreview.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
@@ -36,11 +36,6 @@ interface LinkPreviewProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<LinkPreviewProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}LinkPreview`;
@@ -53,7 +48,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<LinkPreviewProps> = {
     size: Size.regular,
     theme: Theme.light,
 };
@@ -68,10 +63,10 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({
     title,
     description,
     url,
-    size = DEFAULT_PROPS.size,
-    theme = DEFAULT_PROPS.theme,
+    size,
+    theme,
     thumbnail = '',
-    thumbnailProps = {},
+    thumbnailProps,
     ...forwardedProps
 }) => {
     const goToUrl = useCallback(() => window.open(url, '_blank'), [url]);
@@ -136,5 +131,6 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({
 };
 
 LinkPreview.displayName = COMPONENT_NAME;
+LinkPreview.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, LinkPreview, LinkPreviewProps };
+export { CLASSNAME, LinkPreview, LinkPreviewProps };

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -98,7 +98,7 @@ const ListItem: React.FC<ListItemProps> = (props) => {
         className,
         isHighlighted,
         isSelected,
-        size = DEFAULT_PROPS.size,
+        size,
         onItemSelected,
         before,
         linkAs,
@@ -158,5 +158,6 @@ const ListItem: React.FC<ListItemProps> = (props) => {
     );
 };
 ListItem.displayName = COMPONENT_NAME;
+ListItem.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, ListItem, ListItemProps, ListItemSize, ListItemSizes, isClickable };
+export { CLASSNAME, ListItem, ListItemProps, ListItemSize, ListItemSizes, isClickable };

--- a/packages/lumx-react/src/components/list/__snapshots__/List.test.tsx.snap
+++ b/packages/lumx-react/src/components/list/__snapshots__/List.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`<List> Snapshots and structure should render story KeyboardNavigation 1
     onItemSelected={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
+    size="regular"
   >
     Clickable item 1
   </ListItem>
@@ -32,11 +33,13 @@ exports[`<List> Snapshots and structure should render story KeyboardNavigation 1
     onItemSelected={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
+    size="regular"
   >
     Link item 1
   </ListItem>
   <ListItem
     key=".3..0"
+    size="regular"
   >
     Non clickable (=non navigable) item
   </ListItem>
@@ -58,6 +61,7 @@ exports[`<List> Snapshots and structure should render story KeyboardNavigation 1
     onItemSelected={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
+    size="regular"
   >
     Link item 2
   </ListItem>
@@ -82,6 +86,7 @@ exports[`<List> Snapshots and structure should render story KeyboardNavigation 1
     onItemSelected={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
+    size="regular"
   >
     Link item 3
   </ListItem>
@@ -282,6 +287,7 @@ exports[`<List> Snapshots and structure should render story asLink 1`] = `
     onItemSelected={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
+    size="regular"
   >
     <span>
       My first link
@@ -307,6 +313,7 @@ exports[`<List> Snapshots and structure should render story asLink 1`] = `
     onItemSelected={[Function]}
     onMouseDown={[Function]}
     onMouseUp={[Function]}
+    size="regular"
   >
     <span>
       Google

--- a/packages/lumx-react/src/components/message/Message.test.tsx
+++ b/packages/lumx-react/src/components/message/Message.test.tsx
@@ -3,7 +3,9 @@ import { getBasicClass } from '@lumx/react/utils';
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 import React, { ReactElement } from 'react';
-import { CLASSNAME, DEFAULT_PROPS, Message, MessageKind, MessageProps } from './Message';
+import { CLASSNAME, Message, MessageKind, MessageProps } from './Message';
+
+const DEFAULT_PROPS = Message.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/message/Message.tsx
+++ b/packages/lumx-react/src/components/message/Message.tsx
@@ -98,5 +98,6 @@ const Message: React.FC<MessageProps> = (props) => {
     );
 };
 Message.displayName = COMPONENT_NAME;
+Message.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, MessageKind, Message, MessageProps };
+export { CLASSNAME, MessageKind, Message, MessageProps };

--- a/packages/lumx-react/src/components/message/__snapshots__/Message.test.tsx.snap
+++ b/packages/lumx-react/src/components/message/__snapshots__/Message.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<Message> Snapshots and structure should render correctly 1`] = `
 <div
   className="lumx-message lumx-message--color-dark"
+  color="dark"
 >
   <div
     className="lumx-message__text"

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -22,8 +22,6 @@ interface MosaicProps extends GenericProps {
     thumbnails: MosaicElement[];
 }
 
-interface DefaultPropsType extends Partial<MosaicProps> {}
-
 /**
  * The display name of the component.
  */
@@ -37,10 +35,11 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<MosaicProps> = {
     theme: Theme.light,
 };
-const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme, thumbnails, ...forwardedProps }) => (
+
+const Mosaic: React.FC<MosaicProps> = ({ className, theme, thumbnails, ...forwardedProps }) => (
     <div
         {...forwardedProps}
         className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }), {
@@ -83,5 +82,6 @@ const Mosaic: React.FC<MosaicProps> = ({ className, theme = DEFAULT_PROPS.theme,
 );
 
 Mosaic.displayName = COMPONENT_NAME;
+Mosaic.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Mosaic, MosaicProps };
+export { CLASSNAME, Mosaic, MosaicProps };

--- a/packages/lumx-react/src/components/mosaic/__snapshots__/Mosaic.test.tsx.snap
+++ b/packages/lumx-react/src/components/mosaic/__snapshots__/Mosaic.test.tsx.snap
@@ -12,12 +12,26 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
       key="0"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/200"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -25,12 +39,26 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
       key="1"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/210"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -38,12 +66,26 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
       key="2"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/220"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -51,12 +93,26 @@ exports[`<Mosaic> Snapshots and structure should render story clickableThumbnail
       key="3"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/230"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
     </div>
   </div>
@@ -75,11 +131,25 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
       key="0"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/200"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -87,11 +157,25 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
       key="1"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/210"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -99,11 +183,25 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
       key="2"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/220"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -111,11 +209,25 @@ exports[`<Mosaic> Snapshots and structure should render story fourThumbnails 1`]
       key="3"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/230"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
   </div>
@@ -134,11 +246,25 @@ exports[`<Mosaic> Snapshots and structure should render story oneThumbnail 1`] =
       key="0"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/200"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
   </div>
@@ -157,12 +283,26 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
       key="0"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/640/480/?image=24"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -170,12 +310,26 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
       key="1"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/640/480/?image=25"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -183,12 +337,26 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
       key="2"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/640/480/?image=26"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -196,12 +364,26 @@ exports[`<Mosaic> Snapshots and structure should render story sixThumbnails 1`] 
       key="3"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/640/480/?image=27"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         tabIndex="0"
         theme="light"
+        variant="squared"
       />
       <div
         className="lumx-mosaic__overlay"
@@ -228,11 +410,25 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
       key="0"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/200"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -240,11 +436,25 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
       key="1"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/210"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -252,11 +462,25 @@ exports[`<Mosaic> Snapshots and structure should render story threeThumbnails 1`
       key="2"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/220"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
   </div>
@@ -275,11 +499,25 @@ exports[`<Mosaic> Snapshots and structure should render story twoThumbnails 1`] 
       key="0"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/200"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
     <div
@@ -287,11 +525,25 @@ exports[`<Mosaic> Snapshots and structure should render story twoThumbnails 1`] 
       key="1"
     >
       <Thumbnail
+        align="left"
         aspectRatio="free"
+        crossOrigin="anonymous"
+        fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
         fillHeight={true}
+        focusPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
         image="https://picsum.photos/210"
+        isCrossOriginEnabled={true}
+        isFollowingWindowSize={true}
+        loading="lazy"
         onClick={[Function]}
+        resizeDebounceTime={20}
         theme="light"
+        variant="squared"
       />
     </div>
   </div>

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -55,11 +55,6 @@ interface NotificationProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<NotificationProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Notification`;
@@ -72,8 +67,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    content: '',
+const DEFAULT_PROPS: Partial<NotificationProps> = {
     theme: Theme.light,
     zIndex: 9999,
 };
@@ -86,18 +80,18 @@ const DEFAULT_PROPS: DefaultPropsType = {
 const Notification: React.FC<NotificationProps> = ({
     actionCallback,
     actionLabel,
-    content = DEFAULT_PROPS.content,
+    content,
     className,
     handleClick,
-    isOpen = false,
-    theme = DEFAULT_PROPS.theme,
+    isOpen,
+    theme,
     type,
-    zIndex = DEFAULT_PROPS.zIndex,
+    zIndex,
     ...forwardedProps
 }) => {
     const hasAction: boolean = Boolean(actionCallback) && Boolean(actionLabel);
 
-    const isVisible = useDelayedVisibility(isOpen, NOTIFICATION_TRANSITION_DURATION);
+    const isVisible = useDelayedVisibility(!!isOpen, NOTIFICATION_TRANSITION_DURATION);
 
     const handleCallback = (evt: React.MouseEvent) => {
         if (isFunction(actionCallback)) {
@@ -139,5 +133,6 @@ const Notification: React.FC<NotificationProps> = ({
         : null;
 };
 Notification.displayName = COMPONENT_NAME;
+Notification.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Notification, NotificationProps, NotificationType };
+export { CLASSNAME, Notification, NotificationProps, NotificationType };

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import { Chip, FlexBox, Orientation, Placement, Popover, Size } from '@lumx/react';
 import { boolean, select } from '@storybook/addon-knobs';
-import { DEFAULT_PROPS } from './Popover';
 
 export default { title: 'LumX components/popover/Popover' };
+
+const DEFAULT_PROPS = Popover.defaultProps as any;
 
 export const positions = ({ theme }: any) => {
     const demoPopperStyle = {

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -112,11 +112,6 @@ const DEFAULT_PROPS: Partial<PopoverProps> = {
     elevation: 3,
     placement: Placement.AUTO,
     zIndex: 9999,
-    fitToAnchorWidth: false,
-    fitWithinViewportHeight: false,
-    closeOnClickAway: false,
-    closeOnEscape: false,
-    hasArrow: false,
 };
 
 /**
@@ -187,14 +182,14 @@ const Popover: React.FC<PopoverProps> = (props) => {
         placement,
         isOpen,
         children,
-        fitToAnchorWidth = DEFAULT_PROPS.fitToAnchorWidth,
-        fitWithinViewportHeight = DEFAULT_PROPS.fitWithinViewportHeight,
+        fitToAnchorWidth,
+        fitWithinViewportHeight,
         offset,
-        elevation = DEFAULT_PROPS.elevation,
-        zIndex = DEFAULT_PROPS.zIndex,
-        closeOnClickAway = DEFAULT_PROPS.closeOnClickAway,
-        closeOnEscape = DEFAULT_PROPS.closeOnEscape,
-        hasArrow = DEFAULT_PROPS.hasArrow,
+        elevation,
+        zIndex,
+        closeOnClickAway,
+        closeOnEscape,
+        hasArrow,
         focusElement,
         className,
         onClose,
@@ -268,5 +263,6 @@ const Popover: React.FC<PopoverProps> = (props) => {
         : null;
 };
 Popover.displayName = COMPONENT_NAME;
+Popover.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Popover, PopoverProps, Placement, Offset };
+export { CLASSNAME, Popover, PopoverProps, Placement, Offset };

--- a/packages/lumx-react/src/components/post-block/PostBlock.tsx
+++ b/packages/lumx-react/src/components/post-block/PostBlock.tsx
@@ -44,11 +44,6 @@ interface PostBlockProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<PostBlockProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}PostBlock`;
@@ -61,9 +56,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<PostBlockProps> = {
     orientation: Orientation.horizontal,
-    text: undefined,
     theme: Theme.light,
     thumbnailAspectRatio: AspectRatio.horizontal,
 };
@@ -80,13 +74,13 @@ const PostBlock: React.FC<PostBlockProps> = ({
     className,
     meta,
     onClick,
-    orientation = DEFAULT_PROPS.orientation,
+    orientation,
     tags,
-    text = DEFAULT_PROPS.text,
+    text,
     thumbnail,
-    thumbnailAspectRatio = DEFAULT_PROPS.thumbnailAspectRatio,
+    thumbnailAspectRatio,
     title,
-    theme = DEFAULT_PROPS.theme,
+    theme,
 }) => {
     return (
         <div className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, orientation, theme }))}>
@@ -133,5 +127,6 @@ const PostBlock: React.FC<PostBlockProps> = ({
 };
 
 PostBlock.displayName = COMPONENT_NAME;
+PostBlock.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, PostBlock, PostBlockProps };
+export { CLASSNAME, PostBlock, PostBlockProps };

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
@@ -10,14 +10,9 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 /**
  * Defines the props of the component.
  */
-interface ProgressTrackerProps extends GenericProps {}
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ProgressTrackerProps> {
+interface ProgressTrackerProps extends GenericProps {
     /** The active step index. */
-    activeStep: number;
+    activeStep?: number;
     /** The current component theme. */
     theme?: Theme;
 }
@@ -35,7 +30,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ProgressTrackerProps> = {
     activeStep: 0,
     theme: Theme.light,
 };
@@ -49,16 +44,16 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return The component.
  */
 const ProgressTracker: React.FC<ProgressTrackerProps> = ({
-    activeStep = DEFAULT_PROPS.activeStep,
+    activeStep,
     children,
     className,
-    theme = DEFAULT_PROPS.theme,
+    theme,
     ...forwardedProps
 }) => {
     const childrenArray = Children.toArray(children);
     const backgroundPosition: number = childrenArray.length > 0 ? 100 / (childrenArray.length * 2) : 0;
     const trackPosition: number =
-        childrenArray.length > 0 ? ((100 / (childrenArray.length - 1)) * activeStep) / 100 : 0;
+        childrenArray.length > 0 ? ((100 / (childrenArray.length - 1)) * (activeStep as number)) / 100 : 0;
 
     return (
         <div {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }))}>
@@ -81,5 +76,6 @@ const ProgressTracker: React.FC<ProgressTrackerProps> = ({
     );
 };
 ProgressTracker.displayName = COMPONENT_NAME;
+ProgressTracker.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, ProgressTracker, ProgressTrackerProps };
+export { CLASSNAME, ProgressTracker, ProgressTrackerProps };

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.tsx
@@ -14,12 +14,7 @@ import { mdiAlertCircle, mdiCheckCircle, mdiRadioboxBlank, mdiRadioboxMarked } f
 /**
  * Defines the props of the component.
  */
-interface ProgressTrackerStepProps extends GenericProps {}
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ProgressTrackerStepProps> {
+interface ProgressTrackerStepProps extends GenericProps {
     /** Whether the step should be in error state or not. */
     hasError?: boolean;
 
@@ -27,10 +22,10 @@ interface DefaultPropsType extends Partial<ProgressTrackerStepProps> {
     helper?: string | null;
 
     /** Whether the current step is active. */
-    isActive: boolean;
+    isActive?: boolean;
 
     /** Whether the current step is completed. */
-    isComplete: boolean;
+    isComplete?: boolean;
 
     /** The step's label. */
     label: string | null;
@@ -52,12 +47,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    hasError: false,
-    helper: null,
-    isActive: false,
-    isComplete: false,
-    label: null,
+const DEFAULT_PROPS: Partial<ProgressTrackerStepProps> = {
     theme: Theme.light,
 };
 
@@ -68,15 +58,15 @@ const DEFAULT_PROPS: DefaultPropsType = {
  */
 const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
     className,
-    hasError = DEFAULT_PROPS.hasError,
-    helper = DEFAULT_PROPS.helper,
-    isActive = DEFAULT_PROPS.isActive,
-    isComplete = DEFAULT_PROPS.isComplete,
-    label = DEFAULT_PROPS.label,
-    theme = DEFAULT_PROPS.theme,
+    hasError,
+    helper,
+    isActive,
+    isComplete,
+    label,
+    theme,
     ...props
 }) => {
-    const { onClick = null, ...forwardedProps }: ProgressTrackerStepProps = props;
+    const { onClick = null, ...forwardedProps } = props;
 
     const isClickable: boolean = isFunction(onClick);
 
@@ -131,5 +121,6 @@ const ProgressTrackerStep: React.FC<ProgressTrackerStepProps> = ({
 };
 
 ProgressTrackerStep.displayName = COMPONENT_NAME;
+ProgressTrackerStep.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, ProgressTrackerStep, ProgressTrackerStepProps };
+export { CLASSNAME, ProgressTrackerStep, ProgressTrackerStepProps };

--- a/packages/lumx-react/src/components/progress-tracker/__snapshots__/ProgressTracker.test.tsx.snap
+++ b/packages/lumx-react/src/components/progress-tracker/__snapshots__/ProgressTracker.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<ProgressTracker> Snapshots and structure should render defaults 1`] = 
     <ProgressTrackerStep
       label="Step label"
       onClick={[Function]}
+      theme="light"
     />
   </div>
   <div

--- a/packages/lumx-react/src/components/progress/Progress.tsx
+++ b/packages/lumx-react/src/components/progress/Progress.tsx
@@ -28,11 +28,6 @@ interface ProgressProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ProgressProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Progress`;
@@ -45,7 +40,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ProgressProps> = {
     theme: Theme.light,
     variant: ProgressVariant.circular,
 };
@@ -55,13 +50,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
  *
  * @return The component.
  */
-const Progress: React.FC<ProgressProps> = ({
-    className,
-    theme = DEFAULT_PROPS.theme,
-    useCustomColors,
-    variant = DEFAULT_PROPS.variant,
-    ...forwardedProps
-}) => {
+const Progress: React.FC<ProgressProps> = ({ className, theme, useCustomColors, variant, ...forwardedProps }) => {
     return (
         <div
             {...forwardedProps}
@@ -98,5 +87,6 @@ const Progress: React.FC<ProgressProps> = ({
     );
 };
 Progress.displayName = COMPONENT_NAME;
+Progress.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Progress, ProgressProps, ProgressVariant };
+export { CLASSNAME, Progress, ProgressProps, ProgressVariant };

--- a/packages/lumx-react/src/components/radio-button/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/radio-button/Demos.stories.tsx
@@ -1,4 +1,3 @@
 export default { title: 'LumX components/radio-button/Demos' };
 
 export { default as Default } from './demos/default';
-export { default as Helper } from './demos/helper';

--- a/packages/lumx-react/src/components/radio-button/RadioButton.test.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.test.tsx
@@ -73,8 +73,8 @@ describe(`<${RadioButton.displayName}>`, () => {
 
             expect(input).toExist();
             const inputProps: InputHTMLAttributes<HTMLInputElement> = input.props();
-            expect(inputProps.checked).toBe(false);
-            expect(inputProps.disabled).toBe(false);
+            expect(inputProps.checked).toBeFalsy();
+            expect(inputProps.disabled).toBeFalsy();
 
             expect(helper).not.toExist();
         });
@@ -104,8 +104,8 @@ describe(`<${RadioButton.displayName}>`, () => {
 
             expect(input).toExist();
             const inputProps: InputHTMLAttributes<HTMLInputElement> = input.props();
-            expect(inputProps.checked).toBe(false);
-            expect(inputProps.disabled).toBe(false);
+            expect(inputProps.checked).toBeFalsy();
+            expect(inputProps.disabled).toBeFalsy();
 
             expect(label).toExist();
             expect(label.contains(props.label)).toBe(true);

--- a/packages/lumx-react/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.tsx
@@ -45,11 +45,6 @@ interface RadioButtonProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<RadioButtonProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}RadioButton`;
@@ -62,9 +57,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    checked: false,
-    disabled: false,
+const DEFAULT_PROPS: Partial<RadioButtonProps> = {
     theme: Theme.light,
 };
 
@@ -77,13 +70,13 @@ const DEFAULT_PROPS: DefaultPropsType = {
 const RadioButton: React.FC<RadioButtonProps> = (props) => {
     const {
         className,
-        checked = DEFAULT_PROPS.checked,
-        disabled = DEFAULT_PROPS.disabled,
+        checked,
+        disabled,
         helper,
         id,
         label,
         name,
-        theme = DEFAULT_PROPS.theme,
+        theme,
         useCustomColors,
         value,
         onChange,
@@ -146,5 +139,6 @@ const RadioButton: React.FC<RadioButtonProps> = (props) => {
     );
 };
 RadioButton.displayName = COMPONENT_NAME;
+RadioButton.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, RadioButton, RadioButtonProps };
+export { CLASSNAME, RadioButton, RadioButtonProps };

--- a/packages/lumx-react/src/components/radio-button/__snapshots__/RadioButton.test.tsx.snap
+++ b/packages/lumx-react/src/components/radio-button/__snapshots__/RadioButton.test.tsx.snap
@@ -41,9 +41,7 @@ exports[`<RadioButton> Snapshots and structure should render defaults 1`] = `
     className="lumx-radio-button__input-wrapper"
   >
     <input
-      checked={false}
       className="lumx-radio-button__input-native"
-      disabled={false}
       id="lumx-radio-button-1"
       onChange={[Function]}
       tabIndex={0}
@@ -74,9 +72,7 @@ exports[`<RadioButton> Snapshots and structure should render label & helper 1`] 
     className="lumx-radio-button__input-wrapper"
   >
     <input
-      checked={false}
       className="lumx-radio-button__input-native"
-      disabled={false}
       id="lumx-radio-button-2"
       onChange={[Function]}
       tabIndex={0}
@@ -105,6 +101,7 @@ exports[`<RadioButton> Snapshots and structure should render label & helper 1`] 
     </InputLabel>
     <InputHelper
       className="lumx-radio-button__helper"
+      kind="info"
       theme="light"
     >
       Helper

--- a/packages/lumx-react/src/components/radio-button/__snapshots__/RadioGroup.test.tsx.snap
+++ b/packages/lumx-react/src/components/radio-button/__snapshots__/RadioGroup.test.tsx.snap
@@ -14,11 +14,13 @@ exports[`<RadioGroup> Snapshots and structure should render with radio button ch
     checked={true}
     key="0"
     label="Label 1"
+    theme="light"
   />
   <RadioButton
     checked={false}
     key="1"
     label="Label 2"
+    theme="light"
   />
 </div>
 `;

--- a/packages/lumx-react/src/components/select/Select.test.tsx
+++ b/packages/lumx-react/src/components/select/Select.test.tsx
@@ -59,7 +59,7 @@ const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean
             )
             .first(),
         helper: wrapper.findWhere(
-            (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === undefined,
+            (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === Kind.info,
         ),
         input: wrapper.find('#uuid').first(),
         props,

--- a/packages/lumx-react/src/components/select/Select.tsx
+++ b/packages/lumx-react/src/components/select/Select.tsx
@@ -24,9 +24,6 @@ interface SelectProps extends CoreSelectProps {
     value: string;
 }
 
-/** Define the types of the default props. */
-interface DefaultPropsType extends Partial<SelectProps> {}
-
 /** The display name of the component. */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 
@@ -34,10 +31,7 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /** The default value of props. */
-const DEFAULT_PROPS: DefaultPropsType = {
-    hasError: false,
-    isOpen: false,
-    isValid: false,
+const DEFAULT_PROPS: Partial<SelectProps> = {
     selectedValueRender: (choice) => choice,
 };
 
@@ -64,7 +58,7 @@ const SelectField: React.FC<SelectProps> = ({
     anchorRef,
     isRequired,
     hasInputClear,
-    selectedValueRender = DEFAULT_PROPS.selectedValueRender,
+    selectedValueRender,
 }) => {
     return (
         <>
@@ -166,5 +160,6 @@ const Select = (props: SelectProps) => {
 };
 
 Select.displayName = COMPONENT_NAME;
+Select.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Select, SelectProps, SelectVariant };
+export { CLASSNAME, Select, SelectProps, SelectVariant };

--- a/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
@@ -58,7 +58,7 @@ const setup = (props: SetupProps = {}, shallowRendering: boolean = true): Setup 
             )
             .first(),
         helper: wrapper.findWhere(
-            (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === undefined,
+            (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === Kind.info,
         ),
         input: wrapper.find('#uuid').first(),
         props,

--- a/packages/lumx-react/src/components/select/SelectMultiple.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.tsx
@@ -32,9 +32,6 @@ interface SelectMultipleProps extends CoreSelectProps {
     ): ReactNode | string;
 }
 
-/** Define the types of the default props. */
-interface DefaultPropsType extends Partial<SelectMultipleProps> {}
-
 /** The display name of the component. */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 
@@ -42,10 +39,7 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /** The default value of props. */
-const DEFAULT_PROPS: DefaultPropsType = {
-    hasError: false,
-    isOpen: false,
-    isValid: false,
+const DEFAULT_PROPS: Partial<SelectMultipleProps> = {
     selectedChipRender(choice, index, onClear, isDisabled?, theme?) {
         const onClick = (event: React.MouseEvent) => onClear && onClear(event, choice);
         return (
@@ -86,8 +80,8 @@ const SelectMultipleField: React.FC<SelectMultipleProps> = ({
     anchorRef,
     isRequired,
     isDisabled,
-    selectedChipRender = DEFAULT_PROPS.selectedChipRender,
-    selectedValueRender = DEFAULT_PROPS.selectedValueRender,
+    selectedChipRender,
+    selectedValueRender,
 }) => {
     return (
         <>
@@ -188,5 +182,6 @@ const SelectMultiple = (props: any) =>
     });
 
 SelectMultiple.displayName = COMPONENT_NAME;
+SelectMultiple.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, SelectMultiple, SelectMultipleProps, SelectVariant };
+export { CLASSNAME, SelectMultiple, SelectMultipleProps, SelectVariant };

--- a/packages/lumx-react/src/components/select/WithSelectContext.tsx
+++ b/packages/lumx-react/src/components/select/WithSelectContext.tsx
@@ -16,9 +16,6 @@ import { CoreSelectProps, SelectVariant } from './constants';
 /** Defines the props of the component. */
 interface SelectProps extends CoreSelectProps {}
 
-/** Define the types of the default props. */
-interface DefaultPropsType extends Partial<SelectProps> {}
-
 /** The display name of the component. */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 
@@ -26,10 +23,7 @@ const COMPONENT_NAME = `${COMPONENT_PREFIX}Select`;
 const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 
 /** The default value of props. */
-const DEFAULT_PROPS: DefaultPropsType = {
-    hasError: false,
-    isOpen: false,
-    isValid: false,
+const DEFAULT_PROPS: Partial<SelectProps> = {
     theme: Theme.light,
     variant: SelectVariant.input,
 };
@@ -91,14 +85,14 @@ const withSelectContext = (
         children,
         className,
         error,
-        hasError = DEFAULT_PROPS.hasError,
+        hasError,
         helper,
         isDisabled,
         isEmpty,
         isMultiple,
-        isOpen = DEFAULT_PROPS.isOpen,
+        isOpen,
         isRequired,
-        isValid = DEFAULT_PROPS.isValid,
+        isValid,
         closeOnClick = !isMultiple,
         label,
         placeholder,

--- a/packages/lumx-react/src/components/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/lumx-react/src/components/select/__snapshots__/Select.test.tsx.snap
@@ -11,9 +11,8 @@ exports[`<Select> Snapshots and structure should render correctly 1`] = `
       }
     }
     handleKeyboardNav={[Function]}
-    hasError={false}
     isEmpty={true}
-    isValid={false}
+    selectedValueRender={[Function]}
     targetUuid="uuid"
     theme="light"
     value=""
@@ -28,9 +27,11 @@ exports[`<Select> Snapshots and structure should render correctly 1`] = `
     closeOnClick={true}
     closeOnClickAway={true}
     closeOnEscape={true}
-    isOpen={false}
+    fitToAnchorWidth={true}
+    fitWithinViewportHeight={true}
     onClose={[Function]}
     placement="bottom-start"
+    shouldFocusOnOpen={true}
   >
     <span>
       Select Component

--- a/packages/lumx-react/src/components/select/__snapshots__/SelectMultiple.test.tsx.snap
+++ b/packages/lumx-react/src/components/select/__snapshots__/SelectMultiple.test.tsx.snap
@@ -11,9 +11,9 @@ exports[`<SelectMultiple> Snapshots and structure should render chips 1`] = `
       }
     }
     handleKeyboardNav={[Function]}
-    hasError={false}
     isEmpty={true}
-    isValid={false}
+    selectedChipRender={[Function]}
+    selectedValueRender={[Function]}
     targetUuid="uuid"
     theme="light"
     value={Array []}
@@ -28,9 +28,11 @@ exports[`<SelectMultiple> Snapshots and structure should render chips 1`] = `
     closeOnClick={false}
     closeOnClickAway={true}
     closeOnEscape={true}
-    isOpen={false}
+    fitToAnchorWidth={true}
+    fitWithinViewportHeight={true}
     onClose={[Function]}
     placement="bottom-start"
+    shouldFocusOnOpen={true}
   >
     <span>
       Select Component
@@ -50,9 +52,9 @@ exports[`<SelectMultiple> Snapshots and structure should render defaults 1`] = `
       }
     }
     handleKeyboardNav={[Function]}
-    hasError={false}
     isEmpty={true}
-    isValid={false}
+    selectedChipRender={[Function]}
+    selectedValueRender={[Function]}
     targetUuid="uuid"
     theme="light"
     value={Array []}
@@ -67,9 +69,11 @@ exports[`<SelectMultiple> Snapshots and structure should render defaults 1`] = `
     closeOnClick={false}
     closeOnClickAway={true}
     closeOnEscape={true}
-    isOpen={false}
+    fitToAnchorWidth={true}
+    fitWithinViewportHeight={true}
     onClose={[Function]}
     placement="bottom-start"
+    shouldFocusOnOpen={true}
   >
     <span>
       Select Component

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
@@ -8,7 +8,9 @@ import { getBasicClass } from '@lumx/react/utils';
 
 import { mdiAccount } from '@lumx/icons';
 
-import { CLASSNAME, DEFAULT_PROPS, SideNavigationItem, SideNavigationItemProps } from './SideNavigationItem';
+import { CLASSNAME, SideNavigationItem, SideNavigationItemProps } from './SideNavigationItem';
+
+const DEFAULT_PROPS = SideNavigationItem.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -70,19 +70,17 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: Partial<SideNavigationItemProps> = {
     emphasis: Emphasis.high,
-    isOpen: false,
-    isSelected: false,
 };
 
 const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
     const {
         children,
         className,
-        emphasis = DEFAULT_PROPS.emphasis,
+        emphasis,
         label,
         icon,
-        isOpen = DEFAULT_PROPS.isOpen,
-        isSelected = DEFAULT_PROPS.isSelected,
+        isOpen,
+        isSelected,
         linkAs,
         linkProps,
         onClick,
@@ -156,5 +154,6 @@ const SideNavigationItem: React.FC<SideNavigationItemProps> = (props) => {
     );
 };
 SideNavigationItem.displayName = COMPONENT_NAME;
+SideNavigationItem.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, SideNavigationItem, SideNavigationItemProps };
+export { CLASSNAME, SideNavigationItem, SideNavigationItemProps };

--- a/packages/lumx-react/src/components/slider/Slider.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.tsx
@@ -30,22 +30,14 @@ interface SliderProps extends GenericProps {
     precision?: number;
     /** Value between 2 steps */
     steps?: number;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
     /** Value */
     value: number;
     /** Callback function invoked when the slider value changes */
     onChange(value: number): void;
     /** Callback function invoked when the component is clicked */
     onMouseDown?(event: React.SyntheticEvent): void;
-}
-
-/**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<SliderProps> {
-    /**
-     * The theme.
-     */
-    theme?: Theme;
 }
 
 /**
@@ -64,9 +56,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  *
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    disabled: false,
-    hideMinMaxlabel: false,
+const DEFAULT_PROPS: Partial<SliderProps> = {
     precision: 0,
     steps: 0,
     theme: Theme.light,
@@ -120,11 +110,11 @@ const Slider: React.FC<SliderProps> = ({
     onMouseDown,
     onChange,
     steps,
-    precision = DEFAULT_PROPS.precision,
-    hideMinMaxlabel = DEFAULT_PROPS.hideMinMaxlabel,
-    value = DEFAULT_PROPS.value!,
+    precision,
+    hideMinMaxlabel,
+    value,
     disabled,
-    theme = DEFAULT_PROPS.theme,
+    theme,
     ...forwardedProps
 }) => {
     const sliderRef = useRef<HTMLDivElement>(null);
@@ -285,7 +275,7 @@ const Slider: React.FC<SliderProps> = ({
                         className={`${CLASSNAME}__track ${CLASSNAME}__track--active`}
                         style={{ width: percentString }}
                     />
-                    {steps && (
+                    {steps ? (
                         <div className={`${CLASSNAME}__ticks`}>
                             {avaibleSteps.map((step: number, idx: number) => {
                                 return (
@@ -297,7 +287,7 @@ const Slider: React.FC<SliderProps> = ({
                                 );
                             })}
                         </div>
-                    )}
+                    ) : null}
                     <button
                         className={`${CLASSNAME}__handle`}
                         style={{ left: percentString }}
@@ -312,5 +302,6 @@ const Slider: React.FC<SliderProps> = ({
     );
 };
 Slider.displayName = COMPONENT_NAME;
+Slider.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Slider, SliderProps };
+export { CLASSNAME, Slider, SliderProps };

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -34,11 +34,6 @@ interface SlideshowProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<SlideshowProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Slideshow`;
@@ -51,12 +46,9 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SlideshowProps> = {
     activeIndex: 0,
-    autoPlay: false,
-    fillHeight: false,
     groupBy: 1,
-    hasControls: false,
     interval: AUTOPLAY_DEFAULT_INTERVAL,
     theme: Theme.light,
 };
@@ -67,19 +59,19 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return The component.
  */
 const Slideshow: React.FC<SlideshowProps> = ({
-    activeIndex = DEFAULT_PROPS.activeIndex as number,
-    autoPlay = DEFAULT_PROPS.autoPlay,
+    activeIndex,
+    autoPlay,
     children,
     className,
-    fillHeight = DEFAULT_PROPS.fillHeight,
-    groupBy = DEFAULT_PROPS.groupBy as number,
-    hasControls = DEFAULT_PROPS.hasControls,
-    interval = DEFAULT_PROPS.interval as number,
-    theme = DEFAULT_PROPS.theme,
+    fillHeight,
+    groupBy,
+    hasControls,
+    interval,
+    theme,
     useCustomColors,
     ...forwardedProps
 }) => {
-    const [currentIndex, setCurrentIndex] = useState(activeIndex);
+    const [currentIndex, setCurrentIndex] = useState<number>(activeIndex as number);
     const [isAutoPlaying, setIsAutoPlaying] = useState(Boolean(autoPlay));
     const parentRef: React.MutableRefObject<null> = useRef(null);
 
@@ -92,12 +84,12 @@ const Slideshow: React.FC<SlideshowProps> = ({
     /**
      * Number of slides when using groupBy prop.
      */
-    const slidesCount: number = Math.ceil(itemsCount / groupBy);
+    const slidesCount: number = Math.ceil(itemsCount / (groupBy as number));
 
     /**
      * Inline style of wrapper element.
      */
-    const wrapperSyle: CSSProperties = {
+    const wrapperStyle: CSSProperties = {
         transform: `translateX(-${FULL_WIDTH_PERCENT * currentIndex}%)`,
     };
 
@@ -114,7 +106,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
         () => {
             goToNextSlide();
         },
-        isAutoPlaying && slidesCount > 1 ? interval : null,
+        isAutoPlaying && slidesCount > 1 ? (interval as number) : null,
     );
 
     /**
@@ -188,7 +180,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
             ref={parentRef}
         >
             <div className={`${CLASSNAME}__slides`}>
-                <div className={`${CLASSNAME}__wrapper`} style={wrapperSyle}>
+                <div className={`${CLASSNAME}__wrapper`} style={wrapperStyle}>
                     {children}
                 </div>
             </div>
@@ -210,5 +202,6 @@ const Slideshow: React.FC<SlideshowProps> = ({
     );
 };
 Slideshow.displayName = COMPONENT_NAME;
+Slideshow.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Slideshow, SlideshowProps };
+export { CLASSNAME, Slideshow, SlideshowProps };

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -13,7 +13,6 @@ import { COMPONENT_PREFIX, LEFT_KEY_CODE, RIGHT_KEY_CODE } from '@lumx/react/con
 import { GenericProps, detectSwipe, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import isFunction from 'lodash/isFunction';
-import noop from 'lodash/noop';
 
 /**
  * Defines the props of the component.
@@ -37,11 +36,6 @@ interface PaginationRange {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<SlideshowControlsProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}SlideshowControls`;
@@ -54,11 +48,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<SlideshowControlsProps> = {
     activeIndex: 0,
-    onNextClick: noop,
-    onPaginationClick: noop,
-    onPreviousClick: noop,
     theme: Theme.light,
 };
 
@@ -70,7 +61,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
  */
 const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /** Index of the current slide */
-    activeIndex = DEFAULT_PROPS.activeIndex,
+    activeIndex,
     /** Css class */
     className,
     /** Reference of parent element */
@@ -78,13 +69,13 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     /** Number of slides */
     slidesCount,
     /** Callback for the click on a navigation item */
-    onPaginationClick = DEFAULT_PROPS.onPaginationClick,
+    onPaginationClick,
     /** Callback for the click on the "next" arrow */
-    onNextClick = DEFAULT_PROPS.onNextClick,
+    onNextClick,
     /** Callback for the click on the "previous" arrow */
-    onPreviousClick = DEFAULT_PROPS.onPreviousClick,
+    onPreviousClick,
     /** Theme */
-    theme = DEFAULT_PROPS.theme,
+    theme,
     ...forwardedProps
 }) => {
     if (typeof activeIndex === 'undefined' || typeof slidesCount === 'undefined') {
@@ -304,5 +295,6 @@ const SlideshowControls: React.FC<SlideshowControlsProps> = ({
     );
 };
 SlideshowControls.displayName = COMPONENT_NAME;
+SlideshowControls.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, SlideshowControls, SlideshowControlsProps as SlideshowProps };
+export { CLASSNAME, SlideshowControls, SlideshowControlsProps as SlideshowProps };

--- a/packages/lumx-react/src/components/switch/Switch.test.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.test.tsx
@@ -10,7 +10,9 @@ import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/util
 import { getBasicClass } from '@lumx/react/utils';
 
 import { Theme } from '@lumx/react';
-import { CLASSNAME, DEFAULT_PROPS, Switch, SwitchPosition, SwitchProps } from './Switch';
+import { CLASSNAME, Switch, SwitchPosition, SwitchProps } from './Switch';
+
+const DEFAULT_PROPS = Switch.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/switch/Switch.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.tsx
@@ -48,11 +48,6 @@ interface SwitchProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<SwitchProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Switch`;
@@ -65,8 +60,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    checked: false,
+const DEFAULT_PROPS: Partial<SwitchProps> = {
     position: SwitchPosition.left,
     theme: Theme.light,
 };
@@ -79,11 +73,11 @@ const DEFAULT_PROPS: DefaultPropsType = {
 const Switch: React.FC<SwitchProps> = ({
     className,
     children,
-    checked = DEFAULT_PROPS.checked,
+    checked,
     helper,
     onToggle,
-    position = DEFAULT_PROPS.position,
-    theme = DEFAULT_PROPS.theme,
+    position,
+    theme,
     useCustomColors,
     ...forwardedProps
 }) => {
@@ -147,5 +141,6 @@ const Switch: React.FC<SwitchProps> = ({
     );
 };
 Switch.displayName = COMPONENT_NAME;
+Switch.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Switch, SwitchProps, SwitchPosition };
+export { CLASSNAME, Switch, SwitchProps, SwitchPosition };

--- a/packages/lumx-react/src/components/switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/lumx-react/src/components/switch/__snapshots__/Switch.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`<Switch> Conditions should not display the \`helper\` if no \`label\` i
     className="lumx-switch__input-wrapper"
   >
     <input
-      checked={false}
       className="lumx-switch__input-native"
       id="a7b5d992-fe30-4d58-967a-89b8bb7e109c"
       onChange={[Function]}
@@ -36,7 +35,6 @@ exports[`<Switch> Snapshots and structure should render correctly with a \`label
     className="lumx-switch__input-wrapper"
   >
     <input
-      checked={false}
       className="lumx-switch__input-native"
       id="a7b5d992-fe30-4d58-967a-89b8bb7e109c"
       onChange={[Function]}
@@ -65,6 +63,7 @@ exports[`<Switch> Snapshots and structure should render correctly with a \`label
     </InputLabel>
     <InputHelper
       className="lumx-switch__helper"
+      kind="info"
       theme="light"
     >
       Helper
@@ -81,7 +80,6 @@ exports[`<Switch> Snapshots and structure should render correctly with only a \`
     className="lumx-switch__input-wrapper"
   >
     <input
-      checked={false}
       className="lumx-switch__input-native"
       id="a7b5d992-fe30-4d58-967a-89b8bb7e109c"
       onChange={[Function]}
@@ -120,7 +118,6 @@ exports[`<Switch> Snapshots and structure should render correctly without any la
     className="lumx-switch__input-wrapper"
   >
     <input
-      checked={false}
       className="lumx-switch__input-native"
       id="a7b5d992-fe30-4d58-967a-89b8bb7e109c"
       onChange={[Function]}

--- a/packages/lumx-react/src/components/table/Table.tsx
+++ b/packages/lumx-react/src/components/table/Table.tsx
@@ -26,11 +26,6 @@ interface TableProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Table`;
@@ -43,9 +38,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    hasBefore: false,
-    hasDividers: false,
+const DEFAULT_PROPS: Partial<TableProps> = {
     theme: Theme.light,
 };
 
@@ -54,14 +47,7 @@ const DEFAULT_PROPS: DefaultPropsType = {
  *
  * @return The component.
  */
-const Table: React.FC<TableProps> = ({
-    children,
-    className,
-    hasBefore,
-    hasDividers,
-    theme = DEFAULT_PROPS.theme,
-    ...forwardedProps
-}) => (
+const Table: React.FC<TableProps> = ({ children, className, hasBefore, hasDividers, theme, ...forwardedProps }) => (
     <table
         {...forwardedProps}
         className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, hasBefore, hasDividers, theme }))}
@@ -71,5 +57,6 @@ const Table: React.FC<TableProps> = ({
 );
 
 Table.displayName = COMPONENT_NAME;
+Table.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Table, TableProps };
+export { CLASSNAME, Table, TableProps };

--- a/packages/lumx-react/src/components/table/TableBody.tsx
+++ b/packages/lumx-react/src/components/table/TableBody.tsx
@@ -11,11 +11,6 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 interface TableBodyProps extends GenericProps {}
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableBodyProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}TableBody`;
@@ -28,7 +23,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<TableBodyProps> = {};
 
 /**
  * The TableBody component displays an HTML Table Body, composed TableBody-cells in TableBody Rows.
@@ -42,5 +37,6 @@ const TableBody: React.FC<TableBodyProps> = ({ children, className, ...forwarded
 );
 
 TableBody.displayName = COMPONENT_NAME;
+TableBody.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, TableBody, TableBodyProps };
+export { CLASSNAME, TableBody, TableBodyProps };

--- a/packages/lumx-react/src/components/table/TableCell.tsx
+++ b/packages/lumx-react/src/components/table/TableCell.tsx
@@ -70,13 +70,6 @@ interface TableCellProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableCellProps> {
-    variant: TableCellVariant;
-}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}TableCell`;
@@ -89,8 +82,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    onHeaderClick: undefined,
+const DEFAULT_PROPS: Partial<TableCellProps> = {
     variant: TableCellVariant.body,
 };
 
@@ -104,9 +96,9 @@ const TableCell: React.FC<TableCellProps> = ({
     className,
     icon,
     isSortable,
-    onHeaderClick = DEFAULT_PROPS.onHeaderClick,
+    onHeaderClick,
     sortOrder,
-    variant = DEFAULT_PROPS.variant,
+    variant,
     ...forwardedProps
 }) => {
     /**
@@ -163,5 +155,6 @@ const TableCell: React.FC<TableCellProps> = ({
     );
 };
 TableCell.displayName = COMPONENT_NAME;
+TableCell.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, TableCell, TableCellProps, TableCellVariant, ThOrder, ThScope };
+export { CLASSNAME, TableCell, TableCellProps, TableCellVariant, ThOrder, ThScope };

--- a/packages/lumx-react/src/components/table/TableHeader.tsx
+++ b/packages/lumx-react/src/components/table/TableHeader.tsx
@@ -11,11 +11,6 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 interface TableHeaderProps extends GenericProps {}
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TableHeaderProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}TableHeader`;
@@ -28,7 +23,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<TableHeaderProps> = {};
 
 /**
  * The TableHeader component displays an HTML Table Head, composed TableHeader-cells in TableHeader Rows.
@@ -42,5 +37,6 @@ const TableHeader: React.FC<TableHeaderProps> = ({ children, className, ...forwa
 );
 
 TableHeader.displayName = COMPONENT_NAME;
+TableHeader.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, TableHeader, TableHeaderProps };
+export { CLASSNAME, TableHeader, TableHeaderProps };

--- a/packages/lumx-react/src/components/table/TableRow.tsx
+++ b/packages/lumx-react/src/components/table/TableRow.tsx
@@ -41,11 +41,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME, true);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    isClickable: false,
-    isDisabled: false,
-    isSelected: false,
-};
+const DEFAULT_PROPS: DefaultPropsType = {};
 
 /**
  * The TableRow component displays an HTML Table Row, which contains table cells.
@@ -78,5 +74,6 @@ const TableRow: React.FC<TableRowProps> = ({
 );
 
 TableRow.displayName = COMPONENT_NAME;
+TableRow.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, TableRow, TableRowProps };
+export { CLASSNAME, TableRow, TableRowProps };

--- a/packages/lumx-react/src/components/tabs/Tab.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.tsx
@@ -42,12 +42,7 @@ const CLASSNAME = `${CSS_PREFIX}-tabs__link`;
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
-    icon: undefined,
-    isActive: false,
-    isDisabled: false,
-    label: undefined,
-};
+const DEFAULT_PROPS: DefaultPropsType = {};
 
 /**
  * Define a single Tab for Tabs component.

--- a/packages/lumx-react/src/components/tabs/Tabs.tsx
+++ b/packages/lumx-react/src/components/tabs/Tabs.tsx
@@ -38,11 +38,6 @@ interface TabsProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<TabsProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Tabs`;
@@ -55,9 +50,8 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<TabsProps> = {
     activeTab: 0,
-    children: [],
     layout: TabsLayout.fixed,
     position: TabsPosition.left,
     theme: Theme.light,
@@ -69,13 +63,13 @@ const DEFAULT_PROPS: DefaultPropsType = {
  * @return The component.
  */
 const Tabs: React.FC<TabsProps> = ({
-    activeTab = DEFAULT_PROPS.activeTab,
+    activeTab,
     children,
     className,
-    layout = DEFAULT_PROPS.layout,
+    layout,
     onTabClick,
-    position = DEFAULT_PROPS.position,
-    theme = DEFAULT_PROPS.theme,
+    position,
+    theme,
     useCustomColors,
     ...forwardedProps
 }) => {
@@ -97,5 +91,6 @@ const Tabs: React.FC<TabsProps> = ({
     );
 };
 Tabs.displayName = COMPONENT_NAME;
+Tabs.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Tabs, TabsProps, TabsLayout, TabsPosition };
+export { CLASSNAME, Tabs, TabsProps, TabsLayout, TabsPosition };

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -56,7 +56,7 @@ const setup = (props: SetupProps = {}, shallowRendering: boolean = true): Setup 
         (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === Kind.error,
     );
     const helper = wrapper.findWhere(
-        (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === undefined,
+        (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === Kind.info,
     );
 
     return {

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -105,14 +105,6 @@ const MIN_ROWS = 2;
  * The default value of props.
  */
 const DEFAULT_PROPS: Partial<TextFieldProps> = {
-    forceFocusStyle: false,
-    hasError: false,
-    isClearable: false,
-    isDisabled: false,
-    isRequired: false,
-    isValid: false,
-    minimumRows: MIN_ROWS,
-    multiline: false,
     theme: Theme.light,
     type: 'text',
 };
@@ -269,14 +261,14 @@ const TextField: React.FC<TextFieldProps> = (props) => {
         chips,
         className,
         error,
-        forceFocusStyle = DEFAULT_PROPS.forceFocusStyle,
+        forceFocusStyle,
         hasError,
         helper,
         icon,
         id = uuid(),
         isDisabled,
         isRequired,
-        isClearable = DEFAULT_PROPS.isClearable,
+        isClearable,
         isValid,
         label,
         maxLength,
@@ -284,19 +276,19 @@ const TextField: React.FC<TextFieldProps> = (props) => {
         onFocus,
         onBlur,
         placeholder,
-        minimumRows = DEFAULT_PROPS.minimumRows as number,
+        minimumRows,
         inputRef = React.useRef(null),
-        theme = DEFAULT_PROPS.theme,
-        multiline = DEFAULT_PROPS.multiline,
+        theme,
+        multiline,
         useCustomColors,
         textFieldRef,
-        type = DEFAULT_PROPS.type,
+        type,
         value,
         ...forwardedProps
     } = props;
 
     const [isFocus, setFocus] = useState(false);
-    const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(minimumRows);
+    const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(minimumRows || MIN_ROWS);
     const valueLength = (value && `${value}`.length) || 0;
     const isNotEmpty = valueLength > 0;
 
@@ -422,5 +414,6 @@ const TextField: React.FC<TextFieldProps> = (props) => {
     );
 };
 TextField.displayName = COMPONENT_NAME;
+TextField.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, TextField, TextFieldProps };
+export { CLASSNAME, TextField, TextFieldProps };

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -107,11 +107,6 @@ interface ThumbnailProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ThumbnailProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Thumbnail`;
@@ -124,16 +119,14 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<ThumbnailProps> = {
     align: Alignment.left,
     crossOrigin: CrossOrigin.anonymous,
     aspectRatio: AspectRatio.original,
     fallback: mdiImageBrokenVariant,
-    fillHeight: false,
     focusPoint: { x: 0, y: 0 },
     isCrossOriginEnabled: true,
     loading: ImageLoading.lazy,
-    size: undefined,
     theme: Theme.light,
     variant: ThumbnailVariant.squared,
     resizeDebounceTime: 20,
@@ -149,23 +142,22 @@ const DEFAULT_PROPS: DefaultPropsType = {
  */
 const Thumbnail: React.FC<ThumbnailProps> = ({
     className,
-    // tslint:disable-next-line: no-unused
-    isCrossOriginEnabled = DEFAULT_PROPS.isCrossOriginEnabled,
-    crossOrigin = DEFAULT_PROPS.crossOrigin,
-    resizeDebounceTime = DEFAULT_PROPS.resizeDebounceTime,
-    isFollowingWindowSize = DEFAULT_PROPS.isFollowingWindowSize,
-    align = DEFAULT_PROPS.align,
-    aspectRatio = DEFAULT_PROPS.aspectRatio,
-    fallback = DEFAULT_PROPS.fallback,
-    fillHeight = DEFAULT_PROPS.fillHeight,
-    loading = DEFAULT_PROPS.loading,
-    size = DEFAULT_PROPS.size,
-    theme = DEFAULT_PROPS.theme,
-    variant = DEFAULT_PROPS.variant,
+    isCrossOriginEnabled,
+    crossOrigin,
+    resizeDebounceTime,
+    isFollowingWindowSize,
+    align,
+    aspectRatio,
+    fallback,
+    fillHeight,
+    loading,
+    size,
+    theme,
+    variant,
     image,
     alt = 'Thumbnail',
-    onClick = null,
-    focusPoint = DEFAULT_PROPS.focusPoint,
+    onClick,
+    focusPoint,
     imgProps,
     ...forwardedProps
 }: ThumbnailProps): ReactElement => {
@@ -248,10 +240,10 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
     );
 };
 Thumbnail.displayName = COMPONENT_NAME;
+Thumbnail.defaultProps = DEFAULT_PROPS;
 
 export {
     CLASSNAME,
-    DEFAULT_PROPS,
     Thumbnail,
     ThumbnailProps,
     ThumbnailAspectRatio,

--- a/packages/lumx-react/src/components/toolbar/Toolbar.tsx
+++ b/packages/lumx-react/src/components/toolbar/Toolbar.tsx
@@ -19,11 +19,6 @@ interface ToolbarProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<ToolbarProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}Toolbar`;
@@ -36,7 +31,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {};
+const DEFAULT_PROPS: Partial<ToolbarProps> = {};
 
 /**
  * Toolbar component.
@@ -64,5 +59,6 @@ const Toolbar: React.FC<ToolbarProps> = ({ after, before, className, label, ...f
     );
 };
 Toolbar.displayName = COMPONENT_NAME;
+Toolbar.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Toolbar, ToolbarProps };
+export { CLASSNAME, Toolbar, ToolbarProps };

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -9,7 +9,7 @@ import { Placement } from '@lumx/react/components/popover/Popover';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Falsy, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import { useInjectTooltipRef } from './useInjectTooltipRef';
 import { useTooltipOpen } from './useTooltipOpen';
@@ -18,28 +18,23 @@ import { useTooltipOpen } from './useTooltipOpen';
 type TooltipPlacement = Placement.TOP | Placement.RIGHT | Placement.BOTTOM | Placement.LEFT;
 
 /**
- * Defines the optional props of the component.
+ * Defines the props of the component.
  */
-interface OptionalTooltipProps extends GenericProps {
+interface TooltipProps extends GenericProps {
+    /** Tooltip label. */
+    label?: string | Falsy;
+
+    /** Tooltip anchor. */
+    children: ReactNode;
+
+    /** Force tooltip to show even without the mouse over the anchor. */
+    forceOpen?: boolean;
+
     /** Delay in ms before closing the tooltip . */
     delay?: number;
 
     /** Placement of tooltip relative to the anchor element. */
     placement?: TooltipPlacement;
-
-    /** Force tooltip to show even without the mouse over the anchor. */
-    forceOpen?: boolean;
-}
-
-/**
- * Defines the props of the component.
- */
-interface TooltipProps extends OptionalTooltipProps {
-    /** Tooltip label. */
-    label?: string | null | false;
-
-    /** Tooltip anchor. */
-    children: ReactNode;
 }
 
 /**
@@ -55,10 +50,9 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: Required<OptionalTooltipProps> = {
+const DEFAULT_PROPS: Partial<TooltipProps> = {
     delay: 500,
     placement: Placement.BOTTOM,
-    forceOpen: false,
 };
 
 /**
@@ -74,15 +68,7 @@ const OFFSET = 8;
  * @return The component.
  */
 const Tooltip: React.FC<TooltipProps> = (props) => {
-    const {
-        label,
-        children,
-        className,
-        delay = DEFAULT_PROPS.delay,
-        placement = DEFAULT_PROPS.placement,
-        forceOpen = DEFAULT_PROPS.forceOpen,
-        ...forwardedProps
-    } = props;
+    const { label, children, className, delay, placement, forceOpen, ...forwardedProps } = props;
     if (!label) {
         return <>{children}</>;
     }
@@ -102,8 +88,8 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
     });
 
     const position = attributes?.popper?.['data-popper-placement'] ?? placement;
-    const isOpen = useTooltipOpen(delay, anchorElement) || forceOpen;
-    const wrappedChildren = useInjectTooltipRef(children, setAnchorElement, isOpen, id);
+    const isOpen = useTooltipOpen(delay as number, anchorElement) || forceOpen;
+    const wrappedChildren = useInjectTooltipRef(children, setAnchorElement, isOpen as boolean, id);
 
     return (
         <>
@@ -133,5 +119,6 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
     );
 };
 Tooltip.displayName = COMPONENT_NAME;
+Tooltip.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, useTooltipOpen, Tooltip, TooltipPlacement, TooltipProps };
+export { CLASSNAME, useTooltipOpen, Tooltip, TooltipPlacement, TooltipProps };

--- a/packages/lumx-react/src/components/tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/lumx-react/src/components/tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -5,6 +5,9 @@ exports[`<Tooltip> Snapshots and structure should not wrap Button 1`] = `
   <Button
     aria-describedby="tooltip-123"
     buttonRef={[Function]}
+    emphasis="high"
+    size="m"
+    theme="light"
   >
     button
   </Button>
@@ -126,6 +129,9 @@ exports[`<Tooltip> Snapshots and structure should work on disabled elements 1`] 
   >
     <Button
       disabled={true}
+      emphasis="high"
+      size="m"
+      theme="light"
     >
       Empty
     </Button>

--- a/packages/lumx-react/src/components/uploader/Uploader.test.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.test.tsx
@@ -6,7 +6,9 @@ import 'jest-enzyme';
 import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
 import { getBasicClass } from '@lumx/react/utils';
 
-import { CLASSNAME, DEFAULT_PROPS, Uploader, UploaderProps } from './Uploader';
+import { CLASSNAME, Uploader, UploaderProps } from './Uploader';
+
+const DEFAULT_PROPS = Uploader.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -75,16 +75,7 @@ const DEFAULT_PROPS: Partial<UploaderProps> = {
  * @return The component.
  */
 const Uploader: React.FC<UploaderProps> = (props) => {
-    const {
-        aspectRatio = DEFAULT_PROPS.aspectRatio,
-        className,
-        label,
-        icon,
-        size = DEFAULT_PROPS.size,
-        theme = DEFAULT_PROPS.theme,
-        variant = DEFAULT_PROPS.variant,
-        ...forwardedProps
-    } = props;
+    const { aspectRatio, className, label, icon, size, theme, variant, ...forwardedProps } = props;
 
     // Adjust to square aspect ratio when using circle variants.
     const adjustedAspectRatio = variant === UploaderVariant.circle ? AspectRatio.square : aspectRatio;
@@ -118,5 +109,6 @@ const Uploader: React.FC<UploaderProps> = (props) => {
     );
 };
 Uploader.displayName = COMPONENT_NAME;
+Uploader.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, Uploader, UploaderProps, UploaderVariant };
+export { CLASSNAME, Uploader, UploaderProps, UploaderVariant };

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -47,11 +47,6 @@ interface UserBlockProps extends GenericProps {
 }
 
 /**
- * Define the types of the default props.
- */
-interface DefaultPropsType extends Partial<UserBlockProps> {}
-
-/**
  * The display name of the component.
  */
 const COMPONENT_NAME = `${COMPONENT_PREFIX}UserBlock`;
@@ -64,7 +59,7 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
 /**
  * The default value of props.
  */
-const DEFAULT_PROPS: DefaultPropsType = {
+const DEFAULT_PROPS: Partial<UserBlockProps> = {
     orientation: Orientation.horizontal,
     size: Size.m,
     theme: Theme.light,
@@ -77,8 +72,8 @@ const DEFAULT_PROPS: DefaultPropsType = {
  */
 const UserBlock: React.FC<UserBlockProps> = ({
     avatar,
-    theme = DEFAULT_PROPS.theme,
-    orientation = DEFAULT_PROPS.orientation,
+    theme,
+    orientation,
     fields,
     name,
     onClick,
@@ -87,7 +82,7 @@ const UserBlock: React.FC<UserBlockProps> = ({
     className,
     simpleAction,
     multipleActions,
-    size = DEFAULT_PROPS.size,
+    size,
     userBlockRef,
     ...forwardedProps
 }) => {
@@ -152,5 +147,6 @@ const UserBlock: React.FC<UserBlockProps> = ({
     );
 };
 UserBlock.displayName = COMPONENT_NAME;
+UserBlock.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, UserBlock, UserBlockProps, UserBlockSize };
+export { CLASSNAME, UserBlock, UserBlockProps, UserBlockSize };

--- a/packages/yo-generators/generators/component/templates/FunctionalComponent.tsx.ejs
+++ b/packages/yo-generators/generators/component/templates/FunctionalComponent.tsx.ejs
@@ -49,5 +49,6 @@ const <%= componentName %>: React.FC<<%= componentName %>Props> = (props: <%= co
     );
 };
 <%= componentName %>.displayName = COMPONENT_NAME;
+<%= componentName %>.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, DEFAULT_PROPS, <%= componentName %>, <%= componentName %>Props };
+export { CLASSNAME, <%= componentName %>, <%= componentName %>Props };

--- a/packages/yo-generators/generators/tests/templates/Component.test.tsx.ejs
+++ b/packages/yo-generators/generators/tests/templates/Component.test.tsx.ejs
@@ -6,7 +6,9 @@ import 'jest-enzyme';
 import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
 import { getBasicClass } from '@lumx/react/utils';
 
-import { CLASSNAME, DEFAULT_PROPS, <%= componentName %>, <%= componentName %>Props } from './<%= componentName %>';
+import { CLASSNAME, <%= componentName %>, <%= componentName %>Props } from './<%= componentName %>';
+
+const DEFAULT_PROPS = <%= componentName %>.defaultProps as any;
 
 /**
  * Define the overriding properties waited by the `setup` function.


### PR DESCRIPTION
Expose all component default props via the React `Component.defaultProps` property
