### PR TITLE
Chore/split dialog components

### DIFF
--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -16,6 +16,9 @@ import { select } from '@storybook/addon-knobs';
 import React, { RefObject, useRef, useState } from 'react';
 import { Dialog, DialogSizes } from './Dialog';
 import { loremIpsum } from '../../stories/knobs';
+import { DialogHeader } from './DialogHeader';
+import { DialogContent } from './DialogContent';
+import { DialogFooter } from './DialogFooter';
 
 export default {
     title: 'LumX components/dialog/Dialog',
@@ -205,6 +208,39 @@ export const ScrollableDialogWithHeaderAndFooter = ({ theme }: any) => {
                 {header}
                 {longContent}
                 {footer}
+            </Dialog>
+        </>
+    );
+};
+
+export const ComposedDialog = ({ theme }: any) => {
+    const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
+    return (
+        <>
+            {button}
+            <Dialog isOpen={isOpen} onClose={closeDialog} parentElement={buttonRef}>
+                <DialogHeader className="lumx-spacing-padding lumx-typography-title">Dialog Header</DialogHeader>
+                {longContent}
+                <DialogFooter className="lumx-spacing-padding">Dialog Footer</DialogFooter>
+            </Dialog>
+        </>
+    );
+};
+
+const IntermediateComponent = ({ children }: any) => (
+    <DialogHeader className="lumx-spacing-padding lumx-typography-title">{children}</DialogHeader>
+);
+export const ComposedDialogIntermediateComponents = ({ theme }: any) => {
+    const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
+    return (
+        <>
+            {button}
+            <Dialog isOpen={isOpen} onClose={closeDialog} parentElement={buttonRef} wrapContent={false}>
+                <>
+                    <IntermediateComponent>Dialog Header</IntermediateComponent>
+                    <DialogContent>{longContent}</DialogContent>
+                    <DialogFooter className="lumx-spacing-padding">Dialog Footer</DialogFooter>
+                </>
             </Dialog>
         </>
     );

--- a/packages/lumx-react/src/components/dialog/DialogContent.tsx
+++ b/packages/lumx-react/src/components/dialog/DialogContent.tsx
@@ -1,0 +1,31 @@
+import React, { forwardRef, useContext } from 'react';
+import classNames from 'classnames';
+import { GenericProps, getRootClassName } from '@lumx/react/utils';
+import { IntersectionContext } from './intersection-context';
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'DialogContent';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME, true);
+
+export const DialogContent = forwardRef<HTMLDivElement, GenericProps>((props, ref) => {
+    const { className, children, ...forwardedProps } = props;
+    const { setSentinelTop, setSentinelBottom } = useContext(IntersectionContext);
+
+    return (
+        <div ref={ref} className={classNames(CLASSNAME, className)} {...forwardedProps}>
+            <div className={`${CLASSNAME}__sentinel ${CLASSNAME}__sentinel--top`} ref={setSentinelTop} />
+
+            {children}
+
+            <div className={`${CLASSNAME}__sentinel ${CLASSNAME}__sentinel--bottom`} ref={setSentinelBottom} />
+        </div>
+    );
+});
+
+DialogContent.displayName = 'DialogContent';

--- a/packages/lumx-react/src/components/dialog/DialogFooter.tsx
+++ b/packages/lumx-react/src/components/dialog/DialogFooter.tsx
@@ -1,0 +1,41 @@
+import { GenericProps, getRootClassName } from '@lumx/react/utils';
+import React, { useContext } from 'react';
+import classNames from 'classnames';
+import { IntersectionContext } from './intersection-context';
+
+export interface DialogFooterProps extends GenericProps {
+    /** Force divider to display event if there is no bottom intersection. */
+    forceDivier?: boolean;
+}
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'DialogFooter';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME, true);
+
+export const DialogFooter: React.FC<DialogFooterProps> = (props) => {
+    const { forceDivider, children, className, ...forwardedProps } = props;
+    const { intersections, sentinelBottom } = useContext(IntersectionContext);
+
+    const hasBottomIntersection = sentinelBottom && !(intersections.get(sentinelBottom)?.isIntersecting ?? true);
+
+    return (
+        <footer
+            {...forwardedProps}
+            className={classNames(
+                className,
+                CLASSNAME,
+                (forceDivider || hasBottomIntersection) && `${CLASSNAME}--has-divider`,
+            )}
+        >
+            {children}
+        </footer>
+    );
+};
+
+DialogFooter.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/dialog/DialogHeader.tsx
+++ b/packages/lumx-react/src/components/dialog/DialogHeader.tsx
@@ -1,0 +1,41 @@
+import React, { useContext } from 'react';
+import { GenericProps, getRootClassName } from '@lumx/react/utils';
+import classNames from 'classnames';
+import { IntersectionContext } from './intersection-context';
+
+export interface DialogHeaderProps extends GenericProps {
+    /** Force divider to display event if there is no bottom intersection. */
+    forceDivier?: boolean;
+}
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'DialogHeader';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME, true);
+
+export const DialogHeader: React.FC<DialogHeaderProps> = (props) => {
+    const { forceDivider, className, children, ...forwardedProps } = props;
+    const { intersections, sentinelTop } = useContext(IntersectionContext);
+
+    const hasTopIntersection = sentinelTop && !(intersections.get(sentinelTop)?.isIntersecting ?? true);
+
+    return (
+        <header
+            {...forwardedProps}
+            className={classNames(
+                className,
+                CLASSNAME,
+                (forceDivider || hasTopIntersection) && `${CLASSNAME}--has-divider`,
+            )}
+        >
+            {children}
+        </header>
+    );
+};
+
+DialogHeader.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -1,5 +1,194 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Dialog> Snapshots and structure should render story ComposedDialog 1`] = `
+<Fragment>
+  <Button
+    emphasis="high"
+    onClick={[Function]}
+    size="m"
+    theme="light"
+  >
+    Open dialog
+  </Button>
+  <Dialog
+    isOpen={true}
+    onClose={[Function]}
+    parentElement={
+      Object {
+        "current": undefined,
+      }
+    }
+    size="big"
+  >
+    <DialogHeader
+      className="lumx-spacing-padding lumx-typography-title"
+    >
+      Dialog Header
+    </DialogHeader>
+    <div
+      className="lumx-spacing-padding"
+    >
+      
+
+Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros
+Afros. Magna pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum
+dapibus. Praeterea iter est quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea
+commodi consequat. Inmensae subtilitatis, obscuris et malesuada fames. Me non paenitet nullum
+festiviorem excogitasse ad hoc. Cum ceteris in veneratione tui montes, nascetur mus. Etiam
+habebis sem dicantur magna mollis euismod. Quis aute iure reprehenderit in voluptate velit esse.
+Phasellus laoreet lorem vel dolor tempus vehicula. Ambitioni dedisse scripsisse iudicaretur.
+Paullum deliquit, ponderibus modulisque suis ratio utitur. Ab illo tempore, ab est sed
+immemorabili. Nec dubitamus multa iter quae et nos invenerat. Tu quoque, Brute, fili mi, nihil
+timor populi, nihil! Morbi fringilla convallis sapien, id pulvinar odio volutpat. Cras mattis
+iudicium purus sit amet fermentum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus.
+Quisque ut dolor gravida, placerat libero vel, euismod. Unam incolunt Belgae, aliam Aquitani,
+tertiam. Cras mattis iudicium purus sit amet fermentum. Prima luce, cum quibus mons aliud
+consensu ab eo. Vivamus sagittis lacus vel augue laoreet rutrum faucibus. Petierunt uti sibi
+concilium totius Galliae in diem certam indicere. Etiam habebis sem dicantur magna mollis
+euismod. A communi observantia non est recedendum. Ut enim ad minim veniam, quis nostrud
+exercitation. Paullum deliquit, ponderibus modulisque suis ratio utitur. Hi omnes lingua,
+institutis, legibus inter se differunt. Magna pars studiorum, prodita quaerimus. Quisque ut
+dolor gravida, placerat libero vel, euismod. Tityre, tu patulae recubans sub tegmine fagi dolor.
+Excepteur sint obcaecat cupiditat non proident culpa. Plura mihi bona sunt, inclinet, amari
+petere vellent. Quae vero auctorem tractata ab fiducia dicuntur. Inmensae subtilitatis, obscuris
+et malesuada fames. Quo usque tandem abutere, Catilina, patientia nostra? Nihilne te nocturnum
+praesidium Palati, nihil urbis vigiliae. Curabitur blandit tempus ardua ridiculus sed magna. Tu
+quoque, Brute, fili mi, nihil timor populi, nihil! Nihil hic munitissimus habendi senatus locus,
+nihil horum?Tu quoque, Brute, fili mi, nihil timor populi, nihil! Tityre, tu patulae recubans
+sub tegmine fagi dolor. Plura mihi bona sunt, inclinet, amari petere vellent. Ullamco laboris
+nisi ut aliquid ex ea commodi consequat. Pellentesque habitant morbi tristique senectus et
+netus. Salutantibus vitae elit libero, a pharetra augue. Lorem ipsum dolor sit amet, consectetur
+adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Petierunt uti sibi
+concilium totius Galliae in diem certam indicere. Contra legem facit qui id facit quod lex
+prohibet. Integer legentibus erat a ante historiarum dapibus. Petierunt uti sibi concilium
+totius Galliae in diem certam indicere. Ab illo tempore, ab est sed immemorabili. Nihil hic
+munitissimus habendi senatus locus, nihil horum? Quisque ut dolor gravida, placerat libero vel,
+euismod. Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut
+labore et dolore magna aliqua. Nec dubitamus multa iter quae et nos invenerat. Quam temere in
+vitiis, legem sancimus haerentia. Donec sed odio operae, eu vulputate felis rhoncus. Idque
+Caesaris facere voluntate liceret: sese habere. Paullum deliquit, ponderibus modulisque suis
+ratio utitur. Quae vero auctorem tractata ab fiducia dicuntur. Gallia est omnis divisa in partes
+tres, quarum. Etiam habebis sem dicantur magna mollis euismod. Fabio vel iudice vincam, sunt in
+culpa qui officia. Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor
+incidunt ut labore et dolore magna aliqua. Tu quoque, Brute, fili mi, nihil timor populi, nihil!
+Integer legentibus erat a ante historiarum dapibus. Tityre, tu patulae recubans sub tegmine fagi
+dolor. Ullamco laboris nisi ut aliquid ex ea commodi consequat. Idque Caesaris facere voluntate
+liceret: sese habere. Quid securi etiam tamquam eu fugiat nulla pariatur. Pellentesque habitant
+morbi tristique senectus et netus. Ut enim ad minim veniam, quis nostrud exercitation. Petierunt
+uti sibi concilium totius Galliae in diem certam indicere. Curabitur est gravida et libero vitae
+dictum. Qui ipsorum lingua Celtae, nostra Galli appellantur. Quam temere in vitiis, legem
+sancimus haerentia. Phasellus laoreet lorem vel dolor tempus vehicula. Ab illo tempore, ab est
+sed immemorabili. Praeterea iter est quasdam res quas ex communi. Quo usque tandem abutere,
+Catilina, patientia nostra? Non equidem invideo, miror magis posuere velit aliquet. Excepteur
+sint obcaecat cupiditat non proident culpa. Curabitur blandit tempus ardua ridiculus sed magna.
+Plura mihi bona sunt, inclinet, amari petere vellent. Quae vero auctorem tractata ab fiducia
+dicuntur. Me non paenitet nullum festiviorem excogitasse ad hoc. Unam incolunt Belgae, aliam
+Aquitani, tertiam.
+    </div>
+    <DialogFooter
+      className="lumx-spacing-padding"
+    >
+      Dialog Footer
+    </DialogFooter>
+  </Dialog>
+</Fragment>
+`;
+
+exports[`<Dialog> Snapshots and structure should render story ComposedDialogIntermediateComponents 1`] = `
+<Fragment>
+  <Button
+    emphasis="high"
+    onClick={[Function]}
+    size="m"
+    theme="light"
+  >
+    Open dialog
+  </Button>
+  <Dialog
+    isOpen={true}
+    onClose={[Function]}
+    parentElement={
+      Object {
+        "current": undefined,
+      }
+    }
+    size="big"
+    wrapContent={false}
+  >
+    <IntermediateComponent>
+      Dialog Header
+    </IntermediateComponent>
+    <DialogContent>
+      <div
+        className="lumx-spacing-padding"
+      >
+        
+
+Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros
+Afros. Magna pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum
+dapibus. Praeterea iter est quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea
+commodi consequat. Inmensae subtilitatis, obscuris et malesuada fames. Me non paenitet nullum
+festiviorem excogitasse ad hoc. Cum ceteris in veneratione tui montes, nascetur mus. Etiam
+habebis sem dicantur magna mollis euismod. Quis aute iure reprehenderit in voluptate velit esse.
+Phasellus laoreet lorem vel dolor tempus vehicula. Ambitioni dedisse scripsisse iudicaretur.
+Paullum deliquit, ponderibus modulisque suis ratio utitur. Ab illo tempore, ab est sed
+immemorabili. Nec dubitamus multa iter quae et nos invenerat. Tu quoque, Brute, fili mi, nihil
+timor populi, nihil! Morbi fringilla convallis sapien, id pulvinar odio volutpat. Cras mattis
+iudicium purus sit amet fermentum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus.
+Quisque ut dolor gravida, placerat libero vel, euismod. Unam incolunt Belgae, aliam Aquitani,
+tertiam. Cras mattis iudicium purus sit amet fermentum. Prima luce, cum quibus mons aliud
+consensu ab eo. Vivamus sagittis lacus vel augue laoreet rutrum faucibus. Petierunt uti sibi
+concilium totius Galliae in diem certam indicere. Etiam habebis sem dicantur magna mollis
+euismod. A communi observantia non est recedendum. Ut enim ad minim veniam, quis nostrud
+exercitation. Paullum deliquit, ponderibus modulisque suis ratio utitur. Hi omnes lingua,
+institutis, legibus inter se differunt. Magna pars studiorum, prodita quaerimus. Quisque ut
+dolor gravida, placerat libero vel, euismod. Tityre, tu patulae recubans sub tegmine fagi dolor.
+Excepteur sint obcaecat cupiditat non proident culpa. Plura mihi bona sunt, inclinet, amari
+petere vellent. Quae vero auctorem tractata ab fiducia dicuntur. Inmensae subtilitatis, obscuris
+et malesuada fames. Quo usque tandem abutere, Catilina, patientia nostra? Nihilne te nocturnum
+praesidium Palati, nihil urbis vigiliae. Curabitur blandit tempus ardua ridiculus sed magna. Tu
+quoque, Brute, fili mi, nihil timor populi, nihil! Nihil hic munitissimus habendi senatus locus,
+nihil horum?Tu quoque, Brute, fili mi, nihil timor populi, nihil! Tityre, tu patulae recubans
+sub tegmine fagi dolor. Plura mihi bona sunt, inclinet, amari petere vellent. Ullamco laboris
+nisi ut aliquid ex ea commodi consequat. Pellentesque habitant morbi tristique senectus et
+netus. Salutantibus vitae elit libero, a pharetra augue. Lorem ipsum dolor sit amet, consectetur
+adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Petierunt uti sibi
+concilium totius Galliae in diem certam indicere. Contra legem facit qui id facit quod lex
+prohibet. Integer legentibus erat a ante historiarum dapibus. Petierunt uti sibi concilium
+totius Galliae in diem certam indicere. Ab illo tempore, ab est sed immemorabili. Nihil hic
+munitissimus habendi senatus locus, nihil horum? Quisque ut dolor gravida, placerat libero vel,
+euismod. Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut
+labore et dolore magna aliqua. Nec dubitamus multa iter quae et nos invenerat. Quam temere in
+vitiis, legem sancimus haerentia. Donec sed odio operae, eu vulputate felis rhoncus. Idque
+Caesaris facere voluntate liceret: sese habere. Paullum deliquit, ponderibus modulisque suis
+ratio utitur. Quae vero auctorem tractata ab fiducia dicuntur. Gallia est omnis divisa in partes
+tres, quarum. Etiam habebis sem dicantur magna mollis euismod. Fabio vel iudice vincam, sunt in
+culpa qui officia. Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor
+incidunt ut labore et dolore magna aliqua. Tu quoque, Brute, fili mi, nihil timor populi, nihil!
+Integer legentibus erat a ante historiarum dapibus. Tityre, tu patulae recubans sub tegmine fagi
+dolor. Ullamco laboris nisi ut aliquid ex ea commodi consequat. Idque Caesaris facere voluntate
+liceret: sese habere. Quid securi etiam tamquam eu fugiat nulla pariatur. Pellentesque habitant
+morbi tristique senectus et netus. Ut enim ad minim veniam, quis nostrud exercitation. Petierunt
+uti sibi concilium totius Galliae in diem certam indicere. Curabitur est gravida et libero vitae
+dictum. Qui ipsorum lingua Celtae, nostra Galli appellantur. Quam temere in vitiis, legem
+sancimus haerentia. Phasellus laoreet lorem vel dolor tempus vehicula. Ab illo tempore, ab est
+sed immemorabili. Praeterea iter est quasdam res quas ex communi. Quo usque tandem abutere,
+Catilina, patientia nostra? Non equidem invideo, miror magis posuere velit aliquet. Excepteur
+sint obcaecat cupiditat non proident culpa. Curabitur blandit tempus ardua ridiculus sed magna.
+Plura mihi bona sunt, inclinet, amari petere vellent. Quae vero auctorem tractata ab fiducia
+dicuntur. Me non paenitet nullum festiviorem excogitasse ad hoc. Unam incolunt Belgae, aliam
+Aquitani, tertiam.
+      </div>
+    </DialogContent>
+    <DialogFooter
+      className="lumx-spacing-padding"
+    >
+      Dialog Footer
+    </DialogFooter>
+  </Dialog>
+</Fragment>
+`;
+
 exports[`<Dialog> Snapshots and structure should render story DialogWithFocusableElements 1`] = `
 <Fragment>
   <Button

--- a/packages/lumx-react/src/components/dialog/intersection-context.ts
+++ b/packages/lumx-react/src/components/dialog/intersection-context.ts
@@ -1,0 +1,17 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import noop from 'lodash/noop';
+import { Intersections } from '../../hooks/useIntersectionObserver';
+
+export const IntersectionContext = React.createContext<{
+    intersections: Intersections<Element>;
+    sentinelTop: Element | null;
+    sentinelBottom: Element | null;
+    setSentinelTop: Dispatch<SetStateAction<Element | null>>;
+    setSentinelBottom: Dispatch<SetStateAction<Element | null>>;
+}>({
+    intersections: new Map(),
+    sentinelTop: null,
+    sentinelBottom: null,
+    setSentinelTop: noop,
+    setSentinelBottom: noop,
+});


### PR DESCRIPTION
# General summary

Create separate Dialog components to add flexibility in dialog building.

Three new components have been added: 
* HeaderDialog
* HeaderContent
* HeaderFooter

The three components communicate with each other using a react context in order to keep the "intersection" behavior for the header and footer dividers.

This should not introduce breaking changes and previous implementations should still be completely functionnal.
 
<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
