### PR TITLE
feat(comment-block): add header actions prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `headerActions` prop to `CommentBlock` component to add actions to the header.
+
+### Fixed
+
+-   Fixed `text` prop of the `CommentBlock` component to accept `ReactNode` type.
+
 ## [0.28.1][] - 2020-12-03
 
 ### Fixed

--- a/packages/lumx-angularjs/src/components/comment-block/comment-block.html
+++ b/packages/lumx-angularjs/src/components/comment-block/comment-block.html
@@ -28,6 +28,9 @@
                     </span>
 
                     <span class="lumx-comment-block__date" ng-if="lx.date">{{ lx.date }}</span>
+                    <span class="lumx-comment-block__header-actions" ng-if="lx.headerActions"
+                        >{{ lx.headerActions }}</span
+                    >
                 </div>
 
                 <p class="lumx-comment-block__text">

--- a/packages/lumx-core/src/scss/components/comment-block/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/comment-block/lumapps/_index.scss
@@ -6,8 +6,12 @@
     $self: &;
 
     position: relative;
+    margin-bottom: $lumx-spacing-unit * 2;
 
-    &--has-children#{$self}--has-indented-children::before,
+    &:last-child {
+        margin-bottom: 0;
+    }
+
     &--has-children#{$self}--has-indented-children &::before {
         position: absolute;
         top: 52px;
@@ -17,18 +21,16 @@
         content: '';
     }
 
-    &--has-children#{$self}--has-indented-children#{$self}--theme-light::before,
     &--has-children#{$self}--has-indented-children#{$self}--theme-light &::before {
         background-color: lumx-color-variant('dark', 'L5');
     }
 
-    &--has-children#{$self}--has-indented-children#{$self}--theme-dark::before,
     &--has-children#{$self}--has-indented-children#{$self}--theme-dark &::before {
         background-color: lumx-color-variant('light', 'L5');
     }
 
-    &__children & {
-        margin-top: $lumx-spacing-unit * 2;
+    &--has-children#{$self}--has-indented-children &:last-child::before {
+        display: none;
     }
 
     &__wrapper {
@@ -70,8 +72,7 @@
     &__content {
         position: relative;
         overflow: hidden;
-        padding: $lumx-spacing-unit * 1.5;
-        padding-top: $lumx-spacing-unit;
+        padding: $lumx-spacing-unit $lumx-spacing-unit * 1.5;
         border-radius: $lumx-border-radius;
 
         #{$self}--theme-light > #{$self}__wrapper & {
@@ -158,6 +159,8 @@
     }
 
     &__children {
+        margin-top: $lumx-spacing-unit * 2;
+
         #{$self}--has-indented-children & {
             margin-left: map-get($lumx-sizes, lumx-base-const('size', 'M')) + $lumx-spacing-unit * 2;
         }

--- a/packages/lumx-core/src/scss/components/comment-block/lumapps/_index.scss
+++ b/packages/lumx-core/src/scss/components/comment-block/lumapps/_index.scss
@@ -135,6 +135,10 @@
         }
     }
 
+    &__header-actions {
+        margin-left: auto;
+    }
+
     &__text {
         @include lumx-typography('body1');
 

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
@@ -1,0 +1,27 @@
+import { mdiDotsHorizontal, mdiHeart, mdiReply } from '@lumx/icons';
+import { Button, CommentBlock, Emphasis, Size } from '@lumx/react';
+import { IconButton } from '@lumx/react/components/button/IconButton';
+import React from 'react';
+
+export default { title: 'LumX components/comment-block/CommentBlock' };
+
+export const WithHeaderActions = ({ theme }: any) => (
+    <CommentBlock
+        hasActions
+        hasChildren
+        actions={[
+            <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                24 likes
+            </Button>,
+            <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+                Reply
+            </Button>,
+        ]}
+        theme={theme}
+        avatar="https://i.pravatar.cc/40"
+        date="4 hours ago"
+        name="Emmitt O. Lum"
+        text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
+        headerActions={<IconButton icon={mdiDotsHorizontal} emphasis={Emphasis.low} size={Size.s} />}
+    />
+);

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -13,11 +13,13 @@ import isFunction from 'lodash/isFunction';
  */
 interface CommentBlockProps extends GenericProps {
     /* Actions elements to be transcluded into the component */
-    actions?: HTMLElement | ReactNode;
+    actions?: ReactNode;
+    /** The title action elements. */
+    headerActions?: ReactNode;
     /* The url of the avatar picture we want to display */
     avatar: string;
     /* Children elements to be transcluded into the component */
-    children?: HTMLElement | ReactNode;
+    children?: ReactNode;
     /* Comment timestamp */
     date: string;
     /* Where the component has actions to display */
@@ -33,7 +35,7 @@ interface CommentBlockProps extends GenericProps {
     /* Username display */
     name: string;
     /* Content to be displayed */
-    text: HTMLElement | string;
+    text: ReactNode | string;
     /* Component theme */
     theme?: Theme;
     /* Callback for the click event. */
@@ -82,6 +84,7 @@ const CommentBlock: React.FC<CommentBlockProps> = ({
     onMouseLeave,
     text,
     theme,
+    headerActions,
 }: CommentBlockProps): React.ReactElement => {
     const enterKeyPress: KeyboardEventHandler<HTMLElement> = (evt: KeyboardEvent<HTMLElement>) => {
         if (evt.which === ENTER_KEY_CODE && isFunction(onClick)) {
@@ -128,6 +131,7 @@ const CommentBlock: React.FC<CommentBlockProps> = ({
                                 {name}
                             </span>
                             {date && <span className={`${CLASSNAME}__date`}>{date}</span>}
+                            {headerActions && <span className={`${CLASSNAME}__header-actions`}>{headerActions}</span>}
                         </div>
 
                         <div className={`${CLASSNAME}__text`}>{text}</div>

--- a/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
@@ -3,49 +3,68 @@ import { Button, CommentBlock, Emphasis, Size } from '@lumx/react';
 import React from 'react';
 
 export const App = ({ theme }: any) => (
-    <CommentBlock
-        hasActions
-        hasChildren
-        isOpen
-        actions={[
-            <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
-                24 likes
-            </Button>,
-            <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
-                2 replies
-            </Button>,
-        ]}
-        theme={theme}
-        avatar="../avatar/assets/persona.png"
-        date="4 hours ago"
-        name="Emmitt O. Lum"
-        text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
-    >
+    <div>
         <CommentBlock
             hasActions
-            actions={
-                <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+            hasChildren
+            isOpen
+            actions={[
+                <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                     24 likes
-                </Button>
-            }
-            avatar="../avatar/assets/persona.png"
-            date="3 hours ago"
-            name="Jackson Ray"
+                </Button>,
+                <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+                    2 replies
+                </Button>,
+            ]}
             theme={theme}
-            text="Here, I focus on a range of items and features that we use in life without giving them."
-        />
+            avatar="../avatar/assets/persona.png"
+            date="4 hours ago"
+            name="Emmitt O. Lum"
+            text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
+        >
+            <CommentBlock
+                hasActions
+                actions={
+                    <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                        24 likes
+                    </Button>
+                }
+                avatar="../avatar/assets/persona.png"
+                date="3 hours ago"
+                name="Jackson Ray"
+                theme={theme}
+                text="Here, I focus on a range of items and features that we use in life without giving them."
+            />
+            <CommentBlock
+                hasActions
+                actions={
+                    <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                        16 likes
+                    </Button>
+                }
+                avatar="../avatar/assets/persona.png"
+                date="2 hours ago"
+                name="Hettie Powell"
+                theme={theme}
+                text="Differentiate and you stand out in a crowded marketplace."
+            />
+        </CommentBlock>
+
         <CommentBlock
             hasActions
-            actions={
-                <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
-                    16 likes
-                </Button>
-            }
-            avatar="../avatar/assets/persona.png"
-            date="2 hours ago"
-            name="Hettie Powell"
+            actions={[
+                <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                    24 likes
+                </Button>,
+                <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+                    2 replies
+                </Button>,
+            ]}
             theme={theme}
-            text="Differentiate and you stand out in a crowded marketplace."
+            avatar="../avatar/assets/persona.png"
+            date="4 hours ago"
+            name="Emmitt O. Lum"
+            text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
         />
-    </CommentBlock>
+    </div>
 );


### PR DESCRIPTION
CMS-337

# General summary

* Added `headerActions` prop to the `CommentBlock` component to make it possible to add a contextual menu to comments.
* Fixed `text` prop on the `CommentBlock` component to accept `ReactNode`.

<!-- Please describe the PR content -->

# Screenshots

![image](https://user-images.githubusercontent.com/7147342/101467124-37b27880-3942-11eb-9017-73e1f3ae01f4.png)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if ha s code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
