### PR TITLE
Fix popover bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed ClickAwayProvider initialization error using deferred initialization.
 -   Fixed `Popover` placement on children update.
+-   Fixed `Popover` and `Dropdown` scrollbar behavior.
+-   Fixed `Popover` arrow placement on placement variant `start` and `end`.
 
 ## [0.28.0][] - 2020-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fixed ClickAwayProvider initialization error using deferred initialization.
+-   Fixed `Popover` placement on children update.
 
 ## [0.28.0][] - 2020-11-17
 

--- a/packages/lumx-core/src/scss/components/popover/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/popover/lumapps/_index.scss
@@ -5,67 +5,47 @@
 .#{$lumx-base-prefix}-popover {
     $self: &;
 
+    display: flex;
     background-color: lumx-color-variant('light', 'N');
     border-radius: $lumx-border-radius;
+
+    > * {
+        flex: 1 auto;
+    }
 
     &__wrapper {
         position: relative;
     }
 
     &__arrow {
-        position: absolute;
-        width: 0;
-        height: 0;
-        border-style: solid;
-        border-color: lumx-color-variant('light', 'N');
-        margin: $lumx-popover-arrow-size;
-
-        #{$self}--position-top & {
-            bottom: -$lumx-popover-arrow-size;
-            left: 50%;
-            border-width: $lumx-popover-arrow-size $lumx-popover-arrow-size 0 $lumx-popover-arrow-size;
-            border-right-color: transparent;
-            border-bottom-color: transparent;
-            border-left-color: transparent;
-            margin-top: 0;
-            margin-bottom: 0;
-            margin-left: -$lumx-popover-arrow-size;
+        &,
+        &::before {
+            position: absolute;
+            z-index: -1;
+            width: $lumx-popover-arrow-size;
+            height: $lumx-popover-arrow-size;
         }
 
-        #{$self}--position-bottom & {
-            top: -$lumx-popover-arrow-size;
-            left: 50%;
-            border-width: 0 $lumx-popover-arrow-size $lumx-popover-arrow-size $lumx-popover-arrow-size;
-            border-top-color: transparent;
-            border-right-color: transparent;
-            border-left-color: transparent;
-            margin-top: 0;
-            margin-bottom: 0;
-            margin-left: -$lumx-popover-arrow-size;
+        &::before {
+            background: lumx-color-variant('light', 'N');
+            content: '';
+            transform: rotate(45deg);
         }
 
-        #{$self}--position-left & {
-            top: 50%;
-            right: -$lumx-popover-arrow-size;
-            border-width: $lumx-popover-arrow-size 0 $lumx-popover-arrow-size $lumx-popover-arrow-size;
-            border-top-color: transparent;
-            border-right-color: transparent;
-            border-bottom-color: transparent;
-            margin-top: -$lumx-popover-arrow-size;
-            margin-right: 0;
-            margin-left: 0;
+        #{$self}[data-popper-placement^='top'] & {
+            bottom: -$lumx-popover-arrow-size/2;
         }
 
-        #{$self}--position-right & {
-            top: 50%;
-            left: -$lumx-popover-arrow-size;
-            border-width: $lumx-popover-arrow-size $lumx-popover-arrow-size $lumx-popover-arrow-size 0;
-            border-top-color: transparent;
-            border-bottom-color: transparent;
-            border-left-color: transparent;
-            margin-top: -$lumx-popover-arrow-size;
-            margin-right: 0;
-            margin-left: 0;
+        #{$self}[data-popper-placement^='bottom'] & {
+            top: -$lumx-popover-arrow-size/2;
+        }
+
+        #{$self}[data-popper-placement^='left'] & {
+            right: -$lumx-popover-arrow-size/2;
+        }
+
+        #{$self}[data-popper-placement^='righ'] & {
+            left: -$lumx-popover-arrow-size/2;
         }
     }
 }

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -15,7 +15,7 @@
         "focus-visible": "^5.0.2",
         "lodash": "4.17.19",
         "react-is": "^16.13.0",
-        "react-popper": "^2.2.3",
+        "react-popper": "^2.2.4",
         "uuid": "^3.3.2"
     },
     "devDependencies": {

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -92,10 +92,10 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
         onInfiniteScroll,
         ...forwardedProps
     } = props;
-    const popoverRef = useRef<HTMLDivElement>(null);
+    const innerRef = useRef<HTMLDivElement>(null);
     const listElement = useRef(null);
 
-    useInfiniteScroll(popoverRef, onInfiniteScroll);
+    useInfiniteScroll(innerRef, onInfiniteScroll);
 
     const popperElement = useMemo(() => {
         return !Array.isArray(children) && isComponent(List)(children)
@@ -112,14 +112,13 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
                   isClickable: true,
               })
             : children;
-    }, [listElement, popoverRef, children, className, closeOnClick, props]);
+    }, [listElement, innerRef, children, className, closeOnClick, props]);
 
     return isOpen ? (
         <Popover
             {...forwardedProps}
-            className={classNames(className, `${CLASSNAME}__menu`, handleBasicClasses({ prefix: CLASSNAME }))}
+            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}
             anchorRef={anchorRef}
-            popoverRef={popoverRef}
             placement={placement}
             offset={offset}
             zIndex={zIndex}
@@ -131,7 +130,9 @@ const Dropdown: React.FC<DropdownProps> = (props) => {
             closeOnEscape={closeOnEscape}
             focusElement={shouldFocusOnOpen ? listElement : undefined}
         >
-            {popperElement}
+            <div className={`${CLASSNAME}__menu`} ref={innerRef}>
+                {popperElement}
+            </div>
         </Popover>
     ) : null;
 };

--- a/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<Dropdown> Snapshots and structure should render correctly 1`] = `
       "current": null,
     }
   }
-  className="lumx-dropdown__menu lumx-dropdown"
+  className="lumx-dropdown"
   closeOnClickAway={true}
   closeOnEscape={true}
   elevation={3}
@@ -20,15 +20,14 @@ exports[`<Dropdown> Snapshots and structure should render correctly 1`] = `
   }
   isOpen={true}
   placement="bottom-start"
-  popoverRef={
-    Object {
-      "current": null,
-    }
-  }
   zIndex={9999}
 >
-  <div>
-    This is the content of the dropdown
+  <div
+    className="lumx-dropdown__menu"
+  >
+    <div>
+      This is the content of the dropdown
+    </div>
   </div>
 </Popover>
 `;

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -1,7 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Chip, FlexBox, Orientation, Placement, Popover, Size } from '@lumx/react';
+import { mdiAccount, mdiBell } from '@lumx/icons';
+import {
+    Chip,
+    Emphasis,
+    FlexBox,
+    Icon,
+    IconButton,
+    List,
+    ListItem,
+    Orientation,
+    Placement,
+    Popover,
+    Size,
+} from '@lumx/react';
 import { boolean, select } from '@storybook/addon-knobs';
+import range from 'lodash/range';
 
 export default { title: 'LumX components/popover/Popover' };
 
@@ -176,6 +190,103 @@ export const top = ({ theme }: any) => {
             </div>
             <Popover theme={theme} anchorRef={anchorRef} placement={Placement.TOP} isOpen>
                 <div style={demoPopperStyle}>{'Popover'}</div>
+            </Popover>
+        </div>
+    );
+};
+
+export const withUpdatingChildren = ({ theme }: any) => {
+    const anchorRef = React.useRef(null);
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const toggleOpen = () => setIsOpen(!isOpen);
+
+    const [text, setText] = useState('Long loading text with useless words');
+    useEffect(() => {
+        if (isOpen) {
+            const timer = setTimeout(() => {
+                setText('Text');
+            }, 1000);
+            return () => clearTimeout(timer);
+        } else {
+            setText('Long loading text with useless words');
+        }
+    }, [isOpen]);
+
+    return (
+        <div style={{ float: 'right' }} className="lumx-spacing-margin-right-huge">
+            <IconButton
+                className="lumx-spacing-margin-right-huge"
+                buttonRef={anchorRef}
+                emphasis={Emphasis.low}
+                icon={mdiBell}
+                size={Size.m}
+                onClick={toggleOpen}
+            />
+            <Popover
+                closeOnClickAway
+                closeOnEscape
+                theme={theme}
+                isOpen={isOpen}
+                anchorRef={anchorRef}
+                placement={Placement.BOTTOM_END}
+                onClose={toggleOpen}
+                fitWithinViewportHeight
+            >
+                <List>
+                    <ListItem
+                        before={<Icon icon={mdiAccount} />}
+                        className="lumx-spacing-margin-right-huge"
+                    >
+                        <span>{text}</span>
+                    </ListItem>
+                </List>
+            </Popover>
+        </div>
+    );
+};
+
+export const withScrollingPopover = ({ theme }: any) => {
+    const anchorRef = React.useRef(null);
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const toggleOpen = () => setIsOpen(!isOpen);
+
+    return (
+        <div style={{ float: 'right' }} className="lumx-spacing-margin-right-huge">
+            <IconButton
+                className="lumx-spacing-margin-right-huge"
+                buttonRef={anchorRef}
+                emphasis={Emphasis.low}
+                icon={mdiBell}
+                size={Size.m}
+                onClick={toggleOpen}
+            />
+            <Popover
+                closeOnClickAway
+                closeOnEscape
+                theme={theme}
+                isOpen={isOpen}
+                anchorRef={anchorRef}
+                placement={Placement.BOTTOM_START}
+                onClose={toggleOpen}
+                fitWithinViewportHeight
+            >
+                <div style={{ overflowY: 'auto' }}>
+                    <List>
+                        {range(100).map((n: number) => {
+                            return (
+                                <ListItem
+                                    key={`key-${n}`}
+                                    before={<Icon icon={mdiAccount} />}
+                                    className="lumx-spacing-margin-right-huge"
+                                >
+                                    <span>{`List item ${n} and some text`}</span>
+                                </ListItem>
+                            );
+                        })}
+                    </List>
+                </div>
             </Popover>
         </div>
     );

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { RefObject, useEffect, useRef, useState } from 'react';
 
 import { mdiAccount, mdiBell } from '@lumx/icons';
 import {
+    Alignment,
     Chip,
     Emphasis,
     FlexBox,
@@ -16,115 +17,47 @@ import {
 } from '@lumx/react';
 import { boolean, select } from '@storybook/addon-knobs';
 import range from 'lodash/range';
+import startCase from 'lodash/startCase';
 
 export default { title: 'LumX components/popover/Popover' };
 
 const DEFAULT_PROPS = Popover.defaultProps as any;
 
 export const positions = ({ theme }: any) => {
-    const demoPopperStyle = {
-        alignItems: 'center',
-        display: 'flex',
-        height: 80,
-        justifyContent: 'center',
-        width: 100,
-    };
-
-    const demoPopoverHolderStyle = {
-        alignItems: 'center',
-        display: 'flex',
-        height: 132,
-        justifyContent: 'center',
-    };
-
-    const topAnchorRef = React.useRef(null);
-    const rightAnchorRef = React.useRef(null);
-    const bottomAnchorRef = React.useRef(null);
-    const leftAnchorRef = React.useRef(null);
-
-    const hasArrow = boolean('hasArrow', DEFAULT_PROPS.hasArrow as any);
-    const elevation: any = select('elevation', [5, 4, 3, 2, 1], DEFAULT_PROPS.elevation);
+    const popovers: Array<[Placement, RefObject<any>]> = [
+        [Placement.LEFT, useRef(null)],
+        [Placement.TOP, useRef(null)],
+        [Placement.BOTTOM, useRef(null)],
+        [Placement.RIGHT, useRef(null)],
+    ];
+    const hasArrow = boolean('Has arrow', DEFAULT_PROPS.hasArrow as any);
+    const elevation: any = select('Elevation', [5, 4, 3, 2, 1], DEFAULT_PROPS.elevation);
+    const alignOptions = { middle: '', start: '-start', end: '-end' };
+    const align = select('Placement variant', alignOptions, alignOptions.middle);
 
     return (
-        <FlexBox
-            className="lumx-spacing-margin-top-huge lumx-spacing-margin-bottom-huge"
-            orientation={Orientation.horizontal}
-        >
-            <FlexBox fillSpace>
-                <div style={demoPopoverHolderStyle}>
-                    <Chip chipRef={topAnchorRef} theme={theme} size={Size.s}>
-                        TOP
-                    </Chip>
-                </div>
-                <Popover
-                    theme={theme}
-                    anchorRef={topAnchorRef}
-                    placement={Placement.TOP}
-                    isOpen
-                    hasArrow={hasArrow}
-                    elevation={elevation}
-                >
-                    <div style={demoPopperStyle}>{'Popover'}</div>
-                </Popover>
-            </FlexBox>
+        <FlexBox style={{ padding: 80 }} orientation={Orientation.horizontal}>
+            {popovers.map(([placement, ref]) => {
+                const placementVariant = (placement + align) as any;
+                return (
+                    <FlexBox key={placement} fillSpace vAlign={Alignment.center} hAlign={Alignment.center}>
+                        <Chip chipRef={ref} theme={theme} size={Size.s}>
+                            {startCase(placementVariant).toUpperCase()}
+                        </Chip>
 
-            <FlexBox fillSpace>
-                <div style={demoPopoverHolderStyle}>
-                    <Chip chipRef={rightAnchorRef} theme={theme} size={Size.s}>
-                        RIGHT
-                    </Chip>
-                </div>
-                <Popover
-                    theme={theme}
-                    anchorRef={rightAnchorRef}
-                    placement={Placement.RIGHT}
-                    isOpen
-                    hasArrow={hasArrow}
-                    elevation={elevation}
-                >
-                    <div style={demoPopperStyle}>{'Popover'}</div>
-                </Popover>
-            </FlexBox>
-
-            <FlexBox fillSpace />
-
-            <FlexBox fillSpace>
-                <div style={demoPopoverHolderStyle}>
-                    <Chip chipRef={bottomAnchorRef} theme={theme} size={Size.s}>
-                        BOTTOM
-                    </Chip>
-                </div>
-                <Popover
-                    theme={theme}
-                    anchorRef={bottomAnchorRef}
-                    placement={Placement.BOTTOM}
-                    isOpen
-                    hasArrow={hasArrow}
-                    elevation={elevation}
-                >
-                    <div style={demoPopperStyle}>{'Popover'}</div>
-                </Popover>
-            </FlexBox>
-
-            <FlexBox fillSpace />
-
-            <FlexBox fillSpace>
-                <div style={demoPopoverHolderStyle}>
-                    <Chip chipRef={leftAnchorRef} theme={theme} size={Size.s}>
-                        LEFT
-                    </Chip>
-                </div>
-                <Popover
-                    theme={theme}
-                    anchorRef={leftAnchorRef}
-                    placement={Placement.LEFT}
-                    isOpen
-                    hasArrow={hasArrow}
-                    elevation={elevation}
-                >
-                    <div style={demoPopperStyle}>{'Popover'}</div>
-                </Popover>
-            </FlexBox>
+                        <Popover
+                            isOpen
+                            theme={theme}
+                            anchorRef={ref}
+                            placement={placementVariant}
+                            elevation={elevation}
+                            hasArrow={hasArrow}
+                        >
+                            <div className="lumx-spacing-margin-huge">Popover</div>
+                        </Popover>
+                    </FlexBox>
+                );
+            })}
         </FlexBox>
     );
 };
@@ -208,9 +141,8 @@ export const withUpdatingChildren = ({ theme }: any) => {
                 setText('Text');
             }, 1000);
             return () => clearTimeout(timer);
-        } else {
-            setText('Long loading text with useless words');
         }
+        setText('Long loading text with useless words');
     }, [isOpen]);
 
     return (
@@ -234,10 +166,7 @@ export const withUpdatingChildren = ({ theme }: any) => {
                 fitWithinViewportHeight
             >
                 <List>
-                    <ListItem
-                        before={<Icon icon={mdiAccount} />}
-                        className="lumx-spacing-margin-right-huge"
-                    >
+                    <ListItem before={<Icon icon={mdiAccount} />} className="lumx-spacing-margin-right-huge">
                         <span>{text}</span>
                     </ListItem>
                 </List>
@@ -268,25 +197,23 @@ export const withScrollingPopover = ({ theme }: any) => {
                 theme={theme}
                 isOpen={isOpen}
                 anchorRef={anchorRef}
-                placement={Placement.BOTTOM_START}
+                placement={Placement.BOTTOM}
                 onClose={toggleOpen}
                 fitWithinViewportHeight
             >
-                <div style={{ overflowY: 'auto' }}>
-                    <List>
-                        {range(100).map((n: number) => {
-                            return (
-                                <ListItem
-                                    key={`key-${n}`}
-                                    before={<Icon icon={mdiAccount} />}
-                                    className="lumx-spacing-margin-right-huge"
-                                >
-                                    <span>{`List item ${n} and some text`}</span>
-                                </ListItem>
-                            );
-                        })}
-                    </List>
-                </div>
+                <List style={{ overflowY: 'auto' }}>
+                    {range(100).map((n: number) => {
+                        return (
+                            <ListItem
+                                key={`key-${n}`}
+                                before={<Icon icon={mdiAccount} />}
+                                className="lumx-spacing-margin-right-huge"
+                            >
+                                <span>{`List item ${n} and some text`}</span>
+                            </ListItem>
+                        );
+                    })}
+                </List>
             </Popover>
         </div>
     );

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { detectOverflow } from '@popperjs/core';
-import React, { ReactNode, RefObject, useMemo, useRef, useState } from 'react';
+import React, { ReactNode, RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
 
@@ -217,10 +217,11 @@ const Popover: React.FC<PopoverProps> = (props) => {
         modifiers.push(maxSize, applyMaxHeight);
     }
 
-    const { styles, attributes, state } = usePopper(anchorRef.current, popperElement, {
+    const { styles, attributes, state, update } = usePopper(anchorRef.current, popperElement, {
         placement,
         modifiers,
     });
+    useEffect(() => { update?.(); }, [children, update]);
 
     const position = state?.placement ?? placement;
 
@@ -239,30 +240,30 @@ const Popover: React.FC<PopoverProps> = (props) => {
 
     return isOpen
         ? createPortal(
-              <div
-                  {...forwardedProps}
-                  ref={mergeRefs(setPopperElement, popoverRef)}
-                  className={classNames(
-                      className,
-                      handleBasicClasses({ prefix: CLASSNAME, elevation: Math.min(elevation || 0, 5), position }),
-                  )}
-                  style={popoverStyle}
-                  {...attributes.popper}
-              >
-                  <div ref={wrapperRef} className={`${CLASSNAME}__wrapper`}>
-                      <ClickAwayProvider callback={closeOnClickAway && onClose} refs={[wrapperRef, anchorRef]}>
-                          {hasArrow ? (
-                              <>
-                                  <div className={`${CLASSNAME}__arrow`} />
-                                  <div className={`${CLASSNAME}__inner`}>{children}</div>
-                              </>
-                          ) : (
-                              children
-                          )}
-                      </ClickAwayProvider>
-                  </div>
-              </div>,
-              document.body,
+                <div
+                    {...forwardedProps}
+                    ref={mergeRefs(setPopperElement, popoverRef)}
+                    className={classNames(
+                        className,
+                        handleBasicClasses({ prefix: CLASSNAME, elevation: Math.min(elevation || 0, 5), position }),
+                    )}
+                    style={popoverStyle}
+                    {...attributes.popper}
+                >
+                    <div ref={wrapperRef} className={`${CLASSNAME}__wrapper`}>
+                        <ClickAwayProvider callback={closeOnClickAway && onClose} refs={[wrapperRef, anchorRef]}>
+                            {hasArrow ? (
+                                <>
+                                    <div className={`${CLASSNAME}__arrow`} />
+                                    <div className={`${CLASSNAME}__inner`}>{children}</div>
+                                </>
+                            ) : (
+                                children
+                            )}
+                        </ClickAwayProvider>
+                    </div>
+                </div>,
+                document.body,
           )
         : null;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -21891,10 +21891,10 @@ react-popper@^1.3.4:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-popper@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
-  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+react-popper@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
+  integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"


### PR DESCRIPTION
# General summary

- [x] Update placement when children change: https://lumapps.atlassian.net/browse/LUM-11530

Before
![before](https://user-images.githubusercontent.com/2828353/100872754-97bca100-34a2-11eb-9c93-c31c0c75134b.gif)
After
![after](https://user-images.githubusercontent.com/2828353/100872758-99866480-34a2-11eb-8149-253c2a087641.gif)

- [x] Scrolling inside popover should not modify its position so drastically: https://lumapps.atlassian.net/browse/LUM-13372 based on https://lumapps.atlassian.net/browse/LUM-13128. This is due to `applyMaxHeight` modifier when an `overflow: auto` is added to the popover like for notification center. However, without `overflow: auto`, the entire page is scrolling like we can see in `withScrollingPopoverContent` story. The `fitWithinViewportHeight` prop does not work well.

- [x] Click on scrollbar should not close the popover. This is due to the fact that the `ClickAwayProvider` does not consider the scrollbar to be part of the popover.

- [x] Fix arrow placement on placement variant `start` & `end` (only worked with `top`, `bottom`, `right` and `left`)
![Peek 02-12-2020 16-36](https://user-images.githubusercontent.com/939567/100895481-e4fa3c00-34bd-11eb-8a25-c3d411c255fb.gif)

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
