### PR TITLE
fix(list): forward on item selected event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed `Popover` and `Dropdown` scrollbar behavior.
 -   Fixed `Popover` arrow placement on placement variant `start` and `end`.
 
+### Added
+
+-   Forward synthetic event in List `onListItemSelected` prop and ListItem `onItemSelected` prop.
+
 ## [0.28.0][] - 2020-11-17
 
 ### Changed

--- a/packages/lumx-core/src/js/utils.ts
+++ b/packages/lumx-core/src/js/utils.ts
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import React from 'react';
 
 import isBoolean from 'lodash/isBoolean';
 import isEmpty from 'lodash/isEmpty';
@@ -21,7 +22,6 @@ const _isEmpty = (value: any) => {
 
     return isEmpty(value);
 };
-type Callback = () => void;
 
 /**
  * Get the basic CSS class for the given type.
@@ -157,33 +157,39 @@ function detectSwipe(touchSurface: Element, handleSwipe: (direction: SwipeDirect
     };
 }
 
+type KeyboardEventHandler<E extends KeyboardEvent | React.KeyboardEvent> = (event: E) => void;
+
 /**
  * Make sure the pressed key is the enter key before calling the callback.
  *
- * @param  cb The callback to call on enter/return press.
+ * @param  handler The handler to call on enter/return press.
  * @return The decorated function.
  */
-function onEnterPressed(cb: Callback) {
-    return (evt: { key: string }) => {
+function onEnterPressed<E extends KeyboardEvent | React.KeyboardEvent>(
+    handler: KeyboardEventHandler<E>,
+): KeyboardEventHandler<E> {
+    return (evt) => {
         if (evt.key !== 'Enter') {
             return;
         }
-        cb();
+        handler(evt);
     };
 }
 
 /**
  * Make sure the pressed key is the escape key before calling the callback.
  *
- * @param  cb The callback to call on escape press.
+ * @param  handler The handler to call on enter/return press.
  * @return The decorated function.
  */
-function onEscapePressed(cb: Callback) {
-    return (evt: { keyCode: number }) => {
+function onEscapePressed<E extends KeyboardEvent | React.KeyboardEvent>(
+    handler: KeyboardEventHandler<E>,
+): KeyboardEventHandler<E> {
+    return (evt: any) => {
         if (evt.keyCode !== ESCAPE_KEY_CODE) {
             return;
         }
-        cb();
+        handler(evt);
     };
 }
 

--- a/packages/lumx-react/src/components/list/List.tsx
+++ b/packages/lumx-react/src/components/list/List.tsx
@@ -7,7 +7,7 @@ import { GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import classNames from 'classnames';
-import React, { Key, ReactNode, Ref, useRef } from 'react';
+import React, { Key, ReactNode, Ref, SyntheticEvent, useRef } from 'react';
 import { useInteractiveList } from './useInteractiveList';
 
 /**
@@ -37,8 +37,9 @@ interface ListProps extends GenericProps {
      *
      * @param key   React key of the selected item.
      * @param index Index of the selected item among the sibling items.
+     * @param evt   Source event (either mouse or keyboard event).
      */
-    onListItemSelected?(key: Key, index: number): void;
+    onListItemSelected?(key: Key, index: number, evt: SyntheticEvent): void;
 }
 
 /**

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, Ref, useMemo } from 'react';
+import React, { ReactElement, ReactNode, Ref, SyntheticEvent, useMemo } from 'react';
 
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
@@ -57,7 +57,7 @@ interface ListItemProps extends GenericProps {
     linkRef?: Ref<HTMLAnchorElement>;
 
     /** Callback used to retrieved the selected entry. */
-    onItemSelected?(): void;
+    onItemSelected?(evt: SyntheticEvent): void;
 }
 
 /**

--- a/packages/lumx-react/src/components/list/useInteractiveList.tsx
+++ b/packages/lumx-react/src/components/list/useInteractiveList.tsx
@@ -1,12 +1,22 @@
 import { ListItemProps } from '@lumx/react';
 import { isClickable } from '@lumx/react/components/list/ListItem';
+
+import { DOWN_KEY_CODE, UP_KEY_CODE } from '@lumx/react/constants';
 import { isComponent } from '@lumx/react/utils';
 import { flattenChildren } from '@lumx/react/utils/flattenChildren';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
-import { Key, ReactElement, ReactNode, RefObject, cloneElement, useEffect, useMemo, useState } from 'react';
-
-import { DOWN_KEY_CODE, UP_KEY_CODE } from '@lumx/react/constants';
 import get from 'lodash/get';
+import {
+    Key,
+    ReactElement,
+    ReactNode,
+    RefObject,
+    SyntheticEvent,
+    cloneElement,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 
 type Listener = (evt: KeyboardEvent) => void;
 
@@ -27,8 +37,9 @@ interface Options {
      *
      * @param index Index of the selected item among the sibling items.
      * @param key   React key of the selected item.
+     * @param evt   Source event (either mouse or keyboard event).
      */
-    onListItemSelected?(index: number, key: Key | null): void;
+    onListItemSelected?(index: number, key: Key | null, evt: SyntheticEvent): void;
 }
 
 interface Output {
@@ -177,9 +188,9 @@ export const useInteractiveList: useInteractiveList = (options) => {
                         element?.focus();
                     }
                 }),
-                onItemSelected() {
+                onItemSelected(evt) {
                     item.props.onItemSelected?.();
-                    onListItemSelected?.(index, item.key);
+                    onListItemSelected?.(index, item.key, evt);
                 },
                 ...onKeyboardFocus(item.props, () => {
                     setActiveItemIndex(index);


### PR DESCRIPTION
Forward both on click and on enter key press event in the `onListItemSelected` (List component) callback and  `onItemSelected` callback (ListItem component)