### PR TITLE
refactor(avatar): use thumbnail inside avatar LUM-11237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   _[BREAKING]_ Replaced `listElementRef` by `ref` in `List` component.
 -   _[BREAKING]_ Replaced `popoverRef` by `ref` in `Popover` component.
 -   _[BREAKING]_ Replaced `userBlockRef` by `ref` in `UserBlock` component.
--   _[BREAKING]_ The alternative text is now required (`alt` prop in `Thumbnail`, `thumbnails[].alt` in `Mosaic`, `alt` in `ImageBlock`, `thumbnailProps.alt` in `PostBlock` and `thumbnailProps.alt` in `LinkPreview`).
+-   _[BREAKING]_ The alternative text is now required (`alt` prop in `Thumbnail`, `thumbnails[].alt` in `Mosaic`, `alt` in `ImageBlock`, `thumbnailProps.alt` in `PostBlock`, `thumbnailProps.alt` in `LinkPreview`, `alt` in `Avatar`, `avatarProps.alt` in `CommentBlock` and `avatarProps.alt` in `userBlock`).
 -   _[BREAKING]_ The title is now required in `ImageBlock`.
 -   _[BREAKING]_ Reworked Thumbnail CORS default. `crossOrigin` now default to `undefined` instead of `'anonymous'`. `isCrossOriginEnabled` prop was removed (use `crossOrigin={undefined}` instead).
 -   _[BREAKING]_ Upgrade to mdi v5.8.55 and handle backward compatibility (see [details]([./packages/lumx-icons/README-v4-to-v5-migration.md])).
+-   `Avatar` component now uses `Thumbnail` component.
+-   _[BREAKING]_ Since `alt` in now required for `Avatar`, `avatar` and `avatarProps` props have been merged into `avatarProps` for both `CommentBlock` and `UserBlock`.
 
 ### Removed
 

--- a/packages/lumx-core/src/scss/components/avatar/_index.scss
+++ b/packages/lumx-core/src/scss/components/avatar/_index.scss
@@ -10,6 +10,10 @@
     border-radius: 50%;
     outline: none;
 
+    .#{$lumx-base-prefix}-thumbnail__image {
+        border-radius: 50%;
+    }
+
     &__actions {
         position: absolute;
         top: 50%;
@@ -32,6 +36,11 @@
     .#{$lumx-base-prefix}-avatar--size-#{$key} {
         width: $size;
         height: $size;
+
+        .#{$lumx-base-prefix}-thumbnail__image {
+            width: $size;
+            height: $size;
+        }
     }
 }
 

--- a/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
@@ -20,6 +20,7 @@ export const AvatarSizes = () =>
             key={size}
             className="lumx-spacing-margin-bottom"
             image={avatarImageKnob('Avatar', AVATAR_IMAGES.avatar1)}
+            alt={size}
             size={size}
         />
     ));
@@ -33,6 +34,7 @@ export const AvatarWithActions = () =>
         <Avatar
             key={size}
             image={avatarImageKnob('Avatar', AVATAR_IMAGES.avatar2)}
+            alt={size}
             size={size}
             actions={
                 <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -79,6 +81,7 @@ export const AvatarWithBadge = () =>
             key={size}
             className="lumx-spacing-margin-bottom"
             image={avatarImageKnob('Avatar', AVATAR_IMAGES.avatar3)}
+            alt={size}
             badge={
                 <Badge color={select('Colors', ColorPalette, ColorPalette.blue)}>
                     <Icon icon={mdiStar} />

--- a/packages/lumx-react/src/components/avatar/Avatar.test.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.test.tsx
@@ -24,6 +24,7 @@ interface Setup extends CommonSetup {
 const setup = ({ ...propsOverride }: Partial<AvatarProps> = {}, shallowRendering = true): Setup => {
     const props: AvatarProps = {
         image: 'path/to/avatar/image.png',
+        alt: 'Image',
         ...propsOverride,
     };
 

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -1,8 +1,8 @@
-import React, { CSSProperties, forwardRef, ReactElement, ReactNode } from 'react';
+import React, { forwardRef, ReactElement, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Size, Theme } from '@lumx/react';
+import { Size, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
 
 import { COMPONENT_PREFIX } from '@lumx/react/constants';
 
@@ -19,6 +19,8 @@ export type AvatarSize = Size.xs | Size.s | Size.m | Size.l | Size.xl | Size.xxl
 export interface AvatarProps extends GenericProps {
     /** Action toolbar content. */
     actions?: ReactNode;
+    /** Image alternative text. */
+    alt: string;
     /** Badge. */
     badge?: ReactElement;
     /** Image URL. */
@@ -27,6 +29,8 @@ export interface AvatarProps extends GenericProps {
     size?: AvatarSize;
     /** Theme adapting the component to light or dark background. */
     theme?: Theme;
+    /** Props to pass to the thumbnail (minus those already set by the Avatar props). */
+    thumbnailProps?: Omit<ThumbnailProps, 'image' | 'alt' | 'size' | 'theme' | 'align' | 'fillHeight' | 'variant'>;
 }
 
 /**
@@ -55,20 +59,15 @@ const DEFAULT_PROPS: Partial<AvatarProps> = {
  * @return React element.
  */
 export const Avatar: Comp<AvatarProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const { actions, badge, className, image, size, theme, ...forwardedProps } = props;
-    const style: CSSProperties = {
-        backgroundImage: `url(${image})`,
-    };
+    const { actions, alt, badge, className, image, size, theme, thumbnailProps, ...forwardedProps } = props;
+
     return (
         <div
             ref={ref}
             {...forwardedProps}
-            className={classNames(
-                className,
-                handleBasicClasses({ prefix: CLASSNAME, size, variant: 'rounded', theme }),
-            )}
-            style={style}
+            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, size, theme }))}
         >
+            <Thumbnail {...thumbnailProps} image={image} alt={alt} />
             {actions && <div className={`${CLASSNAME}__actions`}>{actions}</div>}
             {badge && <div className={`${CLASSNAME}__badge`}>{badge}</div>}
         </div>

--- a/packages/lumx-react/src/components/avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/packages/lumx-react/src/components/avatar/__snapshots__/Avatar.test.tsx.snap
@@ -3,66 +3,86 @@
 exports[`<Avatar> Snapshots and structure should render story AvatarSizes 1`] = `
 Array [
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xs lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar1.jpg)",
-      }
-    }
-  />,
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xs lumx-avatar--theme-light"
+  >
+    <Thumbnail
+      alt="xs"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar1.jpg"
+      loading="lazy"
+      theme="light"
+    />
+  </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-s lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar1.jpg)",
-      }
-    }
-  />,
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-s lumx-avatar--theme-light"
+  >
+    <Thumbnail
+      alt="s"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar1.jpg"
+      loading="lazy"
+      theme="light"
+    />
+  </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-m lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar1.jpg)",
-      }
-    }
-  />,
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-m lumx-avatar--theme-light"
+  >
+    <Thumbnail
+      alt="m"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar1.jpg"
+      loading="lazy"
+      theme="light"
+    />
+  </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-l lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar1.jpg)",
-      }
-    }
-  />,
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-l lumx-avatar--theme-light"
+  >
+    <Thumbnail
+      alt="l"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar1.jpg"
+      loading="lazy"
+      theme="light"
+    />
+  </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xl lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar1.jpg)",
-      }
-    }
-  />,
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xl lumx-avatar--theme-light"
+  >
+    <Thumbnail
+      alt="xl"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar1.jpg"
+      loading="lazy"
+      theme="light"
+    />
+  </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xxl lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar1.jpg)",
-      }
-    }
-  />,
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xxl lumx-avatar--theme-light"
+  >
+    <Thumbnail
+      alt="xxl"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar1.jpg"
+      loading="lazy"
+      theme="light"
+    />
+  </div>,
 ]
 `;
 
 exports[`<Avatar> Snapshots and structure should render story AvatarWithActions 1`] = `
 Array [
   <div
-    className="lumx-avatar lumx-avatar--size-xs lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar2.jpg)",
-      }
-    }
+    className="lumx-avatar lumx-avatar--size-xs lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="xs"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar2.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__actions"
     >
@@ -115,13 +135,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-avatar lumx-avatar--size-s lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar2.jpg)",
-      }
-    }
+    className="lumx-avatar lumx-avatar--size-s lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="s"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar2.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__actions"
     >
@@ -174,13 +196,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-avatar lumx-avatar--size-m lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar2.jpg)",
-      }
-    }
+    className="lumx-avatar lumx-avatar--size-m lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="m"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar2.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__actions"
     >
@@ -233,13 +257,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-avatar lumx-avatar--size-l lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar2.jpg)",
-      }
-    }
+    className="lumx-avatar lumx-avatar--size-l lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="l"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar2.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__actions"
     >
@@ -292,13 +318,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-avatar lumx-avatar--size-xl lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar2.jpg)",
-      }
-    }
+    className="lumx-avatar lumx-avatar--size-xl lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="xl"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar2.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__actions"
     >
@@ -351,13 +379,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-avatar lumx-avatar--size-xxl lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar2.jpg)",
-      }
-    }
+    className="lumx-avatar lumx-avatar--size-xxl lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="xxl"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar2.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__actions"
     >
@@ -415,13 +445,15 @@ Array [
 exports[`<Avatar> Snapshots and structure should render story AvatarWithBadge 1`] = `
 Array [
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xs lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar3.jpg)",
-      }
-    }
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xs lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="xs"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar3.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__badge"
     >
@@ -435,13 +467,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-s lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar3.jpg)",
-      }
-    }
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-s lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="s"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar3.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__badge"
     >
@@ -455,13 +489,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-m lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar3.jpg)",
-      }
-    }
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-m lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="m"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar3.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__badge"
     >
@@ -475,13 +511,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-l lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar3.jpg)",
-      }
-    }
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-l lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="l"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar3.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__badge"
     >
@@ -495,13 +533,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xl lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar3.jpg)",
-      }
-    }
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xl lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="xl"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar3.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__badge"
     >
@@ -515,13 +555,15 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xxl lumx-avatar--variant-rounded lumx-avatar--theme-light"
-    style={
-      Object {
-        "backgroundImage": "url(avatar3.jpg)",
-      }
-    }
+    className="lumx-spacing-margin-bottom lumx-avatar lumx-avatar--size-xxl lumx-avatar--theme-light"
   >
+    <Thumbnail
+      alt="xxl"
+      fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+      image="avatar3.jpg"
+      loading="lazy"
+      theme="light"
+    />
     <div
       className="lumx-avatar__badge"
     >

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
@@ -17,7 +17,7 @@ export const WithHeaderActions = ({ theme }: any) => (
             </Button>,
         ]}
         theme={theme}
-        avatar="https://i.pravatar.cc/40"
+        avatarProps={{ image: 'https://i.pravatar.cc/40', alt: 'Avatar' }}
         date="4 hours ago"
         name="Emmitt O. Lum"
         text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -23,10 +23,8 @@ export enum CommentBlockVariant {
 export interface CommentBlockProps extends GenericProps {
     /** Action toolbar content. */
     actions?: ReactNode;
-    /** Avatar image URL. */
-    avatar: string;
-    /** Props to pass to the avatar (minus those already set by the CommentBlock props). */
-    avatarProps?: Omit<AvatarProps, 'image' | 'size' | 'tabIndex' | 'onClick' | 'onKeyPress'>;
+    /** Props to pass to the avatar. */
+    avatarProps: AvatarProps;
     /** Comment block replies. */
     children?: ReactNode;
     /** Comment date. */
@@ -83,7 +81,6 @@ const DEFAULT_PROPS: Partial<CommentBlockProps> = {
 export const CommentBlock: Comp<CommentBlockProps, HTMLDivElement> = forwardRef((props, ref) => {
     const {
         actions,
-        avatar,
         avatarProps,
         children,
         date,
@@ -124,7 +121,6 @@ export const CommentBlock: Comp<CommentBlockProps, HTMLDivElement> = forwardRef(
                 <div className={`${CLASSNAME}__avatar`}>
                     <Avatar
                         {...avatarProps}
-                        image={avatar}
                         size={Size.m}
                         tabIndex={onClick ? 0 : -1}
                         onClick={onClick}

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -13,7 +13,7 @@ export const Sizes = () => {
             <UserBlock
                 name="Emmitt O. Lum"
                 fields={['Creative developer', 'Denpasar']}
-                avatar={avatarImageKnob()}
+                avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
                 size={size}
                 onMouseEnter={logAction('Mouse entered')}
                 onMouseLeave={logAction('Mouse left')}
@@ -30,8 +30,9 @@ export const WithBadge = () => {
             <UserBlock
                 name="Emmitt O. Lum"
                 fields={['Creative developer', 'Denpasar']}
-                avatar={avatarImageKnob()}
                 avatarProps={{
+                    image: avatarImageKnob(),
+                    alt: 'Avatar',
                     badge: (
                         <Badge color={ColorPalette.blue}>
                             <Icon icon={mdiStar} />
@@ -56,8 +57,9 @@ export const InList = () => {
                     <UserBlock
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
-                        avatar={avatarImageKnob('Avatar 1', AVATAR_IMAGES.avatar1)}
                         avatarProps={{
+                            image: avatarImageKnob('Avatar 1', AVATAR_IMAGES.avatar1),
+                            alt: 'Avatar',
                             badge: (
                                 <Badge color={ColorPalette.blue}>
                                     <Icon icon={mdiStar} />
@@ -74,8 +76,9 @@ export const InList = () => {
                     <UserBlock
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
-                        avatar={avatarImageKnob('Avatar 2', AVATAR_IMAGES.avatar2)}
                         avatarProps={{
+                            image: avatarImageKnob('Avatar 2', AVATAR_IMAGES.avatar2),
+                            alt: 'Avatar',
                             badge: (
                                 <Badge color={ColorPalette.blue}>
                                     <Icon icon={mdiStar} />
@@ -92,8 +95,9 @@ export const InList = () => {
                     <UserBlock
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
-                        avatar={avatarImageKnob('Avatar 3', AVATAR_IMAGES.avatar3)}
                         avatarProps={{
+                            image: avatarImageKnob('Avatar 3', AVATAR_IMAGES.avatar3),
+                            alt: 'Avatar',
                             badge: (
                                 <Badge color={ColorPalette.blue}>
                                     <Icon icon={mdiStar} />

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -18,10 +18,8 @@ export type UserBlockSize = Size.s | Size.m | Size.l;
  * Defines the props of the component.
  */
 export interface UserBlockProps extends GenericProps {
-    /** Avatar image URL. */
-    avatar?: string;
-    /** Props to pass to the avatar (minus those already set by the UserBlock props). */
-    avatarProps?: Omit<AvatarProps, 'image' | 'size' | 'onClick' | 'tabIndex' | 'theme'>;
+    /** Props to pass to the avatar. */
+    avatarProps?: AvatarProps;
     /** Simple action toolbar content. */
     simpleAction?: ReactNode;
     /** Multiple action toolbar content. */
@@ -72,7 +70,6 @@ const DEFAULT_PROPS: Partial<UserBlockProps> = {
  */
 export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props, ref) => {
     const {
-        avatar,
         avatarProps,
         className,
         fields,
@@ -124,11 +121,10 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
             onMouseLeave={onMouseLeave}
             onMouseEnter={onMouseEnter}
         >
-            {avatar && (
+            {avatarProps && (
                 <div className={`${CLASSNAME}__avatar`}>
                     <Avatar
                         {...avatarProps}
-                        image={avatar}
                         size={componentSize}
                         onClick={onClick}
                         tabIndex={onClick ? 0 : -1}

--- a/packages/lumx-react/src/components/user-block/__snapshots__/UserBlock.test.tsx.snap
+++ b/packages/lumx-react/src/components/user-block/__snapshots__/UserBlock.test.tsx.snap
@@ -11,6 +11,7 @@ Array [
       className="lumx-user-block__avatar"
     >
       <Avatar
+        alt="Avatar"
         badge={
           <Badge
             color="blue"
@@ -64,6 +65,7 @@ Array [
       className="lumx-user-block__avatar"
     >
       <Avatar
+        alt="Avatar"
         badge={
           <Badge
             color="blue"
@@ -117,6 +119,7 @@ Array [
       className="lumx-user-block__avatar"
     >
       <Avatar
+        alt="Avatar"
         badge={
           <Badge
             color="blue"
@@ -175,6 +178,7 @@ Array [
       className="lumx-user-block__avatar"
     >
       <Avatar
+        alt="Avatar"
         image="avatar1.jpg"
         onClick={[Function]}
         size="s"
@@ -203,6 +207,7 @@ Array [
       className="lumx-user-block__avatar"
     >
       <Avatar
+        alt="Avatar"
         image="avatar1.jpg"
         onClick={[Function]}
         size="m"
@@ -247,6 +252,7 @@ Array [
       className="lumx-user-block__avatar"
     >
       <Avatar
+        alt="Avatar"
         image="avatar1.jpg"
         onClick={[Function]}
         size="l"
@@ -295,6 +301,7 @@ exports[`<UserBlock> Snapshots and structure should render story WithBadge 1`] =
     className="lumx-user-block__avatar"
   >
     <Avatar
+      alt="Avatar"
       badge={
         <Badge
           color="blue"

--- a/packages/site-demo/content/product/components/avatar/react/actions.tsx
+++ b/packages/site-demo/content/product/components/avatar/react/actions.tsx
@@ -6,6 +6,7 @@ export const App = ({ theme }: any) => (
     <Avatar
         theme={theme}
         image="/demo-assets/persona.png"
+        alt="Avatar with actions"
         size={Size.xl}
         actions={
             <FlexBox orientation={Orientation.horizontal} vAlign={Alignment.center} gap={Size.regular}>

--- a/packages/site-demo/content/product/components/avatar/react/default.tsx
+++ b/packages/site-demo/content/product/components/avatar/react/default.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 export const App = ({ theme }: any) => (
     <>
-        <Avatar theme={theme} image="/demo-assets/persona.png" size={Size.xs} />
-        <Avatar theme={theme} image="/demo-assets/persona.png" size={Size.s} />
-        <Avatar theme={theme} image="/demo-assets/persona.png" size={Size.m} />
-        <Avatar theme={theme} image="/demo-assets/persona.png" size={Size.l} />
-        <Avatar theme={theme} image="/demo-assets/persona.png" size={Size.xl} />
+        <Avatar theme={theme} image="/demo-assets/persona.png" alt="XS" size={Size.xs} />
+        <Avatar theme={theme} image="/demo-assets/persona.png" alt="S" size={Size.s} />
+        <Avatar theme={theme} image="/demo-assets/persona.png" alt="M" size={Size.m} />
+        <Avatar theme={theme} image="/demo-assets/persona.png" alt="L" size={Size.l} />
+        <Avatar theme={theme} image="/demo-assets/persona.png" alt="XL" size={Size.xl} />
     </>
 );

--- a/packages/site-demo/content/product/components/badge/react/icon.tsx
+++ b/packages/site-demo/content/product/components/badge/react/icon.tsx
@@ -15,6 +15,7 @@ export const App = () => (
 
         <Avatar
             image="/demo-assets/persona.png"
+            alt="Avatar with icon"
             size={Size.m}
             badge={
                 <Badge color={ColorPalette.yellow}>
@@ -25,6 +26,7 @@ export const App = () => (
 
         <Avatar
             image="/demo-assets/persona.png"
+            alt="Avatar with icon"
             size={Size.m}
             badge={
                 <Badge color={ColorPalette.red}>

--- a/packages/site-demo/content/product/components/badge/react/label.tsx
+++ b/packages/site-demo/content/product/components/badge/react/label.tsx
@@ -9,6 +9,7 @@ export const App = () => (
 
         <Avatar
             image="/demo-assets/persona.png"
+            alt="Avatar with label"
             size={Size.m}
             badge={
                 <Badge color={ColorPalette.red}>

--- a/packages/site-demo/content/product/components/comment-block/react/default.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/default.tsx
@@ -14,7 +14,7 @@ export const App = ({ theme }: any) => (
             </Button>,
         ]}
         theme={theme}
-        avatar="/demo-assets/persona.png"
+        avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
         date="4 hours ago"
         name="Emmitt O. Lum"
         text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."

--- a/packages/site-demo/content/product/components/comment-block/react/relevant.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/relevant.tsx
@@ -15,7 +15,7 @@ export const App = ({ theme }: any) => (
             </Button>,
         ]}
         theme={theme}
-        avatar="/demo-assets/persona.png"
+        avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
         date="4 hours ago"
         name="Emmitt O. Lum"
         text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."

--- a/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
@@ -16,7 +16,7 @@ export const App = ({ theme }: any) => (
                 </Button>,
             ]}
             theme={theme}
-            avatar="/demo-assets/persona.png"
+            avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
             date="4 hours ago"
             name="Emmitt O. Lum"
             text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
@@ -28,7 +28,7 @@ export const App = ({ theme }: any) => (
                         24 likes
                     </Button>
                 }
-                avatar="/demo-assets/persona.png"
+                avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
                 date="3 hours ago"
                 name="Jackson Ray"
                 theme={theme}
@@ -41,7 +41,7 @@ export const App = ({ theme }: any) => (
                         16 likes
                     </Button>
                 }
-                avatar="/demo-assets/persona.png"
+                avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
                 date="2 hours ago"
                 name="Hettie Powell"
                 theme={theme}
@@ -60,7 +60,7 @@ export const App = ({ theme }: any) => (
                 </Button>,
             ]}
             theme={theme}
-            avatar="../avatar/assets/persona.png"
+            avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
             date="4 hours ago"
             name="Emmitt O. Lum"
             text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."

--- a/packages/site-demo/content/product/components/list/react/big.tsx
+++ b/packages/site-demo/content/product/components/list/react/big.tsx
@@ -64,7 +64,7 @@ export const App = () => (
 
         <ListItem
             size={Size.big}
-            before={<Avatar image="/demo-assets/persona.png" size={Size.m} />}
+            before={<Avatar image="/demo-assets/persona.png" alt="Avatar" size={Size.m} />}
             after={<Button emphasis={Emphasis.low}>Button</Button>}
         >
             <div>

--- a/packages/site-demo/content/product/components/list/react/huge.tsx
+++ b/packages/site-demo/content/product/components/list/react/huge.tsx
@@ -72,7 +72,7 @@ export const App = () => (
 
         <ListItem
             size={Size.huge}
-            before={<Avatar image="/demo-assets/persona.png" size={Size.m} />}
+            before={<Avatar image="/demo-assets/persona.png" alt="Avatar" size={Size.m} />}
             after={<Button emphasis={Emphasis.low}>Button</Button>}
         >
             <div>

--- a/packages/site-demo/content/product/components/list/react/regular.tsx
+++ b/packages/site-demo/content/product/components/list/react/regular.tsx
@@ -40,7 +40,7 @@ export const App = () => (
         </ListItem>
 
         <ListItem
-            before={<Avatar image="/demo-assets/persona.png" size={Size.m} />}
+            before={<Avatar image="/demo-assets/persona.png" alt="Avatar" size={Size.m} />}
             after={<Button emphasis={Emphasis.low}>Button</Button>}
         >
             Single-line item

--- a/packages/site-demo/content/product/components/list/react/tiny.tsx
+++ b/packages/site-demo/content/product/components/list/react/tiny.tsx
@@ -31,7 +31,7 @@ export const App = () => (
             Single-line item
         </ListItem>
 
-        <ListItem size={Size.tiny} before={<Avatar image="/demo-assets/persona.png" size={Size.xs} />}>
+        <ListItem size={Size.tiny} before={<Avatar image="/demo-assets/persona.png" alt="Avatar" size={Size.xs} />}>
             Single-line item
         </ListItem>
     </List>

--- a/packages/site-demo/content/product/components/post-block/react/default.tsx
+++ b/packages/site-demo/content/product/components/post-block/react/default.tsx
@@ -41,7 +41,7 @@ export const App = ({ theme }: any) => (
             }
             attachments={
                 <UserBlock
-                    avatar="/demo-assets/persona.png"
+                    avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
                     name="Matthias Manoukian"
                     fields={['Head of Design', 'Lyon']}
                     orientation={Orientation.vertical}
@@ -50,7 +50,12 @@ export const App = ({ theme }: any) => (
                 />
             }
             author={
-                <UserBlock avatar="/demo-assets/avatar2.jpg" name="Matthias Manoukian" size={Size.s} theme={theme} />
+                <UserBlock
+                    avatarProps={{ image: '/demo-assets/avatar2.jpg', alt: 'Avatar' }}
+                    name="Matthias Manoukian"
+                    size={Size.s}
+                    theme={theme}
+                />
             }
             tags={
                 <ChipGroup>

--- a/packages/site-demo/content/product/components/user-block/react/extended.tsx
+++ b/packages/site-demo/content/product/components/user-block/react/extended.tsx
@@ -35,7 +35,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             name="Emmitt O. Lum"
             fields={['Creative developer', 'Denpasar']}
-            avatar="/demo-assets/persona.png"
+            avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
             size={Size.l}
             orientation={Orientation.vertical}
             onMouseEnter={logAction('Mouse entered')}

--- a/packages/site-demo/content/product/components/user-block/react/size-l.tsx
+++ b/packages/site-demo/content/product/components/user-block/react/size-l.tsx
@@ -9,7 +9,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             name="Emmitt O. Lum"
             fields={['Creative developer', 'Denpasar']}
-            avatar="/demo-assets/persona.png"
+            avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
             size={Size.l}
             onMouseEnter={logAction('Mouse entered')}
             onMouseLeave={logAction('Mouse left')}

--- a/packages/site-demo/content/product/components/user-block/react/size-m.tsx
+++ b/packages/site-demo/content/product/components/user-block/react/size-m.tsx
@@ -9,7 +9,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             name="Emmitt O. Lum"
             fields={['Creative developer', 'Denpasar']}
-            avatar="/demo-assets/persona.png"
+            avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
             size={Size.m}
             onMouseEnter={logAction('Mouse entered')}
             onMouseLeave={logAction('Mouse left')}

--- a/packages/site-demo/content/product/components/user-block/react/size-s.tsx
+++ b/packages/site-demo/content/product/components/user-block/react/size-s.tsx
@@ -9,7 +9,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             name="Emmitt O. Lum"
             fields={['Creative developer', 'Denpasar']}
-            avatar="/demo-assets/persona.png"
+            avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
             size={Size.s}
             onMouseEnter={logAction('Mouse entered')}
             onMouseLeave={logAction('Mouse left')}

--- a/packages/site-demo/content/product/components/user-block/react/vertical.tsx
+++ b/packages/site-demo/content/product/components/user-block/react/vertical.tsx
@@ -9,7 +9,7 @@ export const App = ({ theme }: any) => {
             theme={theme}
             name="Emmitt O. Lum"
             fields={['Creative developer', 'Denpasar']}
-            avatar="/demo-assets/persona.png"
+            avatarProps={{ image: '/demo-assets/persona.png', alt: 'Avatar' }}
             size={Size.l}
             orientation={Orientation.vertical}
             onMouseEnter={logAction('Mouse entered')}


### PR DESCRIPTION
# General summary

-   _[BREAKING]_ The alternative text is now required ([...], `alt` prop in `Avatar`, `avatarProps.alt` in `CommentBlock` and `avatarProps.alt` in `userBlock`).
-   `Avatar` component now uses `Thumbnail` component.
-   _[BREAKING]_ Since `alt` in now required for `Avatar`, `avatar` and `avatarProps` props have been merged into `avatarProps` for both `CommentBlock` and `UserBlock`.

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
