### PR TITLE
fix(dialog): set disable scroll on content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Dropdown: fix elevation style
+-   Dialog: Fix scroll inside on iOS
 
 ## [2.0.1][] - 2021-09-15
 

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -18,6 +18,7 @@ import {
     partitionMulti,
 } from '@lumx/react/utils';
 import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
+import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
 import { useDisableBodyScroll } from '@lumx/react/hooks/useDisableBodyScroll';
@@ -129,13 +130,18 @@ export const Dialog: Comp<DialogProps, HTMLDivElement> = forwardRef((props, ref)
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const wrapperRef = useRef<HTMLDivElement>(null);
-
+    /**
+     * Since the `contentRef` comes from the parent and is optional,
+     * we need to create a stable contentRef that will always be available.
+     */
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const localContentRef = useRef<HTMLDivElement>(null);
     // Handle focus trap.
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useFocusTrap(wrapperRef.current, focusElement?.current);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useDisableBodyScroll(isOpen && wrapperRef.current);
+    useDisableBodyScroll(isOpen && localContentRef.current);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [sentinelTop, setSentinelTop] = useState<Element | null>(null);
@@ -203,7 +209,7 @@ export const Dialog: Comp<DialogProps, HTMLDivElement> = forwardRef((props, ref)
                                   </header>
                               )}
 
-                              <div ref={contentRef} className={`${CLASSNAME}__content`}>
+                              <div ref={mergeRefs(contentRef, localContentRef)} className={`${CLASSNAME}__content`}>
                                   <div
                                       className={`${CLASSNAME}__sentinel ${CLASSNAME}__sentinel--top`}
                                       ref={setSentinelTop}


### PR DESCRIPTION
SUP-452

# General summary

Use the content div as reference of `useDisableBodyScroll` instead of the wrapper.
This will fix the scrolling issues noticed on IOS devices that made it impossible to scroll inside dialogs using one finger.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
