### PR TITLE
fix(select): fix focus state not updating properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fix Select/Dropdown inside Dialog not closing when clicking outside.
+-   Fix Select focus state not updating correctly.
 
 ## [1.0.17][] - 2021-05-27
 

--- a/packages/lumx-react/src/hooks/useListenFocus.tsx
+++ b/packages/lumx-react/src/hooks/useListenFocus.tsx
@@ -1,0 +1,26 @@
+import { RefObject, useEffect, useState } from 'react';
+
+/**
+ * Listen on element focus to store the focus status.
+ */
+export function useListenFocus(ref: RefObject<HTMLElement>) {
+    const [isFocus, setFocus] = useState(false);
+
+    useEffect(() => {
+        const { current: element } = ref;
+        if (!element) {
+            return undefined;
+        }
+
+        const onFocus = () => setFocus(true);
+        const onBlur = () => setFocus(false);
+        element.addEventListener('focus', onFocus);
+        element.addEventListener('blur', onBlur);
+        return () => {
+            element.removeEventListener('focus', onFocus);
+            element.removeEventListener('blur', onBlur);
+        };
+    }, [ref, setFocus]);
+
+    return isFocus;
+}


### PR DESCRIPTION
# General summary

The focus state of the select was not activating using keyboard navigation and would not deactivate when clinking outside the select. 
I'm refactoring the hook used to listen to this state using a correct element reference.

**Tests:**
Example page: https://5fbfb1d508c0520021560f10-tyxrbjhdfg.chromatic.com/?path=/story/lumx-components-dialog-dialog--dialog-with-focusable-elements
1. Check the select get the focus correctly using Tab key nav or directly clicking on it
2. Check the select looses the focus when clicking outside or navigating to another focusable element
