### PR TITLE
fix(icon-button): fix tooltip with `hasBackground`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Switch: add role `switch` for screen readers correct behavior.
 
+### Fixed
+
+-   IconButton: Fix missing tooltip when activating `hasBackground`
+
 ## [1.0.21][] - 2021-08-05
 
 ### Fixed

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -1,6 +1,6 @@
-import { mdiSend } from '@lumx/icons';
+import { mdiSend, mdiClose } from '@lumx/icons';
 
-import { Button, ColorPalette, Emphasis, Size } from '@lumx/react';
+import { Button, ColorPalette, Emphasis, IconButton, Size } from '@lumx/react';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
@@ -35,4 +35,10 @@ export const DisabledWithHref = () => (
     <Button href="https://google.com" isDisabled>
         Disabled button with redirection
     </Button>
+);
+
+export const IconButtonLowEmphasis = () => <IconButton emphasis={Emphasis.low} icon={mdiClose} label="Close" />;
+
+export const IconButtonLowEmphasisHasBackground = () => (
+    <IconButton emphasis={Emphasis.low} hasBackground icon={mdiClose} label="Close" />
 );

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -122,7 +122,7 @@ export const ButtonRoot: Comp<ButtonRootProps, HTMLButtonElement | HTMLAnchorEle
         ColorPalette.dark;
 
     if (hasBackground) {
-        return renderButtonWrapper({ ...props, variant, color: adaptedColor });
+        return renderButtonWrapper({ ...props, ref, variant, color: adaptedColor });
     }
 
     const buttonClassName = classNames(


### PR DESCRIPTION
CMS-1459

# General summary

Tooltip would not appear on a IconButton when activating the `hasBackground` prop.

