### PR TITLE
feat(icon-button): add showTooltip prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added `hideTooltip` prop to `IconButton` component to control whether the tooltip should be hidden or not.
+    Default at `false`.
+
+### Changed
+
+- Changed `IconButton` jsdoc.
+
 ## [1.0.14][] - 2021-04-23
 
 ### Fixed

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -12,11 +12,16 @@ export interface IconButtonProps extends BaseButtonProps {
     icon: string;
     /**
      * Label text (required for a11y purpose).
-     * If you really don't want a tooltip and aria-label, you can give an empty label (this is not recommended).
+     * If you really don't want an aria-label, you can set an empty label (this is not recommended).
      */
     label: string;
-    /** Props to pass to the tooltip (minus those already set by the IconButton props). */
-    tooltipProps?: Omit<TooltipProps, 'label'>;
+    /**
+     * Props to pass to the tooltip.
+     * If undefined or if tooltipProps.label is undefined, the label prop will be used as tooltip label.
+     * */
+    tooltipProps?: Partial<TooltipProps>;
+    /** Whether the tooltip should be hidden or not. */
+    hideTooltip?: boolean;
 }
 
 /**
@@ -46,10 +51,10 @@ const DEFAULT_PROPS: Partial<IconButtonProps> = {
  * @return React element.
  */
 export const IconButton: Comp<IconButtonProps, HTMLButtonElement> = forwardRef((props, ref) => {
-    const { emphasis, icon, label, size, theme, tooltipProps, ...forwardedProps } = props;
+    const { emphasis, icon, label, size, theme, tooltipProps, hideTooltip, ...forwardedProps } = props;
 
     return (
-        <Tooltip label={label} {...tooltipProps}>
+        <Tooltip label={hideTooltip ? '' : label} {...tooltipProps}>
             <ButtonRoot ref={ref} {...{ emphasis, size, theme, ...forwardedProps }} aria-label={label} variant="icon">
                 <Icon icon={icon} />
             </ButtonRoot>


### PR DESCRIPTION
LUM-13715

# General summary

-   Added `showTooltip` prop to `IconButton` component to control whether the tooltip should be displayed or not. 
Default at `true`.

- Changed `IconButton` jsdoc.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
