### PR TITLE
feat(switch): add role switch for screen readers behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Switch: add role `switch` for screen readers correct behavior.
+
 ## [1.0.21][] - 2021-08-05
 
 ### Fixed

--- a/packages/lumx-react/src/components/switch/Switch.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.tsx
@@ -100,6 +100,7 @@ export const Switch: Comp<SwitchProps, HTMLDivElement> = forwardRef((props, ref)
             <div className={`${CLASSNAME}__input-wrapper`}>
                 <input
                     type="checkbox"
+                    role="switch"
                     id={switchId}
                     className={`${CLASSNAME}__input-native`}
                     name={name}

--- a/packages/lumx-react/src/components/switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/lumx-react/src/components/switch/__snapshots__/Switch.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`<Switch> Conditions should not display the \`helper\` if no \`label\` i
       className="lumx-switch__input-native"
       id="switch-uid"
       onChange={[Function]}
+      role="switch"
       type="checkbox"
     />
     <div
@@ -38,6 +39,7 @@ exports[`<Switch> Snapshots and structure should render correctly with a \`label
       className="lumx-switch__input-native"
       id="switch-uid"
       onChange={[Function]}
+      role="switch"
       type="checkbox"
     />
     <div
@@ -83,6 +85,7 @@ exports[`<Switch> Snapshots and structure should render correctly with only a \`
       className="lumx-switch__input-native"
       id="switch-uid"
       onChange={[Function]}
+      role="switch"
       type="checkbox"
     />
     <div
@@ -121,6 +124,7 @@ exports[`<Switch> Snapshots and structure should render correctly without any la
       className="lumx-switch__input-native"
       id="switch-uid"
       onChange={[Function]}
+      role="switch"
       type="checkbox"
     />
     <div


### PR DESCRIPTION
# General summary
This PR adds a role to the switch input element (checkbox) to enable screen readers to know that's a switch.
This will make is so the screen reader will tell `switch` instead of `checkbox`
<!-- Please describe the PR content -->

Idea comes from this video: https://youtu.be/_KqccADghcA?t=176
Or this article: https://web.dev/building-a-switch-component/

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
