### PR TITLE
fix(tooltip): tooltip now closes on escape LUM-12976

### DIFF
--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -25,7 +25,9 @@ export const ForceOpen = () => {
 export const InlineTooltip = () => (
     <>
         {'Some text with a '}
-        <Tooltip label="A tooltip on the word 'tooltip'">tooltip</Tooltip>
+        <Tooltip label="A tooltip on the word 'tooltip'">
+            <span>tooltip</span>
+        </Tooltip>
         {' on one word.'}
     </>
 );

--- a/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
+++ b/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
@@ -1,3 +1,4 @@
+import { onEscapePressed } from '@lumx/react/utils';
 import { useEffect, useRef, useState } from 'react';
 
 /**
@@ -33,11 +34,13 @@ export function useTooltipOpen(delay: number, anchorElement: HTMLElement | null)
         anchorElement.addEventListener('focusin', handleMouseEnter);
         anchorElement.addEventListener('mouseleave', handleMouseLeave);
         anchorElement.addEventListener('focusout', handleMouseLeave);
+        anchorElement.addEventListener('keydown', onEscapePressed(handleMouseLeave));
         return () => {
             anchorElement.removeEventListener('mouseenter', handleMouseEnter);
             anchorElement.removeEventListener('focusin', handleMouseEnter);
             anchorElement.removeEventListener('mouseleave', handleMouseLeave);
             anchorElement.removeEventListener('focusout', handleMouseLeave);
+            anchorElement.removeEventListener('keydown', onEscapePressed(handleMouseLeave));
 
             if (timer.current) {
                 clearTimeout(timer.current);


### PR DESCRIPTION
# General summary

- [x] Tooltip now closes on escape as recommended: https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard-interaction-21
- [x] Fix story when tooltip surrounds text

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
