### PR TITLE
feat(popover): add usePortal prop to skip portal in some case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `usePortal` prop to `Popover` component (default value is `true`) to be able to not use a portal in some cases.
+
+### Fixed
+
+-   Fixed `Switch` content placement for `right` position.
+
 ## [1.0.2][] - 2021-01-18
 
 ### Fixed
 
 -   Fixed angular z-index system (revert to previous system)
 -   Fixed `Lightbox` close on escape.
--   Fixed `Switch` content placement for `right` position.
 
 ## [1.0.1][] - 2021-01-13
 

--- a/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/lumx-react/src/components/dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`<Dropdown> Snapshots and structure should render correctly 1`] = `
   }
   isOpen={true}
   placement="bottom-start"
+  usePortal={true}
   zIndex={9999}
 >
   <div

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -221,3 +221,43 @@ export const WithScrollingPopover = ({ theme }: any) => {
         </div>
     );
 };
+
+export const WithoutPortal = ({ theme }: any) => {
+    const popovers: Array<[Placement, RefObject<any>]> = [
+        [Placement.LEFT, useRef(null)],
+        [Placement.TOP, useRef(null)],
+        [Placement.BOTTOM, useRef(null)],
+        [Placement.RIGHT, useRef(null)],
+    ];
+    const hasArrow = boolean('Has arrow', DEFAULT_PROPS.hasArrow as any);
+    const elevation: any = select('Elevation', [5, 4, 3, 2, 1], DEFAULT_PROPS.elevation);
+    const alignOptions = { middle: '', start: '-start', end: '-end' };
+    const align = select('Placement variant', alignOptions, alignOptions.middle);
+
+    return (
+        <FlexBox style={{ padding: 80 }} orientation={Orientation.horizontal}>
+            {popovers.map(([placement, ref]) => {
+                const placementVariant = (placement + align) as any;
+                return (
+                    <FlexBox key={placement} fillSpace vAlign={Alignment.center} hAlign={Alignment.center}>
+                        <Chip ref={ref} theme={theme} size={Size.s}>
+                            {startCase(placementVariant).toUpperCase()}
+                        </Chip>
+
+                        <Popover
+                            isOpen
+                            theme={theme}
+                            anchorRef={ref}
+                            placement={placementVariant}
+                            elevation={elevation}
+                            hasArrow={hasArrow}
+                            usePortal={false}
+                        >
+                            <div className="lumx-spacing-margin-huge">Popover</div>
+                        </Popover>
+                    </FlexBox>
+                );
+            })}
+        </FlexBox>
+    );
+};

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -87,6 +87,8 @@ export interface PopoverProps extends GenericProps {
     offset?: Offset;
     /** Placement relative to anchor. */
     placement?: Placement;
+    /** Whether the popover should be rendered into a DOM node that exists outside the DOM hierarchy of the parent component. */
+    usePortal?: boolean;
     /** Z-axis position. */
     zIndex?: number;
     /** On close callback (on click away or Escape pressed). */
@@ -109,6 +111,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
 const DEFAULT_PROPS: Partial<PopoverProps> = {
     elevation: 3,
     placement: Placement.AUTO,
+    usePortal: true,
     zIndex: 9999,
 };
 
@@ -171,6 +174,11 @@ const applyMaxHeight = {
     },
 };
 
+/** Method to render the popover inside a portal if usePortal is true */
+const renderPopover = (children: ReactNode, usePortal?: boolean): any => {
+    return usePortal ? createPortal(children, document.body) : children;
+};
+
 /**
  * Popover component.
  *
@@ -200,6 +208,7 @@ export const Popover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, re
         onClose,
         placement,
         style,
+        usePortal,
         zIndex,
         ...forwardedProps
     } = props;
@@ -256,7 +265,7 @@ export const Popover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, re
     useFocus(focusElement?.current, isOpen && (state?.rects?.popper?.y ?? -1) >= 0);
 
     return isOpen
-        ? createPortal(
+        ? renderPopover(
               <div
                   {...forwardedProps}
                   ref={mergeRefs<HTMLDivElement>(setPopperElement, ref, clickAwayRef)}
@@ -272,7 +281,7 @@ export const Popover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, re
                       {children}
                   </ClickAwayProvider>
               </div>,
-              document.body,
+              usePortal,
           )
         : null;
 });


### PR DESCRIPTION
# General summary

Added `usePortal` prop to `Popover` component (default value is `true`) to be able to not use a portal in some cases

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
