### PR TITLE
chore(ci): build chromatic on tag rather than on push branch

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -4,15 +4,13 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, labeled ]
   push:
-    branches:
-        - master
-        - release/**
+    tags:
+        - v*
 
 jobs:
   deploy:
-    # Run on push (on master or release branch)
-    # OR run if the "need: review-design" label is present or if the target branch is a release branch
-    if: "github.event_name == 'push' || (contains(github.event.pull_request.labels.*.name, 'need: review-design') || startsWith(github.base_ref, 'release/') || startsWith(github.ref, 'release/'))"
+    # Run on push version tag OR on PR with the "need: review-design" label
+    if: "github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'need: review-design')"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"


### PR DESCRIPTION
Build chromatic on push version tag instead of on push branch