### PR TITLE
fix(tooltip): fix closing on covered anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fixed focus on parentElement of the `Dialog` component.
+-   Fixed closing of tooltip when the anchor element gets hidden by another element.
 
 ## [1.0.4][] - 2021-01-25
 

--- a/packages/lumx-react/src/components/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/lumx-react/src/components/table/__snapshots__/Table.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`<Table> Snapshots and structure should render story 'LumX components/ta
         key="calories"
         onHeaderClick={[Function]}
         variant="head"
+        width="100"
       >
         Calories
       </TableCell>
@@ -26,7 +27,9 @@ exports[`<Table> Snapshots and structure should render story 'LumX components/ta
         isSortable={true}
         key="fat"
         onHeaderClick={[Function]}
+        sortOrder="asc"
         variant="head"
+        width="100"
       >
         Fat (g)
       </TableCell>
@@ -36,6 +39,7 @@ exports[`<Table> Snapshots and structure should render story 'LumX components/ta
         key="comments"
         onHeaderClick={[Function]}
         variant="head"
+        width="150"
       >
         Comments
       </TableCell>
@@ -48,7 +52,52 @@ exports[`<Table> Snapshots and structure should render story 'LumX components/ta
       <TableCell
         variant="body"
       >
-        Frozen yogurt
+        <FlexBox
+          hAlign="center"
+          orientation="horizontal"
+        >
+          <Thumbnail
+            alt="Frozen yogurt"
+            aspectRatio="square"
+            className="lumx-spacing-margin-right-big"
+            fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+            image="/demo-assets/landscape1.jpg"
+            loading="lazy"
+            size="m"
+            theme="light"
+            variant="rounded"
+          />
+          <Link
+            color="dark"
+            href="./"
+          >
+            <span
+              className="lumx-typography-subtitle1"
+            >
+              Frozen yogurt
+            </span>
+          </Link>
+          <FlexBox
+            hAlign="center"
+            marginAuto="left"
+            orientation="horizontal"
+          >
+            <IconButton
+              emphasis="low"
+              icon="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
+              label="Informations"
+              size="m"
+              theme="light"
+            />
+            <IconButton
+              emphasis="low"
+              icon="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z"
+              label="More options"
+              size="m"
+              theme="light"
+            />
+          </FlexBox>
+        </FlexBox>
       </TableCell>
       <TableCell
         variant="body"
@@ -72,7 +121,52 @@ exports[`<Table> Snapshots and structure should render story 'LumX components/ta
       <TableCell
         variant="body"
       >
-        Ice cream sandwich
+        <FlexBox
+          hAlign="center"
+          orientation="horizontal"
+        >
+          <Thumbnail
+            alt="Ice cream sandwich"
+            aspectRatio="square"
+            className="lumx-spacing-margin-right-big"
+            fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+            image="/demo-assets/landscape2.jpg"
+            loading="lazy"
+            size="m"
+            theme="light"
+            variant="rounded"
+          />
+          <Link
+            color="dark"
+            href="./"
+          >
+            <span
+              className="lumx-typography-subtitle1"
+            >
+              Ice cream sandwich
+            </span>
+          </Link>
+          <FlexBox
+            hAlign="center"
+            marginAuto="left"
+            orientation="horizontal"
+          >
+            <IconButton
+              emphasis="low"
+              icon="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
+              label="Informations"
+              size="m"
+              theme="light"
+            />
+            <IconButton
+              emphasis="low"
+              icon="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z"
+              label="More options"
+              size="m"
+              theme="light"
+            />
+          </FlexBox>
+        </FlexBox>
       </TableCell>
       <TableCell
         variant="body"
@@ -96,7 +190,52 @@ exports[`<Table> Snapshots and structure should render story 'LumX components/ta
       <TableCell
         variant="body"
       >
-        Eclair
+        <FlexBox
+          hAlign="center"
+          orientation="horizontal"
+        >
+          <Thumbnail
+            alt="Eclair"
+            aspectRatio="square"
+            className="lumx-spacing-margin-right-big"
+            fallback="M21,5V11.59L18,8.58L14,12.59L10,8.59L6,12.59L3,9.58V5A2,2 0 0,1 5,3H19A2,2 0 0,1 21,5M18,11.42L21,14.43V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V12.42L6,15.41L10,11.41L14,15.41"
+            image="/demo-assets/landscape3.jpg"
+            loading="lazy"
+            size="m"
+            theme="light"
+            variant="rounded"
+          />
+          <Link
+            color="dark"
+            href="./"
+          >
+            <span
+              className="lumx-typography-subtitle1"
+            >
+              Eclair
+            </span>
+          </Link>
+          <FlexBox
+            hAlign="center"
+            marginAuto="left"
+            orientation="horizontal"
+          >
+            <IconButton
+              emphasis="low"
+              icon="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
+              label="Informations"
+              size="m"
+              theme="light"
+            />
+            <IconButton
+              emphasis="low"
+              icon="M12,16A2,2 0 0,1 14,18A2,2 0 0,1 12,20A2,2 0 0,1 10,18A2,2 0 0,1 12,16M12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12A2,2 0 0,1 12,10M12,4A2,2 0 0,1 14,6A2,2 0 0,1 12,8A2,2 0 0,1 10,6A2,2 0 0,1 12,4Z"
+              label="More options"
+              size="m"
+              theme="light"
+            />
+          </FlexBox>
+        </FlexBox>
       </TableCell>
       <TableCell
         variant="body"

--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -1,6 +1,7 @@
 import { mdiHelp, mdiPrinter } from '@lumx/icons';
 import {
     Button,
+    Dialog,
     Dropdown,
     FlexBox,
     Icon,
@@ -13,7 +14,8 @@ import {
 } from '@lumx/react';
 import { select, text } from '@storybook/addon-knobs';
 import noop from 'lodash/noop';
-import React, { useRef, useState } from 'react';
+import range from 'lodash/range';
+import React, { Fragment, useRef, useState } from 'react';
 
 export default { title: 'LumX components/tooltip/Tooltip' };
 
@@ -56,7 +58,7 @@ export const MultilineTooltip = () => (
         <Tooltip label="Only one sentence.">
             <Button>One line</Button>
         </Tooltip>
-        <Tooltip label="First sentence.\nSecond sentence.\nThird sentence.\n">
+        <Tooltip label={'First sentence.\nSecond sentence.\nThird sentence.\n'}>
             <Button>Multiline</Button>
         </Tooltip>
     </>
@@ -133,4 +135,35 @@ export const TooltipOnDifferentComponents = () => {
             </FlexBox>
         </FlexBox>
     );
+};
+
+export const HideTooltipOnHiddenAnchor = () => {
+    const anchorRef = useRef(null);
+    const [isOpen, setOpen] = useState(false);
+    return (
+        <>
+            The tooltip should show when the button is hovered but it should disappear when the popover get in-between
+            the mouse and the button
+            <br />
+            <Tooltip label="Tooltip label">
+                <Button ref={anchorRef} onClick={() => setOpen((wasOpen) => !wasOpen)}>
+                    Open popover
+                </Button>
+            </Tooltip>
+            <Dialog isOpen={isOpen} onClose={() => setOpen(false)}>
+                Dialog
+            </Dialog>
+        </>
+    );
+};
+
+export const StressTest = () => {
+    return range(1000).map((i) => (
+        <Fragment key={i}>
+            <Tooltip label={`Label ${i}`}>
+                <Button>Button {i}</Button>
+            </Tooltip>
+            <br />
+        </Fragment>
+    ));
 };


### PR DESCRIPTION
`mouseenter`/`mouseleave` event on the tooltip anchor element do not trigger when an element appear between the anchor element and the mouse

The solution implemented here is to put a `mouseover` event listener on the `document` and check that the element currently being hovered is one of the anchors of the registered tooltips to open and close them.