### PR TITLE
chore(icons): fix v4 to v5 icon aliases

### DIFF
--- a/packages/lumx-icons/v4-to-v5-aliases.d.ts
+++ b/packages/lumx-icons/v4-to-v5-aliases.d.ts
@@ -30,11 +30,7 @@ export declare const mdiBible: string;
 
 export declare const mdiAudiobook: string;
 
-export declare const mdiBookOpenVariant: string;
-
 export declare const mdiSquareInc: string;
-
-export declare const mdiBowl: string;
 
 export declare const mdiCalendarRepeat: string;
 
@@ -75,8 +71,6 @@ export declare const mdiSettingsTransfer: string;
 export declare const mdiSettingsTransferOutline: string;
 
 export declare const mdiCoinOutline: string;
-
-export declare const mdiDatabaseRefresh: string;
 
 export declare const mdiFileSettingsVariant: string;
 
@@ -192,15 +186,11 @@ export declare const mdiTwitterCircle: string;
 
 export declare const mdiLibraryVideo: string;
 
-export declare const mdiPot: string;
-
 export declare const mdiCiscoWebex: string;
 
 export declare const mdiNetworkRouter: string;
 
 export declare const mdiSailing: string;
-
-export declare const mdiCurrentAc: string;
 
 export declare const mdiPlaystation: string;
 
@@ -208,11 +198,7 @@ export declare const mdiSortAlphabetical: string;
 
 export declare const mdiSortNumeric: string;
 
-export declare const mdiStarHalf: string;
-
-export declare const mdiSticker: string;
-
-export declare const mdiStorefront: string;
+export declare const mdiLinkedinBox: string;
 
 export declare const mdiFileDocumentBox: string;
 
@@ -242,10 +228,6 @@ export declare const mdiFileDocumentBoxSearch: string;
 
 export declare const mdiFileDocumentBoxSearchOutline: string;
 
-export declare const mdiTimerOff: string;
-
-export declare const mdiTimer: string;
-
 export declare const mdiTowing: string;
 
 export declare const mdiCamcorderBox: string;
@@ -257,6 +239,3 @@ export declare const mdiWallSconceVariant: string;
 export declare const mdiHackernews: string;
 
 export declare const mdiYoutubeCreatorStudio: string;
-
-export declare const mdiLinkedinBox: string;
-

--- a/packages/lumx-icons/v4-to-v5-aliases.js
+++ b/packages/lumx-icons/v4-to-v5-aliases.js
@@ -15,9 +15,7 @@ import {
     mdiBookAlphabet,
     mdiBookCross,
     mdiBookMusic,
-    mdiBookOpenBlankVariant,
     mdiBookRemoveMultipleOutline,
-    mdiBowlMix,
     mdiCalendarSync,
     mdiCalendarSyncOutline,
     mdiCardAccountDetails,
@@ -38,7 +36,6 @@ import {
     mdiCogTransfer,
     mdiCogTransferOutline,
     mdiCurrencyUsdCircleOutline,
-    mdiDatabaseSync,
     mdiFileCog,
     mdiFileCogOutline,
     mdiFilmstripBox,
@@ -94,17 +91,13 @@ import {
     mdiNpm,
     mdiTwitter,
     mdiPlayBoxMultiple,
-    mdiPotSteam,
     mdiRollerSkateOff,
     mdiRouterNetwork,
     mdiSailBoat,
-    mdiSineWave,
     mdiSonyPlaystation,
     mdiSortAlphabeticalVariant,
     mdiSortNumericVariant,
-    mdiStarHalfFull,
-    mdiStickerCircleOutline,
-    mdiStorefrontOutline,
+    mdiLinkedin,
     mdiTextBox,
     mdiTextBoxCheck,
     mdiTextBoxCheckOutline,
@@ -119,15 +112,12 @@ import {
     mdiTextBoxRemoveOutline,
     mdiTextBoxSearch,
     mdiTextBoxSearchOutline,
-    mdiTimerOffOutline,
-    mdiTimerOutline,
     mdiTowTruck,
     mdiVideoBox,
     mdiVideoBoxOff,
     mdiWallSconceRoundVariant,
     mdiYCombinator,
     mdiYoutubeStudio,
-    mdiLinkedin,
 } from '@mdi/js';
 
 export const mdiCowboy = mdiAccountCowboyHat;
@@ -162,11 +152,7 @@ export const mdiBible = mdiBookCross;
 
 export const mdiAudiobook = mdiBookMusic;
 
-export const mdiBookOpenVariant = mdiBookOpenBlankVariant;
-
 export const mdiSquareInc = mdiBookRemoveMultipleOutline;
-
-export const mdiBowl = mdiBowlMix;
 
 export const mdiCalendarRepeat = mdiCalendarSync;
 
@@ -207,8 +193,6 @@ export const mdiSettingsTransfer = mdiCogTransfer;
 export const mdiSettingsTransferOutline = mdiCogTransferOutline;
 
 export const mdiCoinOutline = mdiCurrencyUsdCircleOutline;
-
-export const mdiDatabaseRefresh = mdiDatabaseSync;
 
 export const mdiFileSettingsVariant = mdiFileCog;
 
@@ -324,15 +308,11 @@ export const mdiTwitterCircle = mdiTwitter;
 
 export const mdiLibraryVideo = mdiPlayBoxMultiple;
 
-export const mdiPot = mdiPotSteam;
-
 export const mdiCiscoWebex = mdiRollerSkateOff;
 
 export const mdiNetworkRouter = mdiRouterNetwork;
 
 export const mdiSailing = mdiSailBoat;
-
-export const mdiCurrentAc = mdiSineWave;
 
 export const mdiPlaystation = mdiSonyPlaystation;
 
@@ -340,11 +320,7 @@ export const mdiSortAlphabetical = mdiSortAlphabeticalVariant;
 
 export const mdiSortNumeric = mdiSortNumericVariant;
 
-export const mdiStarHalf = mdiStarHalfFull;
-
-export const mdiSticker = mdiStickerCircleOutline;
-
-export const mdiStorefront = mdiStorefrontOutline;
+export const mdiLinkedinBox = mdiLinkedin;
 
 export const mdiFileDocumentBox = mdiTextBox;
 
@@ -374,10 +350,6 @@ export const mdiFileDocumentBoxSearch = mdiTextBoxSearch;
 
 export const mdiFileDocumentBoxSearchOutline = mdiTextBoxSearchOutline;
 
-export const mdiTimerOff = mdiTimerOffOutline;
-
-export const mdiTimer = mdiTimerOutline;
-
 export const mdiTowing = mdiTowTruck;
 
 export const mdiCamcorderBox = mdiVideoBox;
@@ -389,6 +361,3 @@ export const mdiWallSconceVariant = mdiWallSconceRoundVariant;
 export const mdiHackernews = mdiYCombinator;
 
 export const mdiYoutubeCreatorStudio = mdiYoutubeStudio;
-
-export const mdiLinkedinBox = mdiLinkedin;
-

--- a/packages/lumx-icons/v4-to-v5-aliases.scss
+++ b/packages/lumx-icons/v4-to-v5-aliases.scss
@@ -62,16 +62,8 @@
     @extend .mdi-book-music;
 }
 
-.mdi-book-open-variant {
-    @extend .mdi-book-open-blank-variant;
-}
-
 .mdi-square-inc {
     @extend .mdi-book-remove-multiple-outline;
-}
-
-.mdi-bowl {
-    @extend .mdi-bowl-mix;
 }
 
 .mdi-calendar-repeat {
@@ -152,10 +144,6 @@
 
 .mdi-coin-outline {
     @extend .mdi-currency-usd-circle-outline;
-}
-
-.mdi-database-refresh {
-    @extend .mdi-database-sync;
 }
 
 .mdi-file-settings-variant {
@@ -380,10 +368,6 @@
     @extend .mdi-play-box-multiple;
 }
 
-.mdi-pot {
-    @extend .mdi-pot-steam;
-}
-
 .mdi-cisco-webex {
     @extend .mdi-roller-skate-off;
 }
@@ -394,10 +378,6 @@
 
 .mdi-sailing {
     @extend .mdi-sail-boat;
-}
-
-.mdi-current-ac {
-    @extend .mdi-sine-wave;
 }
 
 .mdi-playstation {
@@ -412,16 +392,8 @@
     @extend .mdi-sort-numeric-variant;
 }
 
-.mdi-star-half {
-    @extend .mdi-star-half-full;
-}
-
-.mdi-sticker {
-    @extend .mdi-sticker-circle-outline;
-}
-
-.mdi-storefront {
-    @extend .mdi-storefront-outline;
+.mdi-linkedin-box {
+    @extend .mdi-linkedin;
 }
 
 .mdi-file-document-box {
@@ -480,14 +452,6 @@
     @extend .mdi-text-box-search-outline;
 }
 
-.mdi-timer-off {
-    @extend .mdi-timer-off-outline;
-}
-
-.mdi-timer {
-    @extend .mdi-timer-outline;
-}
-
 .mdi-towing {
     @extend .mdi-tow-truck;
 }
@@ -511,8 +475,3 @@
 .mdi-youtube-creator-studio {
     @extend .mdi-youtube-studio;
 }
-
-.mdi-linkedin-box {
-    @extend .mdi-linkedin;
-}
-


### PR DESCRIPTION
Some icons appear to have changed content but still
have an equivalent in v5 so they don't need to be aliased.
