### PR TITLE
refactor(components): allow raw value for enum-based props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `ProgressTrackerStep` components are button instead of anchor for better a11y. Aria attributes have been added according to [WAI ARIA `tab` role](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html) since stepper are similar to tabs in term of a11y.
 -   _[BREAKING]_ `onClick` prop for `ProgressTrackerStep` component is not used anymore. `ProgressTrackerProvider` component has an `onChange` prop instead. Therefore, a step is now clickable if it is not disabled.
 -   _[BREAKING]_ `DatePicker` and `DatePickerField` `value` prop can no longer be a `Moment` object. This will allow us to remove `moment` dep in the future without generating breaking change later. The `value` prop can no longer be a `string` to avoid handling incompatible values. `value` can only be a `Date` (or `undefined` for non selectable values).
+-   Every enum-based props can now accept their raw values. For example, when you were using `Size.xs`, you can now use both `Size.xs` and `"xs"` values.
 
 ### Removed
 
@@ -58,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Removed `onOpen`, `role` and `noWrapper` props from `Lightbox` component.
 -   _[BREAKING]_ `align`, `aspectRatio`, `crossOrigin`, `fillHeight`, `focusPoint`, `isCrossOriginEnabled` and `onClick` props have been removed from `ImageBlock` component. These props will now be passed using the `ImageBlock.thumbnailProps` prop.
 -   _[BREAKING]_ Removed `Tabs` component replaced by the `TabProvider` and `TabList` components.
+-   _[BREAKING]_ Definitely removed `ButtonEmphasis` deprecated type from `Button` component.
+-   _[BREAKING]_ Definitely removed `isClickable` deprecated prop from `List` component.
+-   _[BREAKING]_ Definitely removed `ListItemSize` deprecated type from `ListItem` component.
+-   _[BREAKING]_ Definitely removed `ThumbnailAspectRatio` deprecated type from `Thumbnail` component.
 
 ## [0.28.0][] - 2020-11-17
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { Dropdown, Offset, Placement, TextField, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import { useFocus } from '@lumx/react/hooks/useFocus';
 
@@ -32,7 +32,7 @@ interface AutocompleteProps extends GenericProps {
      * The preferred Dropdown location against the anchor element.
      * @see {@link DropdownProps#placement}
      */
-    placement?: Placement;
+    placement?: ValueOf<Placement>;
     /**
      * Whether the dropdown should fit to the anchor width or not.
      * @see {@link DropdownProps#fitToAnchorWidth}
@@ -88,13 +88,13 @@ interface AutocompleteProps extends GenericProps {
      */
     placeholder?: string;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The children elements. Should be a list of suggestions. */
-    children: React.ReactNode;
+    children: ReactNode;
     /**
      * The list of chips to be displayed before the text field input.
      */
-    chips?: React.ReactNode;
+    chips?: ReactNode;
     /**
      * The value of the text field.
      * @see {@link TextFieldProps#value}

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -6,7 +6,7 @@ import { Size, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
-import { GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, handleBasicClasses } from '@lumx/react/utils';
 import { getRootClassName } from '../../utils/getRootClassName';
 
 /**
@@ -19,15 +19,15 @@ type AvatarSize = Size.xs | Size.s | Size.m | Size.l | Size.xl | Size.xxl;
  */
 interface AvatarProps extends GenericProps {
     /** The action elements. */
-    actions?: HTMLElement | ReactNode;
+    actions?: ReactNode;
     /** The optional avatar badge. */
     badge?: ReactElement;
     /** The avatar image URL. */
     image: string;
     /** The size variant of the component. */
-    size?: AvatarSize;
+    size?: ValueOf<AvatarSize>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
 }
 
 /**

--- a/packages/lumx-react/src/components/badge/Badge.test.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.test.tsx
@@ -82,10 +82,10 @@ describe(`<${Badge.displayName}>`, () => {
             const { badge } = setup(modifiedProps);
 
             expect(badge).toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] as string }),
             );
             expect(badge).not.toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS[testedProp] }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS[testedProp] as string }),
             );
         });
     });

--- a/packages/lumx-react/src/components/button/Button.tsx
+++ b/packages/lumx-react/src/components/button/Button.tsx
@@ -9,12 +9,6 @@ import { getBasicClass, getRootClassName } from '@lumx/react/utils';
 import { BaseButtonProps, ButtonRoot } from './ButtonRoot';
 
 /**
- * The authorized values for the `emphasis` prop.
- * @deprecated Use Emphasis instead.
- */
-const ButtonEmphasis = Emphasis;
-
-/**
  * Defines the props of the component.
  */
 interface ButtonProps extends BaseButtonProps {
@@ -71,4 +65,4 @@ const Button: React.FC<ButtonProps> = (props) => {
 Button.displayName = COMPONENT_NAME;
 Button.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, ButtonEmphasis, Button, ButtonProps };
+export { CLASSNAME, Button, ButtonProps };

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 
 import { Color, ColorPalette, Emphasis, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, handleBasicClasses } from '@lumx/react/utils';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 /**
@@ -20,7 +20,7 @@ interface BaseButtonProps extends GenericProps {
     /** The color variant of the component. */
     color?: Color;
     /** The emphasis variant of the component. */
-    emphasis?: Emphasis;
+    emphasis?: ValueOf<Emphasis>;
     /** Whether or not the button has a background color in low emphasis. */
     hasBackground?: boolean;
     /** The native anchor href property. It determines whether the Button will be a <button> or an <a>. */
@@ -32,11 +32,11 @@ interface BaseButtonProps extends GenericProps {
     /** The native input name property. */
     name?: string;
     /** The size variant of the component. */
-    size?: ButtonSize;
+    size?: ValueOf<ButtonSize>;
     /** The native anchor target property. */
     target?: '_self' | '_blank' | '_parent' | '_top';
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /**

--- a/packages/lumx-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import { mdiCheck } from '@lumx/icons';
 
 import { Icon, InputHelper, InputLabel, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import uniqueId from 'lodash/uniqueId';
 
@@ -27,7 +27,7 @@ interface CheckboxProps extends GenericProps {
     /** The native input name property. */
     name?: string;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /** The native input value property. */

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -7,7 +7,7 @@ import isFunction from 'lodash/isFunction';
 import { Color, ColorPalette, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 
-import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
 
 /**
  * Authorized size values.
@@ -35,9 +35,9 @@ interface ChipProps extends GenericProps {
     /** Whether the component is selected or not. */
     isSelected?: boolean;
     /** The size variant of the component. */
-    size?: ChipSize;
+    size?: ValueOf<ChipSize>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /** The function called when the "after" element is clicked. */

--- a/packages/lumx-react/src/components/chip/ChipGroup.tsx
+++ b/packages/lumx-react/src/components/chip/ChipGroup.tsx
@@ -1,22 +1,24 @@
 import { Alignment } from '@lumx/react/components';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import classNames from 'classnames';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import { useChipGroupNavigation, useChipGroupNavigationType } from '@lumx/react/hooks/useChipGroupNavigation';
+
+type ChipGroupAlignment = Alignment.left | Alignment.center | Alignment.right;
 
 /**
  * Defines the props of the component.
  */
 interface ChipGroupProps extends GenericProps {
     /** The alignment of the component. */
-    align?: string;
+    align?: ValueOf<ChipGroupAlignment>;
     /** The children elements. Should be a list of Chip. */
-    children: React.ReactNode;
+    children: ReactNode;
 }
 
 /**

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { Avatar, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, ENTER_KEY_CODE } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import isFunction from 'lodash/isFunction';
 import { AvatarProps } from '../avatar/Avatar';
@@ -14,7 +14,7 @@ import { AvatarProps } from '../avatar/Avatar';
  */
 interface CommentBlockProps extends GenericProps {
     /** The action elements. */
-    actions?: HTMLElement | ReactNode;
+    actions?: ReactNode;
     /**
      * The url of the avatar picture we want to display.
      * @see {@link AvatarProps#image}
@@ -23,7 +23,7 @@ interface CommentBlockProps extends GenericProps {
     /** The props to pass to the avatar, minus those already set by the CommentBlock props. */
     avatarProps?: Omit<AvatarProps, 'image' | 'size' | 'tabIndex' | 'onClick' | 'onKeyPress'>;
     /** The children elements. */
-    children?: HTMLElement | ReactNode;
+    children?: ReactNode;
     /** The timestamp of the component. */
     date: string;
     /** Whether the component has actions to display or not. */
@@ -41,7 +41,7 @@ interface CommentBlockProps extends GenericProps {
     /** The content of the comment. */
     text: HTMLElement | string;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The function called on click. */
     onClick?(): void;
     /** The function called when the cursor enters the component. */

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -12,10 +12,19 @@ import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useIntersectionObserver } from '@lumx/react/hooks/useIntersectionObserver';
-import { GenericProps, getRootClassName, handleBasicClasses, isComponent, partitionMulti } from '@lumx/react/utils';
+import {
+    GenericProps,
+    ValueOf,
+    getRootClassName,
+    handleBasicClasses,
+    isComponent,
+    partitionMulti,
+} from '@lumx/react/utils';
 import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
+
+type DialogSizes = Size.tiny | Size.regular | Size.big | Size.huge;
 
 /**
  * Defines the props of the component.
@@ -42,14 +51,12 @@ interface DialogProps extends GenericProps {
     /** Whether to keep the dialog open on clickaway or escape press. */
     preventAutoClose?: boolean;
     /** The size variant of the component. */
-    size?: DialogSizes;
+    size?: ValueOf<DialogSizes>;
     /** The z-axis position. */
     zIndex?: number;
     /** The function called on close. */
     onClose?(): void;
 }
-
-type DialogSizes = Size.tiny | Size.regular | Size.big | Size.huge;
 
 const isHeader = isComponent('header');
 const isFooter = isComponent('footer');
@@ -87,7 +94,6 @@ const Dialog: React.FC<DialogProps> = (props) => {
         footer,
         isLoading,
         isOpen,
-        onOpen,
         onClose,
         parentElement,
         contentRef,

--- a/packages/lumx-react/src/components/divider/Divider.test.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.test.tsx
@@ -87,10 +87,10 @@ describe(`<${Divider.displayName}>`, () => {
             const { hr } = setup(modifiedProps);
 
             expect(hr).toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] as string }),
             );
             expect(hr).not.toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS[testedProp] }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS[testedProp] as string }),
             );
         });
     });

--- a/packages/lumx-react/src/components/divider/Divider.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.tsx
@@ -4,14 +4,14 @@ import classNames from 'classnames';
 
 import { Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
 interface DividerProps extends GenericProps {
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
 }
 
 /**

--- a/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
+++ b/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
@@ -6,14 +6,14 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
 import { mdiDragVertical } from '@lumx/icons';
 import { ColorPalette, Icon, Size, Theme } from '@lumx/react';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
 interface DragHandleProps extends GenericProps {
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
 }
 
 /**

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -6,7 +6,7 @@ import { List, ListProps } from '@lumx/react/components/list/List';
 import { Offset, Placement, Popover } from '@lumx/react/components/popover/Popover';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { useInfiniteScroll } from '@lumx/react/hooks/useInfiniteScroll';
-import { GenericProps, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
@@ -56,7 +56,7 @@ interface DropdownProps extends GenericProps {
      * The preferred Dropdown location against the anchor element.
      * @see {@link PopoverProps#placement}
      */
-    placement?: Placement;
+    placement?: ValueOf<Placement>;
     /** Whether the focus should be set on the list when the dropdown is open or not. */
     shouldFocusOnOpen?: boolean;
     /**

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -13,6 +13,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import {
     Callback,
     GenericProps,
+    ValueOf,
     getRootClassName,
     handleBasicClasses,
     isComponent,
@@ -32,7 +33,7 @@ interface ExpansionPanelProps extends GenericProps {
     /** The label text used when no `<header>` was provided in the children. */
     label?: string;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The function called on open. */
     onOpen?: Callback;
     /** The function called on close. */

--- a/packages/lumx-react/src/components/flex-box/FlexBox.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.tsx
@@ -1,6 +1,6 @@
 import { Alignment, Orientation } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import castArray from 'lodash/castArray';
 import React, { ReactNode } from 'react';
@@ -8,6 +8,8 @@ import { Size } from '..';
 
 export type MarginAutoAlignment = Alignment.top | Alignment.bottom | Alignment.right | Alignment.left;
 export type GapSize = Size.regular | Size.big | Size.huge;
+type HorizontalAlignment = Alignment.top | Alignment.center | Alignment.bottom;
+type VerticalAlignment = Alignment.left | Alignment.center | Alignment.right;
 
 /**
  * Defines the props of the component.
@@ -18,17 +20,17 @@ interface FlexBoxProps extends GenericProps {
     /** Whether the "content filling space" is enabled or not. */
     fillSpace?: boolean;
     /** The gap space between flexbox items. */
-    gap?: GapSize;
+    gap?: ValueOf<GapSize>;
     /** The flex horizontal alignment. */
-    hAlign?: Alignment.top | Alignment.center | Alignment.bottom;
+    hAlign?: ValueOf<HorizontalAlignment>;
     /** Whether the "auto margin" is enabled all around or not. */
-    marginAuto?: MarginAutoAlignment | MarginAutoAlignment[];
+    marginAuto?: ValueOf<MarginAutoAlignment> | Array<ValueOf<MarginAutoAlignment>>;
     /** Whether the "content shrink" is disabled or not. */
     noShrink?: boolean;
     /** The flex direction. */
-    orientation?: Orientation;
+    orientation?: ValueOf<Orientation>;
     /** The flex vertical alignment. */
-    vAlign?: Alignment.left | Alignment.center | Alignment.right;
+    vAlign?: ValueOf<VerticalAlignment>;
     /** Whether the "flex wrap" is enabled or not. */
     wrap?: boolean;
 }

--- a/packages/lumx-react/src/components/grid/Grid.tsx
+++ b/packages/lumx-react/src/components/grid/Grid.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 import { Alignment, Orientation, Size } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+
 type GridGutterSize = Size.regular | Size.big | Size.huge;
 
 /**
@@ -12,15 +13,15 @@ type GridGutterSize = Size.regular | Size.big | Size.huge;
  */
 interface GridProps extends GenericProps {
     /** The grid orientation. */
-    orientation?: Orientation;
+    orientation?: ValueOf<Orientation>;
     /** Whether the children are wrapped or not. */
     wrap?: string;
     /** The grid vertical alignment. */
-    vAlign?: Alignment;
+    vAlign?: ValueOf<Alignment>;
     /** The grid horizontal alignment. */
-    hAlign?: Alignment;
+    hAlign?: ValueOf<Alignment>;
     /** The grid gutter size. */
-    gutter?: GridGutterSize;
+    gutter?: ValueOf<GridGutterSize>;
 }
 
 /**

--- a/packages/lumx-react/src/components/grid/GridItem.tsx
+++ b/packages/lumx-react/src/components/grid/GridItem.tsx
@@ -4,14 +4,14 @@ import classNames from 'classnames';
 
 import { Alignment } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
 interface GridItemProps extends GenericProps {
     /** The alignment of the grid item. */
-    align?: Alignment;
+    align?: ValueOf<Alignment>;
     /** The order of the grid item. */
     order?: string;
     /** The width of the grid item. */

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { Color, ColorPalette, ColorVariant, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 type IconSizes = Size.xxs | Size.xs | Size.s | Size.m | Size.l | Size.xl | Size.xxl;
 
@@ -15,7 +15,7 @@ interface IconProps extends GenericProps {
     /** The color of the icon. */
     color?: Color;
     /** The degree of lightness and darkness of the selected icon color. */
-    colorVariant?: ColorVariant;
+    colorVariant?: ValueOf<ColorVariant>;
     /** Whether the icon has a shape. */
     hasShape?: boolean;
     /**
@@ -26,9 +26,9 @@ interface IconProps extends GenericProps {
     /** The reference passed to the <i> element. */
     iconRef?: React.RefObject<HTMLElement>;
     /** The size variant of the component. */
-    size?: IconSizes;
+    size?: ValueOf<IconSizes>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
 }
 
 /**

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -7,7 +7,7 @@ import isObject from 'lodash/isObject';
 import { Alignment, AspectRatio, Size, Theme, Thumbnail } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { ThumbnailProps } from '../thumbnail/Thumbnail';
 
 /**
@@ -30,7 +30,7 @@ interface ImageBlockProps extends GenericProps {
     /** The action elements. */
     actions?: ReactNode;
     /** The position of the caption. */
-    captionPosition?: ImageBlockCaptionPosition;
+    captionPosition?: ValueOf<ImageBlockCaptionPosition>;
     /** The style to apply to the caption section. */
     captionStyle?: CSSProperties;
     /** The image description. Can be either a string, or sanitized html. */
@@ -41,11 +41,11 @@ interface ImageBlockProps extends GenericProps {
      */
     image: string;
     /** The size variant of the component. */
-    size?: ImageBlockSize;
+    size?: ValueOf<ImageBlockSize>;
     /** The tags elements. */
-    tags?: HTMLElement | ReactNode;
+    tags?: ReactNode;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The props to pass to the thumbnail, minus those already set by the ImageBlock props. */
     thumbnailProps?: Omit<ThumbnailProps, 'image' | 'size' | 'theme'>;
     /** The image title to display in the caption. */

--- a/packages/lumx-react/src/components/index.ts
+++ b/packages/lumx-react/src/components/index.ts
@@ -1,3 +1,5 @@
+import { ValueOf } from '../utils/type';
+
 /**
  * Authorized alignments.
  */
@@ -34,7 +36,7 @@ enum ColorPalette {
     red = 'red',
     light = 'light',
 }
-type Color = ColorPalette | string;
+type Color = ValueOf<ColorPalette> | string;
 
 /**
  * See SCSS variable $lumx-color-variants

--- a/packages/lumx-react/src/components/input-helper/InputHelper.tsx
+++ b/packages/lumx-react/src/components/input-helper/InputHelper.tsx
@@ -1,6 +1,6 @@
 import { Kind, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 
@@ -13,9 +13,9 @@ interface InputHelperProps extends GenericProps {
     /** The children elements. */
     children: string | ReactNode;
     /** The kind of helper (error or sucess for exemple). */
-    kind?: Kind;
+    kind?: ValueOf<Kind>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
 }
 
 /**

--- a/packages/lumx-react/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-react/src/components/input-label/InputLabel.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 
@@ -13,7 +13,7 @@ interface InputLabelProps extends GenericProps {
     /** Whether the component is required or not. */
     isRequired?: boolean;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
 }
 
 /**

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -8,7 +8,7 @@ import { createPortal } from 'react-dom';
 import { mdiClose } from '@lumx/icons';
 import { ColorPalette, Emphasis, IconButton, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, DOCUMENT } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import isFunction from 'lodash/isFunction';
 
@@ -29,7 +29,7 @@ interface LightboxProps extends GenericProps {
     /** Whether to keep the dialog open on clickaway or escape press. */
     preventAutoClose?: boolean;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The z-axis position. */
     zIndex?: number;
     /** The function called on close. */

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
@@ -15,7 +15,9 @@ import {
 } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+
+type LinkPreviewSizes = Size.regular | Size.big;
 
 /**
  * Defines the props of the component.
@@ -31,9 +33,9 @@ interface LinkPreviewProps extends GenericProps {
     /** The props to pass to the link, minus those already set by the LinkPreview props. */
     linkProps?: Omit<LinkProps, 'color' | 'colorVariant' | 'href' | 'target'>;
     /** The size variant of the component. */
-    size?: Size.regular | Size.big;
+    size?: ValueOf<LinkPreviewSizes>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /**
      * The image URL of the Thumbnail.
      * @see {@link ThumbnailProps#image}

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -6,7 +6,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import classNames from 'classnames';
 
 import { Color, ColorVariant, Icon, Size, Typography } from '@lumx/react';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 type HTMLAnchorProps = React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
@@ -18,7 +18,7 @@ interface LinkProps extends GenericProps {
     /** The color of the link. */
     color?: Color;
     /** The degree of lightness and darkness of the selected link color. */
-    colorVariant?: ColorVariant;
+    colorVariant?: ValueOf<ColorVariant>;
     /** Link href. */
     href?: HTMLAnchorProps['href'];
     /** Whether the component is disabled or not. */
@@ -40,7 +40,7 @@ interface LinkProps extends GenericProps {
     /** Link target. */
     target?: HTMLAnchorProps['target'];
     /** The typography of the link. */
-    typography?: Typography;
+    typography?: ValueOf<Typography>;
 }
 
 /**

--- a/packages/lumx-react/src/components/list/List.tsx
+++ b/packages/lumx-react/src/components/list/List.tsx
@@ -3,12 +3,14 @@ import { Size } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 
 import { useKeyboardListNavigation, useKeyboardListNavigationType } from '@lumx/react/hooks/useKeyboardListNavigation';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import classNames from 'classnames';
 import React, { Key, ReactNode, Ref, useRef } from 'react';
 import { useInteractiveList } from './useInteractiveList';
+
+type ItemPaddingSizes = Size.big | Size.huge;
 
 /**
  * Defines the props of the component.
@@ -16,13 +18,8 @@ import { useInteractiveList } from './useInteractiveList';
 interface ListProps extends GenericProps {
     /** The children elements. Should be ListItem, ListSubheader or ListDivider. */
     children: ReactNode;
-    /**
-     * Whether the list items are clickable.
-     * @deprecated not needed anymore.
-     */
-    isClickable?: boolean;
     /** The item padding size. */
-    itemPadding?: Size.big | Size.huge;
+    itemPadding?: ValueOf<ItemPaddingSizes>;
     /** The reference passed to the <ul> element. */
     listElementRef?: Ref<HTMLUListElement>;
     /** Whether custom colors are applied to this component or not. */
@@ -48,7 +45,6 @@ interface List {
 const List: React.FC<ListProps> & List = ({
     children,
     className,
-    isClickable,
     itemPadding,
     listElementRef,
     onListItemSelected,
@@ -62,7 +58,7 @@ const List: React.FC<ListProps> & List = ({
         ref,
         onListItemSelected,
     });
-    const clickable = hasClickableItem || isClickable;
+    const clickable = hasClickableItem;
 
     return (
         <ul

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -6,19 +6,8 @@ import isEmpty from 'lodash/isEmpty';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
 import { ListProps, Size } from '@lumx/react';
-import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
 import { renderLink } from '@lumx/react/utils/renderLink';
-
-/**
- *  Authorized size values.
- *  @deprecated use Size instead.
- */
-const ListItemSize = {
-    big: Size.big,
-    huge: Size.huge,
-    regular: Size.regular,
-    tiny: Size.tiny,
-};
 
 type ListItemSizes = Size.tiny | Size.regular | Size.big | Size.huge;
 
@@ -45,7 +34,7 @@ interface ListItemProps extends GenericProps {
     /** The reference passed to the <a> element. */
     linkRef?: Ref<HTMLAnchorElement>;
     /** The size variant of the component. */
-    size?: ListItemSizes;
+    size?: ValueOf<ListItemSizes>;
     /** The function called when an item is selected. */
     onItemSelected?(): void;
 }
@@ -144,4 +133,4 @@ const ListItem: React.FC<ListItemProps> = (props) => {
 ListItem.displayName = COMPONENT_NAME;
 ListItem.defaultProps = DEFAULT_PROPS;
 
-export { CLASSNAME, ListItem, ListItemProps, ListItemSize, ListItemSizes, isClickable };
+export { CLASSNAME, ListItem, ListItemProps, ListItemSizes, isClickable };

--- a/packages/lumx-react/src/components/message/Message.tsx
+++ b/packages/lumx-react/src/components/message/Message.tsx
@@ -1,7 +1,7 @@
 import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons';
 import { ColorPalette, Icon, Size } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 
@@ -20,8 +20,8 @@ interface MessageProps extends GenericProps {
     children?: ReactNode;
     /** Whether the message has a background or not. */
     hasBackground?: boolean;
-    /** The kind of helper (error or sucess for exemple). */
-    kind?: MessageKind;
+    /** The kind of helper (error or sucess for example). */
+    kind?: ValueOf<MessageKind>;
 }
 
 /**
@@ -45,26 +45,26 @@ const DEFAULT_PROPS: Partial<MessageProps> = {
  * The color according to kind props.
  */
 const KIND_COLOR = {
-    [MessageKind.error]: ColorPalette.red,
-    [MessageKind.info]: ColorPalette.dark,
-    [MessageKind.success]: ColorPalette.green,
-    [MessageKind.warning]: ColorPalette.yellow,
+    [MessageKind.error as string]: ColorPalette.red,
+    [MessageKind.info as string]: ColorPalette.dark,
+    [MessageKind.success as string]: ColorPalette.green,
+    [MessageKind.warning as string]: ColorPalette.yellow,
 };
 
 /**
  * The icons according to kind props.
  */
 const KIND_ICON = {
-    [MessageKind.error]: mdiAlert,
-    [MessageKind.info]: mdiInformation,
-    [MessageKind.success]: mdiCheckCircle,
-    [MessageKind.warning]: mdiAlertCircle,
+    [MessageKind.error as string]: mdiAlert,
+    [MessageKind.info as string]: mdiInformation,
+    [MessageKind.success as string]: mdiCheckCircle,
+    [MessageKind.warning as string]: mdiAlertCircle,
 };
 
 const Message: React.FC<MessageProps> = ({ children, className, hasBackground, kind, ...forwardedProps }) => {
-    const icon = kind ? KIND_ICON[kind] : null;
+    const icon = kind ? KIND_ICON[kind as string] : null;
 
-    const color = kind ? KIND_COLOR[kind] : DEFAULT_PROPS.color;
+    const color = kind ? KIND_COLOR[kind as string] : DEFAULT_PROPS.color;
     return (
         <div
             className={classNames(

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -2,7 +2,7 @@ import React, { MouseEvent, MouseEventHandler, useCallback } from 'react';
 
 import { AspectRatio, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import classNames from 'classnames';
 import take from 'lodash/take';
 
@@ -11,7 +11,7 @@ import take from 'lodash/take';
  */
 interface MosaicProps extends GenericProps {
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The list of thumbnails. */
     thumbnails: Array<Omit<ThumbnailProps, 'theme' | 'aspectRatio' | 'fillHeight' | 'tabIndex'>>;
     /** The function called on click on a mosaic image. */

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -11,7 +11,7 @@ import { DOCUMENT, NOTIFICATION_TRANSITION_DURATION } from '@lumx/react/constant
 
 import { NOTIFICATION_CONFIGURATION } from '@lumx/react/components/notification/constants';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
 
@@ -36,9 +36,9 @@ interface NotificationProps extends GenericProps {
     /** Whether the component is open or not. */
     isOpen?: boolean;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The type of notification (error or success for example). */
-    type?: NotificationType;
+    type?: ValueOf<NotificationType>;
     /** The z-axis position. */
     zIndex?: number;
     /** The function called on click on the action button. */

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -11,7 +11,7 @@ import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 /**
@@ -86,7 +86,7 @@ interface PopoverProps extends GenericProps {
     /** The desired offset. */
     offset?: Offset;
     /** The desired placement. */
-    placement?: Placement;
+    placement?: ValueOf<Placement>;
     /** The reference of the popover. */
     popoverRef?: React.RefObject<HTMLDivElement>;
     /** The z-axis position. */
@@ -214,7 +214,7 @@ const Popover: React.FC<PopoverProps> = (props) => {
     const { styles, attributes, state } = usePopper(anchorRef.current, popperElement, {
         placement,
         modifiers,
-    });
+    } as any);
 
     const position = state?.placement ?? placement;
 

--- a/packages/lumx-react/src/components/post-block/PostBlock.tsx
+++ b/packages/lumx-react/src/components/post-block/PostBlock.tsx
@@ -7,7 +7,7 @@ import isObject from 'lodash/isObject';
 import { Orientation, Theme, Thumbnail, ThumbnailProps, ThumbnailVariant } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
@@ -22,13 +22,13 @@ interface PostBlockProps extends GenericProps {
     /** The meta elements. */
     meta?: ReactNode;
     /** The orientation. */
-    orientation?: Orientation;
+    orientation?: ValueOf<Orientation>;
     /** The tag elements. */
     tags?: ReactNode;
     /** Content text. Can be either a string, or sanitized html. */
     text?: string | { __html: string };
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /**
      * The url of the image we want to display.
      * @see {@link ThumbnailProps#image}

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
@@ -53,7 +53,8 @@ const ProgressTracker: React.FC<ProgressTrackerProps> = (props) => {
     const state = useTabProviderContextState();
     const numberOfSteps = state?.ids?.tab?.length || 0;
     const backgroundPosition: number = numberOfSteps > 0 ? 100 / (numberOfSteps * 2) : 0;
-    const trackPosition: number = numberOfSteps > 0 ? ((100 / (numberOfSteps - 1)) * (state?.activeTabIndex || 0)) / 100 : 0;
+    const trackPosition: number =
+        numberOfSteps > 0 ? ((100 / (numberOfSteps - 1)) * (state?.activeTabIndex || 0)) / 100 : 0;
 
     return (
         <div

--- a/packages/lumx-react/src/components/progress/Progress.tsx
+++ b/packages/lumx-react/src/components/progress/Progress.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
  * Authorized variants.
@@ -20,11 +20,11 @@ enum ProgressVariant {
  */
 interface ProgressProps extends GenericProps {
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /** The component variant. */
-    variant?: ProgressVariant;
+    variant?: ValueOf<ProgressVariant>;
 }
 
 /**

--- a/packages/lumx-react/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import uniqueId from 'lodash/uniqueId';
 
@@ -26,7 +26,7 @@ interface RadioButtonProps extends GenericProps {
     /** The native input name property. */
     name?: string;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /** The native input value property. */

--- a/packages/lumx-react/src/components/select/Select.test.tsx
+++ b/packages/lumx-react/src/components/select/Select.test.tsx
@@ -89,7 +89,7 @@ describe(`<${Select.displayName}>`, () => {
 
             expect(container).toHaveClassName(CLASSNAME);
             expect(container).toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: 'theme', value: DEFAULT_PROPS.theme }),
+                getBasicClass({ prefix: CLASSNAME, type: 'theme', value: DEFAULT_PROPS.theme as string }),
             );
             expect(container).toHaveClassName(getBasicClass({ prefix: CLASSNAME, type: 'isEmpty', value: true }));
         });
@@ -103,10 +103,10 @@ describe(`<${Select.displayName}>`, () => {
             const { container } = setup(modifiedProps);
 
             expect(container).toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] as string }),
             );
             expect(container).not.toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS.theme }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS.theme as string }),
             );
         });
 

--- a/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
@@ -93,7 +93,7 @@ describe(`<SelectMultiple>`, () => {
 
             expect(container).toHaveClassName(CLASSNAME);
             expect(container).toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: 'theme', value: DEFAULT_PROPS.theme }),
+                getBasicClass({ prefix: CLASSNAME, type: 'theme', value: DEFAULT_PROPS.theme as string }),
             );
             expect(container).toHaveClassName(getBasicClass({ prefix: CLASSNAME, type: 'isEmpty', value: true }));
         });
@@ -107,10 +107,10 @@ describe(`<SelectMultiple>`, () => {
             const { container } = setup(modifiedProps);
 
             expect(container).toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: modifiedProps[testedProp] as string }),
             );
             expect(container).not.toHaveClassName(
-                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS.theme }),
+                getBasicClass({ prefix: CLASSNAME, type: testedProp, value: DEFAULT_PROPS.theme as string }),
             );
         });
 

--- a/packages/lumx-react/src/components/select/constants.ts
+++ b/packages/lumx-react/src/components/select/constants.ts
@@ -1,5 +1,5 @@
 import { Theme } from '@lumx/react/components';
-import { GenericProps } from '@lumx/react/utils';
+import { GenericProps, ValueOf } from '@lumx/react/utils';
 import { ReactNode, SyntheticEvent } from 'react';
 
 /**
@@ -32,11 +32,11 @@ interface CoreSelectProps extends GenericProps {
     /** The select placeholder (input variant). */
     placeholder?: string;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /** The selected choices area style. */
-    variant?: SelectVariant;
+    variant?: ValueOf<SelectVariant>;
     /** The function called when the clear button is clicked. NB: if not specified, clear buttons won't be displayed. */
     onClear?(event: SyntheticEvent, value?: string): void;
     /** The function called when the select field is blurred. */

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { SideNavigationItem, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
@@ -14,7 +14,7 @@ interface SideNavigationProps extends GenericProps {
     /** The children elements. Should use SideNavigationItem. */
     children: ReactNode;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
 }

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -11,6 +11,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import {
     Callback,
     GenericProps,
+    ValueOf,
     getRootClassName,
     handleBasicClasses,
     isComponent,
@@ -27,7 +28,7 @@ interface SideNavigationItemProps extends GenericProps {
     /** The children elements. Should use SideNavigationItem. */
     children?: ReactNode;
     /** The emphasis variant of the component. */
-    emphasis?: Emphasis;
+    emphasis?: ValueOf<Emphasis>;
     /** The label of the menu item. */
     label: string | ReactNode;
     /** The icon the menu item (SVG path code). */

--- a/packages/lumx-react/src/components/slider/Slider.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.tsx
@@ -6,7 +6,7 @@ import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import useEventCallback from '@lumx/react/hooks/useEventCallback';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import uuid from 'uuid/v4';
 
@@ -33,7 +33,7 @@ interface SliderProps extends GenericProps {
     /** The value between two steps. */
     steps?: number;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The current selected value of the slider. */
     value: number;
     /** The function called on change. */

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -7,7 +7,7 @@ import { Theme } from '@lumx/react';
 import { AUTOPLAY_DEFAULT_INTERVAL, FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 import { useInterval } from '@lumx/react/hooks';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import { SlideshowControls } from './SlideshowControls';
 
@@ -28,7 +28,7 @@ interface SlideshowProps extends GenericProps {
     /** The interval between each slide when automatic rotation is enabled. */
     interval?: number;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /* Callback when slide changes */

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -10,7 +10,7 @@ import {
     PAGINATION_ITEM_SIZE,
 } from '@lumx/react/components/slideshow/constants';
 import { COMPONENT_PREFIX, LEFT_KEY_CODE, RIGHT_KEY_CODE } from '@lumx/react/constants';
-import { GenericProps, detectSwipe, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, detectSwipe, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import isFunction from 'lodash/isFunction';
 
@@ -25,7 +25,7 @@ interface SlideshowControlsProps extends GenericProps {
     /** The number of slides. */
     slidesCount: number;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The function called on click on the "next" arrow */
     onNextClick?(): void;
     /** The function called on click on a navigation item */

--- a/packages/lumx-react/src/components/switch/Switch.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.tsx
@@ -8,7 +8,7 @@ import isEmpty from 'lodash/isEmpty';
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 enum SwitchPosition {
     left = 'left',
@@ -28,9 +28,9 @@ interface SwitchProps extends GenericProps {
     /** The native input name property. */
     name?: string;
     /** The position of the toggle regarding the label. */
-    position?: SwitchPosition;
+    position?: ValueOf<SwitchPosition>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /** The native input value property. */

--- a/packages/lumx-react/src/components/table/Table.tsx
+++ b/packages/lumx-react/src/components/table/Table.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
@@ -16,7 +16,7 @@ interface TableProps extends GenericProps {
     /** Whether the table has dividers or not. */
     hasDividers?: boolean;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
 }
 
 /**

--- a/packages/lumx-react/src/components/table/TableCell.tsx
+++ b/packages/lumx-react/src/components/table/TableCell.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { Icon, Size } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
 
 import { mdiArrowDown, mdiArrowUp } from '@lumx/icons';
 
@@ -43,11 +43,11 @@ interface TableCellProps extends GenericProps {
     /** Whether the column is sortable or not (thead only). */
     isSortable?: boolean;
     /** The scope of the thead. */
-    scope?: ThScope;
+    scope?: ValueOf<ThScope>;
     /** The initial sort order (sortable thead only). */
-    sortOrder?: ThOrder;
+    sortOrder?: ValueOf<ThOrder>;
     /** The variant of the cell. */
-    variant?: TableCellVariant;
+    variant?: ValueOf<TableCellVariant>;
     /** The function called on click on header. */
     onHeaderClick?(): void;
 }
@@ -75,6 +75,7 @@ const TableCell: React.FC<TableCellProps> = ({
     icon,
     isSortable,
     onHeaderClick,
+    scope,
     sortOrder,
     variant,
     ...forwardedProps
@@ -93,6 +94,7 @@ const TableCell: React.FC<TableCellProps> = ({
             {variant === TableCellVariant.head && (
                 <th
                     {...forwardedProps}
+                    scope={scope as string}
                     className={classNames(
                         handleBasicClasses({ prefix: CLASSNAME, isSortable }),
                         className,

--- a/packages/lumx-react/src/components/tabs/TabList.tsx
+++ b/packages/lumx-react/src/components/tabs/TabList.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, handleBasicClasses } from '@lumx/react/utils';
 
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
@@ -26,11 +26,11 @@ interface TabListProps extends GenericProps {
     /** The children elements. */
     children: ReactNode;
     /** The layout of the tabs. */
-    layout?: TabListLayout;
+    layout?: ValueOf<TabListLayout>;
     /** The position of the tabs. */
-    position?: TabListPosition;
+    position?: ValueOf<TabListPosition>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
 }

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -7,14 +7,14 @@ import uuid from 'uuid/v4';
 import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from '@lumx/icons';
 import { Emphasis, Icon, IconButton, InputHelper, InputLabel, Kind, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
 interface TextFieldProps extends GenericProps {
     /** A Chip Group to be rendered before the main text input. */
-    chips?: HTMLElement | ReactNode;
+    chips?: ReactNode;
     /** The error related to the TextField. */
     error?: string | ReactNode;
     /** Whether we force the focus style or not. */
@@ -52,7 +52,7 @@ interface TextFieldProps extends GenericProps {
     /** The reference passed to the wrapper. */
     textFieldRef?: RefObject<HTMLDivElement>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
     /** The value of the text field. */

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -8,7 +8,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
 import isFunction from 'lodash/isFunction';
 
-import { GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
 
 import { mdiImageBrokenVariant } from '@lumx/icons';
 import { useFocusedImage } from '@lumx/react/hooks/useFocusedImage';
@@ -25,12 +25,6 @@ declare module 'react' {
         loading?: 'auto' | 'eager' | 'lazy';
     }
 }
-
-/**
- * All available aspect ratios.
- * @deprecated
- */
-const ThumbnailAspectRatio: Record<string, AspectRatio> = { ...AspectRatio };
 
 /**
  *  Authorized size values.
@@ -72,14 +66,14 @@ enum ImageLoading {
  */
 interface ThumbnailProps extends GenericProps {
     /** The thumbnail alignment. */
-    align?: Alignment;
+    align?: ValueOf<Alignment>;
     /** The image aspect ratio. */
-    aspectRatio?: AspectRatio;
+    aspectRatio?: ValueOf<AspectRatio>;
     /**
      * Allows images that are loaded from foreign origins
      * to be used as if they had been loaded from the current origin.
      */
-    crossOrigin?: CrossOrigin;
+    crossOrigin?: ValueOf<CrossOrigin>;
     /** The fallback svg or react node. */
     fallback?: string | ReactNode;
     /** Whether the image has to fill its container height or not. */
@@ -95,15 +89,15 @@ interface ThumbnailProps extends GenericProps {
     /** Whether the image has to be centered according to the focal point after a window resize. */
     isFollowingWindowSize?: boolean;
     /** The size variant of the component. */
-    size?: ThumbnailSize;
+    size?: ValueOf<ThumbnailSize>;
     /** The image loading mode. */
-    loading?: ImageLoading;
+    loading?: ValueOf<ImageLoading>;
     /** The time before recalculating focal point if isFollowingWindowSize is activated. */
     resizeDebounceTime?: number;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The variant of the component. */
-    variant?: ThumbnailVariant;
+    variant?: ValueOf<ThumbnailVariant>;
 }
 
 /**
@@ -199,10 +193,10 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
                 {...(imgProps || {})}
                 ref={focusImageRef}
                 className={imgClassname}
-                crossOrigin={setCrossOrigin()}
+                crossOrigin={setCrossOrigin() as any}
                 src={image}
                 alt={alt}
-                loading={loading}
+                loading={loading as any}
                 onLoad={onImageLoad}
                 onError={onImageError}
             />
@@ -235,13 +229,4 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
 Thumbnail.displayName = COMPONENT_NAME;
 Thumbnail.defaultProps = DEFAULT_PROPS;
 
-export {
-    CLASSNAME,
-    Thumbnail,
-    ThumbnailProps,
-    ThumbnailAspectRatio,
-    ThumbnailSize,
-    ThumbnailStates,
-    ThumbnailVariant,
-    CrossOrigin,
-};
+export { CLASSNAME, Thumbnail, ThumbnailProps, ThumbnailSize, ThumbnailStates, ThumbnailVariant, CrossOrigin };

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -9,7 +9,7 @@ import { Placement } from '@lumx/react/components/popover/Popover';
 
 import { COMPONENT_PREFIX, DOCUMENT } from '@lumx/react/constants';
 
-import { Falsy, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import { useInjectTooltipRef } from './useInjectTooltipRef';
 import { useTooltipOpen } from './useTooltipOpen';
@@ -30,7 +30,7 @@ interface TooltipProps extends GenericProps {
     /** The label of the tooltip. */
     label?: string | null | false;
     /** The placement of the tooltip based on the anchor element placement. */
-    placement?: TooltipPlacement;
+    placement?: ValueOf<TooltipPlacement>;
 }
 
 /**
@@ -78,7 +78,7 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
                 options: { offset: [0, OFFSET] },
             },
         ],
-    });
+    } as any);
 
     const position = attributes?.popper?.['data-popper-placement'] ?? placement;
     const isOpen = useTooltipOpen(delay as number, anchorElement) || forceOpen;

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { AspectRatio, Icon, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 enum UploaderVariant {
     square = 'square',
@@ -19,17 +19,17 @@ type UploaderSize = Size.xl | Size.xxl;
  */
 interface UploaderProps extends GenericProps {
     /** The aspect ratio the image will get. */
-    aspectRatio?: AspectRatio;
+    aspectRatio?: ValueOf<AspectRatio>;
     /** The icon of the uploader. */
     icon?: string;
     /** The label of the uploader. */
     label?: string;
     /** The size variant of the component. */
-    size?: UploaderSize;
+    size?: ValueOf<UploaderSize>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The variant of the component. */
-    variant?: UploaderVariant;
+    variant?: ValueOf<UploaderVariant>;
     /** The function called on click. */
     onClick?: MouseEventHandler<HTMLDivElement>;
 }

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -6,7 +6,7 @@ import { Avatar, Orientation, Size, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
-import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { GenericProps, ValueOf, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { AvatarProps } from '../avatar/Avatar';
 
 /**
@@ -34,11 +34,11 @@ interface UserBlockProps extends GenericProps {
     /** The name of the user.. */
     name?: string;
     /** The orientation of the user block. */
-    orientation?: Orientation;
+    orientation?: ValueOf<Orientation>;
     /** The size variant of the component. */
-    size?: UserBlockSize;
+    size?: ValueOf<UserBlockSize>;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
+    theme?: ValueOf<Theme>;
     /** The reference passed to the wrapper. */
     userBlockRef?: Ref<HTMLDivElement>;
     /** The function called on click. */

--- a/packages/lumx-react/src/hooks/useFocusedImage.tsx
+++ b/packages/lumx-react/src/hooks/useFocusedImage.tsx
@@ -4,6 +4,7 @@ import { AspectRatio, Size } from '@lumx/react/components';
 import { FocusedImage, LumHTMLImageElement } from '@lumx/react/components/thumbnail/FocusedImage';
 import { FocusPoint } from '@lumx/react/components/thumbnail/FocusedImageOptions';
 import { ThumbnailStates } from '@lumx/react/components/thumbnail/Thumbnail';
+import { ValueOf } from '../utils';
 
 /**
  * Handle the focus point and the aspect ratio of an image.
@@ -18,11 +19,11 @@ import { ThumbnailStates } from '@lumx/react/components/thumbnail/Thumbnail';
  */
 const useFocusedImage = (
     focus: FocusPoint,
-    aspectRatio: AspectRatio,
-    size: Size,
+    aspectRatio: ValueOf<AspectRatio>,
+    size: ValueOf<Size>,
     debounceTime: number,
     isFollowingWindowSize: boolean,
-    thumbnailState: ThumbnailStates,
+    thumbnailState: ValueOf<ThumbnailStates>,
 ) => {
     const focusRef = useRef<FocusedImage | null>(null);
 

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -10,7 +10,7 @@ export { AutocompleteMultiple, AutocompleteMultipleProps } from './components/au
 
 export { Badge, BadgeProps } from './components/badge/Badge';
 
-export { Button, ButtonEmphasis, ButtonProps } from './components/button/Button';
+export { Button, ButtonProps } from './components/button/Button';
 
 export { ButtonGroup, ButtonGroupProps } from './components/button/ButtonGroup';
 
@@ -38,13 +38,7 @@ export { InputHelper, InputHelperProps } from './components/input-helper/InputHe
 
 export { InputLabel, InputLabelProps } from './components/input-label/InputLabel';
 
-export {
-    CrossOrigin,
-    Thumbnail,
-    ThumbnailAspectRatio,
-    ThumbnailProps,
-    ThumbnailVariant,
-} from './components/thumbnail/Thumbnail';
+export { CrossOrigin, Thumbnail, ThumbnailProps, ThumbnailVariant } from './components/thumbnail/Thumbnail';
 
 export { FocusPoint } from './components/thumbnail/FocusedImageOptions';
 
@@ -58,7 +52,7 @@ export { List, ListProps } from './components/list/List';
 
 export { ListDivider, ListDividerProps } from './components/list/ListDivider';
 
-export { ListItem, ListItemProps, ListItemSize, ListItemSizes } from './components/list/ListItem';
+export { ListItem, ListItemProps, ListItemSizes } from './components/list/ListItem';
 
 export { ListSubheader, ListSubheaderProps } from './components/list/ListSubheader';
 

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -3,6 +3,8 @@ import isEmpty from 'lodash/isEmpty';
 import isString from 'lodash/isString';
 import React, { ReactElement, ReactNode } from 'react';
 
+export type ValueOf<T> = T[keyof T];
+
 /**
  * The properties of a component to use to determine it's name.
  * In the order of preference.


### PR DESCRIPTION
# General summary

-   Every enum-based props can now accept their raw values. For example, when you were using `Size.xs`, you can now use both `Size.xs` and `"xs"` values.
-   _[BREAKING]_ Definitely remove `ButtonEmphasis` deprecated type from `Button` component.
-   _[BREAKING]_ Definitely remove `isClickable` deprecated prop from `List` component.
-   _[BREAKING]_ Definitely remove `ListItemSize` deprecated type from `ListItem` component.
-   _[BREAKING]_ Definitely remove `ThumbnailAspectRatio` deprecated type from `Thumbnail` component.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
