### PR TITLE
refactor(link): add button alternative and typo prop LUM-11250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `name` and `value` props to `Switch`, `CheckBox` and `RadioButton` components.
 -   Added `name` prop to `Autocomplete`, `DatePicker`, `TextField`, `Button`, `IconButton` and `Slider` components.
 -   Expose component default props in React `Component.defaultProps`
+-   A `Link` component without an `href` would result in a button looking like a link instead of an anchor.
+-   Added `typography` prop to `Link` component.
 
 ### Changed
 

--- a/packages/lumx-core/src/scss/components/link/lumapps/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/link/lumapps/_mixins.scss
@@ -1,4 +1,6 @@
 @mixin lumx-link-base() {
+    border: none;
+    background: none;
     cursor: pointer;
     outline: none;
     text-decoration: none;

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -26,3 +26,9 @@ export const simpleButton = ({ theme }: any) => {
         </Button>
     );
 };
+
+export const withHref = () => <Button href="https://google.com">Button with redirection</Button>;
+
+export const disabled = () => <Button isDisabled>Disabled button</Button>;
+
+export const disabledWithHref = () => <Button href="https://google.com" isDisabled>Disabled button with redirection</Button>;

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -39,7 +39,6 @@ interface BaseButtonProps extends GenericProps {
     theme?: Theme;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-
     /**
      * Use this property if you specified a URL in the `href` property and you want to customize the react component
      * for the link (can be used to inject react router Link).
@@ -102,6 +101,7 @@ const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
         linkAs,
         name,
         size,
+        target,
         theme,
         useCustomColors,
         variant,
@@ -133,15 +133,21 @@ const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
         { [`${CSS_PREFIX}-custom-colors`]: useCustomColors },
     );
 
-    if (!isEmpty(props.href) || linkAs) {
+    /**
+     * If the linkAs prop is used, we use the linkAs component instead of a <button>.
+     * If there is an href attribute, we display an <a> instead of a <button>.
+     *
+     * However, in any case, if the component is disabled, we returned a <button> since disabled is not compatible with <a>.
+     */
+    if ((linkAs || !isEmpty(props.href)) && !isDisabled) {
         return renderLink(
             {
                 linkAs,
-                ref: buttonRef as RefObject<HTMLAnchorElement>,
-                className: buttonClassName,
-                disabled: isDisabled,
-                href: !isDisabled ? href : undefined,
                 ...forwardedProps,
+                href,
+                target,
+                className: buttonClassName,
+                ref: buttonRef as RefObject<HTMLAnchorElement>,
             },
             children,
         );

--- a/packages/lumx-react/src/components/index.ts
+++ b/packages/lumx-react/src/components/index.ts
@@ -82,6 +82,21 @@ enum Emphasis {
 }
 
 /**
+ * List of typographies.
+ */
+enum Typography {
+    overline = 'overline',
+    caption = 'caption',
+    body1 = 'body1',
+    body2 = 'body2',
+    subtitle1 = 'subtitle1',
+    subtitle2 = 'subtitle2',
+    title = 'title',
+    headline = 'headline',
+    display1 = 'display1',
+}
+
+/**
  * All available aspect ratios.
  */
 enum AspectRatio {
@@ -114,4 +129,5 @@ export {
     Orientation,
     Emphasis,
     Kind,
+    Typography,
 };

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -1,8 +1,11 @@
-import { ColorPalette, ColorVariant, Link } from '@lumx/react';
+import { ColorPalette, ColorVariant, Link, Typography } from '@lumx/react';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
 export default { title: 'LumX components/link/Link' };
+
+// tslint:disable-next-line:no-console
+const onClick = () => console.log('clicked link');
 
 export const simpleLink = () => (
     <>
@@ -11,6 +14,7 @@ export const simpleLink = () => (
             target={boolean('target: _blank', false, 'Link 1') ? '_blank' : ''}
             color={select('Color', ColorPalette, ColorPalette.blue, 'Link 1')}
             colorVariant={select('Color Variant', ColorVariant, ColorVariant.N, 'Link 1')}
+            typography={select('Typography', Typography, Typography.body2, 'Link 1')}
         >
             {text('Value', 'Here is a first link', 'Link 1')}
         </Link>
@@ -18,6 +22,9 @@ export const simpleLink = () => (
         <Link
             href={text('href', 'https://google.fr', 'Link 2')}
             target={boolean('target: _blank', false, 'Link 2') ? '_blank' : ''}
+            color={select('Color', ColorPalette, ColorPalette.blue, 'Link 2')}
+            colorVariant={select('Color Variant', ColorVariant, ColorVariant.N, 'Link 2')}
+            typography={select('Typography', Typography, Typography.body1, 'Link 2')}
         >
             {text('Value', 'Here is a second link', 'Link 2')}
         </Link>
@@ -25,13 +32,20 @@ export const simpleLink = () => (
         <Link
             href={text('href', 'https://google.co.jp', 'Link 3')}
             target={boolean('target: _blank', false, 'Link 3') ? '_blank' : ''}
+            color={select('Color', ColorPalette, ColorPalette.blue, 'Link 3')}
+            colorVariant={select('Color Variant', ColorVariant, ColorVariant.N, 'Link 3')}
+            typography={select('Typography', Typography, Typography.caption, 'Link 3')}
         >
             {text('Value', 'Here is a third link', 'Link 3')}
         </Link>
     </>
 );
 
+export const withoutHref = () => <Link onClick={onClick}>Link without redirection</Link>;
+
 const CustomLink: React.FC = ({ children, ...props }) =>
     React.createElement('a', { ...props, style: { color: 'red' } }, children);
 
-export const withCustomLink = () => <Link linkAs={CustomLink}>My link text</Link>;
+export const withCustomLink = () => <Link linkAs={CustomLink} href="https://google.com">Custom link</Link>;
+
+export const disabledLink = () => <Link onClick={onClick} disabled>Disabled link</Link>;

--- a/packages/lumx-react/src/components/link/Link.test.tsx
+++ b/packages/lumx-react/src/components/link/Link.test.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, createRef } from 'react';
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
-import { ColorPalette, ColorVariant } from '@lumx/react';
+import { ColorPalette, ColorVariant, Typography } from '@lumx/react';
 import { CommonSetup, Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
 import { CLASSNAME, Link, LinkProps } from './Link';
 
@@ -46,12 +46,22 @@ describe(`<${Link.displayName}>`, () => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', () => {
         it('should render correctly', () => {
-            const { wrapper } = setup();
+            const { wrapper } = setup({ href: 'https://google.com' });
             expect(wrapper).toMatchSnapshot();
         });
 
         it('should render color & color variant', () => {
-            const { wrapper } = setup({ color: ColorPalette.primary, colorVariant: ColorVariant.D1 });
+            const { wrapper } = setup({ href: 'https://google.com', color: ColorPalette.primary, colorVariant: ColorVariant.D1 });
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it('should render typography', () => {
+            const { wrapper } = setup({ href: 'https://google.com', typography: Typography.title });
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it('should render a button if href attribute is missing', () => {
+            const { wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -1,9 +1,11 @@
 import React, { Ref } from 'react';
 
+import isEmpty from 'lodash/isEmpty';
+
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import classNames from 'classnames';
 
-import { Color, ColorVariant } from '@lumx/react';
+import { Color, ColorVariant, Typography } from '@lumx/react';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
@@ -13,20 +15,22 @@ type HTMLAnchorProps = React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAn
  * Defines the props of the component.
  */
 interface LinkProps extends GenericProps {
-    /** The color of the icon. */
+    /** The color of the link. */
     color?: Color;
-    /** The degree of lightness and darkness of the selected icon color. */
+    /** The degree of lightness and darkness of the selected link color. */
     colorVariant?: ColorVariant;
+    /** Link href. */
+    href?: HTMLAnchorProps['href'];
+    /** Whether the component is disabled or not. */
+    isDisabled?: boolean;
     /** Sets a custom react component for the link (can be used to inject react router Link). */
     linkAs?: 'a' | any;
     /** The reference passed to the <a> element. */
     linkRef?: Ref<HTMLAnchorElement>;
-
-    /** Link href. */
-    href?: HTMLAnchorProps['href'];
-
     /** Link target. */
     target?: HTMLAnchorProps['target'];
+    /** The typography of the link. */
+    typography?: Typography;
 }
 
 /**
@@ -44,15 +48,46 @@ const Link: React.FC<LinkProps> = ({
     className,
     color,
     colorVariant,
+    disabled,
+    isDisabled = disabled,
+    href,
     linkAs,
     linkRef,
+    target,
+    typography,
     ...forwardedProps
 }) => {
+    /**
+     * If there is no linkAs prop and no href, we returned a <button> instead of a <a>.
+     * If the component is disabled, we also returned a <button> since disabled is not compatible with <a>.
+     */
+    if ((!linkAs && isEmpty(href)) || isDisabled) {
+        return (
+            <button
+                {...forwardedProps}
+                disabled={isDisabled}
+                ref={linkRef as any}
+                className={classNames(
+                    className,
+                    handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }),
+                    { [`lumx-typography-${typography}`]: typography },
+                )}
+            >
+                {children}
+            </button>
+        );
+    }
     return renderLink(
         {
             linkAs,
             ...forwardedProps,
-            className: classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, colorVariant })),
+            href,
+            target,
+            className: classNames(
+                className,
+                handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }),
+                { [`lumx-typography-${typography}`]: typography },
+            ),
             ref: linkRef,
         },
         children,

--- a/packages/lumx-react/src/components/link/__snapshots__/Link.test.tsx.snap
+++ b/packages/lumx-react/src/components/link/__snapshots__/Link.test.tsx.snap
@@ -1,13 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Link> Snapshots and structure should render a button if href attribute is missing 1`] = `
+<button
+  className="lumx-link"
+/>
+`;
+
 exports[`<Link> Snapshots and structure should render color & color variant 1`] = `
 <a
   className="lumx-link lumx-link--color-primary lumx-link--color-variant-D1"
+  href="https://google.com"
 />
 `;
 
 exports[`<Link> Snapshots and structure should render correctly 1`] = `
 <a
   className="lumx-link"
+  href="https://google.com"
+/>
+`;
+
+exports[`<Link> Snapshots and structure should render typography 1`] = `
+<a
+  className="lumx-link lumx-typography-title"
+  href="https://google.com"
 />
 `;


### PR DESCRIPTION
# General summary

- A `Link` component without an `href` would result in a button looking like a link instead of an anchor.
![Capture d’écran de 2020-11-09 17-30-00](https://user-images.githubusercontent.com/2828353/98568733-b8357900-22b1-11eb-854d-94ff1cc45750.png)
- Added `typography` prop to `Link` component.
![Capture d’écran de 2020-11-09 17-32-39](https://user-images.githubusercontent.com/2828353/98568753-bd92c380-22b1-11eb-827c-a60ee7ac8291.png)

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
