### PR TITLE
feat(dialog): add onVisibilityChange prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Switch: add attribute `aria-checked` for screen readers correct behavior.
+-   Dialog: add `onVisibilityChange` prop to trigger an action when the dialog is actually visible / invisible.
 
 ## [1.0.22][] - 2021-08-25
 

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -198,6 +198,28 @@ export const ScrollableDialog = ({ theme }: any) => {
     );
 };
 
+export const WithAnimationCallbacks = ({ theme }: any) => {
+    const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
+    const handleVisibiltyCallback = (isVisible: boolean) => {
+        alert(isVisible ? 'OPEN' : 'CLOSE');
+    };
+
+    return (
+        <>
+            {button}
+            <Dialog
+                isOpen={isOpen}
+                onClose={closeDialog}
+                size={Size.regular}
+                parentElement={buttonRef}
+                onVisibilityChange={handleVisibiltyCallback}
+            >
+                {content}
+            </Dialog>
+        </>
+    );
+};
+
 export const ScrollableDialogWithHeaderAndFooter = ({ theme }: any) => {
     const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
     return (

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -54,6 +54,8 @@ export interface DialogProps extends GenericProps {
     dialogProps?: GenericProps;
     /** On close callback. */
     onClose?(): void;
+    /** Callback called when the open animation starts and the close animation finishes. */
+    onVisibilityChange?(isVisible: boolean): void;
 }
 
 export type DialogSizes = Extract<Size, 'tiny' | 'regular' | 'big' | 'huge'>;
@@ -108,6 +110,7 @@ export const Dialog: Comp<DialogProps, HTMLDivElement> = forwardRef((props, ref)
         size,
         zIndex,
         dialogProps,
+        onVisibilityChange,
         ...forwardedProps
     } = props;
 
@@ -158,7 +161,7 @@ export const Dialog: Comp<DialogProps, HTMLDivElement> = forwardRef((props, ref)
     const footerChildContent = footerChildProps?.children;
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const isVisible = useDelayedVisibility(Boolean(isOpen), DIALOG_TRANSITION_DURATION);
+    const isVisible = useDelayedVisibility(Boolean(isOpen), DIALOG_TRANSITION_DURATION, onVisibilityChange);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const clickAwayRefs = useRef([wrapperRef]);

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -752,3 +752,46 @@ Aquitani, tertiam.
   </Dialog>
 </Fragment>
 `;
+
+exports[`<Dialog> Snapshots and structure should render story WithAnimationCallbacks 1`] = `
+<Fragment>
+  <Button
+    emphasis="high"
+    onClick={[Function]}
+    size="m"
+    theme="light"
+  >
+    Open dialog
+  </Button>
+  <Dialog
+    isOpen={true}
+    onClose={[Function]}
+    onVisibilityChange={[Function]}
+    parentElement={
+      Object {
+        "current": undefined,
+      }
+    }
+    size="regular"
+  >
+    <div
+      className="lumx-spacing-padding"
+    >
+      
+Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros
+Afros. Magna pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum
+dapibus. Praeterea iter est quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea
+commodi consequat. Inmensae subtilitatis, obscuris et malesuada fames. Me non paenitet nullum
+festiviorem excogitasse ad hoc. Cum ceteris in veneratione tui montes, nascetur mus. Etiam
+habebis sem dicantur magna mollis euismod. Quis aute iure reprehenderit in voluptate velit esse.
+Phasellus laoreet lorem vel dolor tempus vehicula. Ambitioni dedisse scripsisse iudicaretur.
+Paullum deliquit, ponderibus modulisque suis ratio utitur. Ab illo tempore, ab est sed
+immemorabili. Nec dubitamus multa iter quae et nos invenerat. Tu quoque, Brute, fili mi, nihil
+timor populi, nihil! Morbi fringilla convallis sapien, id pulvinar odio volutpat. Cras mattis
+iudicium purus sit amet fermentum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus.
+Quisque ut dolor gravida, placerat libero vel, euismod. Unam incolunt Belgae, aliam Aquitani,
+tertiam. Cras mattis iudicium purus sit amet fermentum
+    </div>
+  </Dialog>
+</Fragment>
+`;

--- a/packages/lumx-react/src/hooks/useDelayedVisibility.tsx
+++ b/packages/lumx-react/src/hooks/useDelayedVisibility.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 /**
  * Returns true if the component is visible taking into account the component's
@@ -6,9 +6,14 @@ import { useEffect, useState } from 'react';
  *
  * @param isComponentVisible Whether the component intends to be visible or not.
  * @param transitionDuration time in ms that the transition takes for the specific component.
+ * @param onVisibilityChange Callback called when the visibility changes.
  * @return true if the component should be rendered
  */
-export function useDelayedVisibility(isComponentVisible: boolean, transitionDuration: number): boolean {
+export function useDelayedVisibility(
+    isComponentVisible: boolean,
+    transitionDuration: number,
+    onVisibilityChange?: (isVisible: boolean) => void,
+): boolean {
     // Delay visibility to account for the 400ms of CSS opacity animation.
     const [isVisible, setVisible] = useState(isComponentVisible);
 
@@ -19,6 +24,21 @@ export function useDelayedVisibility(isComponentVisible: boolean, transitionDura
             setTimeout(() => setVisible(false), transitionDuration);
         }
     }, [isComponentVisible, transitionDuration]);
+
+    /**
+     * Since we don't want onVisibiltyChange function to trigger itself if when it changes,
+     * we store the previous visibility and only trigger when visibility is different
+     * than previous value.
+     */
+
+    const previousVisibility = useRef(isVisible);
+
+    useEffect(() => {
+        if (onVisibilityChange && previousVisibility.current !== isVisible) {
+            onVisibilityChange(isVisible);
+            previousVisibility.current = isVisible;
+        }
+    }, [isVisible, onVisibilityChange]);
 
     return isComponentVisible || isVisible;
 }


### PR DESCRIPTION
# General summary

Added a prop to allow triggering a callback when dialog's actual visibility changes.
The callback will be called with `true` when dialog opening animation **starts**.
It will however be called with `false` when dialog closing animation **finishes**.

<!-- Please describe the PR content -->

# Screenshots
![dialog-on-change-visibility](https://user-images.githubusercontent.com/7147342/131135501-43a1717d-7c87-4bc3-997b-cfc10bb3cc7e.gif)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [x] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
