### PR TITLE
feat(popover): add boundaryRef prop to change overflow boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `boundaryRef` prop to `Popover` component to override default boundary settings.
+
 ## [1.0.10][] - 2021-02-25
 
 ### Fixed

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -18,6 +18,7 @@ import {
 import { boolean, select } from '@storybook/addon-knobs';
 import range from 'lodash/range';
 import startCase from 'lodash/startCase';
+import { Button } from '../button';
 
 export default { title: 'LumX components/popover/Popover' };
 
@@ -259,5 +260,122 @@ export const WithoutPortal = ({ theme }: any) => {
                 );
             })}
         </FlexBox>
+    );
+};
+
+export const NestedWithoutPortal = () => {
+    const rootButtonRef = React.useRef(null);
+    const firstButtonRef = React.useRef(null);
+    const secondButtonRef = React.useRef(null);
+    const thirdButtonRef = React.useRef(null);
+    const fourthButtonRef = React.useRef(null);
+    const [rootOpen, setRootOpen] = React.useState(false);
+    const [firstOpen, setFirstOpen] = React.useState(false);
+    const [secondOpen, setSecondOpen] = React.useState(false);
+    const [thirdOpen, setThirdOpen] = React.useState(false);
+    const [fourthOpen, setFourthOpen] = React.useState(false);
+    const boundaryReference = React.useRef(document.querySelector('body'));
+
+    return (
+        <div style={{ height: '100vh' }}>
+            <Button ref={rootButtonRef} onClick={() => setRootOpen(!rootOpen)}>
+                Click
+            </Button>
+            <Popover
+                boundaryReference={boundaryReference}
+                fitWithinViewportHeight
+                offset={{ along: -16 }}
+                placement={Placement.RIGHT_START}
+                isOpen={rootOpen}
+                anchorRef={rootButtonRef}
+                usePortal={false}
+            >
+                <div className="lumx-spacing-margin-huge" style={{ overflowY: 'auto' }}>
+                    <List>
+                        <li ref={firstButtonRef}>
+                            <Button onClick={() => setFirstOpen(!firstOpen)}>Click</Button>
+                            <Popover
+                                boundaryReference={boundaryReference}
+                                fitWithinViewportHeight
+                                placement={Placement.RIGHT_START}
+                                isOpen={firstOpen}
+                                anchorRef={firstButtonRef}
+                                usePortal={false}
+                                offset={{ along: -16 }}
+                            >
+                                <div className="lumx-spacing-margin-huge" style={{ overflowY: 'auto' }}>
+                                    <List>
+                                        <li ref={secondButtonRef}>
+                                            <Button onClick={() => setSecondOpen(!secondOpen)}>Click</Button>
+                                            <Popover
+                                                boundaryReference={boundaryReference}
+                                                fitWithinViewportHeight
+                                                placement={Placement.RIGHT_START}
+                                                isOpen={secondOpen}
+                                                anchorRef={secondButtonRef}
+                                                usePortal={false}
+                                                offset={{ along: -16 }}
+                                            >
+                                                <div className="lumx-spacing-margin-huge" style={{ overflowY: 'auto' }}>
+                                                    <List>
+                                                        <li ref={thirdButtonRef}>
+                                                            <Button onClick={() => setThirdOpen(!thirdOpen)}>
+                                                                Click
+                                                            </Button>
+                                                            <Popover
+                                                                boundaryReference={boundaryReference}
+                                                                fitWithinViewportHeight
+                                                                placement={Placement.RIGHT_START}
+                                                                isOpen={thirdOpen}
+                                                                anchorRef={thirdButtonRef}
+                                                                usePortal={false}
+                                                                offset={{ along: -16 }}
+                                                            >
+                                                                <div
+                                                                    className="lumx-spacing-margin-huge"
+                                                                    style={{ overflowY: 'auto' }}
+                                                                >
+                                                                    <List>
+                                                                        <li ref={fourthButtonRef}>
+                                                                            <Button
+                                                                                onClick={() =>
+                                                                                    setFourthOpen(!fourthOpen)
+                                                                                }
+                                                                            >
+                                                                                Click
+                                                                            </Button>
+                                                                            <Popover
+                                                                                boundaryReference={boundaryReference}
+                                                                                fitWithinViewportHeight
+                                                                                placement={Placement.RIGHT_START}
+                                                                                isOpen={fourthOpen}
+                                                                                anchorRef={fourthButtonRef}
+                                                                                usePortal={false}
+                                                                                offset={{ along: -16 }}
+                                                                            >
+                                                                                <div
+                                                                                    className="lumx-spacing-margin-huge"
+                                                                                    style={{ overflowY: 'auto' }}
+                                                                                >
+                                                                                    <List>Popover</List>
+                                                                                </div>
+                                                                            </Popover>
+                                                                        </li>
+                                                                    </List>
+                                                                </div>
+                                                            </Popover>
+                                                        </li>
+                                                    </List>
+                                                </div>
+                                            </Popover>
+                                        </li>
+                                    </List>
+                                </div>
+                            </Popover>
+                        </li>
+                    </List>
+                </div>
+            </Popover>
+        </div>
     );
 };

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -65,6 +65,8 @@ const ARROW_SIZE = 8;
 export interface PopoverProps extends GenericProps {
     /** Reference to the DOM element used to set the position of the popover. */
     anchorRef: React.RefObject<HTMLElement>;
+    /** Element which will act as boundary when opening the popover. */
+    boundaryRef?: RefObject<HTMLElement>;
     /** Content. */
     children: ReactNode;
     /** Whether a click anywhere out of the popover would close it. */
@@ -194,6 +196,7 @@ export const Popover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, re
 
     const {
         anchorRef,
+        boundaryRef,
         children,
         className,
         closeOnClickAway,
@@ -233,7 +236,10 @@ export const Popover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, re
         modifiers.push(sameWidth);
     }
     if (fitWithinViewportHeight) {
-        modifiers.push(maxSize, applyMaxHeight);
+        modifiers.push({ ...maxSize, options: boundaryRef ? { boundary: boundaryRef.current } : {} }, applyMaxHeight);
+    }
+    if (boundaryRef) {
+        modifiers.push({ name: 'flip', options: { boundary: boundaryRef.current } });
     }
 
     // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
# General summary

Make it possible to give a custom element reference to the Popover element to change boundary element.

<!-- Please describe the PR content -->

# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/7147342/109187488-40248d80-7792-11eb-988d-dcb722932780.png)

**After**
![image](https://user-images.githubusercontent.com/7147342/109187608-57fc1180-7792-11eb-8aff-d72fdd425917.png)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
