### PR TITLE
fix(tabs): remove default props preventing onChange from being called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed `TabProvider` & `ProgressTrackerProvider` not calling `onChange` when the index is not provided via the props.
+
 ## [1.0.8][] - 2021-02-08
 
 ### Added

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTracker.stories.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTracker.stories.tsx
@@ -116,11 +116,13 @@ export const Controlled = () => {
                                 >
                                     Toggle error
                                 </Button>
-                                {index === steps.length - 1 && step.isComplete ? undefined : (
-                                    <Button onClick={next(index)} color={ColorPalette.primary}>
-                                        {index === steps.length - 1 ? 'Complete' : 'Next with success'}
-                                    </Button>
-                                )}
+                                <Button
+                                    onClick={next(index)}
+                                    color={ColorPalette.primary}
+                                    isDisabled={index === steps.length - 1 && step.isComplete}
+                                >
+                                    {index === steps.length - 1 ? 'Complete' : 'Next with success'}
+                                </Button>
                             </FlexBox>
                         </FlexBox>
                         <FlexBox fillSpace />
@@ -130,3 +132,14 @@ export const Controlled = () => {
         </ProgressTrackerProvider>
     );
 };
+
+export const NotControlled = () => (
+    <ProgressTrackerProvider onChange={console.log}>
+        <ProgressTracker aria-label="Steps with a linear progression">
+            <ProgressTrackerStep label="Step 1" />
+            <ProgressTrackerStep label="Step 2" />
+        </ProgressTracker>
+        <ProgressTrackerStepPanel className="lumx-spacing-padding">Step 1 panel</ProgressTrackerStepPanel>
+        <ProgressTrackerStepPanel className="lumx-spacing-padding">Step 2 panel</ProgressTrackerStepPanel>
+    </ProgressTrackerProvider>
+);

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTrackerProvider.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTrackerProvider.tsx
@@ -15,9 +15,8 @@ export interface ProgressTrackerProviderProps {
 }
 
 const DEFAULT_PROPS: Partial<ProgressTrackerProviderProps> = {
-    activeStepIndex: 0,
-    isLazy: true,
-    shouldActivateOnFocus: false,
+    isLazy: INIT_STATE.isLazy,
+    shouldActivateOnFocus: INIT_STATE.shouldActivateOnFocus,
 };
 
 /**
@@ -42,7 +41,7 @@ export const ProgressTrackerProvider: React.FC<ProgressTrackerProviderProps> = (
                 type: 'update',
                 payload: {
                     ...propState,
-                    activeTabIndex: propState.activeStepIndex,
+                    activeTabIndex: propState.activeStepIndex || INIT_STATE.activeTabIndex,
                 },
             });
         },

--- a/packages/lumx-react/src/components/tabs/TabProvider.tsx
+++ b/packages/lumx-react/src/components/tabs/TabProvider.tsx
@@ -16,7 +16,6 @@ export interface TabProviderProps {
 }
 
 const DEFAULT_PROPS: Partial<TabProviderProps> = {
-    activeTabIndex: INIT_STATE.activeTabIndex,
     isLazy: INIT_STATE.isLazy,
     shouldActivateOnFocus: INIT_STATE.shouldActivateOnFocus,
 };

--- a/packages/lumx-react/src/components/tabs/Tabs.stories.tsx
+++ b/packages/lumx-react/src/components/tabs/Tabs.stories.tsx
@@ -56,7 +56,7 @@ export const Controlled = ({ theme }: any) => {
 /* Control active tab internally (with activate tab on focus). */
 export const NotControlled = ({ theme }: any) => {
     return (
-        <TabProvider shouldActivateOnFocus>
+        <TabProvider shouldActivateOnFocus onChange={console.log}>
             <TabList theme={theme} aria-label="Tab list">
                 <Tab label="Tab a" />
                 <Tab label="Tab b" />


### PR DESCRIPTION
The default props for TabProvider and ProgressTrackerProvider was preventing the onChange to be called when the parent component doesn't update the `activeTabIndex` prop.

This PR removes the active index default prop (the reducer initial state already initializes the index correctly).

Test scenario:
- Check "Tabs > Not controlled" story.
- Clicking on any tabs should log it's index in the console.
- Repeat the test on "Progress tracker > Not controlled" story.
