### PR TITLE
feat(icon-button): add image prop to use image url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   New `image` prop for `IconButton`, allowing to use an image url instead of an svg path. Will render a `<img>` tag an can only be set if `icon` prop is undefined (and vice-versa);
+
 ## [2.1.0][] - 2021-10-26
 
 ### Changed

--- a/packages/lumx-core/src/scss/components/button/_index.scss
+++ b/packages/lumx-core/src/scss/components/button/_index.scss
@@ -59,7 +59,9 @@
             }
 
             &.#{$lumx-base-prefix}-button--variant-icon {
-                & > i {
+                & > i,
+                & > img
+                 {
                     @include lumx-button-icon('icon', $key);
                 }
             }

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import { mdiSend, mdiClose } from '@lumx/icons';
 
 import { Button, ColorPalette, Emphasis, IconButton, Size } from '@lumx/react';
+import { squareImageKnob } from '@lumx/react/stories/knobs';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 
@@ -41,4 +42,18 @@ export const IconButtonLowEmphasis = () => <IconButton emphasis={Emphasis.low} i
 
 export const IconButtonLowEmphasisHasBackground = () => (
     <IconButton emphasis={Emphasis.low} hasBackground icon={mdiClose} label="Close" />
+);
+
+export const IconButtonWithImage = ({ theme }: any) => (
+    <div>
+        <IconButton
+            theme={theme}
+            label="Image label"
+            image={squareImageKnob()}
+            size={select('Size', [Size.m, Size.s], DEFAULT_PROPS.size)}
+            hasBackground={boolean('Has background', false)}
+            emphasis={select('Emphasis', Emphasis, DEFAULT_PROPS.emphasis)}
+            color={select('color', ColorPalette, DEFAULT_PROPS.color)}
+        />
+    </div>
 );

--- a/packages/lumx-react/src/components/button/IconButton.test.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.test.tsx
@@ -24,6 +24,7 @@ const setup = (propsOverride: SetupProps = {}, shallowRendering = true) => {
     return {
         buttonRoot: wrapper.find('ButtonRoot'),
         icon: wrapper.find('Icon'),
+        img: wrapper.find('img'),
         props,
         wrapper,
     };
@@ -33,10 +34,19 @@ describe(`<${IconButton.displayName}>`, () => {
     // 1. Test render via snapshot (default states of component).
     describe('Snapshots and structure', () => {
         it('should render icon button', () => {
-            const { buttonRoot, icon, wrapper } = setup({});
+            const { buttonRoot, icon, img, wrapper } = setup({});
             expect(wrapper).toMatchSnapshot();
             expect(buttonRoot).toExist();
             expect(icon).toExist();
+            expect(img).not.toExist();
+        });
+
+        it('should render icon button with an image', () => {
+            const { buttonRoot, icon, img, wrapper } = setup({ image: 'http://foo.com' });
+            expect(wrapper).toMatchSnapshot();
+            expect(buttonRoot).toExist();
+            expect(icon).not.toExist();
+            expect(img).toExist();
         });
     });
 

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -4,12 +4,27 @@ import { Emphasis, Icon, Size, Theme, Tooltip, TooltipProps } from '@lumx/react'
 import { BaseButtonProps, ButtonRoot } from '@lumx/react/components/button/ButtonRoot';
 import { Comp, getRootClassName } from '@lumx/react/utils';
 
-/**
- * Defines the props of the component.
- */
-export interface IconButtonProps extends BaseButtonProps {
-    /** Icon (SVG path). */
-    icon: string;
+/** Either icon or image prop must be defined */
+type ImageOrIconType =
+    /** Svg path type icon */
+    | {
+          /**
+           * Icon SVG path (recommended over an image).
+           */
+          icon: string;
+          image?: undefined;
+      }
+    /** Image url type icon */
+    | {
+          /**
+           * Image URL (use icon SVG path when possible).
+           */
+          image: string;
+          icon?: undefined;
+      };
+
+/** Props common to icon and image type icon. */
+export interface IconButtonBaseProps {
     /**
      * Label text (required for a11y purpose).
      * If you really don't want an aria-label, you can set an empty label (this is not recommended).
@@ -23,6 +38,11 @@ export interface IconButtonProps extends BaseButtonProps {
     /** Whether the tooltip should be hidden or not. */
     hideTooltip?: boolean;
 }
+
+/**
+ * Defines the props of the component.
+ */
+export type IconButtonProps = IconButtonBaseProps & ImageOrIconType & BaseButtonProps;
 
 /**
  * Component display name.
@@ -51,12 +71,20 @@ const DEFAULT_PROPS: Partial<IconButtonProps> = {
  * @return React element.
  */
 export const IconButton: Comp<IconButtonProps, HTMLButtonElement> = forwardRef((props, ref) => {
-    const { emphasis, icon, label, size, theme, tooltipProps, hideTooltip, ...forwardedProps } = props;
+    const { emphasis, image, icon, label, size, theme, tooltipProps, hideTooltip, ...forwardedProps } = props;
 
     return (
         <Tooltip label={hideTooltip ? '' : label} {...tooltipProps}>
             <ButtonRoot ref={ref} {...{ emphasis, size, theme, ...forwardedProps }} aria-label={label} variant="icon">
-                <Icon icon={icon} />
+                {image ? (
+                    <img
+                        // no need to set alt as an aria-label is already set on the button
+                        alt=""
+                        src={image}
+                    />
+                ) : (
+                    <Icon icon={icon as string} />
+                )}
             </ButtonRoot>
         </Tooltip>
     );

--- a/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
@@ -48,3 +48,22 @@ exports[`<IconButton> Snapshots and structure should render icon button 1`] = `
   </ButtonRoot>
 </Tooltip>
 `;
+
+exports[`<IconButton> Snapshots and structure should render icon button with an image 1`] = `
+<Tooltip
+  delay={500}
+  placement="bottom"
+>
+  <ButtonRoot
+    emphasis="high"
+    size="m"
+    theme="light"
+    variant="icon"
+  >
+    <img
+      alt=""
+      src="http://foo.com"
+    />
+  </ButtonRoot>
+</Tooltip>
+`;

--- a/packages/site-demo/content/product/components/button/index.mdx
+++ b/packages/site-demo/content/product/components/button/index.mdx
@@ -36,7 +36,7 @@ Use small size when space is a constraint.
 
 ### Button properties
 
-<PropTable component="ButtonRoot" />
+
 <PropTable component="Button" />
 
 ### IconButton properties


### PR DESCRIPTION
# General summary

Added a `image` prop to the `IconButton` component to allow using urls for images.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
