### PR TITLE
chore(demo): Handle prefix-based routing

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -22,9 +22,18 @@ http {
 
     server {
         listen 8080 default_server;
+        set $upstream_app 127.0.0.1;
+        set $upstream_port 8080;
+        set $upstream_proto http;
 
         location /healthz {
             return 200;
+        }
+
+        # Strip the prefix from all paths starting with /lumapps-*/ in order to serve the content
+        # from /var/www/ instead of /var/www/lumapps-cp/
+        location ~ ^/lumapps-[a-z]+/(.*) {
+            proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1;
         }
 
         location / {


### PR DESCRIPTION
# General summary

Handle properly the prefix-based routing (`/lumapps-cp/`, `/lumapps-prod/` and `/`).
