### PR TITLE
feat(aspect-ratio): add wide aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   New `wide` 16/9 aspect ratio for `Thumbnail`, `Uploader` and `SkeletonRectangle`.
+
 ## [2.0.2][] - 2021-09-22
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/thumbnail/_variables.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_variables.scss
@@ -1,5 +1,10 @@
 $lumx-thumbnail-aspect-ratio: (
+    // Ratio 3:2
     'horizontal': 66.66%,
+    // Ratio 16:9
+    'wide': 56.25%,
+    // Ratio 1:1
     'square': 100%,
+    // Ratio 2:3
     'vertical': 150%,
 );

--- a/packages/lumx-react/src/components/index.ts
+++ b/packages/lumx-react/src/components/index.ts
@@ -106,10 +106,17 @@ export type Typography = ValueOf<typeof Typography>;
  * All available aspect ratios.
  */
 export const AspectRatio = {
+    /** Intrinsic content ratio. */
     original: 'original',
+    /** Ratio 16:9 */
+    wide: 'wide',
+    /** Ratio 3:2 */
     horizontal: 'horizontal',
+    /** Ratio 3:2 */
     vertical: 'vertical',
+    /** Ratio 1:1 */
     square: 'square',
+    /** Ratio constrained by the parent. */
     free: 'free',
 } as const;
 export type AspectRatio = ValueOf<typeof AspectRatio>;

--- a/packages/lumx-react/src/components/skeleton/SkeletonRectangle.stories.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonRectangle.stories.tsx
@@ -21,7 +21,7 @@ const variants = [
     SkeletonRectangleVariant.pill,
 ] as const;
 const sizes = [Size.xxs, Size.xs, Size.s, Size.m, Size.l, Size.xl, Size.xxl] as const;
-const aspectRatios = [AspectRatio.vertical, AspectRatio.square, AspectRatio.horizontal] as const;
+const aspectRatios = [AspectRatio.vertical, AspectRatio.square, AspectRatio.horizontal, AspectRatio.wide] as const;
 
 export const Rectangle = ({ theme }: any) => (
     <>

--- a/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
@@ -15,7 +15,7 @@ export type SkeletonRectangleVariant = ValueOf<typeof SkeletonRectangleVariant>;
  */
 export interface SkeletonRectangleProps extends GenericProps {
     /** Aspect ratio (use with width and not height). */
-    aspectRatio?: Extract<AspectRatio, 'square' | 'horizontal' | 'vertical'>;
+    aspectRatio?: Extract<AspectRatio, 'square' | 'horizontal' | 'vertical' | 'wide'>;
     /** Height size. */
     height?: GlobalSize;
     /** Theme adapting the component to light or dark background. */

--- a/packages/lumx-react/src/components/skeleton/__snapshots__/SkeletonRectangle.test.tsx.snap
+++ b/packages/lumx-react/src/components/skeleton/__snapshots__/SkeletonRectangle.test.tsx.snap
@@ -103,5 +103,12 @@ Array [
       className="lumx-skeleton-rectangle__inner"
     />
   </div>,
+  <div
+    className="lumx-spacing-margin lumx-skeleton-rectangle lumx-skeleton-rectangle--aspect-ratio-wide lumx-skeleton-rectangle--theme-light lumx-skeleton-rectangle--variant-squared lumx-skeleton-rectangle--width-xl"
+  >
+    <div
+      className="lumx-skeleton-rectangle__inner"
+    />
+  </div>,
 ]
 `;


### PR DESCRIPTION
# General summary

Add `wide` 16/9 aspect ratio for `Thumbnail`, `Uploader` and `SkeletonRectangle`.

# Screenshots

