### PR TITLE
refactor(image-block-and-mosaic): move thumbnail props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Default color of `Badge` is now `primary`.
 -   _[BREAKING]_ Removed `Tabs` component replaced by the `TabProvider` and `TabList` components.
 -   _[BREAKING]_ `Tab` component doesn't wrap the tab content anymore (use `TabPanel` for that). Implements the [WAI-ARIA `tab` role](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html#rps_label).
+-   _[BREAKING]_ `onClick` prop for `Mosaic.thumbnail` prop is no longer automatically passing the index.
 
 ### Removed
 
 -   _[BREAKING]_ Removed `onOpen` prop from `Dialog` component. User should use `isOpen` from its side.
 -   _[BREAKING]_ Removed `thumbnailAspectRatio` prop from `PostBlock` component. User should pass it using `thumbnailProps` instead.
 -   _[BREAKING]_ Removed `onOpen`, `role` and `noWrapper` props from `Lightbox` component.
+-   _[BREAKING]_ `align`, `aspectRatio`, `crossOrigin`, `fillHeight`, `focusPoint`, `isCrossOriginEnabled` and `onClick` props have been removed from `ImageBlock` component. These props will now be passed using the `ImageBlock.thumbnailProps` prop.
 
 ## [0.28.0][] - 2020-11-17
 

--- a/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
@@ -59,17 +59,19 @@ export const defaultImageBlock = ({ theme }: any) => {
 
     return (
         <ImageBlock
-            align={align}
-            aspectRatio={aspectRatio}
-            crossOrigin={crossOrigin}
             description={description}
-            focusPoint={focusPoint}
             image={htmlDecode(imageUrl)}
-            isCrossOriginEnabled={isCrossOriginEnabled}
             size={size}
             tags={isDisplayedTags && tags}
             title={title}
             theme={theme}
+            thumbnailProps={{
+                align,
+                aspectRatio,
+                crossOrigin,
+                focusPoint,
+                isCrossOriginEnabled,
+            }}
         />
     );
 };

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import isObject from 'lodash/isObject';
 
-import { Alignment, AspectRatio, CrossOrigin, FocusPoint, Size, Theme, Thumbnail } from '@lumx/react';
+import { Alignment, AspectRatio, Size, Theme, Thumbnail } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
@@ -27,77 +27,29 @@ type ImageBlockSize = Size.xl | Size.xxl;
  * Defines the props of the component.
  */
 interface ImageBlockProps extends GenericProps {
-    /**
-     * The caption wrapper alignment.
-     * @see {@link ThumbnailProps#align}
-     */
-    align?: Alignment;
-    /**
-     * The aspect ratio the image will get.
-     * @see {@link ThumbnailProps#aspectRatio}
-     */
-    aspectRatio?: AspectRatio;
+    /** The action elements. */
+    actions?: ReactNode;
     /** The position of the caption. */
     captionPosition?: ImageBlockCaptionPosition;
     /** The style to apply to the caption section. */
     captionStyle?: CSSProperties;
-    /**
-     * Allows images that are loaded from foreign origins to be used as if they had been loaded from the current origin.
-     * @see {@link ThumbnailProps#crossOrigin}
-     */
-    crossOrigin?: CrossOrigin;
     /** The image description. Can be either a string, or sanitized html. */
     description?: string | { __html: string };
-    /**
-     * Whether the image has to fill its container's height.
-     * @see {@link ThumbnailProps#fillHeight}
-     */
-    fillHeight?: boolean;
-    /**
-     * The focal point coordinates.
-     * @see {@link ThumbnailProps#focusPoint}
-     */
-    focusPoint?: FocusPoint;
     /**
      * The url of the image we want to display.
      * @see {@link ThumbnailProps#image}
      */
     image: string;
-    /** The props to pass to the thumbnail, minus those already set by the ImageBlock props. */
-    thumbnailProps?: Omit<
-        ThumbnailProps,
-        | 'align'
-        | 'aspectRatio'
-        | 'crossOrigin'
-        | 'fillHeight'
-        | 'focusPoint'
-        | 'image'
-        | 'isCrossOriginEnabled'
-        | 'size'
-        | 'theme'
-        | 'onClick'
-    >;
-    /**
-     * Whether the cross origin attribute is enabled.
-     * @see {@link ThumbnailProps#isCrossOriginEnabled}
-     */
-    isCrossOriginEnabled?: boolean;
-    /**
-     * The size variant of the component.
-     * @see {@link ThumbnailProps#size}
-     */
+    /** The size variant of the component. */
     size?: ImageBlockSize;
     /** The tags elements. */
     tags?: HTMLElement | ReactNode;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
+    /** The props to pass to the thumbnail, minus those already set by the ImageBlock props. */
+    thumbnailProps?: Omit<ThumbnailProps, 'image' | 'size' | 'theme'>;
     /** The image title to display in the caption. */
     title?: string;
-    /**
-     * The function called on click.
-     * @see {@link ThumbnailProps#onClick}
-     */
-    onClick?(): void;
 }
 
 /**
@@ -114,26 +66,21 @@ const CLASSNAME: string = getRootClassName(COMPONENT_NAME);
  * The default value of props.
  */
 const DEFAULT_PROPS: Partial<ImageBlockProps> = {
-    align: Alignment.left,
-    aspectRatio: AspectRatio.original,
     captionPosition: ImageBlockCaptionPosition.below,
     theme: Theme.light,
+    thumbnailProps: {
+        align: Alignment.left,
+        aspectRatio: AspectRatio.original,
+    },
 };
 
 const ImageBlock: React.FC<ImageBlockProps> = ({
     actions,
-    align,
-    aspectRatio,
     captionPosition,
     captionStyle,
     className,
-    crossOrigin,
     description,
-    fillHeight,
-    focusPoint,
     image,
-    isCrossOriginEnabled,
-    onClick,
     size,
     tags,
     theme,
@@ -147,31 +94,20 @@ const ImageBlock: React.FC<ImageBlockProps> = ({
             className={classNames(
                 className,
                 handleBasicClasses({
-                    align,
-                    aspectRatio,
+                    align: thumbnailProps?.align,
+                    aspectRatio: thumbnailProps?.aspectRatio,
+                    fillHeight: thumbnailProps?.fillHeight,
                     captionPosition,
                     prefix: CLASSNAME,
                     size,
                     theme,
                 }),
-                {
-                    [`${CLASSNAME}--fill-height`]: fillHeight,
-                    [`${CLASSNAME}--format-crop`]: aspectRatio && aspectRatio !== AspectRatio.original,
-                    [`${CLASSNAME}--format-original`]: !aspectRatio || aspectRatio === AspectRatio.original,
-                },
             )}
         >
             <Thumbnail
                 {...thumbnailProps}
-                align={align}
-                aspectRatio={aspectRatio}
                 className={classNames(`${CLASSNAME}__image`, thumbnailProps?.className)}
-                crossOrigin={crossOrigin}
-                fillHeight={fillHeight}
-                focusPoint={focusPoint}
                 image={image}
-                isCrossOriginEnabled={isCrossOriginEnabled}
-                onClick={onClick}
                 size={size}
                 theme={theme}
             />

--- a/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
@@ -66,11 +66,12 @@ export const clickableThumbnails = ({ theme }: any) => {
         <div style={{ width: 250 }}>
             <Mosaic
                 theme={theme}
+                onImageClick={onClick}
                 thumbnails={[
-                    { image: imageKnob('Image 1', IMAGES.landscape1), onClick },
-                    { image: imageKnob('Image 2', IMAGES.landscape2), onClick },
-                    { image: imageKnob('Image 3', IMAGES.landscape3), onClick },
-                    { image: imageKnob('Image 4', IMAGES.portrait1), onClick },
+                    { image: imageKnob('Image 1', IMAGES.landscape1) },
+                    { image: imageKnob('Image 2', IMAGES.landscape2) },
+                    { image: imageKnob('Image 3', IMAGES.landscape3) },
+                    { image: imageKnob('Image 4', IMAGES.portrait1) },
                 ]}
             />
         </div>
@@ -79,41 +80,37 @@ export const clickableThumbnails = ({ theme }: any) => {
 
 export const sixThumbnails = ({ theme }: any) => {
     const [activeIndex, setActiveIndex] = useState<number>();
-    const lightBoxParent = useRef(null);
     const thumbnails = [
-        { onClick: setActiveIndex, image: imageKnob('Image 1', IMAGES.landscape1) },
-        { onClick: setActiveIndex, image: imageKnob('Image 2', IMAGES.landscape2) },
-        { onClick: setActiveIndex, image: imageKnob('Image 3', IMAGES.landscape3) },
-        { onClick: setActiveIndex, image: imageKnob('Image 4', IMAGES.portrait1) },
-        { onClick: setActiveIndex, image: imageKnob('Image 5', IMAGES.portrait2) },
-        { onClick: setActiveIndex, image: imageKnob('Image 6', IMAGES.square1) },
+        { image: imageKnob('Image 1', IMAGES.landscape1) },
+        { image: imageKnob('Image 2', IMAGES.landscape2) },
+        { image: imageKnob('Image 3', IMAGES.landscape3) },
+        { image: imageKnob('Image 4', IMAGES.portrait1) },
+        { image: imageKnob('Image 5', IMAGES.portrait2) },
+        { image: imageKnob('Image 6', IMAGES.square1) },
     ];
+    const lightBoxParent = useRef(null);
     const closeLightBox = useCallback(() => {
-        setActiveIndex(0);
+        setActiveIndex(undefined);
     }, [setActiveIndex]);
 
     return (
         <div ref={lightBoxParent} style={{ width: 250 }}>
-            <Mosaic theme={theme} thumbnails={thumbnails} />
+            <Mosaic theme={theme} onImageClick={setActiveIndex} thumbnails={thumbnails} />
 
-            <Lightbox
-                isOpen={activeIndex !== undefined && activeIndex !== null}
-                parentElement={lightBoxParent}
-                onClose={closeLightBox}
-            >
-                <Slideshow activeIndex={activeIndex} hasControls={true} fillHeight={true} theme={Theme.dark}>
-                    {thumbnails.map((th, idx) => {
-                        return (
-                            <SlideshowItem key={`${th.image}-${idx}`}>
-                                <ImageBlock
-                                    image={th.image}
-                                    align={Alignment.center}
-                                    fillHeight={true}
-                                    theme={Theme.dark}
-                                />
-                            </SlideshowItem>
-                        );
-                    })}
+            <Lightbox isOpen={activeIndex !== undefined} parentElement={lightBoxParent} onClose={closeLightBox}>
+                <Slideshow activeIndex={activeIndex} hasControls fillHeight theme={Theme.dark}>
+                    {thumbnails.map((thumbnail, index) => (
+                        <SlideshowItem key={`${thumbnail.image}-${index}`}>
+                            <ImageBlock
+                                image={thumbnail.image}
+                                theme={Theme.dark}
+                                thumbnailProps={{
+                                    align: Alignment.center,
+                                    fillHeight: true,
+                                }}
+                            />
+                        </SlideshowItem>
+                    ))}
                 </Slideshow>
             </Lightbox>
         </div>

--- a/packages/lumx-react/src/components/mosaic/Mosaic.test.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.test.tsx
@@ -129,7 +129,6 @@ describe(`<${Mosaic.displayName}>`, () => {
                 thumbnail.simulate('click');
             });
             expect(clickOnFirstThumbnail).toHaveBeenCalledTimes(1);
-            expect(clickOnFirstThumbnail).toHaveBeenCalledWith(0);
         });
     });
 

--- a/packages/lumx-react/src/components/post-block/Demos.stories.tsx
+++ b/packages/lumx-react/src/components/post-block/Demos.stories.tsx
@@ -1,0 +1,3 @@
+export default { title: 'LumX components/post-block/Demos' };
+
+export { App as Default } from './demos/default';

--- a/packages/lumx-react/src/components/post-block/demos
+++ b/packages/lumx-react/src/components/post-block/demos
@@ -1,0 +1,1 @@
+../../../../site-demo/content/product/components/post-block/react

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -31,7 +31,7 @@ export const Simple = ({ theme }: any) => {
         >
             {images.map((image, index) => (
                 <SlideshowItem key={`${image}-${index}`}>
-                    <ImageBlock aspectRatio={AspectRatio.horizontal} image={image} theme={theme} />
+                    <ImageBlock thumbnailProps={{ aspectRatio: AspectRatio.horizontal }} image={image} theme={theme} />
                 </SlideshowItem>
             ))}
         </Slideshow>

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
@@ -60,7 +60,7 @@ export const ControllingSlideshow = ({ theme }: any) => {
             >
                 {items.map((item) => (
                     <SlideshowItem key={item}>
-                        <ImageBlock aspectRatio={AspectRatio.vertical} image={item} theme={theme} />
+                        <ImageBlock image={item} thumbnailProps={{ aspectRatio: AspectRatio.vertical }} theme={theme} />
                     </SlideshowItem>
                 ))}
             </Slideshow>

--- a/packages/site-demo/content/product/components/image-block/react/default.tsx
+++ b/packages/site-demo/content/product/components/image-block/react/default.tsx
@@ -29,8 +29,8 @@ export const App = ({ theme }: any) => (
                 </div>
             </FlexBox>
         }
-        aspectRatio={AspectRatio.horizontal}
         description="Lorem ipsum dolor sit amet, consectur adipiscing "
+        image="/demo-assets/landscape1.jpg"
         tags={
             <ChipGroup>
                 <Chip size={Size.s} theme={theme}>
@@ -44,6 +44,6 @@ export const App = ({ theme }: any) => (
         }
         theme={theme}
         title="Lorem ipsum"
-        image="/demo-assets/landscape1.jpg"
+        thumbnailProps={{ aspectRatio: AspectRatio.horizontal }}
     />
 );

--- a/packages/site-demo/content/product/components/image-block/react/image-block-above.tsx
+++ b/packages/site-demo/content/product/components/image-block/react/image-block-above.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 
 export const App = ({ theme }: any) => (
     <ImageBlock
-        aspectRatio={AspectRatio.horizontal}
         captionPosition={ImageBlockCaptionPosition.over}
         description="Lorem ipsum dolor sit amet, consectur adipiscing "
+        image="/demo-assets/landscape2.jpg"
         tags={
             <ChipGroup>
                 <Chip size={Size.s} theme={theme}>
@@ -19,6 +19,6 @@ export const App = ({ theme }: any) => (
         }
         theme={theme}
         title="Lorem ipsum"
-        image="/demo-assets/landscape2.jpg"
+        thumbnailProps={{ aspectRatio: AspectRatio.horizontal }}
     />
 );

--- a/packages/site-demo/content/product/components/image-block/react/image-block-alignment.tsx
+++ b/packages/site-demo/content/product/components/image-block/react/image-block-alignment.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 
 export const App = ({ theme }: any) => (
     <ImageBlock
-        align={Alignment.center}
-        aspectRatio={AspectRatio.original}
         description="Lorem ipsum dolor sit amet, consectur adipiscing "
+        image="/demo-assets/portrait1.jpg"
         tags={
             <ChipGroup align={Alignment.center}>
                 <Chip size={Size.s} theme={theme}>
@@ -19,6 +18,9 @@ export const App = ({ theme }: any) => (
         }
         theme={theme}
         title="Lorem ipsum"
-        image="/demo-assets/portrait1.jpg"
+        thumbnailProps={{
+            align: Alignment.center,
+            aspectRatio: AspectRatio.original,
+        }}
     />
 );

--- a/packages/site-demo/content/product/components/image-block/react/image-block-padding.tsx
+++ b/packages/site-demo/content/product/components/image-block/react/image-block-padding.tsx
@@ -5,9 +5,9 @@ export const App = () => (
     <div className="lumx-color-background-dark-L5 lumx-spacing-padding-huge">
         <ImageBlock
             className="lumx-color-background-light-N"
-            aspectRatio={AspectRatio.horizontal}
             captionStyle={{ padding: 16 }}
             description="Lorem ipsum dolor sit amet, consectur adipiscing "
+            image="/demo-assets/landscape3.jpg"
             tags={
                 <ChipGroup>
                     <Chip size={Size.s}>Tag 1</Chip>
@@ -15,7 +15,7 @@ export const App = () => (
                 </ChipGroup>
             }
             title="Lorem ipsum"
-            image="/demo-assets/landscape3.jpg"
+            thumbnailProps={{ aspectRatio: AspectRatio.horizontal }}
         />
     </div>
 );

--- a/packages/site-demo/content/product/components/slideshow/react/auto.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/auto.tsx
@@ -9,22 +9,46 @@ export const App = ({ theme }: any) => {
     return (
         <Slideshow activeIndex={0} hasControls theme={theme} autoPlay groupBy={1} style={slideshowStyle}>
             <SlideshowItem>
-                <ImageBlock aspectRatio={AspectRatio.vertical} image="/demo-assets/landscape1.jpg" theme={theme} />
+                <ImageBlock
+                    thumbnailProps={{ aspectRatio: AspectRatio.vertical }}
+                    image="/demo-assets/landscape1.jpg"
+                    theme={theme}
+                />
             </SlideshowItem>
             <SlideshowItem>
-                <ImageBlock aspectRatio={AspectRatio.vertical} image="/demo-assets/landscape2.jpg" theme={theme} />
+                <ImageBlock
+                    thumbnailProps={{ aspectRatio: AspectRatio.vertical }}
+                    image="/demo-assets/landscape2.jpg"
+                    theme={theme}
+                />
             </SlideshowItem>
             <SlideshowItem>
-                <ImageBlock aspectRatio={AspectRatio.vertical} image="/demo-assets/landscape3.jpg" theme={theme} />
+                <ImageBlock
+                    thumbnailProps={{ aspectRatio: AspectRatio.vertical }}
+                    image="/demo-assets/landscape3.jpg"
+                    theme={theme}
+                />
             </SlideshowItem>
             <SlideshowItem>
-                <ImageBlock aspectRatio={AspectRatio.vertical} image="/demo-assets/portrait1.jpg" theme={theme} />
+                <ImageBlock
+                    thumbnailProps={{ aspectRatio: AspectRatio.vertical }}
+                    image="/demo-assets/portrait1.jpg"
+                    theme={theme}
+                />
             </SlideshowItem>
             <SlideshowItem>
-                <ImageBlock aspectRatio={AspectRatio.vertical} image="/demo-assets/portrait2.jpg" theme={theme} />
+                <ImageBlock
+                    thumbnailProps={{ aspectRatio: AspectRatio.vertical }}
+                    image="/demo-assets/portrait2.jpg"
+                    theme={theme}
+                />
             </SlideshowItem>
             <SlideshowItem>
-                <ImageBlock aspectRatio={AspectRatio.vertical} image="/demo-assets/portrait3.jpg" theme={theme} />
+                <ImageBlock
+                    thumbnailProps={{ aspectRatio: AspectRatio.vertical }}
+                    image="/demo-assets/portrait3.jpg"
+                    theme={theme}
+                />
             </SlideshowItem>
         </Slideshow>
     );

--- a/packages/site-demo/content/product/components/slideshow/react/default.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/default.tsx
@@ -42,10 +42,10 @@ export const App = ({ theme }: any) => {
             {images.map((image) => (
                 <SlideshowItem key={image}>
                     <ImageBlock
-                        aspectRatio={AspectRatio.horizontal}
                         captionPosition={ImageBlockCaptionPosition.over}
                         image={image}
                         theme={theme}
+                        thumbnailProps={{ aspectRatio: AspectRatio.horizontal }}
                         {...imageBlockDemoProps}
                     />
                 </SlideshowItem>

--- a/packages/site-demo/content/product/components/slideshow/react/group.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/group.tsx
@@ -21,10 +21,10 @@ export const App = ({ theme }: any) => {
             {images.map((image) => (
                 <SlideshowItem key={image}>
                     <ImageBlock
-                        aspectRatio={AspectRatio.horizontal}
                         captionPosition={ImageBlockCaptionPosition.over}
                         image={image}
                         theme={theme}
+                        thumbnailProps={{ aspectRatio: AspectRatio.horizontal }}
                         {...imageBlockDemoProps}
                     />
                 </SlideshowItem>


### PR DESCRIPTION
# General summary

-   _[BREAKING]_ `onClick` prop for `Mosaic.thumbnail` prop is no longer automatically passing the index.
-   _[BREAKING]_ `align`, `aspectRatio`, `crossOrigin`, `fillHeight`, `focusPoint`, `isCrossOriginEnabled` and `onClick` props have been removed from `ImageBlock` component. These props will now be passed using the `ImageBlock.thumbnailProps` prop.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
