### PR TITLE
fix(use-infinite-scroll): add error margin to trigger the scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Dialog/Lightbox: Fix unexpected scroll to top when closing a dialog or lightbox.
+-   useInfiniteScroll: Add an error margin of 5px for triggering the infinite scroll so edge cases browser sizes also work.
 
 ## [2.0.0][] - 2021-09-01
 

--- a/packages/lumx-react/src/hooks/useInfiniteScroll.tsx
+++ b/packages/lumx-react/src/hooks/useInfiniteScroll.tsx
@@ -7,6 +7,9 @@ type useInfiniteScrollType = (
 ) => void;
 type EventCallback = (evt?: Event) => void;
 
+// The error margin in px we want to have for triggering infinite scroll
+const SCROLL_TRIGGER_MARGIN = 5;
+
 /**
  * Listen to clicks away from a given element and callback the passed in function.
  *
@@ -14,14 +17,22 @@ type EventCallback = (evt?: Event) => void;
  * @param  [callback]        A callback function to call when the bottom of the reference element is reached.
  * @param  [callbackOnMount] A callback function to call when the component is mounted.
  */
-export const useInfiniteScroll: useInfiniteScrollType = (ref, callback, callbackOnMount = false) => {
+export const useInfiniteScroll: useInfiniteScrollType = (
+    ref,
+    callback,
+    callbackOnMount = false,
+    scrollTriggerMargin = SCROLL_TRIGGER_MARGIN,
+) => {
     useEffect(() => {
         const { current } = ref;
         if (!callback || !current) {
             return undefined;
         }
 
-        const isAtBottom = () => Boolean(current && current.scrollTop + current.clientHeight >= current.scrollHeight);
+        const isAtBottom = () =>
+            Boolean(
+                current && current.scrollHeight - (current.scrollTop + current.clientHeight) <= scrollTriggerMargin,
+            );
 
         const onScroll = (e?: Event): void => {
             if (isAtBottom()) {
@@ -39,7 +50,7 @@ export const useInfiniteScroll: useInfiniteScrollType = (ref, callback, callback
             current.removeEventListener('scroll', onScroll);
             current.removeEventListener('resize', onScroll);
         };
-    }, [ref, callback]);
+    }, [ref, callback, scrollTriggerMargin]);
 
     useEffect(() => {
         if (callback && callbackOnMount) {


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Add a margin of error to trigger the infinite scroll, so that it work on every browser resolution/zoom

# Screenshots

Trigger the scroll when the difference is <= 5px
![Capture d’écran du 2021-09-15 17-09-54](https://user-images.githubusercontent.com/63426102/133460001-2de6cfb9-6e58-46d5-86d7-95f8bf97d8a5.png)


<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [X] (if has react) Check through the [react dev check list]
-   [X] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
