### PR TITLE
chore(click-away): fix ClickAwayProvider initialization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed ClickAwayProvider initialization error using deferred initialization.
+
 ## [0.28.0][] - 2020-11-17
 
 ### Changed

--- a/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.tsx
+++ b/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.tsx
@@ -19,7 +19,9 @@ export const ClickAwayProvider: React.FC<ClickAwayParameters> = ({ children, cal
 
     const appendChildrenRefs = useCallback(
         (newChildrenRefs: ClickAwayParameters['refs']) => {
-            setChildrenRefs(uniq([...childrenRefs, ...newChildrenRefs]));
+            setTimeout(() => {
+                setChildrenRefs(uniq([...childrenRefs, ...newChildrenRefs]));
+            });
         },
         [childrenRefs, setChildrenRefs],
     );


### PR DESCRIPTION
Delay click away provider init to remove the error appearing since the last React update.