### PR TITLE
Fix/LUM-13688 - Chips color contrast

### DIFF
--- a/packages/lumx-core/src/scss/core/state/lumapps/_mixins.scss
+++ b/packages/lumx-core/src/scss/core/state/lumapps/_mixins.scss
@@ -31,7 +31,7 @@
 @mixin lumx-state-medium($state, $color, $has-focus-inset: false) {
     @if $state == lumx-base-const('state', 'DEFAULT') {
         background-color: lumx-color-variant($color, 'L5');
-        color: lumx-color-variant($color, 'N');
+        color: lumx-color-variant($color, 'D3');
     } @else if $state == lumx-base-const('state', 'HOVER') {
         background-color: lumx-color-variant($color, 'L4');
     } @else if $state == lumx-base-const('state', 'ACTIVE') {
@@ -49,7 +49,7 @@
     @if $theme == lumx-base-const('theme', 'LIGHT') {
         @if $state == lumx-base-const('state', 'DEFAULT') {
             background-color: lumx-color-variant('primary', 'L4');
-            color: lumx-color-variant('primary', 'D2');
+            color: lumx-color-variant('primary', 'D3');
         } @else if $state == lumx-base-const('state', 'HOVER') {
             background-color: lumx-color-variant('primary', 'L3');
         } @else if $state == lumx-base-const('state', 'ACTIVE') {
@@ -107,7 +107,7 @@
 }
 
 @mixin lumx-state-disabled-input() {
-    opacity: 0.5;
+    opacity: 0.7;
     pointer-events: none;
 }
 

--- a/packages/lumx-react/src/components/chip/Chip.stories.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { mdiClose, mdiViewList } from '@lumx/icons';
 import { Chip, Icon } from '@lumx/react';
+import { ColorPalette } from '..';
 
 export default { title: 'LumX components/chip/Chip' };
 
@@ -17,5 +18,37 @@ export const WithAfterAndBefore = ({ theme }: any) => (
         isClickable
     >
         content
+    </Chip>
+);
+
+export const WithColor = ({ theme }: any) => (
+    <>
+        <Chip theme={theme} color={ColorPalette.primary}>
+            My chip
+        </Chip>
+        <Chip theme={theme} color={ColorPalette.secondary}>
+            My chip
+        </Chip>
+        <Chip theme={theme} color={ColorPalette.blue}>
+            My chip
+        </Chip>
+        <Chip theme={theme} color={ColorPalette.red}>
+            My chip
+        </Chip>
+        <Chip theme={theme} color={ColorPalette.dark}>
+            My chip
+        </Chip>
+    </>
+);
+
+export const Highlighted = ({ theme }: any) => (
+    <Chip theme={theme} color={ColorPalette.primary} isHighlighted>
+        My chip
+    </Chip>
+);
+
+export const Disabled = ({ theme }: any) => (
+    <Chip theme={theme} color={ColorPalette.primary} isDisabled>
+        My chip
     </Chip>
 );


### PR DESCRIPTION
# General summary

The color contrast on Chip wasn't satisfying a11y rules


# Screenshots

<img width="1005" alt="Screenshot 2020-12-29 at 17 06 51" src="https://user-images.githubusercontent.com/14941730/103297291-4ac3e000-49f8-11eb-9f13-b6e67782799f.png">

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
