### PR TITLE
fix(table-row): move tabIndex above forward props spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Make `TableRow` component's `tabIndex` controllable
+
 ### Changed
 
 -   Cleanup `Flag` makup and styles
+-   Use `uid` instead of `uniqueid` for `Checkbox` default id.
+-   Use `uid` instead of `uniqueid` for `RadioButton` default id.
 
 ## [1.0.9][] - 2021-02-22
 

--- a/packages/lumx-react/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.test.tsx
@@ -16,7 +16,7 @@ type SetupProps = Partial<CheckboxProps>;
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  */
 const setup = (propsOverride: SetupProps = {}, shallowRendering = true) => {
-    const props: any = { ...propsOverride };
+    const props: any = { id: 'fixedId', ...propsOverride };
     const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
     const wrapper: Wrapper = renderer(<Checkbox {...props} />);
 

--- a/packages/lumx-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.tsx
@@ -1,13 +1,12 @@
-import React, { forwardRef, ReactNode, SyntheticEvent } from 'react';
+import React, { useMemo, forwardRef, ReactNode, SyntheticEvent } from 'react';
 
 import classNames from 'classnames';
+import { uid } from 'uid';
 
 import { mdiCheck } from '@lumx/icons';
 
 import { Icon, InputHelper, InputLabel, Theme } from '@lumx/react';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
-
-import uniqueId from 'lodash/uniqueId';
 
 /**
  * Defines the props of the component.
@@ -73,7 +72,8 @@ export const Checkbox: Comp<CheckboxProps, HTMLDivElement> = forwardRef((props, 
         value,
         ...forwardedProps
     } = props;
-    const inputId = id || uniqueId(`${CLASSNAME.toLowerCase()}-`);
+    const inputId = useMemo(() => id || `${CLASSNAME.toLowerCase()}-${uid()}`, [id]);
+
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
             onChange(!isChecked, value, name, event);

--- a/packages/lumx-react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/lumx-react/src/components/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<Checkbox> Props should use the given props 1`] = `
   >
     <input
       className="lumx-checkbox__input-native"
-      id="lumx-checkbox-3"
+      id="fixedId"
       onChange={[Function]}
       tabIndex={0}
       type="checkbox"
@@ -34,7 +34,7 @@ exports[`<Checkbox> Props should use the given props 1`] = `
   >
     <InputLabel
       className="lumx-checkbox__label"
-      htmlFor="lumx-checkbox-3"
+      htmlFor="fixedId"
       theme="light"
     >
       Test label
@@ -59,7 +59,7 @@ exports[`<Checkbox> Snapshots and structure should render correctly 1`] = `
   >
     <input
       className="lumx-checkbox__input-native"
-      id="lumx-checkbox-1"
+      id="fixedId"
       onChange={[Function]}
       tabIndex={0}
       type="checkbox"

--- a/packages/lumx-react/src/components/radio-button/RadioButton.test.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.test.tsx
@@ -17,7 +17,7 @@ type SetupProps = Partial<RadioButtonProps>;
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  */
 const setup = (propsOverride: SetupProps = {}, shallowRendering = true) => {
-    const props: any = { ...propsOverride };
+    const props: any = { id: 'fixedId', ...propsOverride };
     const renderer: (el: ReactElement) => Wrapper = shallowRendering ? shallow : mount;
     const wrapper: Wrapper = renderer(<RadioButton {...props} />);
 

--- a/packages/lumx-react/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.tsx
@@ -1,12 +1,11 @@
-import React, { forwardRef, ReactNode, SyntheticEvent } from 'react';
+import React, { useMemo, forwardRef, ReactNode, SyntheticEvent } from 'react';
 
 import classNames from 'classnames';
+import { uid } from 'uid';
 
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
-
-import uniqueId from 'lodash/uniqueId';
 
 /**
  * Defines the props of the component.
@@ -72,7 +71,8 @@ export const RadioButton: Comp<RadioButtonProps, HTMLDivElement> = forwardRef((p
         value,
         ...forwardedProps
     } = props;
-    const radioButtonId: string = id || uniqueId(`${CLASSNAME.toLowerCase()}-`);
+    const radioButtonId = useMemo(() => id || `${CLASSNAME.toLowerCase()}-${uid()}`, [id]);
+
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
             onChange(value, name, event);

--- a/packages/lumx-react/src/components/radio-button/__snapshots__/RadioButton.test.tsx.snap
+++ b/packages/lumx-react/src/components/radio-button/__snapshots__/RadioButton.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`<RadioButton> Snapshots and structure should render defaults 1`] = `
   >
     <input
       className="lumx-radio-button__input-native"
-      id="lumx-radio-button-1"
+      id="fixedId"
       onChange={[Function]}
       tabIndex={0}
       type="radio"
@@ -73,7 +73,7 @@ exports[`<RadioButton> Snapshots and structure should render label & helper 1`] 
   >
     <input
       className="lumx-radio-button__input-native"
-      id="lumx-radio-button-2"
+      id="fixedId"
       onChange={[Function]}
       tabIndex={0}
       type="radio"
@@ -94,7 +94,7 @@ exports[`<RadioButton> Snapshots and structure should render label & helper 1`] 
   >
     <InputLabel
       className="lumx-radio-button__label"
-      htmlFor="lumx-radio-button-2"
+      htmlFor="fixedId"
       theme="light"
     >
       Label

--- a/packages/lumx-react/src/components/table/TableRow.tsx
+++ b/packages/lumx-react/src/components/table/TableRow.tsx
@@ -44,6 +44,7 @@ export const TableRow: Comp<TableRowProps, HTMLTableRowElement> = forwardRef((pr
     return (
         <tr
             ref={ref}
+            tabIndex={isClickable && !isDisabled ? 0 : -1}
             {...forwardedProps}
             className={classNames(
                 className,
@@ -54,7 +55,6 @@ export const TableRow: Comp<TableRowProps, HTMLTableRowElement> = forwardRef((pr
                     prefix: CLASSNAME,
                 }),
             )}
-            tabIndex={isClickable && !isDisabled ? 0 : -1}
             aria-disabled={isDisabled}
         >
             {children}


### PR DESCRIPTION
# General summary

### Fixed

-   Make `TableRow` component's `tabIndex` controllable

### Changed

-   Use `uid` instead of `uniqueid` for `Checkbox` default id.
-   Use `uid` instead of `uniqueid` for `RadioButton` default id.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
