### PR TITLE
fix(input-field): fix isRequired props ui and support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   TextField: Add space after asterisk if component has `isRequired` props
+
 ## [1.0.18][] - 2021-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   AutoComplete: Added `isRequired` prop to the component to indicated if field is required
+-   AutoCompleteMultiple: Added `isRequired` prop to the component to indicated if field is required
+
+### Fixed
+
 -   TextField: Add space after asterisk if component has `isRequired` props
 
 ## [1.0.18][] - 2021-06-28

--- a/packages/lumx-core/src/scss/components/input-label/_index.scss
+++ b/packages/lumx-core/src/scss/components/input-label/_index.scss
@@ -4,6 +4,7 @@
 
 .#{$lumx-base-prefix}-input-label {
     &--is-required:before {
+        margin-right: $lumx-spacing-unit-tiny;
         content: '*';
         font-weight: 700;
     }

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.test.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.test.tsx
@@ -49,7 +49,9 @@ describe(`<${Autocomplete.displayName}>`, () => {
                         ))}
                     </List>
                 ),
+                label: 'Field label',
                 isOpen: true,
+                isRequired: true,
                 onChange: jest.fn(),
                 value: '',
             });

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -75,6 +75,11 @@ export interface AutocompleteProps extends GenericProps {
      */
     isDisabled?: boolean;
     /**
+     * Whether the component is required or not.
+     * @see {@link TextFieldProps#isRequired}
+     */
+    isRequired?: boolean;
+    /**
      * Whether the text field is displayed with valid style or not.
      * @see {@link TextFieldProps#isValid}
      */
@@ -200,6 +205,7 @@ export const Autocomplete: Comp<AutocompleteProps, HTMLDivElement> = forwardRef(
         inputRef,
         clearButtonProps,
         isDisabled = disabled,
+        isRequired,
         isOpen,
         isValid,
         label,
@@ -241,6 +247,7 @@ export const Autocomplete: Comp<AutocompleteProps, HTMLDivElement> = forwardRef(
                 inputRef={mergeRefs(inputAnchorRef, inputRef) as any}
                 clearButtonProps={clearButtonProps}
                 isDisabled={isDisabled}
+                isRequired={isRequired}
                 isValid={isValid}
                 label={label}
                 name={name}

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.test.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.test.tsx
@@ -55,7 +55,9 @@ describe(`<${AutocompleteMultiple.displayName}>`, () => {
                         text: 'Montevideo',
                     },
                 ],
+                label: 'Field label',
                 isOpen: true,
+                isRequired: true,
                 onChange: jest.fn(),
                 value: '',
             });

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
@@ -79,6 +79,7 @@ export const AutocompleteMultiple: Comp<AutocompleteMultipleProps, HTMLDivElemen
         inputRef,
         clearButtonProps,
         isDisabled,
+        isRequired,
         isOpen,
         isValid,
         label,
@@ -130,6 +131,7 @@ export const AutocompleteMultiple: Comp<AutocompleteMultipleProps, HTMLDivElemen
                 </ChipGroup>
             }
             isDisabled={isDisabled}
+            isRequired={isRequired}
             clearButtonProps={clearButtonProps}
             isValid={isValid}
             label={label}

--- a/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/lumx-react/src/components/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -109,6 +109,8 @@ exports[`<Autocomplete> Snapshots and structure should render correctly 1`] = `
 >
   <TextField
     inputRef={[Function]}
+    isRequired={true}
+    label="Field label"
     onChange={[MockFunction]}
     textFieldRef={
       Object {

--- a/packages/lumx-react/src/components/autocomplete/__snapshots__/AutocompleteMultiple.test.tsx.snap
+++ b/packages/lumx-react/src/components/autocomplete/__snapshots__/AutocompleteMultiple.test.tsx.snap
@@ -13,6 +13,8 @@ exports[`<AutocompleteMultiple> Snapshots and structure should render correctly 
   closeOnClickAway={true}
   closeOnEscape={true}
   isOpen={true}
+  isRequired={true}
+  label="Field label"
   onChange={[MockFunction]}
   shouldFocusOnClose={false}
   value=""


### PR DESCRIPTION
# General summary

The asterisk of a required label was too close to the label. So we add a tiny space.
And the props was not supported by the `Autocomplete` and `AutocompleteMultiple` components so we add the support of the props.


<!-- Please describe the PR content -->

# Screenshots

<img width="365" alt="Capture d’écran 2021-07-09 à 18 40 16" src="https://user-images.githubusercontent.com/6178321/125110628-1dfa2f00-e0e5-11eb-93e7-bc8441c794d6.png">

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
