### PR TITLE
refactor(icon-button): add tooltip and aria-label for a11y LUM-12977

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Added required `label` prop for `IconButton`. The label is used as `aria-label` for the button and to add a tooltip. This prop is required for a11y purpose. If you really don't want a tooltip, you can give an empty label (this is not recommended).
 -   _[BREAKING]_ Added `nextButtonProps` and `previousButtonProps` props to `DatePickerControlled`, `DatePicker` and `DatePickerField` components to allow setting custom props to the `IconButton`s used to change month. These fields are **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
 -   _[BREAKING]_ Added `nextButtonProps` and `previousButtonProps` props to `SlideshowControls` component to allow setting custom props to the `IconButton`s used to change image. These fields are **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   Added `slideshowControlsProps` to the `Slideshow` component to allow setting custom props to the slideshow controls. Controls are not displayed if this prop is not set.
 -   _[BREAKING]_ Added `toggleButtonProps` prop to `ExpansionPanel` component to allow setting custom props to the `IconButton`s used to toggle the panel. This field is **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
 -   _[BREAKING]_ Added `toggleButtonProps` prop to `SideNavigationItem` component to allow setting custom props to the `IconButton`s used to toggle the menu. This field is **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
 -   Added `clearButtonProps` prop to `Select` component to allow setting custom props to the `IconButton`s used to clear the select. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `clearButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
@@ -72,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Removed `thumbnails.url` prop on the `Mosaic` (use `image` instead).
 -   _[BREAKING]_ `isClosingButtonVisible` prop of `Lightbox` component has been removed. Passing the `label` prop using `closeButtonProps` prop is enough to determine the visibility of the icon button.
 -   _[BREAKING]_ `isClearable` prop of `TextField`, `Autocomplete` and `AutocompleteMultiple` components has been removed. Passing the `label` prop using `clearButtonProps` prop is enough to determine the visibility of the icon button.
+-   _[BREAKING]_ `hasControls` prop of `Slideshow` component has been removed. Using `slideshowControlsProps` prop is enough to determine the visibility of the slideshow controls.
 
 ## [0.28.2][] - 2020-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `ProgressTrackerStepPanel` component that wraps the content of a step. Implements the [WAI-ARIA `tabpanel` role](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html#rps_label).
 -   Added `isDisabled` prop to `ProgressTrackerStep` component.
 -   Added `rightIcon` and `leftIcon` props for `Link` component. Sizes of icons are based on `typography` prop.
+-   _[BREAKING]_ Added required `label` prop for `IconButton`. The label is used as `aria-label` for the button and to add a tooltip. This prop is required for a11y purpose. If you really don't want a tooltip, you can give an empty label (this is not recommended).
+-   _[BREAKING]_ Added `nextButtonProps` and `previousButtonProps` props to `DatePickerControlled`, `DatePicker` and `DatePickerField` components to allow setting custom props to the `IconButton`s used to change month. These fields are **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   _[BREAKING]_ Added `nextButtonProps` and `previousButtonProps` props to `SlideshowControls` component to allow setting custom props to the `IconButton`s used to change image. These fields are **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   _[BREAKING]_ Added `toggleButtonProps` prop to `ExpansionPanel` component to allow setting custom props to the `IconButton`s used to toggle the panel. This field is **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   _[BREAKING]_ Added `toggleButtonProps` prop to `SideNavigationItem` component to allow setting custom props to the `IconButton`s used to toggle the menu. This field is **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   Added `clearButtonProps` prop to `Select` component to allow setting custom props to the `IconButton`s used to clear the select. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `clearButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   Added `clearButtonProps` prop to `TextField` component to allow setting custom props to the `IconButton`s used to clear the field. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `clearButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   Added `closeButtonProps` prop to `Lightbox` component to allow setting custom props to the `IconButton`s used to close the lightbox. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `closeButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
 
 ### Changed
 
@@ -62,6 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ `aspectRatio`, `crossOrigin`, `focusPoint`, `isCrossOriginEnabled` and `onClick` props have been removed from `ImageBlock` component. These props will now be passed using the `ImageBlock.thumbnailProps` prop.
 -   _[BREAKING]_ Removed `Tabs` component replaced by the `TabProvider` and `TabList` components.
 -   _[BREAKING]_ Removed `thumbnails.url` prop on the `Mosaic` (use `image` instead).
+-   _[BREAKING]_ `isClosingButtonVisible` prop of `Lightbox` component has been removed. Passing the `label` prop using `closeButtonProps` prop is enough to determine the visibility of the icon button.
+-   _[BREAKING]_ `isClearable` prop of `TextField`, `Autocomplete` and `AutocompleteMultiple` components has been removed. Passing the `label` prop using `clearButtonProps` prop is enough to determine the visibility of the icon button.
 
 ## [0.28.2][] - 2020-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `clearButtonProps` prop to `Select` component to allow setting custom props to the `IconButton`s used to clear the select. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `clearButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
 -   Added `clearButtonProps` prop to `TextField` component to allow setting custom props to the `IconButton`s used to clear the field. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `clearButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
 -   Added `closeButtonProps` prop to `Lightbox` component to allow setting custom props to the `IconButton`s used to close the lightbox. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `closeButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
+-   Added `tooltipProps` to `IconButton` to allow setting custom props to the tooltip.
 
 ### Changed
 
@@ -74,6 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ `isClosingButtonVisible` prop of `Lightbox` component has been removed. Passing the `label` prop using `closeButtonProps` prop is enough to determine the visibility of the icon button.
 -   _[BREAKING]_ `isClearable` prop of `TextField`, `Autocomplete` and `AutocompleteMultiple` components has been removed. Passing the `label` prop using `clearButtonProps` prop is enough to determine the visibility of the icon button.
 -   _[BREAKING]_ `hasControls` prop of `Slideshow` component has been removed. Using `slideshowControlsProps` prop is enough to determine the visibility of the slideshow controls.
+
+### Fixed
+
+-   Fixed `DatePicker` component to prevent switching month when selecting a date.
+-   Fixed `Tooltip` placement on `Icon` and `IconButton`.
 
 ## [0.28.2][] - 2020-12-11
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, RefObject, SyntheticEvent, useRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Dropdown, Offset, Placement, TextField, Theme } from '@lumx/react';
+import { Dropdown, IconButtonProps, Offset, Placement, TextField, Theme } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
@@ -19,6 +19,13 @@ export interface AutocompleteProps extends GenericProps {
      * @see {@link DropdownProps#anchorToInput}
      */
     anchorToInput?: boolean;
+    /**
+     * The props to pass to the clear button, minus those already set by the TextField props.
+     * If not specified, the button won't be displayed.
+     * @see {@link TextFieldProps#clearButtonProps}
+     */
+    clearButtonProps?: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
     /**
      * The reference passed to the <input> or <textarea> element.
      * @see {@link TextFieldProps#inputRef}
@@ -53,11 +60,6 @@ export interface AutocompleteProps extends GenericProps {
      * Whether the text box should be focused upon closing the suggestions or not.
      */
     shouldFocusOnClose?: boolean;
-    /**
-     * Whether the text field displays a clear button or not.
-     * @see {@link TextFieldProps#isClearable}
-     */
-    isClearable?: boolean;
     /**
      * The helper message of the text field.
      * @see {@link TextFieldProps#helper}
@@ -189,7 +191,7 @@ export const Autocomplete: Comp<AutocompleteProps> = ({
     helper,
     icon,
     inputRef,
-    isClearable,
+    clearButtonProps,
     isDisabled = disabled,
     isOpen,
     isValid,
@@ -229,7 +231,7 @@ export const Autocomplete: Comp<AutocompleteProps> = ({
                 helper={helper}
                 icon={icon}
                 inputRef={mergeRefs(inputAnchorRef, inputRef) as any}
-                isClearable={isClearable}
+                clearButtonProps={clearButtonProps}
                 isDisabled={isDisabled}
                 isValid={isValid}
                 label={label}

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
@@ -80,7 +80,7 @@ export const AutocompleteMultiple: Comp<AutocompleteMultipleProps> = ({
     helper,
     icon,
     inputRef,
-    isClearable,
+    clearButtonProps,
     isDisabled,
     isOpen,
     isValid,
@@ -130,7 +130,7 @@ export const AutocompleteMultiple: Comp<AutocompleteMultipleProps> = ({
             </ChipGroup>
         }
         isDisabled={isDisabled}
-        isClearable={isClearable}
+        clearButtonProps={clearButtonProps}
         isValid={isValid}
         label={label}
         placeholder={placeholder}

--- a/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
@@ -37,15 +37,36 @@ export const AvatarWithActions = () =>
             actions={
                 <div style={{ display: 'flex', justifyContent: 'center' }}>
                     <div className="lumx-spacing-margin-right-regular">
-                        <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiPencil} size={Size.s} />
+                        <IconButton
+                            label="Edit"
+                            color="dark"
+                            emphasis={Emphasis.low}
+                            hasBackground
+                            icon={mdiPencil}
+                            size={Size.s}
+                        />
                     </div>
 
                     <div className="lumx-spacing-margin-right-regular">
-                        <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiEye} size={Size.s} />
+                        <IconButton
+                            label="See"
+                            color="dark"
+                            emphasis={Emphasis.low}
+                            hasBackground
+                            icon={mdiEye}
+                            size={Size.s}
+                        />
                     </div>
 
                     <div>
-                        <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiDelete} size={Size.s} />
+                        <IconButton
+                            label="Delete"
+                            color="dark"
+                            emphasis={Emphasis.low}
+                            hasBackground
+                            icon={mdiDelete}
+                            size={Size.s}
+                        />
                     </div>
                 </div>
             }

--- a/packages/lumx-react/src/components/avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/lumx-react/src/components/avatar/__snapshots__/Avatar.test.tsx.snap
@@ -82,6 +82,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+            label="Edit"
             size="s"
             theme="light"
           />
@@ -94,6 +95,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
+            label="See"
             size="s"
             theme="light"
           />
@@ -104,6 +106,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"
+            label="Delete"
             size="s"
             theme="light"
           />
@@ -138,6 +141,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+            label="Edit"
             size="s"
             theme="light"
           />
@@ -150,6 +154,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
+            label="See"
             size="s"
             theme="light"
           />
@@ -160,6 +165,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"
+            label="Delete"
             size="s"
             theme="light"
           />
@@ -194,6 +200,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+            label="Edit"
             size="s"
             theme="light"
           />
@@ -206,6 +213,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
+            label="See"
             size="s"
             theme="light"
           />
@@ -216,6 +224,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"
+            label="Delete"
             size="s"
             theme="light"
           />
@@ -250,6 +259,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+            label="Edit"
             size="s"
             theme="light"
           />
@@ -262,6 +272,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
+            label="See"
             size="s"
             theme="light"
           />
@@ -272,6 +283,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"
+            label="Delete"
             size="s"
             theme="light"
           />
@@ -306,6 +318,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+            label="Edit"
             size="s"
             theme="light"
           />
@@ -318,6 +331,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
+            label="See"
             size="s"
             theme="light"
           />
@@ -328,6 +342,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"
+            label="Delete"
             size="s"
             theme="light"
           />
@@ -362,6 +377,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+            label="Edit"
             size="s"
             theme="light"
           />
@@ -374,6 +390,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
+            label="See"
             size="s"
             theme="light"
           />
@@ -384,6 +401,7 @@ Array [
             emphasis="low"
             hasBackground={true}
             icon="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"
+            label="Delete"
             size="s"
             theme="light"
           />

--- a/packages/lumx-react/src/components/button/ButtonGroup.test.tsx
+++ b/packages/lumx-react/src/components/button/ButtonGroup.test.tsx
@@ -38,7 +38,7 @@ const setup = ({ ...propsOverride }: SetupProps = {}, shallowRendering = true): 
         children: (
             <>
                 <Button>Label</Button>
-                <IconButton icon={mdiPlus} />
+                <IconButton label="Add" icon={mdiPlus} />
             </>
         ),
         ...propsOverride,

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -17,6 +17,8 @@ type HTMLButtonProps = DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>
 export type ButtonSize = Size.s | Size.m;
 
 export interface BaseButtonProps extends GenericProps {
+    /** The label that describes the button if necessary. */
+    ['aria-label']?: string;
     /** The reference passed to the <a> or <button> element. */
     buttonRef?: RefObject<HTMLButtonElement> | RefObject<HTMLAnchorElement>;
     /** The color variant of the component. */
@@ -93,6 +95,7 @@ const renderButtonWrapper: React.FC<ButtonRootProps> = (props) => {
 
 export const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
     const {
+        'aria-label': ariaLabel,
         buttonRef,
         children,
         className,
@@ -150,6 +153,7 @@ export const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
             {
                 linkAs,
                 ...forwardedProps,
+                'aria-label': ariaLabel,
                 href,
                 target,
                 className: buttonClassName,
@@ -162,6 +166,8 @@ export const ButtonRoot: React.FC<ButtonRootProps> = (props) => {
         <button
             {...forwardedProps}
             disabled={isDisabled}
+            aria-disabled={isDisabled}
+            aria-label={ariaLabel}
             ref={buttonRef as RefObject<HTMLButtonElement>}
             className={buttonClassName}
             name={name}

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Emphasis, Icon, Size, Theme } from '@lumx/react';
+import { Emphasis, Icon, Size, Theme, Tooltip } from '@lumx/react';
 import { BaseButtonProps, ButtonRoot } from '@lumx/react/components/button/ButtonRoot';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { Comp, getRootClassName } from '@lumx/react/utils';
@@ -14,6 +14,11 @@ export interface IconButtonProps extends BaseButtonProps {
      * @see {@link IconProps#icon}
      */
     icon: string;
+    /**
+     * The label of the tooltip. It is required for a11y purpose.
+     * If you really don't want a tooltip and aria-label, you can give an empty label (this is not recommended).
+     */
+    label: string;
 }
 
 /**
@@ -36,12 +41,14 @@ const DEFAULT_PROPS: Partial<IconButtonProps> = {
 };
 
 export const IconButton: Comp<IconButtonProps> = (props) => {
-    const { emphasis, icon, size, theme, ...forwardedProps } = props;
+    const { emphasis, icon, label, size, theme, ...forwardedProps } = props;
 
     return (
-        <ButtonRoot {...{ emphasis, size, theme, ...forwardedProps }} variant="icon">
-            <Icon icon={icon} />
-        </ButtonRoot>
+        <Tooltip label={label}>
+            <ButtonRoot {...{ emphasis, size, theme, ...forwardedProps }} aria-label={label} variant="icon">
+                <Icon icon={icon} />
+            </ButtonRoot>
+        </Tooltip>
     );
 };
 IconButton.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Emphasis, Icon, Size, Theme, Tooltip } from '@lumx/react';
+import { Emphasis, Icon, Size, Theme, Tooltip, TooltipProps } from '@lumx/react';
 import { BaseButtonProps, ButtonRoot } from '@lumx/react/components/button/ButtonRoot';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { Comp, getRootClassName } from '@lumx/react/utils';
@@ -19,6 +19,8 @@ export interface IconButtonProps extends BaseButtonProps {
      * If you really don't want a tooltip and aria-label, you can give an empty label (this is not recommended).
      */
     label: string;
+    /** The props to pass to the tooltip, minus those already set by the IconButton props. */
+    tooltipProps?: Omit<TooltipProps, 'label'>;
 }
 
 /**
@@ -41,10 +43,10 @@ const DEFAULT_PROPS: Partial<IconButtonProps> = {
 };
 
 export const IconButton: Comp<IconButtonProps> = (props) => {
-    const { emphasis, icon, label, size, theme, ...forwardedProps } = props;
+    const { emphasis, icon, label, size, theme, tooltipProps, ...forwardedProps } = props;
 
     return (
-        <Tooltip label={label}>
+        <Tooltip label={label} {...tooltipProps}>
             <ButtonRoot {...{ emphasis, size, theme, ...forwardedProps }} aria-label={label} variant="icon">
                 <Icon icon={icon} />
             </ButtonRoot>

--- a/packages/lumx-react/src/components/button/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/ButtonGroup.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`<ButtonGroup> Snapshots and structure should render correctly a group b
   <IconButton
     emphasis="high"
     icon="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+    label="Add"
     size="m"
     theme="light"
   />

--- a/packages/lumx-react/src/components/button/__snapshots__/ButtonRoot.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/ButtonRoot.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ButtonRoot> Props should not have default color in low or medium empha
 >
   <button
     className="lumx-button lumx-button--color-dark lumx-button--emphasis-low"
-    type="button"
+    role="button"
   />
 </ButtonRoot>
 `;
@@ -15,7 +15,7 @@ exports[`<ButtonRoot> Props should use default color 1`] = `
 <ButtonRoot>
   <button
     className="lumx-button lumx-button--color-dark"
-    type="button"
+    role="button"
   />
 </ButtonRoot>
 `;
@@ -42,7 +42,7 @@ exports[`<ButtonRoot> Props should use given props 1`] = `
     >
       <button
         className="lumx-button lumx-button--color-red lumx-button--emphasis-high lumx-button--size-s lumx-button--theme-dark lumx-button--variant-icon"
-        type="button"
+        role="button"
       />
     </ButtonRoot>
   </div>
@@ -95,7 +95,7 @@ exports[`<ButtonRoot> Snapshots and structure should render button with label 1`
 <ButtonRoot>
   <button
     className="lumx-button lumx-button--color-dark"
-    type="button"
+    role="button"
   >
     Label
   </button>
@@ -115,7 +115,7 @@ exports[`<ButtonRoot> Snapshots and structure should render button with wrapper 
     >
       <button
         className="lumx-button lumx-button--color-dark"
-        type="button"
+        role="button"
       >
         Label
       </button>

--- a/packages/lumx-react/src/components/button/__snapshots__/ButtonRoot.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/ButtonRoot.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ButtonRoot> Props should not have default color in low or medium empha
 >
   <button
     className="lumx-button lumx-button--color-dark lumx-button--emphasis-low"
-    role="button"
+    type="button"
   />
 </ButtonRoot>
 `;
@@ -15,7 +15,7 @@ exports[`<ButtonRoot> Props should use default color 1`] = `
 <ButtonRoot>
   <button
     className="lumx-button lumx-button--color-dark"
-    role="button"
+    type="button"
   />
 </ButtonRoot>
 `;
@@ -42,7 +42,7 @@ exports[`<ButtonRoot> Props should use given props 1`] = `
     >
       <button
         className="lumx-button lumx-button--color-red lumx-button--emphasis-high lumx-button--size-s lumx-button--theme-dark lumx-button--variant-icon"
-        role="button"
+        type="button"
       />
     </ButtonRoot>
   </div>
@@ -95,7 +95,7 @@ exports[`<ButtonRoot> Snapshots and structure should render button with label 1`
 <ButtonRoot>
   <button
     className="lumx-button lumx-button--color-dark"
-    role="button"
+    type="button"
   >
     Label
   </button>
@@ -115,7 +115,7 @@ exports[`<ButtonRoot> Snapshots and structure should render button with wrapper 
     >
       <button
         className="lumx-button lumx-button--color-dark"
-        role="button"
+        type="button"
       >
         Label
       </button>

--- a/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
@@ -1,35 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<IconButton> Props should forward any CSS class 1`] = `
-<ButtonRoot
-  className="component component--is-tested"
-  emphasis="high"
-  size="m"
-  theme="light"
-  variant="icon"
+<Tooltip
+  delay={500}
+  placement="bottom"
 >
-  <Icon />
-</ButtonRoot>
+  <ButtonRoot
+    className="component component--is-tested"
+    emphasis="high"
+    size="m"
+    theme="light"
+    variant="icon"
+  >
+    <Icon />
+  </ButtonRoot>
+</Tooltip>
 `;
 
 exports[`<IconButton> Props should use default props 1`] = `
-<ButtonRoot
-  emphasis="high"
-  size="m"
-  theme="light"
-  variant="icon"
+<Tooltip
+  delay={500}
+  placement="bottom"
 >
-  <Icon />
-</ButtonRoot>
+  <ButtonRoot
+    emphasis="high"
+    size="m"
+    theme="light"
+    variant="icon"
+  >
+    <Icon />
+  </ButtonRoot>
+</Tooltip>
 `;
 
 exports[`<IconButton> Snapshots and structure should render icon button 1`] = `
-<ButtonRoot
-  emphasis="high"
-  size="m"
-  theme="light"
-  variant="icon"
+<Tooltip
+  delay={500}
+  placement="bottom"
 >
-  <Icon />
-</ButtonRoot>
+  <ButtonRoot
+    emphasis="high"
+    size="m"
+    theme="light"
+    variant="icon"
+  >
+    <Icon />
+  </ButtonRoot>
+</Tooltip>
 `;

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
@@ -22,6 +22,6 @@ export const WithHeaderActions = ({ theme }: any) => (
         date="4 hours ago"
         name="Emmitt O. Lum"
         text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
-        headerActions={<IconButton icon={mdiDotsHorizontal} emphasis={Emphasis.low} size={Size.s} />}
+        headerActions={<IconButton label="Actions" icon={mdiDotsHorizontal} emphasis={Emphasis.low} size={Size.s} />}
     />
 );

--- a/packages/lumx-react/src/components/date-picker/DatePicker.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.test.tsx
@@ -1,8 +1,9 @@
-import { CommonSetup, Wrapper } from '@lumx/react/testing/utils';
+import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
-import React, { ReactElement } from 'react';
+
+import { CommonSetup, Wrapper } from '@lumx/react/testing/utils';
 import { DatePickerProps } from '@lumx/react';
 import { DatePicker } from './DatePicker';
 
@@ -24,6 +25,8 @@ const setup = ({ ...propsOverride }: SetupProps = {}, shallowRendering = true): 
         locale: 'fr',
         onChange: jest.fn(),
         value: mockedDate,
+        nextButtonProps: { label: 'Next month' },
+        previousButtonProps: { label: 'Previous month' },
         ...propsOverride,
     };
 

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -5,7 +5,7 @@ import { CLASSNAME, COMPONENT_NAME } from './constants';
 import { DatePickerControlled } from './DatePickerControlled';
 import { DatePickerProps } from './types';
 
-export const DatePicker: Comp<DatePickerProps> = ({ defaultMonth, locale, value, ...forwardedProps }) => {
+export const DatePicker: Comp<DatePickerProps> = ({ defaultMonth, locale, value, onChange, ...forwardedProps }) => {
     let castedValue;
     if (value) {
         castedValue = moment(value);
@@ -16,14 +16,19 @@ export const DatePicker: Comp<DatePickerProps> = ({ defaultMonth, locale, value,
         // eslint-disable-next-line no-console
         console.warn(`[@lumx/react/DatePicker] Invalid date provided ${castedValue}`);
     }
-    const today = castedValue && castedValue.isValid() ? castedValue : moment();
+    const selectedDay = castedValue && castedValue.isValid() ? castedValue : moment();
 
     const [monthOffset, setMonthOffset] = useState(0);
 
     const setPrevMonth = () => setMonthOffset(monthOffset - 1);
     const setNextMonth = () => setMonthOffset(monthOffset + 1);
 
-    const selectedMonth = moment(today).locale(locale).add(monthOffset, 'months').toDate();
+    const onDatePickerChange = (newDate?: Date) => {
+        onChange(newDate);
+        setMonthOffset(0);
+    };
+
+    const selectedMonth = moment(selectedDay).locale(locale).add(monthOffset, 'months').toDate();
 
     return (
         <DatePickerControlled
@@ -34,6 +39,7 @@ export const DatePicker: Comp<DatePickerProps> = ({ defaultMonth, locale, value,
             onPrevMonthChange={setPrevMonth}
             onNextMonthChange={setNextMonth}
             selectedMonth={selectedMonth}
+            onChange={onDatePickerChange}
         />
     );
 };

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
@@ -28,6 +28,8 @@ const setup = ({ ...propsOverride }: SetupProps = {}, shallowRendering = true): 
         onPrevMonthChange: jest.fn(),
         selectedMonth: mockedDate,
         value: mockedDate,
+        nextButtonProps: { label: 'Next month' },
+        previousButtonProps: { label: 'Previous month' },
         ...propsOverride,
     };
 

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -28,9 +28,11 @@ export const DatePickerControlled: Comp<DatePickerControlledProps> = ({
     locale,
     maxDate,
     minDate,
+    nextButtonProps,
     onChange,
     onNextMonthChange,
     onPrevMonthChange,
+    previousButtonProps,
     selectedMonth,
     todayOrSelectedDateRef,
     value,
@@ -47,8 +49,22 @@ export const DatePickerControlled: Comp<DatePickerControlledProps> = ({
         <div className={`${CLASSNAME}`}>
             <Toolbar
                 className={`${CLASSNAME}__toolbar`}
-                after={<IconButton emphasis={Emphasis.low} icon={mdiChevronRight} onClick={onNextMonthChange} />}
-                before={<IconButton emphasis={Emphasis.low} icon={mdiChevronLeft} onClick={onPrevMonthChange} />}
+                after={
+                    <IconButton
+                        {...nextButtonProps}
+                        emphasis={Emphasis.low}
+                        icon={mdiChevronRight}
+                        onClick={onNextMonthChange}
+                    />
+                }
+                before={
+                    <IconButton
+                        {...previousButtonProps}
+                        emphasis={Emphasis.low}
+                        icon={mdiChevronLeft}
+                        onClick={onPrevMonthChange}
+                    />
+                }
                 label={
                     <span className={`${CLASSNAME}__month`}>
                         {moment(selectedMonth).locale(locale).format('MMMM YYYY')}

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.stories.tsx
@@ -15,6 +15,8 @@ export const Simple = ({ theme }: any) => {
             theme={theme}
             onChange={setValue}
             value={value}
+            nextButtonProps={{ label: 'Next month' }}
+            previousButtonProps={{ label: 'Previous month' }}
         />
     );
 };
@@ -30,6 +32,8 @@ export const WithDefaultValue = ({ theme }: any) => {
             theme={theme}
             onChange={setValue}
             value={value}
+            nextButtonProps={{ label: 'Next month' }}
+            previousButtonProps={{ label: 'Previous month' }}
         />
     );
 };
@@ -47,6 +51,8 @@ export const WithErrorAndHelper = ({ theme }: any) => {
             value={value}
             hasError
             helper="Helper"
+            nextButtonProps={{ label: 'Next month' }}
+            previousButtonProps={{ label: 'Previous month' }}
         />
     );
 };
@@ -63,6 +69,8 @@ export const CustomMonth = ({ theme }: any) => {
             onChange={setValue}
             value={value}
             defaultMonth={new Date('2019-07-14')}
+            nextButtonProps={{ label: 'Next month' }}
+            previousButtonProps={{ label: 'Previous month' }}
         />
     );
 };
@@ -78,6 +86,8 @@ export const With28FebruarySelected = ({ theme }: any) => {
             theme={theme}
             onChange={setValue}
             value={value}
+            nextButtonProps={{ label: 'Next month' }}
+            previousButtonProps={{ label: 'Previous month' }}
         />
     );
 };

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
@@ -26,6 +26,8 @@ const setup = ({ ...propsOverride }: SetupProps = {}, shallowRendering = true): 
         locale: 'fr',
         onChange: jest.fn(),
         value: mockedDate,
+        nextButtonProps: { label: 'Next month' },
+        previousButtonProps: { label: 'Previous month' },
         ...propsOverride,
     };
 

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -1,4 +1,4 @@
-import { Placement, Popover, TextField } from '@lumx/react';
+import { Placement, Popover, TextField, IconButtonProps } from '@lumx/react';
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 
 import moment from 'moment';
@@ -27,6 +27,11 @@ export interface DatePickerFieldProps extends GenericProps {
     minDate?: Date;
     /** The native input name property. */
     name?: string;
+    /** The props to pass to the next month change button, minus those already set by the DatePickerControlled props. */
+    nextButtonProps: Pick<IconButtonProps, 'label'> & Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
+    /** The props to pass to the previous month change button, minus those already set by the DatePickerControlled props. */
+    previousButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
     /** The current value of the text field. */
     value: Date | undefined;
     /** The function called on change. */
@@ -46,7 +51,9 @@ export const DatePickerField: Comp<DatePickerFieldProps> = ({
     maxDate,
     minDate,
     name,
+    nextButtonProps,
     onChange,
+    previousButtonProps,
     value,
     ...textFieldProps
 }) => {
@@ -117,6 +124,8 @@ export const DatePickerField: Comp<DatePickerFieldProps> = ({
                             onChange={onDatePickerChange}
                             todayOrSelectedDateRef={todayOrSelectedDateRef}
                             defaultMonth={defaultMonth}
+                            nextButtonProps={nextButtonProps}
+                            previousButtonProps={previousButtonProps}
                         />
                     </div>
                 </Popover>

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -3,9 +3,19 @@
 exports[`<DatePicker> Snapshots and structure should render correctly 1`] = `
 <DatePickerControlled
   locale="fr"
-  onChange={[MockFunction]}
+  nextButtonProps={
+    Object {
+      "label": "Next month",
+    }
+  }
+  onChange={[Function]}
   onNextMonthChange={[Function]}
   onPrevMonthChange={[Function]}
+  previousButtonProps={
+    Object {
+      "label": "Previous month",
+    }
+  }
   selectedMonth={1970-01-17T23:15:21.000Z}
   value={1970-01-17T23:15:21.000Z}
 />

--- a/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
+++ b/packages/lumx-react/src/components/date-picker/__snapshots__/DatePickerControlled.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`<DatePickerControlled> Snapshots and structure should render correctly 
       <IconButton
         emphasis="low"
         icon="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+        label="Next month"
         onClick={[MockFunction]}
         size="m"
         theme="light"
@@ -18,6 +19,7 @@ exports[`<DatePickerControlled> Snapshots and structure should render correctly 
       <IconButton
         emphasis="low"
         icon="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+        label="Previous month"
         onClick={[MockFunction]}
         size="m"
         theme="light"

--- a/packages/lumx-react/src/components/date-picker/types.ts
+++ b/packages/lumx-react/src/components/date-picker/types.ts
@@ -1,3 +1,4 @@
+import { IconButtonProps } from '@lumx/react';
 import { GenericProps } from '@lumx/react/utils';
 import { RefObject } from 'react';
 
@@ -13,6 +14,11 @@ export interface DatePickerProps extends GenericProps {
     maxDate?: Date;
     /** The date before which no date can be selected. */
     minDate?: Date;
+    /** The props to pass to the next month change button, minus those already set by the DatePickerControlled props. */
+    nextButtonProps: Pick<IconButtonProps, 'label'> & Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
+    /** The props to pass to the previous month change button, minus those already set by the DatePickerControlled props. */
+    previousButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
     /** The reference passed to the <button> element if it corresponds to the current date or the selected date. */
     todayOrSelectedDateRef?: RefObject<HTMLButtonElement>;
     /** The current value of the text field. */

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -232,7 +232,9 @@ export const DialogWithFocusableElements = ({ theme }: any) => {
                 <header>
                     <Toolbar
                         label={<span className="lumx-typography-title">Dialog header</span>}
-                        after={<IconButton icon={mdiClose} onClick={closeDialog} emphasis={Emphasis.low} />}
+                        after={
+                            <IconButton label="Close" icon={mdiClose} onClick={closeDialog} emphasis={Emphasis.low} />
+                        }
                     />
                 </header>
                 <div className="lumx-spacing-padding-horizontal-huge lumx-spacing-padding-bottom-huge">

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithFocusabl
           <IconButton
             emphasis="low"
             icon="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+            label="Close"
             onClick={[Function]}
             size="m"
             theme="light"

--- a/packages/lumx-react/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.stories.tsx
@@ -24,7 +24,7 @@ export const MatchAnchorWithMinWidth = () => {
         <>
             <div>Match anchor width only if the dropdown is smaller</div>
             <FlexBox orientation={Orientation.horizontal}>
-                <IconButton icon={mdiHome} buttonRef={buttonRef1} />
+                <IconButton label="Home" icon={mdiHome} buttonRef={buttonRef1} />
                 <Dropdown anchorRef={buttonRef1} isOpen>
                     Big dropdown
                 </Dropdown>

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
@@ -34,6 +34,7 @@ interface Setup extends CommonSetup {
  */
 const setup = ({ ...propsOverride }: SetupProps = {}, shallowRendering = true): Setup => {
     const props: ExpansionPanelProps = {
+        toggleButtonProps: { label: 'Toggle' },
         ...propsOverride,
     };
 

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -8,7 +8,7 @@ import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
 
-import { ColorPalette, DragHandle, Emphasis, IconButton, Theme } from '@lumx/react';
+import { ColorPalette, DragHandle, Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import {
     Callback,
@@ -38,6 +38,9 @@ export interface ExpansionPanelProps extends GenericProps {
     onOpen?: Callback;
     /** The function called on close. */
     onClose?: Callback;
+    /** The props to pass to the toggle button, minus those already set by the ExpansionPanel props. */
+    toggleButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
     /** The function called on open or close. */
     onToggleOpen?(shouldOpen: boolean): void;
 }
@@ -66,6 +69,7 @@ const isFooter = isComponent('footer');
 export const ExpansionPanel: Comp<ExpansionPanelProps> = (props) => {
     const {
         className,
+        children: anyChildren,
         hasBackground,
         hasHeaderDivider,
         isOpen,
@@ -74,7 +78,7 @@ export const ExpansionPanel: Comp<ExpansionPanelProps> = (props) => {
         onOpen,
         onToggleOpen,
         theme,
-        children: anyChildren,
+        toggleButtonProps,
         ...forwardedProps
     } = props;
 
@@ -141,7 +145,12 @@ export const ExpansionPanel: Comp<ExpansionPanelProps> = (props) => {
                 </div>
 
                 <div className={`${CLASSNAME}__header-toggle`}>
-                    <IconButton color={color} emphasis={Emphasis.low} icon={isOpen ? mdiChevronUp : mdiChevronDown} />
+                    <IconButton
+                        {...toggleButtonProps}
+                        color={color}
+                        emphasis={Emphasis.low}
+                        icon={isOpen ? mdiChevronUp : mdiChevronDown}
+                    />
                 </div>
             </header>
 

--- a/packages/lumx-react/src/components/expansion-panel/__snapshots__/ExpansionPanel.test.tsx.snap
+++ b/packages/lumx-react/src/components/expansion-panel/__snapshots__/ExpansionPanel.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`<ExpansionPanel> Snapshots and structure should render correctly 1`] = 
         color="dark"
         emphasis="low"
         icon="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+        label="Toggle"
         size="m"
         theme="light"
       />

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { createPortal } from 'react-dom';
 
 import { mdiClose } from '@lumx/icons';
-import { ColorPalette, Emphasis, IconButton, Theme } from '@lumx/react';
+import { ColorPalette, Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, DOCUMENT } from '@lumx/react/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
@@ -21,8 +21,9 @@ const LIGHTBOX_TRANSITION_DURATION = 400;
 export interface LightboxProps extends GenericProps {
     /** The label for accessibility assistive devices. */
     ariaLabel?: string;
-    /** Whether the closing button should be visible or not. */
-    isCloseButtonVisible?: boolean;
+    /** The props to pass to the close button, minus those already set by the Lightbox props. */
+    closeButtonProps?: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
     /** Whether the component is open or not. */
     isOpen?: boolean;
     /** The reference of the element that triggered modal opening to set focus on. */
@@ -52,7 +53,6 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: Partial<LightboxProps> = {
     ariaLabel: 'Lightbox',
-    isCloseButtonVisible: true,
     theme: Theme.light,
 };
 
@@ -65,7 +65,7 @@ export const Lightbox: Comp<LightboxProps> = ({
     ariaLabel,
     children,
     className,
-    isCloseButtonVisible,
+    closeButtonProps,
     isOpen,
     onClose,
     parentElement,
@@ -118,8 +118,9 @@ export const Lightbox: Comp<LightboxProps> = ({
             style={{ zIndex }}
             ref={wrapperRef}
         >
-            {isCloseButtonVisible && (
+            {closeButtonProps && (
                 <IconButton
+                    {...closeButtonProps}
                     className={`${CLASSNAME}__close`}
                     color={ColorPalette.light}
                     emphasis={Emphasis.low}

--- a/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
@@ -89,8 +89,19 @@ export const SixThumbnails = ({ theme }: any) => {
         <div ref={lightBoxParent} style={{ width: 250 }}>
             <Mosaic theme={theme} onImageClick={setActiveIndex} thumbnails={thumbnails} />
 
-            <Lightbox isOpen={activeIndex !== undefined} parentElement={lightBoxParent} onClose={closeLightBox}>
-                <Slideshow activeIndex={activeIndex} hasControls fillHeight theme={Theme.dark}>
+            <Lightbox
+                isOpen={activeIndex !== undefined}
+                parentElement={lightBoxParent}
+                onClose={closeLightBox}
+                closeButtonProps={{ label: 'Close' }}
+            >
+                <Slideshow
+                    activeIndex={activeIndex}
+                    nextButtonProps={{ label: 'Next' }}
+                    previousButtonProps={{ label: 'Previous' }}
+                    fillHeight
+                    theme={Theme.dark}
+                >
                     {thumbnails.map((thumbnail, index) => (
                         <SlideshowItem key={`${thumbnail.image}-${index}`}>
                             <ImageBlock

--- a/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.stories.tsx
@@ -97,8 +97,10 @@ export const SixThumbnails = ({ theme }: any) => {
             >
                 <Slideshow
                     activeIndex={activeIndex}
-                    nextButtonProps={{ label: 'Next' }}
-                    previousButtonProps={{ label: 'Previous' }}
+                    slideshowControlsProps={{
+                        nextButtonProps: { label: 'Next' },
+                        previousButtonProps: { label: 'Previous' },
+                    }}
                     fillHeight
                     theme={Theme.dark}
                 >

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -149,6 +149,7 @@ export const WithUpdatingChildren = ({ theme }: any) => {
     return (
         <div style={{ float: 'right' }} className="lumx-spacing-margin-right-huge">
             <IconButton
+                label="Notifications"
                 className="lumx-spacing-margin-right-huge"
                 buttonRef={anchorRef}
                 emphasis={Emphasis.low}
@@ -185,6 +186,7 @@ export const WithScrollingPopover = ({ theme }: any) => {
     return (
         <div style={{ float: 'right' }} className="lumx-spacing-margin-right-huge">
             <IconButton
+                label="Notifications"
                 className="lumx-spacing-margin-right-huge"
                 buttonRef={anchorRef}
                 emphasis={Emphasis.low}

--- a/packages/lumx-react/src/components/select/Select.stories.tsx
+++ b/packages/lumx-react/src/components/select/Select.stories.tsx
@@ -149,6 +149,7 @@ export const SelectWithClearButton = ({ theme }: any) => {
             isOpen={isOpen}
             value={value}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             label={LABEL}
             placeholder={PLACEHOLDER}
             theme={theme}
@@ -213,6 +214,7 @@ export const SelectWithAnotherField = ({ theme }: any) => {
                 isOpen={isOpen}
                 value={value}
                 onClear={clearSelected}
+                clearButtonProps={{ label: 'Clear' }}
                 label={LABEL}
                 placeholder={PLACEHOLDER}
                 theme={theme}
@@ -370,6 +372,7 @@ export const SelectWithChipVariant = ({ theme }: any) => {
             onDropdownClose={closeSelect}
             variant={SelectVariant.chip}
             onClear={onClear}
+            clearButtonProps={{ label: 'Clear' }}
         >
             <List isClickable>
                 {CHOICES.length > 0

--- a/packages/lumx-react/src/components/select/Select.test.tsx
+++ b/packages/lumx-react/src/components/select/Select.test.tsx
@@ -229,9 +229,9 @@ describe(`<${Select.displayName}>`, () => {
         it('should call onClear when clear icon is clicked in select input', () => {
             const value = 'Value';
             const onClear: jest.Mock = jest.fn();
-            const { input } = setup({ value, onClear }, false);
+            const { input } = setup({ value, onClear, clearButtonProps: { label: 'Clear' } }, false);
 
-            input.find(`.${CLASSNAME}__input-clear`).first().simulate('click');
+            input.find('[aria-label="Clear"]').first().simulate('click');
             expect(onClear).toHaveBeenCalled();
         });
     });

--- a/packages/lumx-react/src/components/select/Select.tsx
+++ b/packages/lumx-react/src/components/select/Select.tsx
@@ -46,6 +46,7 @@ const stopPropagation = (evt: Event) => evt.stopPropagation();
  */
 const SelectField: Comp<SelectProps> = ({
     anchorRef,
+    clearButtonProps,
     handleKeyboardNav,
     hasError,
     hasInputClear,
@@ -107,8 +108,9 @@ const SelectField: Comp<SelectProps> = ({
                             </div>
                         )}
 
-                        {hasInputClear && (
+                        {hasInputClear && clearButtonProps && (
                             <IconButton
+                                {...clearButtonProps}
                                 className={`${CLASSNAME}__input-clear`}
                                 icon={mdiCloseCircle}
                                 emphasis={Emphasis.low}
@@ -148,7 +150,7 @@ const SelectField: Comp<SelectProps> = ({
 
 export const Select: Comp<SelectProps> = (props) => {
     const isEmpty = lodashIsEmpty(props.value);
-    const hasInputClear = props.onClear && !isEmpty;
+    const hasInputClear = props.onClear && props.clearButtonProps && !isEmpty;
 
     return WithSelectContext(SelectField, {
         ...props,

--- a/packages/lumx-react/src/components/select/SelectMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.stories.tsx
@@ -34,6 +34,7 @@ export const DefaultSelectMultiple = ({ theme }: any) => {
             isOpen={isOpen}
             value={values}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             label={LABEL}
             placeholder={PLACEHOLDER}
             theme={theme}
@@ -68,6 +69,7 @@ export const SelectMultipleWithNoData = ({ theme }: any) => {
             isOpen
             value={[]}
             onClear={noop}
+            clearButtonProps={{ label: 'Clear' }}
             label="Select label"
             placeholder="Select values"
             theme={theme}
@@ -89,6 +91,7 @@ export const DisabledSelectMultiple = ({ theme }: any) => {
             isOpen
             value={[]}
             onClear={noop}
+            clearButtonProps={{ label: 'Clear' }}
             label="Select label"
             placeholder="Select values"
             theme={theme}
@@ -123,6 +126,7 @@ export const ChipsSelectMultiple = ({ theme }: any) => {
             isOpen={isOpen}
             value={values}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             label={LABEL}
             placeholder={PLACEHOLDER}
             theme={theme}
@@ -190,6 +194,7 @@ export const ChipsCustomSelectMultiple = ({ theme }: any) => {
             isOpen={isOpen}
             value={values}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             label={LABEL}
             placeholder={PLACEHOLDER}
             theme={theme}

--- a/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
@@ -237,6 +237,7 @@ describe(`<SelectMultiple>`, () => {
                     onClear,
                     value: ['val 1', 'val 2'],
                     variant: SelectVariant.input,
+                    clearButtonProps: { label: 'Clear' },
                 },
                 false,
             );
@@ -256,6 +257,7 @@ describe(`<SelectMultiple>`, () => {
                     onClear,
                     value: [value1, value2],
                     variant: SelectVariant.chip,
+                    clearButtonProps: { label: 'Clear' },
                 },
                 false,
             );

--- a/packages/lumx-react/src/components/select/constants.ts
+++ b/packages/lumx-react/src/components/select/constants.ts
@@ -1,5 +1,6 @@
+import { IconButtonProps } from '@lumx/react';
 import { Theme } from '@lumx/react/components';
-import { Comp, GenericProps } from '@lumx/react/utils';
+import { GenericProps } from '@lumx/react/utils';
 import { ReactNode, SyntheticEvent } from 'react';
 
 /**
@@ -11,6 +12,9 @@ export enum SelectVariant {
 }
 
 export interface CoreSelectProps extends GenericProps {
+    /** The props to pass to the clear button, minus those already set by the Select props. If not specified, the button won't be displayed. */
+    clearButtonProps?: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
     /** Whether the select (input variant) is displayed with error style or not. */
     hasError?: boolean;
     /** The error related to the component. */
@@ -37,7 +41,7 @@ export interface CoreSelectProps extends GenericProps {
     useCustomColors?: boolean;
     /** The selected choices area style. */
     variant?: SelectVariant;
-    /** The function called when the clear button is clicked. NB: if not specified, clear buttons won't be displayed. */
+    /** The function called when the clear button is clicked. If not specified, the button won't be displayed. */
     onClear?(event: SyntheticEvent, value?: string): void;
     /** The function called when the select field is blurred. */
     onBlur?(): void;

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
@@ -11,26 +11,29 @@ const CustomLink: React.FC = ({ children, ...props }) =>
 
 export const Simple = () => (
     <SideNavigation>
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
         <SideNavigationItem
             label="Navigation item"
             emphasis={Emphasis.low}
             linkProps={{ href: 'https://www.google.com' }}
+            toggleButtonProps={{ label: 'Toggle' }}
         />
         <SideNavigationItem
             label="Navigation item"
             emphasis={Emphasis.low}
             linkProps={{ href: 'https://www.google.com/not-visited' }}
+            toggleButtonProps={{ label: 'Toggle' }}
         />
         <SideNavigationItem
             label="Navigation item (custom link)"
             emphasis={Emphasis.low}
             linkAs={CustomLink}
             linkProps={{ href: 'https://www.google.com/not-visited-1' }}
+            toggleButtonProps={{ label: 'Toggle' }}
         />
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
     </SideNavigation>
 );
 
@@ -42,9 +45,25 @@ export const With3Levels = () => {
 
     return (
         <SideNavigation>
-            <SideNavigationItem label="Level 1" emphasis={Emphasis.high} isOpen={l1IsOpen} onClick={toggleL1}>
-                <SideNavigationItem label="Level 2" emphasis={Emphasis.medium} isOpen={l2IsOpen} onClick={toggleL2}>
-                    <SideNavigationItem label="Level 3" emphasis={Emphasis.low} />
+            <SideNavigationItem
+                label="Level 1"
+                emphasis={Emphasis.high}
+                isOpen={l1IsOpen}
+                onClick={toggleL1}
+                toggleButtonProps={{ label: 'Toggle' }}
+            >
+                <SideNavigationItem
+                    label="Level 2"
+                    emphasis={Emphasis.medium}
+                    isOpen={l2IsOpen}
+                    onClick={toggleL2}
+                    toggleButtonProps={{ label: 'Toggle' }}
+                >
+                    <SideNavigationItem
+                        label="Level 3"
+                        emphasis={Emphasis.low}
+                        toggleButtonProps={{ label: 'Toggle' }}
+                    />
                 </SideNavigationItem>
             </SideNavigationItem>
         </SideNavigation>
@@ -65,6 +84,7 @@ export const With3LevelsAndIcons = () => {
                 isOpen={l1IsOpen}
                 onClick={toggleL1}
                 icon={mdiAccount}
+                toggleButtonProps={{ label: 'Toggle' }}
             >
                 <SideNavigationItem
                     label="Level 2"
@@ -72,10 +92,26 @@ export const With3LevelsAndIcons = () => {
                     isOpen={l2IsOpen}
                     onClick={toggleL2}
                     icon={mdiAccount}
+                    toggleButtonProps={{ label: 'Toggle' }}
                 >
-                    <SideNavigationItem label="Level 3.1" emphasis={Emphasis.low} isSelected />
-                    <SideNavigationItem label="Level 3.2" emphasis={Emphasis.low} icon={mdiAccount} />
-                    <SideNavigationItem label="Level 3.3" emphasis={Emphasis.low} icon={mdiAccount} />
+                    <SideNavigationItem
+                        label="Level 3.1"
+                        emphasis={Emphasis.low}
+                        isSelected
+                        toggleButtonProps={{ label: 'Toggle' }}
+                    />
+                    <SideNavigationItem
+                        label="Level 3.2"
+                        emphasis={Emphasis.low}
+                        icon={mdiAccount}
+                        toggleButtonProps={{ label: 'Toggle' }}
+                    />
+                    <SideNavigationItem
+                        label="Level 3.3"
+                        emphasis={Emphasis.low}
+                        icon={mdiAccount}
+                        toggleButtonProps={{ label: 'Toggle' }}
+                    />
                 </SideNavigationItem>
             </SideNavigationItem>
         </SideNavigation>
@@ -98,6 +134,7 @@ export const With3LevelsAndMultiActions = () => {
                 linkProps={{ href: 'javascript:alert("Level 1")' }}
                 icon={mdiAccount}
                 onActionClick={toggleL1}
+                toggleButtonProps={{ label: 'Toggle' }}
             >
                 <SideNavigationItem
                     label="Level 2"
@@ -105,18 +142,21 @@ export const With3LevelsAndMultiActions = () => {
                     isOpen={l2IsOpen}
                     linkProps={{ href: 'javascript:alert("Level 2")' }}
                     onActionClick={toggleL2}
+                    toggleButtonProps={{ label: 'Toggle' }}
                 >
                     <SideNavigationItem
                         label="Level 3.1"
                         emphasis={Emphasis.low}
                         linkProps={{ href: 'javascript:alert("Level 3.1 item is clicked")' }}
                         onActionClick={alertMessage('Level 3.1 action is clicked')}
+                        toggleButtonProps={{ label: 'Toggle' }}
                     />
                     <SideNavigationItem
                         label="Level 3.2"
                         emphasis={Emphasis.low}
                         onClick={alertMessage('Level 3.2 item is clicked')}
                         onActionClick={alertMessage('Level 3.2 action is clicked')}
+                        toggleButtonProps={{ label: 'Toggle' }}
                     />
                 </SideNavigationItem>
             </SideNavigationItem>

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
@@ -36,7 +36,10 @@ interface Setup extends CommonSetup {
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  */
 const setup = ({ ...propsOverride }: SetupProps = {}, shallowRendering = true): Setup => {
-    const props: any = { ...propsOverride };
+    const props: any = {
+        toggleButtonProps: { label: 'Toggle' },
+        ...propsOverride,
+    };
     const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
     const wrapper: Wrapper = renderer(<SideNavigationItem {...props} />);
 
@@ -107,7 +110,10 @@ describe(`<${SideNavigationItem.displayName}>`, () => {
     describe('Conditions', () => {
         // Here is an example of children types check.
 
-        const items = [<SideNavigationItem key="a" label="a" />, <SideNavigationItem key="b" label="b" />];
+        const items = [
+            <SideNavigationItem key="a" label="a" toggleButtonProps={{ label: 'Toggle' }} />,
+            <SideNavigationItem key="b" label="b" toggleButtonProps={{ label: 'Toggle' }} />,
+        ];
 
         it('should hide chevron when no children are passed', () => {
             const { chevron } = setup({

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -5,7 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 
 import { mdiChevronDown, mdiChevronUp } from '@lumx/icons';
 
-import { Emphasis, Icon, Size } from '@lumx/react';
+import { Emphasis, Icon, Size, IconButton, IconButtonProps } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import {
@@ -18,8 +18,6 @@ import {
     onEnterPressed,
 } from '@lumx/react/utils';
 import { renderLink } from '@lumx/react/utils/renderLink';
-
-import { IconButton } from '../button/IconButton';
 
 /**
  * Defines the props of the component.
@@ -41,6 +39,9 @@ export interface SideNavigationItemProps extends GenericProps {
     linkAs?: 'a' | any;
     /** The props to pass to the link, minus those already set by the SideNavigationItem props. */
     linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+    /** The props to pass to the toggle button, minus those already set by the SideNavigationItem props. */
+    toggleButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color' | 'size'>;
     /** The function called on click on the action button. */
     onActionClick?(evt: React.MouseEvent): void;
     /** The function called on click on the component. */
@@ -77,6 +78,7 @@ export const SideNavigationItem: Comp<SideNavigationItemProps> = (props) => {
         linkProps,
         onActionClick,
         onClick,
+        toggleButtonProps,
         ...forwardedProps
     } = props;
 
@@ -112,6 +114,7 @@ export const SideNavigationItem: Comp<SideNavigationItemProps> = (props) => {
                     )}
 
                     <IconButton
+                        {...toggleButtonProps}
                         className={`${CLASSNAME}__toggle`}
                         icon={isOpen ? mdiChevronUp : mdiChevronDown}
                         size={Size.m}

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -28,6 +28,8 @@ export const Simple = ({ theme }: any) => {
             theme={theme}
             groupBy={groupBy}
             style={{ width: '50%' }}
+            nextButtonProps={{ label: 'Next' }}
+            previousButtonProps={{ label: 'Previous' }}
         >
             {images.map((image, index) => (
                 <SlideshowItem key={`${image}-${index}`}>

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -1,4 +1,4 @@
-import { AspectRatio, ImageBlock, Slideshow, SlideshowItem } from '@lumx/react';
+import { AspectRatio, ImageBlock, Slideshow, SlideshowItem, SlideshowProps } from '@lumx/react';
 import { IMAGES, imageKnob } from '@lumx/react/stories/knobs';
 import { boolean, number } from '@storybook/addon-knobs';
 import React from 'react';
@@ -16,15 +16,19 @@ export const Simple = ({ theme }: any) => {
     ];
     const activeIndex = number('Active index', 0);
     const groupBy = number('Group by', 1);
-    const hasControls = boolean('Has controls', true);
     const autoPlay = boolean('Autoplay', false);
     const interval = number('Autoplay interval (in milliseconds)', 1000);
+
+    const slideshowControlsProps: SlideshowProps['slideshowControlsProps'] = {
+        nextButtonProps: { label: 'Next' },
+        previousButtonProps: { label: 'Previous' },
+    };
     return (
         <Slideshow
             activeIndex={activeIndex}
             autoPlay={autoPlay}
             interval={interval}
-            hasControls={hasControls}
+            slideshowControlsProps={slideshowControlsProps}
             theme={theme}
             groupBy={groupBy}
             style={{ width: '50%' }}

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useCallback, useEffect, useRef, useState } from '
 
 import classNames from 'classnames';
 
-import { Theme } from '@lumx/react';
+import { IconButtonProps, Theme } from '@lumx/react';
 
 import { AUTOPLAY_DEFAULT_INTERVAL, FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
@@ -27,7 +27,12 @@ export interface SlideshowProps extends GenericProps {
     hasControls?: boolean;
     /** The interval between each slide when automatic rotation is enabled. */
     interval?: number;
-    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    /** The props to pass to the next button, minus those already set by the SlideshowControls props. */
+    nextButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
+    /** The props to pass to the previous button, minus those already set by the SlideshowControls props. */
+    previousButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
     theme?: Theme;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
@@ -65,9 +70,11 @@ export const Slideshow: Comp<SlideshowProps> = ({
     groupBy,
     hasControls,
     interval,
+    nextButtonProps,
+    onChange,
+    previousButtonProps,
     theme,
     useCustomColors,
-    onChange,
     ...forwardedProps
 }) => {
     const [currentIndex, setCurrentIndex] = useState<number>(activeIndex as number);
@@ -206,6 +213,8 @@ export const Slideshow: Comp<SlideshowProps> = ({
                         slidesCount={slidesCount}
                         parentRef={parentRef}
                         theme={theme}
+                        nextButtonProps={nextButtonProps}
+                        previousButtonProps={previousButtonProps}
                     />
                 </div>
             )}

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -2,14 +2,12 @@ import React, { CSSProperties, useCallback, useEffect, useRef, useState } from '
 
 import classNames from 'classnames';
 
-import { IconButtonProps, Theme } from '@lumx/react';
+import { SlideshowControls, SlideshowControlsProps, Theme } from '@lumx/react';
 
 import { AUTOPLAY_DEFAULT_INTERVAL, FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 import { useInterval } from '@lumx/react/hooks';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
-
-import { SlideshowControls } from './SlideshowControls';
 
 /**
  * Defines the props of the component.
@@ -23,16 +21,21 @@ export interface SlideshowProps extends GenericProps {
     fillHeight?: boolean;
     /** The number of slides to group together. */
     groupBy?: number;
-    /** Whether slideshow has controls or not. */
-    hasControls?: boolean;
     /** The interval between each slide when automatic rotation is enabled. */
     interval?: number;
-    /** The props to pass to the next button, minus those already set by the SlideshowControls props. */
-    nextButtonProps: Pick<IconButtonProps, 'label'> &
-        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
-    /** The props to pass to the previous button, minus those already set by the SlideshowControls props. */
-    previousButtonProps: Pick<IconButtonProps, 'label'> &
-        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
+    /** The props to pass to the slideshow controls, minus those already set by the Slideshow props. */
+    slideshowControlsProps?: Pick<SlideshowControlsProps, 'nextButtonProps' | 'previousButtonProps'> &
+        Omit<
+            SlideshowControlsProps,
+            | 'activeIndex'
+            | 'onPaginationClick'
+            | 'onNextClick'
+            | 'onPreviousClick'
+            | 'slidesCount'
+            | 'parentRef'
+            | 'theme'
+        >;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
@@ -68,11 +71,9 @@ export const Slideshow: Comp<SlideshowProps> = ({
     className,
     fillHeight,
     groupBy,
-    hasControls,
     interval,
-    nextButtonProps,
     onChange,
-    previousButtonProps,
+    slideshowControlsProps,
     theme,
     useCustomColors,
     ...forwardedProps
@@ -175,12 +176,12 @@ export const Slideshow: Comp<SlideshowProps> = ({
     };
 
     /* If the activeIndex props changes, update the current slide */
-    React.useEffect(() => {
+    useEffect(() => {
         setCurrentIndex(activeIndex as number);
     }, [activeIndex]);
 
     /* If the slide changes, with autoplay for example, trigger "onChange" */
-    React.useEffect(() => {
+    useEffect(() => {
         if (onChange) {
             onChange(currentIndex);
         }
@@ -203,9 +204,10 @@ export const Slideshow: Comp<SlideshowProps> = ({
                 </div>
             </div>
 
-            {hasControls && slidesCount > 1 && (
+            {slideshowControlsProps && slidesCount > 1 && (
                 <div className={`${CLASSNAME}__controls`}>
                     <SlideshowControls
+                        {...slideshowControlsProps}
                         activeIndex={currentIndex}
                         onPaginationClick={handleControlGotToSlide}
                         onNextClick={handleControlNextSlide}
@@ -213,8 +215,6 @@ export const Slideshow: Comp<SlideshowProps> = ({
                         slidesCount={slidesCount}
                         parentRef={parentRef}
                         theme={theme}
-                        nextButtonProps={nextButtonProps}
-                        previousButtonProps={previousButtonProps}
                     />
                 </div>
             )}

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
@@ -53,7 +53,6 @@ export const ControllingSlideshow = ({ theme }: any) => {
         <div style={{ height: 400, width: 500, position: 'relative' }}>
             <Slideshow
                 activeIndex={activeIndex}
-                hasControls={false}
                 theme={theme}
                 autoPlay
                 groupBy={1}

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
@@ -23,6 +23,8 @@ export const Simple = () => {
             onNextClick={onNextClick}
             onPreviousClick={onPreviousClick}
             onPaginationClick={onPaginationClick}
+            nextButtonProps={{ label: 'Next' }}
+            previousButtonProps={{ label: 'Previous' }}
         />
     );
 };
@@ -72,6 +74,8 @@ export const ControllingSlideshow = ({ theme }: any) => {
                     onNextClick={onNextClick}
                     onPreviousClick={onPreviousClick}
                     onPaginationClick={onPaginationClick}
+                    nextButtonProps={{ label: 'Next' }}
+                    previousButtonProps={{ label: 'Previous' }}
                 />
             </div>
         </div>

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -3,7 +3,7 @@ import React, { RefObject, useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 
 import { mdiChevronLeft, mdiChevronRight } from '@lumx/icons';
-import { Emphasis, IconButton, Theme } from '@lumx/react';
+import { Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
 import {
     EDGE_FROM_ACTIVE_INDEX,
     PAGINATION_ITEMS_MAX,
@@ -20,8 +20,14 @@ import isFunction from 'lodash/isFunction';
 export interface SlideshowControlsProps extends GenericProps {
     /** The index of the current slide. */
     activeIndex?: number;
+    /** The props to pass to the next button, minus those already set by the SlideshowControls props. */
+    nextButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
     /** The reference of the parent element. */
     parentRef: RefObject<HTMLDivElement>;
+    /** The props to pass to the previous button, minus those already set by the SlideshowControls props. */
+    previousButtonProps: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
     /** The number of slides. */
     slidesCount: number;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
@@ -64,10 +70,12 @@ const DEFAULT_PROPS: Partial<SlideshowControlsProps> = {
 export const SlideshowControls: Comp<SlideshowControlsProps> = ({
     activeIndex,
     className,
+    nextButtonProps,
     onNextClick,
     onPaginationClick,
     onPreviousClick,
     parentRef,
+    previousButtonProps,
     slidesCount,
     theme,
     ...forwardedProps
@@ -261,6 +269,7 @@ export const SlideshowControls: Comp<SlideshowControlsProps> = ({
             })}
         >
             <IconButton
+                {...nextButtonProps}
                 icon={mdiChevronLeft}
                 className={`${CLASSNAME}__navigation`}
                 color={theme === Theme.dark ? 'light' : 'dark'}
@@ -274,6 +283,7 @@ export const SlideshowControls: Comp<SlideshowControlsProps> = ({
                 </div>
             </div>
             <IconButton
+                {...previousButtonProps}
                 icon={mdiChevronRight}
                 className={`${CLASSNAME}__navigation`}
                 color={theme === Theme.dark ? 'light' : 'dark'}

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -5,7 +5,7 @@ import get from 'lodash/get';
 import { uid } from 'uid';
 
 import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from '@lumx/icons';
-import { Emphasis, Icon, IconButton, InputHelper, InputLabel, Kind, Size, Theme } from '@lumx/react';
+import { Emphasis, Icon, IconButton, IconButtonProps, InputHelper, InputLabel, Kind, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
@@ -16,6 +16,9 @@ import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 export interface TextFieldProps extends GenericProps {
     /** A Chip Group to be rendered before the main text input. */
     chips?: HTMLElement | ReactNode;
+    /** The props to pass to the clear button, minus those already set by the TextField props. If not specified, the button won't be displayed. */
+    clearButtonProps?: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
     /** The error related to the TextField. */
     error?: string | ReactNode;
     /** Whether we force the focus style or not. */
@@ -30,8 +33,6 @@ export interface TextFieldProps extends GenericProps {
     id?: string;
     /** The reference passed to the <input> or <textarea> element. */
     inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
-    /** Whether the text field shows a cross to clear its content or not. */
-    isClearable?: boolean;
     /** Whether the component is disabled or not. */
     isDisabled?: boolean;
     /** Whether the component is required or not. */
@@ -225,6 +226,7 @@ const renderInputNative: Comp<InputNativeProps> = (props) => {
 export const TextField: Comp<TextFieldProps> = ({
     chips,
     className,
+    clearButtonProps,
     disabled,
     error,
     forceFocusStyle,
@@ -233,7 +235,6 @@ export const TextField: Comp<TextFieldProps> = ({
     icon,
     id,
     inputRef,
-    isClearable,
     isDisabled = disabled,
     isRequired,
     isValid,
@@ -282,7 +283,7 @@ export const TextField: Comp<TextFieldProps> = ({
                     hasError: !isValid && hasError,
                     hasIcon: Boolean(icon),
                     hasInput: !multiline,
-                    hasInputClear: isClearable && isNotEmpty,
+                    hasInputClear: clearButtonProps && isNotEmpty,
                     hasLabel: Boolean(label),
                     hasPlaceholder: Boolean(placeholder),
                     hasTextarea: multiline,
@@ -360,8 +361,9 @@ export const TextField: Comp<TextFieldProps> = ({
                         />
                     )}
 
-                    {isClearable && isNotEmpty && (
+                    {clearButtonProps && isNotEmpty && (
                         <IconButton
+                            {...clearButtonProps}
                             className={`${CLASSNAME}__input-clear`}
                             icon={mdiCloseCircle}
                             emphasis={Emphasis.low}

--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -1,8 +1,19 @@
-import { Button, Placement, Switch, Tooltip } from '@lumx/react';
+import { mdiHelp, mdiPrinter } from '@lumx/icons';
+import {
+    Button,
+    Dropdown,
+    FlexBox,
+    Icon,
+    IconButton,
+    Orientation,
+    Placement,
+    Size,
+    Switch,
+    Tooltip,
+} from '@lumx/react';
 import { select, text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
 import React, { useRef, useState } from 'react';
-import { Dropdown } from '../dropdown/Dropdown';
 
 export default { title: 'LumX components/tooltip/Tooltip' };
 
@@ -23,13 +34,21 @@ export const ForceOpen = () => {
 };
 
 export const InlineTooltip = () => (
-    <>
-        {'Some text with a '}
-        <Tooltip label="A tooltip on the word 'tooltip'">
-            <span>tooltip</span>
+    <div className="lumx-spacing-margin-huge">
+        Some text with a
+        <Tooltip label="extremely complex and difficult to follow" forceOpen>
+            <abbr style={{ borderBottom: '1px dotted', margin: '0 4px' }}>convoluted</abbr>
         </Tooltip>
-        {' on one word.'}
-    </>
+        word in it. And some text with a contextual help at the end
+        <Tooltip
+            label="A contextual help is help that is displayed in your product or web site"
+            placement={Placement.TOP}
+            forceOpen
+        >
+            <Icon icon={mdiHelp} size={Size.xxs} style={{ display: 'inline-block', verticalAlign: 'super' }} />
+        </Tooltip>
+        .
+    </div>
 );
 
 export const MultilineTooltip = () => (
@@ -82,5 +101,36 @@ export const TooltipOnDisabledButton = () => {
                 </Button>
             </Tooltip>
         </>
+    );
+};
+
+export const TooltipOnDifferentComponents = () => {
+    return (
+        <FlexBox orientation={Orientation.horizontal} className="lumx-spacing-margin-top-huge">
+            <FlexBox fillSpace />
+            <FlexBox fillSpace>
+                <Tooltip forceOpen label="Tooltip on Button">
+                    <Button>Button</Button>
+                </Tooltip>
+            </FlexBox>
+            <FlexBox fillSpace>
+                <IconButton icon={mdiPrinter} label="Tooltip on IconButton" tooltipProps={{ forceOpen: true }} />
+            </FlexBox>
+            <FlexBox fillSpace>
+                <Tooltip forceOpen label="Tooltip on Icon">
+                    <Icon icon={mdiPrinter} style={{ display: 'inline-block' }} />
+                </Tooltip>
+            </FlexBox>
+            <FlexBox fillSpace>
+                <Tooltip forceOpen label="Tooltip on shaped Icon">
+                    <Icon icon={mdiPrinter} hasShape />
+                </Tooltip>
+            </FlexBox>
+            <FlexBox fillSpace>
+                <Tooltip forceOpen label="Tooltip on word">
+                    <span>word</span>
+                </Tooltip>
+            </FlexBox>
+        </FlexBox>
     );
 };

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import React, { ReactNode, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
@@ -66,14 +67,10 @@ export const Tooltip: Comp<TooltipProps> = (props) => {
         return <>{children}</>;
     }
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const id = useMemo(() => `tooltip-${uid()}`, []);
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [popperElement, setPopperElement] = useState<null | HTMLElement>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { styles, attributes } = usePopper(anchorElement, popperElement, {
         placement,
         modifiers: [
@@ -85,9 +82,7 @@ export const Tooltip: Comp<TooltipProps> = (props) => {
     });
 
     const position = attributes?.popper?.['data-popper-placement'] ?? placement;
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const isOpen = useTooltipOpen(delay as number, anchorElement) || forceOpen;
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const wrappedChildren = useInjectTooltipRef(children, setAnchorElement, isOpen as boolean, id);
 
     return (

--- a/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
+++ b/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
@@ -43,7 +43,11 @@ export const useInjectTooltipRef = (
             }
 
             // Button, IconButton
-            if (type?.displayName === 'Button' || type?.displayName === 'IconButton') {
+            if (
+                type?.displayName === 'Button' ||
+                type?.displayName === 'ButtonRoot' ||
+                type?.displayName === 'IconButton'
+            ) {
                 const element = children as any;
                 return cloneElement(element, {
                     ...element.props,

--- a/packages/site-demo/content/product/components/avatar/react/actions.tsx
+++ b/packages/site-demo/content/product/components/avatar/react/actions.tsx
@@ -9,9 +9,30 @@ export const App = ({ theme }: any) => (
         size={Size.xl}
         actions={
             <FlexBox orientation={Orientation.horizontal} vAlign={Alignment.center} gap={Size.regular}>
-                <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiPencil} size={Size.s} />
-                <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiEye} size={Size.s} />
-                <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiDelete} size={Size.s} />
+                <IconButton
+                    label="Edit"
+                    color="dark"
+                    emphasis={Emphasis.low}
+                    hasBackground
+                    icon={mdiPencil}
+                    size={Size.s}
+                />
+                <IconButton
+                    label="See"
+                    color="dark"
+                    emphasis={Emphasis.low}
+                    hasBackground
+                    icon={mdiEye}
+                    size={Size.s}
+                />
+                <IconButton
+                    label="Delete"
+                    color="dark"
+                    emphasis={Emphasis.low}
+                    hasBackground
+                    icon={mdiDelete}
+                    size={Size.s}
+                />
             </FlexBox>
         }
     />

--- a/packages/site-demo/content/product/components/button/react/emphasis-high.tsx
+++ b/packages/site-demo/content/product/components/button/react/emphasis-high.tsx
@@ -20,9 +20,9 @@ export const App = ({ theme }: any) => (
 
         <ButtonGroup>
             <Button theme={theme}>Split</Button>
-            <IconButton icon={mdiMenuDown} theme={theme} />
+            <IconButton label="More" icon={mdiMenuDown} theme={theme} />
         </ButtonGroup>
 
-        <IconButton icon={mdiPlus} theme={theme} />
+        <IconButton label="Add" icon={mdiPlus} theme={theme} />
     </>
 );

--- a/packages/site-demo/content/product/components/button/react/emphasis-low.tsx
+++ b/packages/site-demo/content/product/components/button/react/emphasis-low.tsx
@@ -20,6 +20,6 @@ export const App = ({ theme }: any) => (
             Dropdown
         </Button>
 
-        <IconButton emphasis={Emphasis.low} icon={mdiPlus} theme={theme} />
+        <IconButton label="Add" emphasis={Emphasis.low} icon={mdiPlus} theme={theme} />
     </>
 );

--- a/packages/site-demo/content/product/components/button/react/emphasis-medium.tsx
+++ b/packages/site-demo/content/product/components/button/react/emphasis-medium.tsx
@@ -24,9 +24,9 @@ export const App = ({ theme }: any) => (
             <Button emphasis={Emphasis.medium} theme={theme}>
                 Split
             </Button>
-            <IconButton emphasis={Emphasis.medium} icon={mdiMenuDown} theme={theme} />
+            <IconButton label="More" emphasis={Emphasis.medium} icon={mdiMenuDown} theme={theme} />
         </ButtonGroup>
 
-        <IconButton emphasis={Emphasis.medium} icon={mdiPlus} theme={theme} />
+        <IconButton label="Add" emphasis={Emphasis.medium} icon={mdiPlus} theme={theme} />
     </>
 );

--- a/packages/site-demo/content/product/components/button/react/small.tsx
+++ b/packages/site-demo/content/product/components/button/react/small.tsx
@@ -26,10 +26,10 @@ export const App = ({ theme }: any) => (
                 <Button size={Size.s} theme={theme}>
                     Split
                 </Button>
-                <IconButton size={Size.s} icon={mdiMenuDown} theme={theme} />
+                <IconButton label="More" size={Size.s} icon={mdiMenuDown} theme={theme} />
             </ButtonGroup>
 
-            <IconButton icon={mdiPlus} size={Size.s} theme={theme} />
+            <IconButton label="Add" icon={mdiPlus} size={Size.s} theme={theme} />
         </FlexBox>
 
         <FlexBox gap={Size.big} orientation={Orientation.horizontal}>
@@ -52,10 +52,10 @@ export const App = ({ theme }: any) => (
                 <Button emphasis={Emphasis.medium} size={Size.s} theme={theme}>
                     Split
                 </Button>
-                <IconButton emphasis={Emphasis.medium} icon={mdiMenuDown} size={Size.s} theme={theme} />
+                <IconButton label="More" emphasis={Emphasis.medium} icon={mdiMenuDown} size={Size.s} theme={theme} />
             </ButtonGroup>
 
-            <IconButton icon={mdiPlus} emphasis={Emphasis.medium} size={Size.s} theme={theme} />
+            <IconButton label="Add" icon={mdiPlus} emphasis={Emphasis.medium} size={Size.s} theme={theme} />
         </FlexBox>
 
         <FlexBox gap={Size.big} orientation={Orientation.horizontal}>
@@ -75,7 +75,7 @@ export const App = ({ theme }: any) => (
                 Dropdown
             </Button>
 
-            <IconButton icon={mdiPlus} emphasis={Emphasis.low} size={Size.s} theme={theme} />
+            <IconButton label="Add" icon={mdiPlus} emphasis={Emphasis.low} size={Size.s} theme={theme} />
         </FlexBox>
     </>
 );

--- a/packages/site-demo/content/product/components/date-picker/react/default.tsx
+++ b/packages/site-demo/content/product/components/date-picker/react/default.tsx
@@ -4,5 +4,15 @@ import React, { useState } from 'react';
 export const App = () => {
     const [datePicked, setDatePicked] = useState<Date | undefined>(new Date());
 
-    return <DatePicker value={datePicked} locale="en" onChange={setDatePicked} />;
+    return (
+        <DatePicker
+            value={datePicked}
+            locale="en"
+            onChange={(newDate?: Date) => {
+                setDatePicked(newDate);
+            }}
+            nextButtonProps={{ label: 'Next month' }}
+            previousButtonProps={{ label: 'Previous month' }}
+        />
+    );
 };

--- a/packages/site-demo/content/product/components/date-picker/react/input.tsx
+++ b/packages/site-demo/content/product/components/date-picker/react/input.tsx
@@ -12,6 +12,8 @@ export const App = () => {
             icon={mdiCalendar}
             value={datePicked}
             onChange={setDatePicked}
+            nextButtonProps={{ label: 'Next month' }}
+            previousButtonProps={{ label: 'Previous month' }}
         />
     );
 };

--- a/packages/site-demo/content/product/components/date-picker/react/restricted.tsx
+++ b/packages/site-demo/content/product/components/date-picker/react/restricted.tsx
@@ -9,8 +9,22 @@ export const App = () => {
 
     return (
         <>
-            <DatePicker value={datePicked} locale="en" onChange={setDatePicked} minDate={minDate} />
-            <DatePicker value={datePicked} locale="en" onChange={setDatePicked} maxDate={maxDate} />
+            <DatePicker
+                value={datePicked}
+                locale="en"
+                onChange={setDatePicked}
+                minDate={minDate}
+                nextButtonProps={{ label: 'Next month' }}
+                previousButtonProps={{ label: 'Previous month' }}
+            />
+            <DatePicker
+                value={datePicked}
+                locale="en"
+                onChange={setDatePicked}
+                maxDate={maxDate}
+                nextButtonProps={{ label: 'Next month' }}
+                previousButtonProps={{ label: 'Previous month' }}
+            />
         </>
     );
 };

--- a/packages/site-demo/content/product/components/expansion-panel/react/default.tsx
+++ b/packages/site-demo/content/product/components/expansion-panel/react/default.tsx
@@ -7,7 +7,14 @@ export const App = ({ theme }: any) => {
     const [isOpen, setOpen] = useState(false);
 
     return (
-        <ExpansionPanel hasBackground label="Lorem ipsum" theme={theme} isOpen={isOpen} onToggleOpen={setOpen}>
+        <ExpansionPanel
+            hasBackground
+            label="Lorem ipsum"
+            theme={theme}
+            isOpen={isOpen}
+            onToggleOpen={setOpen}
+            toggleButtonProps={{ label: 'Toggle' }}
+        >
             <div className="lumx-spacing-padding-big lumx-spacing-padding-top-none">
                 <p
                     className={classNames(

--- a/packages/site-demo/content/product/components/expansion-panel/react/drag-handle.tsx
+++ b/packages/site-demo/content/product/components/expansion-panel/react/drag-handle.tsx
@@ -7,7 +7,14 @@ export const App = ({ theme }: any) => {
     const [isOpen, setOpen] = useState(false);
 
     return (
-        <ExpansionPanel hasBackground label="Lorem ipsum" theme={theme} isOpen={isOpen} onToggleOpen={setOpen}>
+        <ExpansionPanel
+            hasBackground
+            label="Lorem ipsum"
+            theme={theme}
+            isOpen={isOpen}
+            onToggleOpen={setOpen}
+            toggleButtonProps={{ label: 'Toggle' }}
+        >
             <DragHandle theme={theme} />
 
             <div className="lumx-spacing-padding-big lumx-spacing-padding-top-none">

--- a/packages/site-demo/content/product/components/expansion-panel/react/examples.tsx
+++ b/packages/site-demo/content/product/components/expansion-panel/react/examples.tsx
@@ -25,7 +25,13 @@ export const App = () => {
 
     return (
         <>
-            <ExpansionPanel hasBackground hasHeaderDivider isOpen={isOpen1} onToggleOpen={setOpen1}>
+            <ExpansionPanel
+                hasBackground
+                hasHeaderDivider
+                isOpen={isOpen1}
+                onToggleOpen={setOpen1}
+                toggleButtonProps={{ label: 'Toggle' }}
+            >
                 <header>
                     <FlexBox
                         className="lumx-spacing-margin-left-regular"
@@ -44,7 +50,13 @@ export const App = () => {
                 </div>
             </ExpansionPanel>
 
-            <ExpansionPanel hasBackground hasHeaderDivider isOpen={isOpen2} onToggleOpen={setOpen2}>
+            <ExpansionPanel
+                hasBackground
+                hasHeaderDivider
+                isOpen={isOpen2}
+                onToggleOpen={setOpen2}
+                toggleButtonProps={{ label: 'Toggle' }}
+            >
                 <header>
                     <FlexBox
                         className="lumx-spacing-margin-left-regular"
@@ -68,7 +80,12 @@ export const App = () => {
                 </div>
             </ExpansionPanel>
 
-            <ExpansionPanel hasBackground isOpen={isOpen3} onToggleOpen={setOpen3}>
+            <ExpansionPanel
+                hasBackground
+                isOpen={isOpen3}
+                onToggleOpen={setOpen3}
+                toggleButtonProps={{ label: 'Toggle' }}
+            >
                 <header>
                     <FlexBox
                         className="lumx-spacing-margin-left-big"
@@ -79,6 +96,7 @@ export const App = () => {
 
                         <FlexBox marginAuto={Alignment.left}>
                             <IconButton
+                                label="Secondary actions"
                                 icon={mdiDotsVertical}
                                 emphasis={Emphasis.low}
                                 size={Size.m}
@@ -94,7 +112,7 @@ export const App = () => {
                 </div>
             </ExpansionPanel>
 
-            <ExpansionPanel isOpen={isOpen4} onToggleOpen={setOpen4}>
+            <ExpansionPanel isOpen={isOpen4} onToggleOpen={setOpen4} toggleButtonProps={{ label: 'Toggle' }}>
                 <header>
                     <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
                         <Thumbnail image="/demo-assets/square1.jpg" size={Size.m} variant={ThumbnailVariant.rounded} />
@@ -111,7 +129,7 @@ export const App = () => {
 
             <Divider />
 
-            <ExpansionPanel isOpen={isOpen5} onToggleOpen={setOpen5}>
+            <ExpansionPanel isOpen={isOpen5} onToggleOpen={setOpen5} toggleButtonProps={{ label: 'Toggle' }}>
                 <header>
                     <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
                         <Thumbnail image="/demo-assets/square1.jpg" size={Size.m} variant={ThumbnailVariant.rounded} />
@@ -128,7 +146,7 @@ export const App = () => {
 
             <Divider />
 
-            <ExpansionPanel isOpen={isOpen6} onToggleOpen={setOpen6}>
+            <ExpansionPanel isOpen={isOpen6} onToggleOpen={setOpen6} toggleButtonProps={{ label: 'Toggle' }}>
                 <header>
                     <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
                         <Thumbnail image="/demo-assets/square1.jpg" size={Size.m} variant={ThumbnailVariant.rounded} />

--- a/packages/site-demo/content/product/components/expansion-panel/react/trimmed.tsx
+++ b/packages/site-demo/content/product/components/expansion-panel/react/trimmed.tsx
@@ -7,7 +7,13 @@ export const App = ({ theme }: any) => {
     const [isOpen, setOpen] = useState(false);
 
     return (
-        <ExpansionPanel label="Lorem ipsum" theme={theme} isOpen={isOpen} onToggleOpen={setOpen}>
+        <ExpansionPanel
+            label="Lorem ipsum"
+            theme={theme}
+            isOpen={isOpen}
+            onToggleOpen={setOpen}
+            toggleButtonProps={{ label: 'Toggle' }}
+        >
             <div className="lumx-spacing-padding-top">
                 <p
                     className={classNames(

--- a/packages/site-demo/content/product/components/image-block/react/default.tsx
+++ b/packages/site-demo/content/product/components/image-block/react/default.tsx
@@ -17,15 +17,15 @@ export const App = ({ theme }: any) => (
         actions={
             <FlexBox orientation={Orientation.horizontal}>
                 <div className="lumx-spacing-margin-right-regular">
-                    <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiPencil} />
+                    <IconButton label="Edit" color="dark" emphasis={Emphasis.low} hasBackground icon={mdiPencil} />
                 </div>
 
                 <div className="lumx-spacing-margin-right-regular">
-                    <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiEye} />
+                    <IconButton label="See" color="dark" emphasis={Emphasis.low} hasBackground icon={mdiEye} />
                 </div>
 
                 <div>
-                    <IconButton color="dark" emphasis={Emphasis.low} hasBackground icon={mdiDelete} />
+                    <IconButton label="Delete" color="dark" emphasis={Emphasis.low} hasBackground icon={mdiDelete} />
                 </div>
             </FlexBox>
         }

--- a/packages/site-demo/content/product/components/lightbox/react/default.tsx
+++ b/packages/site-demo/content/product/components/lightbox/react/default.tsx
@@ -52,8 +52,10 @@ export const App = () => {
             >
                 <Slideshow
                     activeIndex={activeIndex}
-                    nextButtonProps={{ label: 'Next' }}
-                    previousButtonProps={{ label: 'Previous' }}
+                    slideshowControlsProps={{
+                        nextButtonProps: { label: 'Next' },
+                        previousButtonProps: { label: 'Previous' },
+                    }}
                     autoPlay
                     fillHeight
                     theme={Theme.dark}

--- a/packages/site-demo/content/product/components/lightbox/react/default.tsx
+++ b/packages/site-demo/content/product/components/lightbox/react/default.tsx
@@ -44,8 +44,20 @@ export const App = () => {
 
     return (
         <div style={{ width: 536, margin: '0 auto' }}>
-            <Lightbox isOpen={isOpen} parentElement={triggerElement} onClose={close}>
-                <Slideshow activeIndex={activeIndex} hasControls autoPlay fillHeight theme={Theme.dark}>
+            <Lightbox
+                isOpen={isOpen}
+                parentElement={triggerElement}
+                onClose={close}
+                closeButtonProps={{ label: 'Close' }}
+            >
+                <Slideshow
+                    activeIndex={activeIndex}
+                    nextButtonProps={{ label: 'Next' }}
+                    previousButtonProps={{ label: 'Previous' }}
+                    autoPlay
+                    fillHeight
+                    theme={Theme.dark}
+                >
                     {images.map(({ image }) => (
                         <SlideshowItem key={image}>
                             <ImageBlock

--- a/packages/site-demo/content/product/components/list/react/big.tsx
+++ b/packages/site-demo/content/product/components/list/react/big.tsx
@@ -44,7 +44,7 @@ export const App = () => (
         <ListItem
             size={Size.big}
             before={<Thumbnail variant={ThumbnailVariant.rounded} image="/demo-assets/square1.jpg" size={Size.m} />}
-            after={<IconButton emphasis={Emphasis.low} icon={mdiDotsHorizontal} />}
+            after={<IconButton label="More" emphasis={Emphasis.low} icon={mdiDotsHorizontal} />}
         >
             <div>
                 <span>Two-line item</span>

--- a/packages/site-demo/content/product/components/list/react/huge.tsx
+++ b/packages/site-demo/content/product/components/list/react/huge.tsx
@@ -49,7 +49,7 @@ export const App = () => (
         <ListItem
             size={Size.huge}
             before={<Thumbnail variant={ThumbnailVariant.rounded} image="/demo-assets/square1.jpg" size={Size.m} />}
-            after={<IconButton emphasis={Emphasis.low} icon={mdiDotsHorizontal} />}
+            after={<IconButton label="More" emphasis={Emphasis.low} icon={mdiDotsHorizontal} />}
         >
             <div>
                 <span>Multi-line item</span>

--- a/packages/site-demo/content/product/components/list/react/regular.tsx
+++ b/packages/site-demo/content/product/components/list/react/regular.tsx
@@ -27,7 +27,7 @@ export const App = () => (
 
         <ListItem
             before={<Thumbnail variant={ThumbnailVariant.rounded} image="/demo-assets/square1.jpg" size={Size.m} />}
-            after={<IconButton emphasis={Emphasis.low} icon={mdiDotsHorizontal} />}
+            after={<IconButton label="More" emphasis={Emphasis.low} icon={mdiDotsHorizontal} />}
         >
             Single-line item
         </ListItem>

--- a/packages/site-demo/content/product/components/select/react/multi-select-chip.tsx
+++ b/packages/site-demo/content/product/components/select/react/multi-select-chip.tsx
@@ -33,6 +33,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             variant={SelectVariant.chip}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             onDropdownClose={closeSelect}
             onInputClick={toggleSelect}
         >

--- a/packages/site-demo/content/product/components/select/react/multi-select-search.tsx
+++ b/packages/site-demo/content/product/components/select/react/multi-select-search.tsx
@@ -83,6 +83,7 @@ export const App = ({ theme }: any) => {
             placeholder={PLACEHOLDER}
             theme={theme}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             onDropdownClose={closeSelect}
             onInputClick={toggleSelect}
             onInfiniteScroll={onInfiniteScroll}

--- a/packages/site-demo/content/product/components/select/react/multi-select.tsx
+++ b/packages/site-demo/content/product/components/select/react/multi-select.tsx
@@ -35,6 +35,7 @@ export const App = ({ theme }: any) => {
             placeholder={PLACEHOLDER}
             theme={theme}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
         >
             <List>
                 {CHOICES.length > 0

--- a/packages/site-demo/content/product/components/select/react/select-chip.tsx
+++ b/packages/site-demo/content/product/components/select/react/select-chip.tsx
@@ -34,6 +34,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             variant={SelectVariant.chip}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             onDropdownClose={closeSelect}
             onInputClick={toggleSelect}
         >

--- a/packages/site-demo/content/product/components/select/react/single-select-search.tsx
+++ b/packages/site-demo/content/product/components/select/react/single-select-search.tsx
@@ -40,6 +40,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             value={value}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             onInputClick={toggleSelect}
             onDropdownClose={closeSelect}
         >

--- a/packages/site-demo/content/product/components/select/react/single-select.tsx
+++ b/packages/site-demo/content/product/components/select/react/single-select.tsx
@@ -31,6 +31,7 @@ export const App = ({ theme }: any) => {
             isOpen={isOpen}
             value={value}
             onClear={clearSelected}
+            clearButtonProps={{ label: 'Clear' }}
             label={LABEL}
             placeholder={PLACEHOLDER}
             theme={theme}

--- a/packages/site-demo/content/product/components/side-navigation/react/default.tsx
+++ b/packages/site-demo/content/product/components/side-navigation/react/default.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 export const App = () => (
     <SideNavigation>
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
-        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
+        <SideNavigationItem label="Navigation item" emphasis={Emphasis.low} toggleButtonProps={{ label: 'Toggle' }} />
     </SideNavigation>
 );

--- a/packages/site-demo/content/product/components/side-navigation/react/emphasis.tsx
+++ b/packages/site-demo/content/product/components/side-navigation/react/emphasis.tsx
@@ -4,8 +4,23 @@ import React from 'react';
 
 export const App = () => (
     <SideNavigation>
-        <SideNavigationItem label="Low" icon={mdiArrowTopRightThick} emphasis={Emphasis.low} />
-        <SideNavigationItem label="Medium" icon={mdiArrowTopRightThick} emphasis={Emphasis.medium} />
-        <SideNavigationItem label="High" icon={mdiArrowTopRightThick} emphasis={Emphasis.high} />
+        <SideNavigationItem
+            label="Low"
+            icon={mdiArrowTopRightThick}
+            emphasis={Emphasis.low}
+            toggleButtonProps={{ label: 'Toggle' }}
+        />
+        <SideNavigationItem
+            label="Medium"
+            icon={mdiArrowTopRightThick}
+            emphasis={Emphasis.medium}
+            toggleButtonProps={{ label: 'Toggle' }}
+        />
+        <SideNavigationItem
+            label="High"
+            icon={mdiArrowTopRightThick}
+            emphasis={Emphasis.high}
+            toggleButtonProps={{ label: 'Toggle' }}
+        />
     </SideNavigation>
 );

--- a/packages/site-demo/content/product/components/side-navigation/react/nested.tsx
+++ b/packages/site-demo/content/product/components/side-navigation/react/nested.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 
 export const App = () => (
     <SideNavigation>
-        <SideNavigationItem label="Level 0 (closed)">
-            <SideNavigationItem label="Level 1" emphasis={Emphasis.medium} />
+        <SideNavigationItem label="Level 0 (closed)" toggleButtonProps={{ label: 'Toggle' }}>
+            <SideNavigationItem label="Level 1" emphasis={Emphasis.medium} toggleButtonProps={{ label: 'Toggle' }} />
         </SideNavigationItem>
 
-        <SideNavigationItem label="Level 0 (open)" isOpen>
-            <SideNavigationItem label="Level 1" emphasis={Emphasis.medium} />
-            <SideNavigationItem label="Level 1" emphasis={Emphasis.medium} />
+        <SideNavigationItem label="Level 0 (open)" isOpen toggleButtonProps={{ label: 'Toggle' }}>
+            <SideNavigationItem label="Level 1" emphasis={Emphasis.medium} toggleButtonProps={{ label: 'Toggle' }} />
+            <SideNavigationItem label="Level 1" emphasis={Emphasis.medium} toggleButtonProps={{ label: 'Toggle' }} />
         </SideNavigationItem>
     </SideNavigation>
 );

--- a/packages/site-demo/content/product/components/side-navigation/react/states.tsx
+++ b/packages/site-demo/content/product/components/side-navigation/react/states.tsx
@@ -4,7 +4,18 @@ import React from 'react';
 
 export const App = () => (
     <SideNavigation>
-        <SideNavigationItem label="Resting" icon={mdiEmail} emphasis={Emphasis.low} />
-        <SideNavigationItem label="Selected" icon={mdiEmail} emphasis={Emphasis.low} isSelected />
+        <SideNavigationItem
+            label="Resting"
+            icon={mdiEmail}
+            emphasis={Emphasis.low}
+            toggleButtonProps={{ label: 'Toggle' }}
+        />
+        <SideNavigationItem
+            label="Selected"
+            icon={mdiEmail}
+            emphasis={Emphasis.low}
+            isSelected
+            toggleButtonProps={{ label: 'Toggle' }}
+        />
     </SideNavigation>
 );

--- a/packages/site-demo/content/product/components/side-navigation/react/with-icon.tsx
+++ b/packages/site-demo/content/product/components/side-navigation/react/with-icon.tsx
@@ -4,6 +4,11 @@ import React from 'react';
 
 export const App = () => (
     <SideNavigation>
-        <SideNavigationItem label="With leading icon" icon={mdiEmail} emphasis={Emphasis.low} />
+        <SideNavigationItem
+            label="With leading icon"
+            icon={mdiEmail}
+            emphasis={Emphasis.low}
+            toggleButtonProps={{ label: 'Toggle' }}
+        />
     </SideNavigation>
 );

--- a/packages/site-demo/content/product/components/slideshow/react/auto.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/auto.tsx
@@ -9,8 +9,10 @@ export const App = ({ theme }: any) => {
     return (
         <Slideshow
             activeIndex={0}
-            nextButtonProps={{ label: 'Next' }}
-            previousButtonProps={{ label: 'Previous' }}
+            slideshowControlsProps={{
+                nextButtonProps: { label: 'Next' },
+                previousButtonProps: { label: 'Previous' },
+            }}
             theme={theme}
             autoPlay
             groupBy={1}

--- a/packages/site-demo/content/product/components/slideshow/react/auto.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/auto.tsx
@@ -7,7 +7,15 @@ export const App = ({ theme }: any) => {
     };
 
     return (
-        <Slideshow activeIndex={0} hasControls theme={theme} autoPlay groupBy={1} style={slideshowStyle}>
+        <Slideshow
+            activeIndex={0}
+            nextButtonProps={{ label: 'Next' }}
+            previousButtonProps={{ label: 'Previous' }}
+            theme={theme}
+            autoPlay
+            groupBy={1}
+            style={slideshowStyle}
+        >
             <SlideshowItem>
                 <ImageBlock
                     thumbnailProps={{ aspectRatio: AspectRatio.vertical }}

--- a/packages/site-demo/content/product/components/slideshow/react/default.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/default.tsx
@@ -40,8 +40,10 @@ export const App = ({ theme }: any) => {
     return (
         <Slideshow
             activeIndex={0}
-            nextButtonProps={{ label: 'Next' }}
-            previousButtonProps={{ label: 'Previous' }}
+            slideshowControlsProps={{
+                nextButtonProps: { label: 'Next' },
+                previousButtonProps: { label: 'Previous' },
+            }}
             theme={theme}
             groupBy={1}
             style={{ width: '50%' }}

--- a/packages/site-demo/content/product/components/slideshow/react/default.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/default.tsx
@@ -38,7 +38,14 @@ export const App = ({ theme }: any) => {
     ];
 
     return (
-        <Slideshow activeIndex={0} hasControls theme={theme} groupBy={1} style={{ width: '50%' }}>
+        <Slideshow
+            activeIndex={0}
+            nextButtonProps={{ label: 'Next' }}
+            previousButtonProps={{ label: 'Previous' }}
+            theme={theme}
+            groupBy={1}
+            style={{ width: '50%' }}
+        >
             {images.map((image) => (
                 <SlideshowItem key={image}>
                     <ImageBlock

--- a/packages/site-demo/content/product/components/slideshow/react/group.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/group.tsx
@@ -19,8 +19,10 @@ export const App = ({ theme }: any) => {
     return (
         <Slideshow
             activeIndex={0}
-            nextButtonProps={{ label: 'Next' }}
-            previousButtonProps={{ label: 'Previous' }}
+            slideshowControlsProps={{
+                nextButtonProps: { label: 'Next' },
+                previousButtonProps: { label: 'Previous' },
+            }}
             theme={theme}
             autoPlay
             groupBy={2}

--- a/packages/site-demo/content/product/components/slideshow/react/group.tsx
+++ b/packages/site-demo/content/product/components/slideshow/react/group.tsx
@@ -17,7 +17,15 @@ export const App = ({ theme }: any) => {
     ];
 
     return (
-        <Slideshow activeIndex={0} hasControls theme={theme} autoPlay groupBy={2} style={{ width: '100%' }}>
+        <Slideshow
+            activeIndex={0}
+            nextButtonProps={{ label: 'Next' }}
+            previousButtonProps={{ label: 'Previous' }}
+            theme={theme}
+            autoPlay
+            groupBy={2}
+            style={{ width: '100%' }}
+        >
             {images.map((image) => (
                 <SlideshowItem key={image}>
                     <ImageBlock

--- a/packages/site-demo/content/product/components/text-field/index.mdx
+++ b/packages/site-demo/content/product/components/text-field/index.mdx
@@ -28,7 +28,7 @@ Use `hasError` to tell that entered values are considered incorrect.
 
 ## Options
 
-There are seven options: `isRequired`, `helper`, `placeholder`, `icon`, `isClearable`, `maxLength` and `chips`.
+There are seven options: `isRequired`, `helper`, `placeholder`, `icon`, `clearButtonProps`, `maxLength` and `chips`.
 
 ### Is required
 
@@ -56,7 +56,7 @@ Use `icon` to illustrate text fields `label`, `icon` complements `label` but can
 
 ### Is clearable
 
-Use `clearable` when it is useful for users or if it trigger an action like clearing a text filter to remove the filtering.
+To allow the user to clear the text field, you would have to pass a `label` prop through `clearButtonProps` prop. This corresponds to the label which will be used inside the tooltip of the clear icon button. Setting the label is enough to determine the visbility of the clear button. Use `onClear` to pass the function triggered by a click on the clear icon button. 
 
 <DemoBlock demo="clearable" withThemeSwitcher />
 

--- a/packages/site-demo/content/product/components/text-field/react/clearable.tsx
+++ b/packages/site-demo/content/product/components/text-field/react/clearable.tsx
@@ -4,5 +4,13 @@ import React, { useState } from 'react';
 export const App = ({ theme }: any) => {
     const [value, setValue] = useState('Clearable value');
 
-    return <TextField label="Text field label" isClearable value={value} onChange={setValue} theme={theme} />;
+    return (
+        <TextField
+            label="Text field label"
+            clearButtonProps={{ label: 'Clear' }}
+            value={value}
+            onChange={setValue}
+            theme={theme}
+        />
+    );
 };

--- a/packages/site-demo/content/product/components/toolbar/react/back.tsx
+++ b/packages/site-demo/content/product/components/toolbar/react/back.tsx
@@ -10,7 +10,7 @@ export const App = ({ theme }: any) => {
 
     return (
         <Toolbar
-            before={<IconButton emphasis={Emphasis.low} theme={theme} icon={mdiChevronLeft} />}
+            before={<IconButton label="Previous" emphasis={Emphasis.low} theme={theme} icon={mdiChevronLeft} />}
             label={
                 <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
                     <span
@@ -34,6 +34,7 @@ export const App = ({ theme }: any) => {
             after={
                 <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
                     <IconButton
+                        label="Grid"
                         className="lumx-spacing-margin-right-regular"
                         emphasis={Emphasis.low}
                         theme={theme}

--- a/packages/site-demo/content/product/components/toolbar/react/default.tsx
+++ b/packages/site-demo/content/product/components/toolbar/react/default.tsx
@@ -17,6 +17,6 @@ export const App = ({ theme }: any) => (
                 Toolbar title
             </span>
         }
-        after={<IconButton emphasis={Emphasis.low} theme={theme} icon={mdiMagnify} />}
+        after={<IconButton label="Search" emphasis={Emphasis.low} theme={theme} icon={mdiMagnify} />}
     />
 );

--- a/packages/site-demo/content/product/components/toolbar/react/media-picker.tsx
+++ b/packages/site-demo/content/product/components/toolbar/react/media-picker.tsx
@@ -33,6 +33,7 @@ export const App = ({ theme }: any) => {
             after={
                 <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center}>
                     <IconButton
+                        label="Grid"
                         className="lumx-spacing-margin-right-regular"
                         emphasis={Emphasis.low}
                         theme={theme}

--- a/packages/site-demo/content/product/components/tooltip/react/default.tsx
+++ b/packages/site-demo/content/product/components/tooltip/react/default.tsx
@@ -1,9 +1,9 @@
 import { mdiPrinter } from '@lumx/icons';
-import { Emphasis, IconButton, Tooltip } from '@lumx/react';
+import { Icon, Tooltip } from '@lumx/react';
 import React from 'react';
 
 export const App = () => (
     <Tooltip label="Print">
-        <IconButton emphasis={Emphasis.medium} icon={mdiPrinter} />
+        <Icon icon={mdiPrinter} />
     </Tooltip>
 );

--- a/packages/site-demo/content/product/components/tooltip/react/default.tsx
+++ b/packages/site-demo/content/product/components/tooltip/react/default.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const App = () => (
     <Tooltip label="Print">
-        <Icon icon={mdiPrinter} />
+        <Icon icon={mdiPrinter} hasShape />
     </Tooltip>
 );

--- a/packages/site-demo/content/product/components/tooltip/react/delay.tsx
+++ b/packages/site-demo/content/product/components/tooltip/react/delay.tsx
@@ -1,9 +1,9 @@
 import { mdiPrinter } from '@lumx/icons';
-import { Emphasis, IconButton, Tooltip } from '@lumx/react';
+import { Icon, Tooltip } from '@lumx/react';
 import React from 'react';
 
 export const App = () => (
     <Tooltip delay={2000} label="Print">
-        <IconButton emphasis={Emphasis.medium} icon={mdiPrinter} />
+        <Icon icon={mdiPrinter} />
     </Tooltip>
 );

--- a/packages/site-demo/content/product/components/tooltip/react/delay.tsx
+++ b/packages/site-demo/content/product/components/tooltip/react/delay.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const App = () => (
     <Tooltip delay={2000} label="Print">
-        <Icon icon={mdiPrinter} />
+        <Icon icon={mdiPrinter} hasShape />
     </Tooltip>
 );

--- a/packages/site-demo/content/product/components/tooltip/react/placement.tsx
+++ b/packages/site-demo/content/product/components/tooltip/react/placement.tsx
@@ -1,23 +1,23 @@
 import { mdiPrinter } from '@lumx/icons';
-import { Emphasis, IconButton, Placement, Tooltip } from '@lumx/react';
+import { Icon, Placement, Tooltip } from '@lumx/react';
 import React from 'react';
 
 export const App = () => (
     <>
         <Tooltip label="Print" placement={Placement.LEFT} forceOpen>
-            <IconButton emphasis={Emphasis.medium} icon={mdiPrinter} />
+            <Icon icon={mdiPrinter} />
         </Tooltip>
 
         <Tooltip label="Print" placement={Placement.BOTTOM} forceOpen>
-            <IconButton emphasis={Emphasis.medium} icon={mdiPrinter} />
+            <Icon icon={mdiPrinter} />
         </Tooltip>
 
         <Tooltip label="Print" placement={Placement.TOP} forceOpen>
-            <IconButton emphasis={Emphasis.medium} icon={mdiPrinter} />
+            <Icon icon={mdiPrinter} />
         </Tooltip>
 
         <Tooltip label="Print" placement={Placement.RIGHT} forceOpen>
-            <IconButton emphasis={Emphasis.medium} icon={mdiPrinter} />
+            <Icon icon={mdiPrinter} />
         </Tooltip>
     </>
 );

--- a/packages/site-demo/content/product/components/tooltip/react/placement.tsx
+++ b/packages/site-demo/content/product/components/tooltip/react/placement.tsx
@@ -1,23 +1,23 @@
 import { mdiPrinter } from '@lumx/icons';
-import { Icon, Placement, Tooltip } from '@lumx/react';
+import { FlexBox, Icon, Orientation, Placement, Size, Tooltip } from '@lumx/react';
 import React from 'react';
 
 export const App = () => (
-    <>
+    <FlexBox orientation={Orientation.horizontal} gap={Size.regular}>
         <Tooltip label="Print" placement={Placement.LEFT} forceOpen>
-            <Icon icon={mdiPrinter} />
+            <Icon hasShape icon={mdiPrinter} />
         </Tooltip>
 
         <Tooltip label="Print" placement={Placement.BOTTOM} forceOpen>
-            <Icon icon={mdiPrinter} />
+            <Icon hasShape icon={mdiPrinter} />
         </Tooltip>
 
         <Tooltip label="Print" placement={Placement.TOP} forceOpen>
-            <Icon icon={mdiPrinter} />
+            <Icon hasShape icon={mdiPrinter} />
         </Tooltip>
 
         <Tooltip label="Print" placement={Placement.RIGHT} forceOpen>
-            <Icon icon={mdiPrinter} />
+            <Icon hasShape icon={mdiPrinter} />
         </Tooltip>
-    </>
+    </FlexBox>
 );

--- a/packages/site-demo/content/product/components/user-block/react/extended.tsx
+++ b/packages/site-demo/content/product/components/user-block/react/extended.tsx
@@ -20,6 +20,7 @@ export const App = ({ theme }: any) => {
         demoActions.map((demoAction, idx) => (
             <IconButton
                 key={idx}
+                label={`Action ${idx}`}
                 emphasis={Emphasis.low}
                 color={theme === Theme.dark ? 'light' : undefined}
                 icon={demoAction}

--- a/packages/site-demo/content/product/patterns/filter-and-sort/react/facets.tsx
+++ b/packages/site-demo/content/product/patterns/filter-and-sort/react/facets.tsx
@@ -56,6 +56,7 @@ export const App = () => {
                         label="Color"
                         variant={SelectVariant.chip}
                         onClear={clearSelected}
+                        clearButtonProps={{ label: 'Clear' }}
                         onDropdownClose={closeSelect}
                         onInputClick={toggleSelect}
                     >

--- a/packages/site-demo/src/components/PropTable.tsx
+++ b/packages/site-demo/src/components/PropTable.tsx
@@ -48,7 +48,12 @@ const PropTableRow: React.FC<{ property: Property }> = ({ property }) => {
     };
 
     return (
-        <ExpansionPanel label="Lorem ipsum" isOpen={isOpen} onToggleOpen={toggleOpen}>
+        <ExpansionPanel
+            label="Lorem ipsum"
+            isOpen={isOpen}
+            onToggleOpen={toggleOpen}
+            toggleButtonProps={{ label: 'Toggle' }}
+        >
             <header>
                 <Grid hAlign={Alignment.center}>
                     <GridItem width="4">

--- a/packages/site-demo/src/components/design-tokens/DesignToken.tsx
+++ b/packages/site-demo/src/components/design-tokens/DesignToken.tsx
@@ -42,6 +42,7 @@ export const DesignToken: React.FC<DesignTokenProps> = ({
             isOpen={isOpen}
             onToggleOpen={setIsOpen}
             theme={theme}
+            toggleButtonProps={{ label: 'Toggle' }}
         >
             <header>
                 <div className="design-token__header">

--- a/packages/site-demo/src/components/layout/MainNav.tsx
+++ b/packages/site-demo/src/components/layout/MainNav.tsx
@@ -82,6 +82,7 @@ const renderNavItem = (
         emphasis: EMPHASIS_BY_LEVEL[level],
         isOpen: includes(openPaths, path),
         isSelected: locationPath === path,
+        toggleButtonProps: { label: 'Toggle' },
     };
 
     if (!children?.length) {


### PR DESCRIPTION
# General summary

## Added

-   _[BREAKING]_ Added required `label` prop for `IconButton`. The label is used as `aria-label` for the button and to add a tooltip. This prop is required for a11y purpose. If you really don't want a tooltip, you can give an empty label (this is not recommended).
-   _[BREAKING]_ Added `nextButtonProps` and `previousButtonProps` props to `DatePickerControlled`, `DatePicker` and `DatePickerField` components to allow setting custom props to the `IconButton`s used to change month. These fields are **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
-   _[BREAKING]_ Added `nextButtonProps` and `previousButtonProps` props to `SlideshowControls` component to allow setting custom props to the `IconButton`s used to change image. These fields are **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
-   Added `slideshowControlsProps` to the `Slideshow` component to allow setting custom props to the slideshow controls. Controls are not displayed if this prop is not set.
-   _[BREAKING]_ Added `toggleButtonProps` prop to `ExpansionPanel` component to allow setting custom props to the `IconButton`s used to toggle the panel. This field is **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
-   _[BREAKING]_ Added `toggleButtonProps` prop to `SideNavigationItem` component to allow setting custom props to the `IconButton`s used to toggle the menu. This field is **required** because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
-   Added `clearButtonProps` prop to `Select` component to allow setting custom props to the `IconButton`s used to clear the select. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `clearButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
-   Added `clearButtonProps` prop to `TextField` component to allow setting custom props to the `IconButton`s used to clear the field. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `clearButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
-   Added `closeButtonProps` prop to `Lightbox` component to allow setting custom props to the `IconButton`s used to close the lightbox. This prop is not required since the icon button is not automatically displayed. However, when used to display the button, the `label` prop inside the `closeButtonProps` prop will be required because translation are not handled inside the Design System and the `IconButton` now requires a `label` for a11y purposes.
-   Added `tooltipProps` to `IconButton` to allow setting custom props to the tooltip.

## Removed

-   _[BREAKING]_ `isClosingButtonVisible` prop of `Lightbox` component has been removed. Passing the `label` prop using `closeButtonProps` prop is enough to determine the visibility of the icon button.
-   _[BREAKING]_ `isClearable` prop of `TextField`, `Autocomplete` and `AutocompleteMultiple` components has been removed. Passing the `label` prop using `clearButtonProps` prop is enough to determine the visibility of the icon button.
-   _[BREAKING]_ `hasControls` prop of `Slideshow` component has been removed. Using `slideshowControlsProps` prop is enough to determine the visibility of the slideshow controls.

### Fixed

-   Fixed `DatePicker` component to prevent switching month when selecting a date.
-   Fixed `Tooltip` placement on `Icon` and `IconButton`.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
