### PR TITLE
feat(thumbnail): add thumbnail badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added `light` theme by default on Skeleton components.
+-   Added `badge` prop on `Thumbnail` component.
 
 ## [1.0.7][] - 2021-02-03
 

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -5,6 +5,7 @@
 .#{$lumx-base-prefix}-thumbnail {
     $self: &;
 
+    position: relative;
     flex-shrink: 0;
     padding: 0;
     border: none;
@@ -70,6 +71,12 @@
         width: fit-content;
         /* Center fallback icon when using fill-height prop */
         margin: 0 auto;
+    }
+
+    &__badge {
+        position: absolute;
+        right: -$lumx-spacing-unit / 2;
+        bottom: -$lumx-spacing-unit / 2;
     }
 }
 

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -43,7 +43,8 @@
         max-width: none;
     }
 
-    &__background, &__image {
+    &__background,
+    &__image {
         display: block;
         max-width: 100%;
         /* IE11 hack related to a bug with IE flexbox implementation (cf. https://stackoverflow.com/a/54054592) */
@@ -142,5 +143,23 @@
 .#{$lumx-base-prefix}-thumbnail--theme-dark.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
     &[data-focus-visible-added]::after {
         @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'light');
+    }
+}
+
+/* Thumbnail badge mask
+   ========================================================================== */
+
+@each $key, $size in $lumx-sizes {
+    $mask-size: map-get($lumx-sizes, lumx-base-const('size', 'XS')) - $lumx-spacing-unit;
+    $mask-offset: $size - 6;
+
+    .#{$lumx-base-prefix}-thumbnail--has-badge.#{$lumx-base-prefix}-thumbnail--size-#{$key} {
+        .#{$lumx-base-prefix}-thumbnail__background, .#{$lumx-base-prefix}-thumbnail__fallback {
+            mask-image: radial-gradient(
+                circle at $mask-offset $mask-offset,
+                transparent $mask-size,
+                /* offset circle size (+1) to soften the edge */ black $mask-size + 1
+            );
+        }
     }
 }

--- a/packages/lumx-react/src/components/badge/Badge.stories.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.stories.tsx
@@ -1,23 +1,23 @@
 import { mdiHeart } from '@lumx/icons';
 import { AspectRatio, Badge, ColorPalette, Icon, Size, Thumbnail, ThumbnailVariant } from '@lumx/react';
 import { select, text } from '@storybook/addon-knobs';
-import React from 'react';
+import React, { Fragment } from 'react';
 
 export default { title: 'LumX components/badge/Badge' };
 
-export const simpleBadgeWithValue = () => (
+export const WithText = () => (
     <Badge color={select('Colors', ColorPalette, ColorPalette.blue)}>
         <span>{text('Value', '30')}</span>
     </Badge>
 );
 
-export const simpleBadgeWithIcon = () => (
+export const WithIcon = () => (
     <Badge color={select('Colors', ColorPalette, ColorPalette.red)}>
         <Icon icon={mdiHeart} />
     </Badge>
 );
 
-export const simpleBadgeWithThumbnail = () => (
+export const WithThumbnail = () => (
     <Badge color={select('Colors', ColorPalette, ColorPalette.light)}>
         <Thumbnail
             alt="Logo"
@@ -27,4 +27,19 @@ export const simpleBadgeWithThumbnail = () => (
             variant={ThumbnailVariant.rounded}
         />
     </Badge>
+);
+
+export const AllColors = () => (
+    <dl>
+        {Object.values(ColorPalette).map((color) => (
+            <Fragment key={color}>
+                <dt>{color}</dt>
+                <dd>
+                    <Badge color={color}>
+                        <Icon icon={mdiHeart} />
+                    </Badge>
+                </dd>
+            </Fragment>
+        ))}
+    </dl>
 );

--- a/packages/lumx-react/src/components/index.ts
+++ b/packages/lumx-react/src/components/index.ts
@@ -30,6 +30,7 @@ export const ColorPalette = {
     yellow: 'yellow',
     red: 'red',
     light: 'light',
+    grey: 'grey',
 } as const;
 export type ColorPalette = ValueOf<typeof ColorPalette>;
 export type Color = ColorPalette | string;

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -37,10 +37,12 @@ export const WithBadge = () => {
     const thumbnailSize = sizeKnob('Thumbnail size', Size.l);
     const variant = select<ThumbnailVariant>('Thumbnail variant', ThumbnailVariant, ThumbnailVariant.rounded);
     const badgeColor = select('Badge color', ColorPalette, ColorPalette.primary);
+    const activateFallback = boolean('Activate fallback', false);
+    const image = imageKnob();
     return (
         <Thumbnail
             alt="Image alt text"
-            image={imageKnob()}
+            image={activateFallback ? '' : image}
             variant={variant}
             aspectRatio={AspectRatio.square}
             size={thumbnailSize}

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
 
 import { mdiAbTesting } from '@lumx/icons';
-import { Alignment, AspectRatio, FlexBox, Size, Thumbnail, ThumbnailVariant } from '@lumx/react';
+import {
+    Alignment,
+    AspectRatio,
+    Badge,
+    ColorPalette,
+    FlexBox,
+    Icon,
+    Size,
+    Thumbnail,
+    ThumbnailVariant,
+} from '@lumx/react';
 import { imageKnob, IMAGES } from '@lumx/react/stories/knobs';
 import { htmlDecode } from '@lumx/react/utils/htmlDecode';
 import { boolean, select, text } from '@storybook/addon-knobs';
@@ -22,6 +32,25 @@ export const IconFallback = () => <Thumbnail alt="foo" image="foo" fallback={mdi
 export const CustomFallback = () => (
     <Thumbnail alt="foo" image="foo" fallback={<Thumbnail alt="missing image" image="/logo.svg" />} />
 );
+
+export const WithBadge = () => {
+    const thumbnailSize = sizeKnob('Thumbnail size', Size.xxl);
+    const variant = select<ThumbnailVariant>('Thumbnail variant', ThumbnailVariant, ThumbnailVariant.squared);
+    const badgeColor = select('Badge color', ColorPalette, ColorPalette.light);
+    return (
+        <Thumbnail
+            alt="Image alt text"
+            image={imageKnob()}
+            variant={variant}
+            size={thumbnailSize}
+            badge={
+                <Badge color={badgeColor}>
+                    <Icon icon={mdiAbTesting} />
+                </Badge>
+            }
+        />
+    );
+};
 
 export const ParentSizeConstraint = () => {
     const fillHeight = boolean('Fill Height', true);
@@ -57,7 +86,7 @@ export const Knobs = ({ theme }: any) => {
     const focusPoint = { x: focusKnob('Focus X'), y: focusKnob('Focus Y') };
     const image = imageKnob('Image', IMAGES.landscape1);
     const variant = select<ThumbnailVariant>('Variant', ThumbnailVariant, ThumbnailVariant.squared);
-    const size = sizeKnob(Size.xxl);
+    const size = sizeKnob('Size', Size.xxl);
     const onClick = boolean('clickable?', false) ? () => console.log('ok') : undefined;
 
     return (

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -34,14 +34,15 @@ export const CustomFallback = () => (
 );
 
 export const WithBadge = () => {
-    const thumbnailSize = sizeKnob('Thumbnail size', Size.xxl);
-    const variant = select<ThumbnailVariant>('Thumbnail variant', ThumbnailVariant, ThumbnailVariant.squared);
-    const badgeColor = select('Badge color', ColorPalette, ColorPalette.light);
+    const thumbnailSize = sizeKnob('Thumbnail size', Size.l);
+    const variant = select<ThumbnailVariant>('Thumbnail variant', ThumbnailVariant, ThumbnailVariant.rounded);
+    const badgeColor = select('Badge color', ColorPalette, ColorPalette.primary);
     return (
         <Thumbnail
             alt="Image alt text"
             image={imageKnob()}
             variant={variant}
+            aspectRatio={AspectRatio.square}
             size={thumbnailSize}
             badge={
                 <Badge color={badgeColor}>

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.test.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.test.tsx
@@ -5,7 +5,7 @@ import 'jest-enzyme';
 import { commonTestsSuite, itShouldRenderStories } from '@lumx/react/testing/utils';
 
 import { Thumbnail, ThumbnailProps } from './Thumbnail';
-import { Clickable, CustomFallback, Default, DefaultFallback, IconFallback } from './Thumbnail.stories';
+import { Clickable, CustomFallback, Default, DefaultFallback, IconFallback, WithBadge } from './Thumbnail.stories';
 
 const CLASSNAME = Thumbnail.className as string;
 
@@ -21,7 +21,10 @@ const setup = (props: Partial<ThumbnailProps> = {}, shallowRendering = true) => 
 describe(`<${Thumbnail.displayName}>`, () => {
     // 1. Test render via snapshot.
     describe('Snapshots and structure', () => {
-        itShouldRenderStories({ Default, Clickable, DefaultFallback, CustomFallback, IconFallback }, Thumbnail);
+        itShouldRenderStories(
+            { Default, Clickable, DefaultFallback, CustomFallback, IconFallback, WithBadge },
+            Thumbnail,
+        );
     });
 
     // Common tests suite.

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -1,13 +1,4 @@
-import React, {
-    forwardRef,
-    HTMLProps,
-    ImgHTMLAttributes,
-    MouseEventHandler,
-    ReactNode,
-    Ref,
-    useRef,
-    useState,
-} from 'react';
+import React, { forwardRef, ImgHTMLAttributes, MouseEventHandler, ReactNode, Ref, useRef, useState } from 'react';
 import classNames from 'classnames';
 
 import { AspectRatio, HorizontalAlignment, Icon, Size, Theme } from '@lumx/react';
@@ -34,6 +25,8 @@ export interface ThumbnailProps extends GenericProps {
     alt: string;
     /** Image aspect ratio. */
     aspectRatio?: AspectRatio;
+    /** Badge. */
+    badge?: ReactNode;
     /** Image cross origin resource policy. */
     crossOrigin?: ImgHTMLProps['crossOrigin'];
     /** Fallback icon (SVG path) or react node when image fails to load. */
@@ -91,6 +84,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
         align,
         alt,
         aspectRatio,
+        badge,
         className,
         crossOrigin,
         fallback,
@@ -161,6 +155,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
                 ) : (
                     <div className={`${CLASSNAME}__fallback`}>{fallback}</div>
                 ))}
+            {badge && <div className={`${CLASSNAME}__badge`}>{badge}</div>}
         </div>
     );
 });

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -130,7 +130,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
     };
 
     // Update img style according to focus point and aspect ratio.
-    const style = useFocusPoint({ focusPoint, aspectRatio, imgRef, loadingState, wrapper });
+    const style = useFocusPoint({ image, focusPoint, aspectRatio, imgRef, loadingState, wrapper });
 
     return (
         <div {...wrapperProps}>

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -1,4 +1,13 @@
-import React, { forwardRef, ImgHTMLAttributes, MouseEventHandler, ReactNode, Ref, useRef, useState } from 'react';
+import React, {
+    forwardRef,
+    ImgHTMLAttributes,
+    MouseEventHandler,
+    ReactElement,
+    ReactNode,
+    Ref,
+    useRef,
+    useState,
+} from 'react';
 import classNames from 'classnames';
 
 import { AspectRatio, HorizontalAlignment, Icon, Size, Theme } from '@lumx/react';
@@ -26,7 +35,7 @@ export interface ThumbnailProps extends GenericProps {
     /** Image aspect ratio. */
     aspectRatio?: AspectRatio;
     /** Badge. */
-    badge?: ReactNode;
+    badge?: ReactElement;
     /** Image cross origin resource policy. */
     crossOrigin?: ImgHTMLProps['crossOrigin'];
     /** Fallback icon (SVG path) or react node when image fails to load. */
@@ -112,7 +121,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
         ref: mergeRefs(setWrapper, ref),
         className: classNames(
             className,
-            handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant }),
+            handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant, hasBadge: !!badge }),
             isLoading && wrapper?.getBoundingClientRect()?.height && 'lumx-color-background-dark-L6',
             fillHeight && `${CLASSNAME}--fill-height`,
         ),
@@ -155,7 +164,8 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
                 ) : (
                     <div className={`${CLASSNAME}__fallback`}>{fallback}</div>
                 ))}
-            {badge && <div className={`${CLASSNAME}__badge`}>{badge}</div>}
+            {badge &&
+                React.cloneElement(badge, { className: classNames(`${CLASSNAME}__badge`, badge.props.className) })}
         </div>
     );
 });

--- a/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
+++ b/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`<Thumbnail> Snapshots and structure should render story 'IconFallback' 
 
 exports[`<Thumbnail> Snapshots and structure should render story 'WithBadge' 1`] = `
 <div
-  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--variant-squared"
+  className="lumx-thumbnail lumx-thumbnail--aspect-ratio-square lumx-thumbnail--size-l lumx-thumbnail--theme-light lumx-thumbnail--variant-rounded lumx-thumbnail--has-badge"
 >
   <div
     className="lumx-thumbnail__background"
@@ -145,16 +145,13 @@ exports[`<Thumbnail> Snapshots and structure should render story 'WithBadge' 1`]
       style={Object {}}
     />
   </div>
-  <div
+  <Badge
     className="lumx-thumbnail__badge"
+    color="primary"
   >
-    <Badge
-      color="light"
-    >
-      <Icon
-        icon="M4 2A2 2 0 0 0 2 4V12H4V8H6V12H8V4A2 2 0 0 0 6 2H4M4 4H6V6H4M22 15.5V14A2 2 0 0 0 20 12H16V22H20A2 2 0 0 0 22 20V18.5A1.54 1.54 0 0 0 20.5 17A1.54 1.54 0 0 0 22 15.5M20 20H18V18H20V20M20 16H18V14H20M5.79 21.61L4.21 20.39L18.21 2.39L19.79 3.61Z"
-      />
-    </Badge>
-  </div>
+    <Icon
+      icon="M4 2A2 2 0 0 0 2 4V12H4V8H6V12H8V4A2 2 0 0 0 6 2H4M4 4H6V6H4M22 15.5V14A2 2 0 0 0 20 12H16V22H20A2 2 0 0 0 22 20V18.5A1.54 1.54 0 0 0 20.5 17A1.54 1.54 0 0 0 22 15.5M20 20H18V18H20V20M20 16H18V14H20M5.79 21.61L4.21 20.39L18.21 2.39L19.79 3.61Z"
+    />
+  </Badge>
 </div>
 `;

--- a/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
+++ b/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
@@ -123,3 +123,38 @@ exports[`<Thumbnail> Snapshots and structure should render story 'IconFallback' 
   </div>
 </div>
 `;
+
+exports[`<Thumbnail> Snapshots and structure should render story 'WithBadge' 1`] = `
+<div
+  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--variant-squared"
+>
+  <div
+    className="lumx-thumbnail__background"
+    style={
+      Object {
+        "display": undefined,
+        "visibility": "hidden",
+      }
+    }
+  >
+    <img
+      alt="Image alt text"
+      className="lumx-thumbnail__image"
+      loading="lazy"
+      src="landscape1.jpg"
+      style={Object {}}
+    />
+  </div>
+  <div
+    className="lumx-thumbnail__badge"
+  >
+    <Badge
+      color="light"
+    >
+      <Icon
+        icon="M4 2A2 2 0 0 0 2 4V12H4V8H6V12H8V4A2 2 0 0 0 6 2H4M4 4H6V6H4M22 15.5V14A2 2 0 0 0 20 12H16V22H20A2 2 0 0 0 22 20V18.5A1.54 1.54 0 0 0 20.5 17A1.54 1.54 0 0 0 22 15.5M20 20H18V18H20V20M20 16H18V14H20M5.79 21.61L4.21 20.39L18.21 2.39L19.79 3.61Z"
+      />
+    </Badge>
+  </div>
+</div>
+`;

--- a/packages/lumx-react/src/components/thumbnail/useFocusPoint.ts
+++ b/packages/lumx-react/src/components/thumbnail/useFocusPoint.ts
@@ -108,13 +108,14 @@ function calculateImageStyle(sizes: Sizes, point: Required<FocusPoint>): Styles 
  * Hook that calculate CSS style to shift the image in it's container according to the focus point.
  */
 export const useFocusPoint = (options: {
+    image: string;
     focusPoint?: FocusPoint;
     aspectRatio?: AspectRatio;
     imgRef: RefObject<HTMLImageElement>;
     loadingState: LoadingState;
     wrapper?: HTMLElement;
 }): Styles | undefined => {
-    const { aspectRatio, focusPoint, imgRef, loadingState, wrapper } = options;
+    const { image, aspectRatio, focusPoint, imgRef, loadingState, wrapper } = options;
 
     const point = parseFocusPoint(focusPoint);
 
@@ -144,7 +145,7 @@ export const useFocusPoint = (options: {
     );
 
     // Update on image loaded.
-    useLayoutEffect(update, [update, loadingState]);
+    useLayoutEffect(update, [image, update, loadingState]);
 
     // Update on parent resize.
     useOnResize(wrapper, updateRef);

--- a/packages/lumx-react/src/stories/knobs/sizeKnob.ts
+++ b/packages/lumx-react/src/stories/knobs/sizeKnob.ts
@@ -1,5 +1,5 @@
 import { Size } from '@lumx/react';
 import { enumKnob } from '@lumx/react/stories/knobs/enumKnob';
 
-export const sizeKnob = (size?: Size) =>
-    enumKnob('Size', [undefined, Size.xxs, Size.xs, Size.s, Size.m, Size.l, Size.xl, Size.xxl] as const, size as any);
+export const sizeKnob = (name = 'Size', size?: Size) =>
+    enumKnob(name, [undefined, Size.xxs, Size.xs, Size.s, Size.m, Size.l, Size.xl, Size.xxl] as const, size as any);


### PR DESCRIPTION
- Add `badge` prop to `Thumbnail`
- Add style to create a transparent border around the thumbnail badge (only works on fixed size thumbnails)

<details>
<summary>Badge mask adapting to fixed size thumbnails</summary>
<img src="https://user-images.githubusercontent.com/939567/106784268-70be4f00-664c-11eb-80ef-60aa33e94ce9.gif" />
</details>

<details>
<summary>Badge mask transparency</summary>
<img src="https://user-images.githubusercontent.com/939567/106784272-71ef7c00-664c-11eb-83e2-d5378c45dfc3.gif" />
</details>


