### PR TITLE
refactor(comment-block): add variant and remove useless props LUM-13511

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `tooltipProps` to `IconButton` to allow setting custom props to the tooltip.
 -   _[BREAKING]_ Added `htmlFor` prop required for `InputLabel` since it is required for `<label>` for a11y purposes.
 -   Added forwarded props to the `Select` component.
+-   Added `variant` prop for `CommentBlock` component (either `indented` by default or `linear`).
 
 ### Changed
 
@@ -85,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ `isClosingButtonVisible` prop of `Lightbox` component has been removed. Passing the `label` prop using `closeButtonProps` prop is enough to determine the visibility of the icon button.
 -   _[BREAKING]_ `isClearable` prop of `TextField`, `Autocomplete` and `AutocompleteMultiple` components has been removed. Passing the `label` prop using `clearButtonProps` prop is enough to determine the visibility of the icon button.
 -   _[BREAKING]_ `hasControls` prop of `Slideshow` component has been removed. Using `slideshowControlsProps` prop is enough to determine the visibility of the slideshow controls.
+-   _[BREAKING]_ `hasChildren` and `hasIndentedChildren` props for `CommentBlock` component have been removed.
 
 ### Fixed
 

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
@@ -8,7 +8,6 @@ export default { title: 'LumX components/comment-block/CommentBlock' };
 export const WithHeaderActions = ({ theme }: any) => (
     <CommentBlock
         hasActions
-        hasChildren
         actions={[
             <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                 24 likes

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, KeyboardEvent, KeyboardEventHandler, ReactNode } from 'react';
+import React, { Children, forwardRef, KeyboardEvent, KeyboardEventHandler, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
@@ -8,6 +8,14 @@ import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/
 
 import isFunction from 'lodash/isFunction';
 import { AvatarProps } from '../avatar/Avatar';
+
+/**
+ * The authorized variants.
+ */
+export enum CommentBlockVariant {
+    indented = 'indented',
+    linear = 'linear',
+}
 
 /**
  * Defines the props of the component.
@@ -28,10 +36,6 @@ export interface CommentBlockProps extends GenericProps {
     date: string;
     /** Whether the component has actions to display or not. */
     hasActions?: boolean;
-    /** Whether the component has children blocks to display or not. */
-    hasChildren?: boolean;
-    /** Whether the component children are indented below parent or not. */
-    hasIndentedChildren?: boolean;
     /** The title action elements. */
     headerActions?: ReactNode;
     /** Whether the component is open or not. */
@@ -40,16 +44,18 @@ export interface CommentBlockProps extends GenericProps {
     isRelevant?: boolean;
     /** The name of the comment author. */
     name: string;
-    /** The content of the comment. */
-    text: ReactNode | string;
-    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
-    theme?: Theme;
     /** The function called on click. */
     onClick?(): void;
     /** The function called when the cursor enters the component. */
     onMouseEnter?(): void;
     /** The function called when the cursor exists the component. */
     onMouseLeave?(): void;
+    /** The content of the comment. */
+    text: ReactNode | string;
+    /** The theme to apply to the component. Can be either 'light' or 'dark'. */
+    theme?: Theme;
+    /** The component variant. */
+    variant?: CommentBlockVariant;
 }
 
 /**
@@ -67,6 +73,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: Partial<CommentBlockProps> = {
     theme: Theme.light,
+    variant: CommentBlockVariant.indented,
 };
 
 /**
@@ -84,8 +91,6 @@ export const CommentBlock: Comp<CommentBlockProps, HTMLDivElement> = forwardRef(
         children,
         date,
         hasActions,
-        hasChildren,
-        hasIndentedChildren,
         headerActions,
         isOpen,
         isRelevant,
@@ -95,12 +100,14 @@ export const CommentBlock: Comp<CommentBlockProps, HTMLDivElement> = forwardRef(
         onMouseLeave,
         text,
         theme,
+        variant,
     } = props;
     const enterKeyPress: KeyboardEventHandler<HTMLElement> = (evt: KeyboardEvent<HTMLElement>) => {
         if (evt.which === ENTER_KEY_CODE && isFunction(onClick)) {
             onClick();
         }
     };
+    const hasChildren = Children.count(children) > 0;
 
     return (
         <div
@@ -108,8 +115,8 @@ export const CommentBlock: Comp<CommentBlockProps, HTMLDivElement> = forwardRef(
             className={classNames(
                 handleBasicClasses({
                     hasChildren: hasChildren && isOpen,
-                    hasIndentedChildren: hasChildren && hasIndentedChildren,
-                    hasLinearChildren: hasChildren && !hasIndentedChildren,
+                    hasIndentedChildren: hasChildren && variant === CommentBlockVariant.indented,
+                    hasLinearChildren: hasChildren && variant === CommentBlockVariant.linear,
                     isRelevant,
                     prefix: CLASSNAME,
                     theme,

--- a/packages/lumx-react/src/components/progress/Progress.tsx
+++ b/packages/lumx-react/src/components/progress/Progress.tsx
@@ -8,7 +8,7 @@ import { COMPONENT_PREFIX, CSS_PREFIX } from '@lumx/react/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
- * Authorized variants.
+ * The authorized variants.
  */
 export enum ProgressVariant {
     linear = 'linear',

--- a/packages/lumx-react/src/components/select/constants.ts
+++ b/packages/lumx-react/src/components/select/constants.ts
@@ -39,7 +39,7 @@ export interface CoreSelectProps extends GenericProps {
     theme?: Theme;
     /** Whether custom colors are applied to this component or not. */
     useCustomColors?: boolean;
-    /** The selected choices area style. */
+    /** The component variant. */
     variant?: SelectVariant;
     /** The function called when the clear button is clicked. If not specified, the button won't be displayed. */
     onClear?(event: SyntheticEvent, value?: string): void;

--- a/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
@@ -6,7 +6,7 @@ import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 /**
- * Authorized variants.
+ * The authorized variants.
  */
 export enum SkeletonRectangleVariant {
     squared = 'squared',
@@ -24,7 +24,7 @@ export interface SkeletonRectangleProps extends GenericProps {
     height?: GlobalSize;
     /** Theme. */
     theme?: Theme;
-    /** The variant of the component. */
+    /** The component variant. */
     variant?: SkeletonRectangleVariant;
     /** The width of the component from Size enum. */
     width?: GlobalSize;

--- a/packages/lumx-react/src/components/table/TableCell.tsx
+++ b/packages/lumx-react/src/components/table/TableCell.tsx
@@ -46,7 +46,7 @@ export interface TableCellProps extends GenericProps {
     scope?: ThScope;
     /** The initial sort order (sortable thead only). */
     sortOrder?: ThOrder;
-    /** The variant of the cell. */
+    /** The component variant. */
     variant?: TableCellVariant;
     /** The function called on click on header. */
     onHeaderClick?(): void;

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -50,7 +50,7 @@ export enum CrossOrigin {
 }
 
 /**
- * Authorized variants.
+ * The authorized variants.
  */
 export enum ThumbnailVariant {
     squared = 'squared',
@@ -92,7 +92,7 @@ export interface ThumbnailProps extends GenericProps {
     resizeDebounceTime?: number;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** The variant of the component. */
+    /** The component variant. */
     variant?: ThumbnailVariant;
 }
 

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -6,6 +6,9 @@ import { AspectRatio, Icon, Size, Theme } from '@lumx/react';
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
+/**
+ * The authorized variants.
+ */
 export enum UploaderVariant {
     square = 'square',
     rounded = 'rounded',
@@ -28,7 +31,7 @@ export interface UploaderProps extends GenericProps {
     size?: UploaderSize;
     /** The theme to apply to the component. Can be either 'light' or 'dark'. */
     theme?: Theme;
-    /** The variant of the component. */
+    /** The component variant. */
     variant?: UploaderVariant;
     /** The function called on click. */
     onClick?: MouseEventHandler<HTMLDivElement>;

--- a/packages/site-demo/content/product/components/comment-block/react/default.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/default.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 export const App = ({ theme }: any) => (
     <CommentBlock
         hasActions
-        hasChildren
         actions={[
             <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                 24 likes

--- a/packages/site-demo/content/product/components/comment-block/react/relevant.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/relevant.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 export const App = ({ theme }: any) => (
     <CommentBlock
         hasActions
-        hasChildren
         isRelevant
         actions={[
             <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>

--- a/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
@@ -6,7 +6,6 @@ export const App = ({ theme }: any) => (
     <>
         <CommentBlock
             hasActions
-            hasChildren
             isOpen
             actions={[
                 <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>


### PR DESCRIPTION
# General summary

- Added `variant` prop for `CommentBlock` component (either `indented` by default or `linear`).
- _[BREAKING]_ `hasChildren` and `hasIndentedChildren` props for `CommentBlock` component have been removed.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
