### PR TITLE
refactor(date-picker): value prop should be a date LUM-13240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ `activeStep` prop for `ProgressTracker` component has been removed and is now handled by `ProgressTrackerProvider` component.
 -   `ProgressTrackerStep` components are button instead of anchor for better a11y. Aria attributes have been added according to [WAI ARIA `tab` role](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html) since stepper are similar to tabs in term of a11y.
 -   _[BREAKING]_ `onClick` prop for `ProgressTrackerStep` component is not used anymore. `ProgressTrackerProvider` component has an `onChange` prop instead. Therefore, a step is now clickable if it is not disabled.
+-   _[BREAKING]_ `DatePicker` and `DatePickerField` `value` prop can no longer be a `Moment` object. This will allow us to remove `moment` dep in the future without generating breaking change later. The `value` prop can no longer be a `string` to avoid handling incompatible values. `value` can only be a `Date` (or `undefined` for non selectable values).
 
 ### Removed
 

--- a/packages/lumx-react/src/components/date-picker/DatePicker.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.test.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import moment from 'moment';
-
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
@@ -9,39 +7,24 @@ import { CommonSetup, Wrapper } from '@lumx/react/testing/utils';
 
 import { DatePicker, DatePickerProps } from './DatePicker';
 
-Date.now = jest.fn(() =>
-    new Date(
-        new Date(1487721600).toLocaleString('en-US', {
-            timeZone: 'America/Toronto',
-        }),
-    ).valueOf(),
+const mockedDate = new Date(
+    new Date(1487721600).toLocaleString('en-US', {
+        timeZone: 'America/Toronto',
+    }),
 );
+Date.now = jest.fn(() => mockedDate.valueOf());
 
-/**
- * Define the overriding properties waited by the `setup` function.
- */
 type SetupProps = Partial<DatePickerProps>;
 
-/**
- * Defines what the `setup` function will return.
- */
 interface Setup extends CommonSetup {
     props: SetupProps;
 }
 
-/**
- * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
- *
- * @param props  The props to use to override the default props of the component.
- * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
- *                       component.
- */
 const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean = true): Setup => {
     const props: DatePickerProps = {
         locale: 'fr',
         onChange: jest.fn(),
-        value: moment(),
+        value: mockedDate,
         ...propsOverrides,
     };
 
@@ -56,31 +39,10 @@ const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean
 };
 
 describe(`<${DatePicker.displayName}>`, () => {
-    // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', () => {
         it('should render correctly', () => {
             const { wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
         });
-    });
-
-    // 2. Test defaultProps value and important props custom values.
-    describe('Props', () => {
-        // Nothing to do here.
-    });
-
-    // 3. Test events.
-    describe('Events', () => {
-        // Nothing to do here.
-    });
-
-    // 4. Test conditions (i.e. things that display or not in the UI based on props).
-    describe('Conditions', () => {
-        // Nothing to do here.
-    });
-
-    // 5. Test state.
-    describe('State', () => {
-        // Nothing to do here.
     });
 });

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -8,15 +8,13 @@ import { GenericProps } from '@lumx/react/utils';
 import { getRootClassName } from '../../utils/getRootClassName';
 
 import { DatePickerControlled } from './DatePickerControlled';
-import DatePickerValueProp from './DatePickerValueProp';
 
 /**
  * Defines the props of the component.
  */
-
 interface DatePickerProps extends GenericProps {
     /** The month to display by default. */
-    defaultMonth?: DatePickerValueProp;
+    defaultMonth?: Date;
     /** The locale (language or region) to use. */
     locale: string;
     /** The date after which no date can be selected. */
@@ -26,9 +24,9 @@ interface DatePickerProps extends GenericProps {
     /** The reference passed to the <button> element if it corresponds to the current date or the selected date. */
     todayOrSelectedDateRef?: RefObject<HTMLButtonElement>;
     /** The current value of the text field. */
-    value: DatePickerValueProp;
+    value: Date | undefined;
     /** The function called on change. */
-    onChange(value?: moment.Moment): void;
+    onChange(value: Date | undefined): void;
 }
 
 /**
@@ -65,7 +63,8 @@ const DatePicker: React.FC<DatePickerProps> = ({ defaultMonth, locale, value, ..
 
     const selectedMonth = moment(today)
         .locale(locale)
-        .add(monthOffset, 'months');
+        .add(monthOffset, 'months')
+        .toDate();
 
     return (
         <DatePickerControlled

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import moment from 'moment';
-
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
@@ -9,42 +7,27 @@ import { CommonSetup, Wrapper } from '@lumx/react/testing/utils';
 
 import { DatePickerControlled, DatePickerControlledProps } from './DatePickerControlled';
 
-Date.now = jest.fn(() =>
-    new Date(
-        new Date(1487721600).toLocaleString('en-US', {
-            timeZone: 'America/Toronto',
-        }),
-    ).valueOf(),
+const mockedDate = new Date(
+    new Date(1487721600).toLocaleString('en-US', {
+        timeZone: 'America/Toronto',
+    }),
 );
+Date.now = jest.fn(() => mockedDate.valueOf());
 
-/**
- * Define the overriding properties waited by the `setup` function.
- */
 type SetupProps = Partial<DatePickerControlledProps>;
 
-/**
- * Defines what the `setup` function will return.
- */
 interface Setup extends CommonSetup {
     props: SetupProps;
 }
 
-/**
- * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
- *
- * @param props  The props to use to override the default props of the component.
- * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
- *                       component.
- */
 const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean = true): Setup => {
     const props: DatePickerControlledProps = {
         locale: 'fr',
         onChange: jest.fn(),
         onNextMonthChange: jest.fn(),
         onPrevMonthChange: jest.fn(),
-        selectedMonth: moment(),
-        value: moment(),
+        selectedMonth: mockedDate,
+        value: mockedDate,
         ...propsOverrides,
     };
 
@@ -59,31 +42,10 @@ const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean
 };
 
 describe(`<${DatePickerControlled.displayName}>`, () => {
-    // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', () => {
         it('should render correctly', () => {
             const { wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
         });
-    });
-
-    // 2. Test defaultProps value and important props custom values.
-    describe('Props', () => {
-        // Nothing to do here.
-    });
-
-    // 3. Test events.
-    describe('Events', () => {
-        // Nothing to do here.
-    });
-
-    // 4. Test conditions (i.e. things that display or not in the UI based on props).
-    describe('Conditions', () => {
-        // Nothing to do here.
-    });
-
-    // 5. Test state.
-    describe('State', () => {
-        // Nothing to do here.
     });
 });

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -15,10 +15,9 @@ import { CLASSNAME, DatePickerProps } from './DatePicker';
 /**
  * Defines the props of the component.
  */
-
 type DatePickerControlledProps = DatePickerProps & {
     /** The selected month to display. */
-    selectedMonth: moment.Moment;
+    selectedMonth: Date;
     /** The function called when switching to previous month. */
     onPrevMonthChange(): void;
     /** The function called when switching to next month. */
@@ -42,7 +41,7 @@ const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
     value,
 }) => {
     const days = React.useMemo(() => {
-        return getAnnotatedMonthCalendar(locale, minDate, maxDate, selectedMonth);
+        return getAnnotatedMonthCalendar(locale, minDate, maxDate, moment(selectedMonth));
     }, [locale, minDate, maxDate, selectedMonth]);
 
     const weekDays = React.useMemo(() => {
@@ -97,7 +96,7 @@ const DatePickerControlled: React.FC<DatePickerControlledProps> = ({
                                         })}
                                         disabled={!annotatedDate.isClickable}
                                         // tslint:disable-next-line: jsx-no-lambda
-                                        onClick={() => onChange(annotatedDate.date)}
+                                        onClick={() => onChange(moment(annotatedDate.date).toDate())}
                                     >
                                         <span>{annotatedDate.date.format('DD')}</span>
                                     </button>

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
@@ -1,13 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import moment from 'moment';
-
-import { DatePickerField, DatePickerProps } from '@lumx/react';
+import { DatePickerField } from '@lumx/react';
 
 export default { title: 'LumX components/date-picker/DatePickerField' };
 
 export const simple = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>();
+    const [value, setValue] = useState<Date | undefined>();
 
     return (
         <DatePickerField
@@ -22,7 +20,7 @@ export const simple = ({ theme }: any) => {
 };
 
 export const withDefaultValue = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>(moment().add(20, 'days'));
+    const [value, setValue] = useState<Date | undefined>(new Date('2020-05-18'));
 
     return (
         <DatePickerField
@@ -37,7 +35,7 @@ export const withDefaultValue = ({ theme }: any) => {
 };
 
 export const withErrorAndHelper = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>();
+    const [value, setValue] = useState<Date | undefined>(new Date('2020-05-18'));
 
     return (
         <DatePickerField
@@ -54,7 +52,7 @@ export const withErrorAndHelper = ({ theme }: any) => {
 };
 
 export const customMonth = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>();
+    const [value, setValue] = useState<Date | undefined>();
 
     return (
         <DatePickerField
@@ -64,58 +62,13 @@ export const customMonth = ({ theme }: any) => {
             theme={theme}
             onChange={setValue}
             value={value}
-            defaultMonth={moment('2019-07-14')}
-        />
-    );
-};
-
-export const withDateObject = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>(new Date('2020-05-18'));
-
-    return (
-        <DatePickerField
-            locale="fr"
-            label="Start date"
-            placeholder="Pick a date"
-            theme={theme}
-            onChange={setValue}
-            value={value}
-        />
-    );
-};
-
-export const withCompatibleString = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>('2020-05-22');
-
-    return (
-        <DatePickerField
-            locale="fr"
-            label="Start date"
-            placeholder="Pick a date"
-            theme={theme}
-            onChange={setValue}
-            value={value}
-        />
-    );
-};
-
-export const withIncompatibleString = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>('not a real date');
-
-    return (
-        <DatePickerField
-            locale="fr"
-            label="Start date"
-            placeholder="Pick a date"
-            theme={theme}
-            onChange={setValue}
-            value={value}
+            defaultMonth={new Date('2019-07-14')}
         />
     );
 };
 
 export const with28FebruarySelected = ({ theme }: any) => {
-    const [value, setValue] = React.useState<DatePickerProps['value']>(new Date('2019-02-28'));
+    const [value, setValue] = useState<Date | undefined>(new Date('2019-02-28'));
 
     return (
         <DatePickerField

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement } from 'react';
 
-import moment from 'moment';
-
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
@@ -9,40 +7,25 @@ import { CommonSetup, Wrapper } from '@lumx/react/testing/utils';
 
 import { DatePickerField, DatePickerFieldProps } from './DatePickerField';
 
-Date.now = jest.fn(() =>
-    new Date(
-        new Date(1487721600).toLocaleString('en-US', {
-            timeZone: 'America/Toronto',
-        }),
-    ).valueOf(),
+const mockedDate = new Date(
+    new Date(1487721600).toLocaleString('en-US', {
+        timeZone: 'America/Toronto',
+    }),
 );
+Date.now = jest.fn(() => mockedDate.valueOf());
 
-/**
- * Define the overriding properties waited by the `setup` function.
- */
 type SetupProps = Partial<DatePickerFieldProps>;
 
-/**
- * Defines what the `setup` function will return.
- */
 interface Setup extends CommonSetup {
     props: SetupProps;
 }
 
-/**
- * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
- *
- * @param props  The props to use to override the default props of the component.
- * @param     [shallowRendering=true] Indicates if we want to do a shallow or a full rendering.
- * @return      An object with the props, the component wrapper and some shortcut to some element inside of the
- *                       component.
- */
 const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean = true): Setup => {
     const props: DatePickerFieldProps = {
         label: 'DatePickerField',
         locale: 'fr',
         onChange: jest.fn(),
-        value: moment(),
+        value: mockedDate,
         ...propsOverrides,
     };
 
@@ -57,53 +40,15 @@ const setup = ({ ...propsOverrides }: SetupProps = {}, shallowRendering: boolean
 };
 
 describe(`<${DatePickerField.displayName}>`, () => {
-    // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', () => {
-        const originalConsoleWarn = console.warn;
-
-        beforeEach(() => {
-            console.warn = jest.fn();
-        });
-        afterEach(() => {
-            console.warn = originalConsoleWarn;
-        });
-
         it('should render correctly', () => {
             const { wrapper } = setup();
             expect(wrapper).toMatchSnapshot();
         });
+
         it('should render correctly when passed a date object', () => {
             const { wrapper } = setup({ value: new Date('January 18, 1970') });
             expect(wrapper).toMatchSnapshot();
         });
-        it('should render correctly when passed a compatible string', () => {
-            const { wrapper } = setup({ value: '1970-01-18' });
-            expect(wrapper).toMatchSnapshot();
-        });
-        it('should render without selected date when passed a invalid string', () => {
-            const { wrapper } = setup({ value: 'not a real date' });
-            expect(wrapper).toMatchSnapshot();
-            expect(console.warn).toHaveBeenCalled();
-        });
-    });
-
-    // 2. Test defaultProps value and important props custom values.
-    describe('Props', () => {
-        // Nothing to do here.
-    });
-
-    // 3. Test events.
-    describe('Events', () => {
-        // Nothing to do here.
-    });
-
-    // 4. Test conditions (i.e. things that display or not in the UI based on props).
-    describe('Conditions', () => {
-        // Nothing to do here.
-    });
-
-    // 5. Test state.
-    describe('State', () => {
-        // Nothing to do here.
     });
 });

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -7,7 +7,6 @@ import React, { SyntheticEvent, useCallback, useRef, useState } from 'react';
 
 import { ENTER_KEY_CODE, SPACE_KEY_CODE } from '@lumx/react/constants';
 import { CLASSNAME, DatePicker } from './DatePicker';
-import DatePickerValueProp from './DatePickerValueProp';
 
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { GenericProps } from '@lumx/react/utils';
@@ -17,7 +16,7 @@ import { GenericProps } from '@lumx/react/utils';
  */
 interface DatePickerFieldProps extends GenericProps {
     /** The month to display by default. */
-    defaultMonth?: DatePickerValueProp;
+    defaultMonth?: Date;
     /** Whether the component is disabled or not. */
     isDisabled?: boolean;
     /** The locale (language or region) to use. */
@@ -29,9 +28,9 @@ interface DatePickerFieldProps extends GenericProps {
     /** The native input name property. */
     name?: string;
     /** The current value of the text field. */
-    value: DatePickerValueProp;
+    value: Date | undefined;
     /** The function called on change. */
-    onChange(value?: moment.Moment, name?: string, event?: SyntheticEvent): void;
+    onChange(value: Date | undefined, name?: string, event?: SyntheticEvent): void;
 }
 
 /**
@@ -81,16 +80,11 @@ const DatePickerField = ({
         }
     };
 
-    const onDatePickerChange = (newDate?: moment.Moment) => {
+    const onDatePickerChange = (newDate?: Date) => {
         onChange(newDate, name);
         onClose();
     };
 
-    const castedValue = value && moment(value).isValid() ? moment(value) : undefined;
-    const castedDefaultMonth = defaultMonth && moment(defaultMonth).isValid() ? moment(defaultMonth) : undefined;
-    if ((value && !moment(value).isValid()) || (defaultMonth && !moment(defaultMonth).isValid())) {
-        console.warn(`[@lumx/react/DatePickerField] Invalid date provided '${value}'`);
-    }
     return (
         <>
             <TextField
@@ -98,7 +92,13 @@ const DatePickerField = ({
                 name={name}
                 forceFocusStyle={isOpen}
                 textFieldRef={anchorRef}
-                value={castedValue ? castedValue.locale(locale).format('LL') : ''}
+                value={
+                    value
+                        ? moment(value)
+                              .locale(locale)
+                              .format('LL')
+                        : ''
+                }
                 onClick={toggleSimpleMenu}
                 onChange={onTextFieldChange}
                 onKeyPress={handleKeyboardNav}
@@ -119,10 +119,10 @@ const DatePickerField = ({
                             locale={locale}
                             maxDate={maxDate}
                             minDate={minDate}
-                            value={castedValue}
+                            value={value}
                             onChange={onDatePickerChange}
                             todayOrSelectedDateRef={todayOrSelectedDateRef}
-                            defaultMonth={castedDefaultMonth}
+                            defaultMonth={defaultMonth}
                         />
                     </div>
                 </Popover>

--- a/packages/lumx-react/src/components/date-picker/DatePickerValueProp.ts
+++ b/packages/lumx-react/src/components/date-picker/DatePickerValueProp.ts
@@ -1,5 +1,0 @@
-import moment from 'moment';
-
-type DatePickerValueProp = Date | moment.Moment | string | undefined;
-
-export default DatePickerValueProp;

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<DatePicker> Snapshots and structure should render correctly 1`] = `
   onChange={[MockFunction]}
   onNextMonthChange={[Function]}
   onPrevMonthChange={[Function]}
-  selectedMonth={"1970-01-17T23:15:21.000Z"}
-  value={"1970-01-17T23:15:21.000Z"}
+  selectedMonth={1970-01-17T23:15:21.000Z}
+  value={1970-01-17T23:15:21.000Z}
 />
 `;

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerField.test.tsx.snap
@@ -21,27 +21,6 @@ exports[`<DatePickerField> Snapshots and structure should render correctly 1`] =
 </Fragment>
 `;
 
-exports[`<DatePickerField> Snapshots and structure should render correctly when passed a compatible string 1`] = `
-<Fragment>
-  <TextField
-    forceFocusStyle={false}
-    label="DatePickerField"
-    onChange={[Function]}
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    readOnly={true}
-    textFieldRef={
-      Object {
-        "current": null,
-      }
-    }
-    theme="light"
-    type="text"
-    value="18 janvier 1970"
-  />
-</Fragment>
-`;
-
 exports[`<DatePickerField> Snapshots and structure should render correctly when passed a date object 1`] = `
 <Fragment>
   <TextField
@@ -59,27 +38,6 @@ exports[`<DatePickerField> Snapshots and structure should render correctly when 
     theme="light"
     type="text"
     value="18 janvier 1970"
-  />
-</Fragment>
-`;
-
-exports[`<DatePickerField> Snapshots and structure should render without selected date when passed a invalid string 1`] = `
-<Fragment>
-  <TextField
-    forceFocusStyle={false}
-    label="DatePickerField"
-    onChange={[Function]}
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    readOnly={true}
-    textFieldRef={
-      Object {
-        "current": null,
-      }
-    }
-    theme="light"
-    type="text"
-    value=""
   />
 </Fragment>
 `;


### PR DESCRIPTION
# General summary

-   _[BREAKING]_ `DatePicker` and `DatePickerField` `value` prop can no longer be a `Moment` object. This will allow us to remove `moment` dep in the future without generating breaking change later. The `value` prop can no longer be a `string` to avoid handling incompatible values. `value` can only be a `Date` (or `undefined` for non selectable values).

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
