### PR TITLE
feat(message): add icon prop to cutomize the icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Message: add `icon` prop to customize the message icon.
+
 ## [1.0.23][] - 2021-08-27
 
 ### Added

--- a/packages/lumx-react/src/components/message/Message.stories.tsx
+++ b/packages/lumx-react/src/components/message/Message.stories.tsx
@@ -2,6 +2,7 @@ import { Kind, Message } from '@lumx/react';
 import { boolean, text } from '@storybook/addon-knobs';
 import React from 'react';
 import { enumKnob } from '@lumx/react/stories/knobs/enumKnob';
+import { mdiDelete } from '@lumx/icons/';
 
 export default { title: 'LumX components/message/Message' };
 
@@ -15,5 +16,12 @@ export const Default = () => (
             `Message text quisque tincidunt lobortis dui non auctor.Donec porta,
                 ligula volutpat vehicula aliquet, dui sapien tempus felis, sed.`,
         )}
+    </Message>
+);
+
+export const CustomIcon = () => (
+    <Message icon={mdiDelete} kind="info" hasBackground>
+        Lorem ipsum quisque tincidunt lobortis dui non auctor.Donec porta, ligula volutpat vehicula aliquet, dui sapien
+        tempus felis, sed.
     </Message>
 );

--- a/packages/lumx-react/src/components/message/Message.tsx
+++ b/packages/lumx-react/src/components/message/Message.tsx
@@ -14,6 +14,8 @@ export interface MessageProps extends GenericProps {
     hasBackground?: boolean;
     /** Message variant. */
     kind?: Kind;
+    /** Message custom icon SVG path. */
+    icon?: string;
 }
 
 /**
@@ -44,7 +46,7 @@ const CONFIG = {
  * @return React element.
  */
 export const Message: Comp<MessageProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const { children, className, hasBackground, kind, ...forwardedProps } = props;
+    const { children, className, hasBackground, kind, icon: customIcon, ...forwardedProps } = props;
     const { color, icon } = CONFIG[kind as Kind] || {};
 
     return (
@@ -60,7 +62,7 @@ export const Message: Comp<MessageProps, HTMLDivElement> = forwardRef((props, re
             )}
             {...forwardedProps}
         >
-            {icon && <Icon className="lumx-message__icon" icon={icon} size={Size.xs} />}
+            {(customIcon || icon) && <Icon className="lumx-message__icon" icon={customIcon || icon} size={Size.xs} />}
             <div className="lumx-message__text">{children}</div>
         </div>
     );


### PR DESCRIPTION
# General summary

Add `icon` prop to the `Message` component to make the icon customizable.

# Screenshots

![2021-09-01-151358_784x101_scrot](https://user-images.githubusercontent.com/939567/131677762-4455070a-ad91-4db9-a9d2-330ad6d714e4.png)

