### PR TITLE
feat(button): allow button to take available width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed `IconButton` typing by making both `icon` and `image` props conditional.
     This fixes an issue that would occur when extending the interface and forwarding parent props to a children `IconButton`.
 
+### Added
+
+-   `Button`: Added `fullWidth` prop to match the parent width when possible.
+
 ## [2.1.1][] - 2021-10-28
 
 ### Added

--- a/packages/lumx-core/src/scss/components/button/_index.scss
+++ b/packages/lumx-core/src/scss/components/button/_index.scss
@@ -60,8 +60,7 @@
 
             &.#{$lumx-base-prefix}-button--variant-icon {
                 & > i,
-                & > img
-                 {
+                & > img {
                     @include lumx-button-icon('icon', $key);
                 }
             }
@@ -114,6 +113,8 @@
    ========================================================================== */
 
 .#{$lumx-base-prefix}-button-wrapper {
+    width: fit-content;
+
     &--variant-button {
         border-radius: var(--lumx-border-radius);
     }
@@ -151,4 +152,13 @@
             border-radius: 0 var(--lumx-border-radius) var(--lumx-border-radius) 0 !important;
         }
     }
+}
+
+/* Button full width
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-button--is-full-width:not(.#{$lumx-base-prefix}-button--variant-icon),
+.#{$lumx-base-prefix}-button-wrapper--is-full-width:not(.#{$lumx-base-prefix}-button-wrapper--variant-icon) {
+    width: 100%;
+    flex-grow: 1;
 }

--- a/packages/lumx-core/src/scss/components/button/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/button/_mixins.scss
@@ -14,7 +14,8 @@
     user-select: none;
     vertical-align: top;
 
-    &:hover {
+    &:hover,
+    &[class*='--is-hovered'] {
         cursor: pointer;
     }
 
@@ -69,7 +70,8 @@
         }
     }
 
-    &:hover {
+    &:hover,
+    &[class*='--is-hovered'] {
         @if $variant == 'button' {
             @if $size == lumx-base-const('size', 'M') {
                 padding: 0 var(--lumx-button-#{$emphasis}-state-hover-padding-horizontal);
@@ -83,7 +85,8 @@
         }
     }
 
-    &:active {
+    &:active,
+    &[class*='--is-active'] {
         @if $variant == 'button' {
             @if $size == lumx-base-const('size', 'M') {
                 padding: 0 var(--lumx-button-#{$emphasis}-state-active-padding-horizontal);
@@ -124,7 +127,8 @@
         }
     }
 
-    &:hover {
+    &:hover,
+    &[class*='--is-hovered'] {
         @if $color == 'primary' and $emphasis == lumx-base-const('emphasis', 'HIGH') {
             background-color: var(--lumx-button-#{$emphasis}-state-hover-#{$theme}-background-color);
             color: var(--lumx-button-#{$emphasis}-state-hover-#{$theme}-color);
@@ -149,7 +153,8 @@
         }
     }
 
-    &:active {
+    &:active,
+    &[class*='--is-active'] {
         @if $color == 'primary' and $emphasis == lumx-base-const('emphasis', 'HIGH') {
             background-color: var(--lumx-button-#{$emphasis}-state-active-#{$theme}-background-color);
             color: var(--lumx-button-#{$emphasis}-state-active-#{$theme}-color);
@@ -174,7 +179,8 @@
         }
     }
 
-    &[data-focus-visible-added] {
+    &[data-focus-visible-added],
+    &[class*='--is-focused'] {
         @include lumx-state(lumx-base-const('state', 'FOCUS'), $emphasis, $color, $theme);
     }
 
@@ -187,15 +193,18 @@
 @mixin lumx-button-is-selected($theme) {
     @include lumx-state-as-selected(lumx-base-const('state', 'DEFAULT'), $theme);
 
-    &:hover {
+    &:hover,
+    &[class*='--is-hovered'] {
         @include lumx-state-as-selected(lumx-base-const('state', 'HOVER'), $theme);
     }
 
-    &:active {
+    &:active,
+    &[class*='--is-active'] {
         @include lumx-state-as-selected(lumx-base-const('state', 'ACTIVE'), $theme);
     }
 
-    &[data-focus-visible-added] {
+    &[data-focus-visible-added],
+    &[class*='--is-focused'] {
         @include lumx-state-as-selected(lumx-base-const('state', 'FOCUS'), $theme);
     }
 }

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -1,9 +1,8 @@
-import { mdiSend, mdiClose } from '@lumx/icons';
-
+import React, { Fragment } from 'react';
+import { mdiSend } from '@lumx/icons';
 import { Button, ColorPalette, Emphasis, IconButton, Size } from '@lumx/react';
 import { squareImageKnob } from '@lumx/react/stories/knobs';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 
 export default { title: 'LumX components/button/Button' };
 
@@ -38,12 +37,6 @@ export const DisabledWithHref = () => (
     </Button>
 );
 
-export const IconButtonLowEmphasis = () => <IconButton emphasis={Emphasis.low} icon={mdiClose} label="Close" />;
-
-export const IconButtonLowEmphasisHasBackground = () => (
-    <IconButton emphasis={Emphasis.low} hasBackground icon={mdiClose} label="Close" />
-);
-
 export const IconButtonWithImage = ({ theme }: any) => (
     <div>
         <IconButton
@@ -57,3 +50,78 @@ export const IconButtonWithImage = ({ theme }: any) => (
         />
     </div>
 );
+
+export const FullWidthButton = () => <Button fullWidth>Full width button</Button>;
+
+/**
+ * Template story to generate all variants for button and icon button.
+ */
+const AllVariantTemplate = (Component: any, props: any) => () => {
+    // Major variants.
+    const variants = {
+        'Default (emphasis high)': {},
+        'Full width': { fullWidth: true },
+        'Emphasis medium': { emphasis: 'medium' },
+        'Emphasis low': { emphasis: 'low' },
+        'Has background (emphasis low)': { emphasis: 'low', hasBackground: true },
+        'Has background + Full width': { emphasis: 'low', hasBackground: true, fullWidth: true },
+    } as const;
+
+    // Color modifiers.
+    const colorModifiers = {
+        Default: {},
+        'Color: light': { color: 'light' },
+        'Color: dark': { color: 'dark' },
+        'Color: red': { color: 'red' },
+        'Theme: dark': { theme: 'dark' },
+    } as const;
+
+    // State modifiers.
+    const stateModifiers = {
+        'Default state': {},
+        Selected: { isSelected: true },
+        Hovered: { isHovered: true },
+        Focused: { isFocused: true },
+        Active: { isActive: true },
+        Disabled: { isDisabled: true },
+    };
+
+    return (
+        <div style={{ background: 'lightgray' }}>
+            {Object.entries(stateModifiers).map(([stateKey, state]) => (
+                <Fragment key={stateKey}>
+                    <h2>{stateKey}</h2>
+                    <table style={{ width: '100%' }}>
+                        <tr>
+                            <td style={{ whiteSpace: 'nowrap', width: 200 }} />
+                            {Object.keys(colorModifiers).map((colorKey) => (
+                                <td key={colorKey}>{colorKey}</td>
+                            ))}
+                        </tr>
+
+                        {Object.entries(variants).map(([variantKey, variant]: any) => (
+                            <tr key={variantKey}>
+                                <td>{variantKey}</td>
+                                {Object.entries(colorModifiers).map(([colorKey, color]) => (
+                                    <td key={colorKey}>
+                                        <Component {...props} {...variant} {...color} {...state} />
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </table>
+                </Fragment>
+            ))}
+        </div>
+    );
+};
+
+/**
+ * Check button style variations (color, states, emphasis, etc.)
+ */
+export const ButtonVariations = AllVariantTemplate(Button, { children: 'Button' });
+
+/**
+ * Check icon button style variations (color, states, emphasis, etc.)
+ */
+export const IconButtonVariations = AllVariantTemplate(IconButton, { label: 'Send', icon: mdiSend });

--- a/packages/lumx-react/src/components/button/Button.tsx
+++ b/packages/lumx-react/src/components/button/Button.tsx
@@ -23,6 +23,8 @@ export interface ButtonProps extends BaseButtonProps {
     leftIcon?: string;
     /** Right icon (SVG path). */
     rightIcon?: string;
+    /** When `true`, the button gets as large as possible. */
+    fullWidth?: boolean;
 }
 
 /**

--- a/packages/lumx-react/src/components/button/ButtonRoot.test.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.test.tsx
@@ -168,6 +168,19 @@ describe(`<${ButtonRoot.displayName}>`, () => {
                 expect(buttonWrapper).toHaveClassName(getBasicClass({ prefix: BUTTON_WRAPPER_CLASSNAME, type, value }));
             }
         });
+
+        it('should be full width', () => {
+            const buttonProps: Partial<ButtonRootProps> = {
+                fullWidth: true,
+                emphasis: Emphasis.high,
+                theme: Theme.light,
+            };
+
+            const { wrapper, button } = setup(buttonProps);
+            expect(wrapper).toMatchSnapshot();
+
+            expect(button).toHaveClassName(getBasicClass({ prefix: BUTTON_CLASSNAME, type: 'fullWidth', value: true }));
+        });
     });
 
     // 3. Test events.

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -64,7 +64,7 @@ export const BUTTON_CLASSNAME = `${CSS_PREFIX}-button`;
  * @return React element.
  */
 const renderButtonWrapper: React.FC<ButtonRootProps> = (props) => {
-    const { color, emphasis, variant } = props;
+    const { color, emphasis, variant, fullWidth } = props;
 
     const adaptedColor =
         emphasis === Emphasis.low && (color === ColorPalette.light ? ColorPalette.dark : ColorPalette.light);
@@ -74,6 +74,7 @@ const renderButtonWrapper: React.FC<ButtonRootProps> = (props) => {
             color: adaptedColor,
             prefix: BUTTON_WRAPPER_CLASSNAME,
             variant,
+            fullWidth,
         }),
     );
     const buttonProps = { ...props, hasBackground: false };
@@ -105,6 +106,9 @@ export const ButtonRoot: Comp<ButtonRootProps, HTMLButtonElement | HTMLAnchorEle
         href,
         isDisabled = disabled,
         isSelected,
+        isActive,
+        isFocused,
+        isHovered,
         linkAs,
         name,
         size,
@@ -112,6 +116,7 @@ export const ButtonRoot: Comp<ButtonRootProps, HTMLButtonElement | HTMLAnchorEle
         theme,
         variant,
         type = 'button',
+        fullWidth,
         ...forwardedProps
     } = props;
 
@@ -132,10 +137,14 @@ export const ButtonRoot: Comp<ButtonRootProps, HTMLButtonElement | HTMLAnchorEle
             emphasis,
             isSelected,
             isDisabled,
+            isActive,
+            isFocused,
+            isHovered,
             prefix: BUTTON_CLASSNAME,
             size,
             theme: emphasis === Emphasis.high && theme,
             variant,
+            fullWidth,
         }),
     );
 

--- a/packages/lumx-react/src/components/button/__snapshots__/ButtonRoot.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/ButtonRoot.test.tsx.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<ButtonRoot> Props should be full width 1`] = `
+<ButtonRoot
+  emphasis="high"
+  fullWidth={true}
+  theme="light"
+>
+  <button
+    className="lumx-button lumx-button--color-primary lumx-button--emphasis-high lumx-button--theme-light lumx-button--is-full-width"
+    type="button"
+  />
+</ButtonRoot>
+`;
+
 exports[`<ButtonRoot> Props should not have default color in low or medium emphasis 1`] = `
 <ButtonRoot
   emphasis="low"

--- a/packages/lumx-react/src/stories/generated/Button/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/Button/Demos.stories.tsx
@@ -6,5 +6,6 @@ export default { title: 'LumX components/button/Demos' };
 export { App as EmphasisHigh } from './emphasis-high';
 export { App as EmphasisLow } from './emphasis-low';
 export { App as EmphasisMedium } from './emphasis-medium';
+export { App as FullWidth } from './full-width';
 export { App as Small } from './small';
 export { App as Toggle } from './toggle';

--- a/packages/lumx-react/src/stories/generated/Button/full-width.tsx
+++ b/packages/lumx-react/src/stories/generated/Button/full-width.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/button/react/full-width.tsx

--- a/packages/site-demo/content/product/components/button/index.mdx
+++ b/packages/site-demo/content/product/components/button/index.mdx
@@ -34,8 +34,13 @@ Use small size when space is a constraint.
 
 <DemoBlock vAlign="center" demo="small" withThemeSwitcher />
 
-### Button properties
+## Full width
 
+Use full width when you need to get the button full width.
+
+<DemoBlock vAlign="center" demo="full-width" withThemeSwitcher />
+
+### Button properties
 
 <PropTable component="Button" />
 

--- a/packages/site-demo/content/product/components/button/react/full-width.tsx
+++ b/packages/site-demo/content/product/components/button/react/full-width.tsx
@@ -1,0 +1,32 @@
+import { Button, Emphasis, FlexBox, Orientation, Size } from '@lumx/react';
+import React from 'react';
+
+export const App = ({ theme }: any) => (
+    <>
+        <div style={{ display: 'flex', width: '100%', flexDirection: 'column', gap: 16 }}>
+            <FlexBox fillSpace gap={Size.big} orientation={Orientation.horizontal}>
+                <Button fullWidth emphasis={Emphasis.high} theme={theme}>
+                    Single full width button
+                </Button>
+            </FlexBox>
+
+            <FlexBox fillSpace gap={Size.big} orientation={Orientation.horizontal}>
+                <Button fullWidth emphasis={Emphasis.medium} theme={theme}>
+                    Two full width buttons
+                </Button>
+                <Button fullWidth emphasis={Emphasis.medium} theme={theme}>
+                    Two full width buttons
+                </Button>
+            </FlexBox>
+
+            <FlexBox fillSpace gap={Size.big} orientation={Orientation.horizontal}>
+                <Button fullWidth emphasis={Emphasis.medium} theme={theme}>
+                    Single full width button
+                </Button>
+                <Button emphasis={Emphasis.medium} theme={theme}>
+                    Button
+                </Button>
+            </FlexBox>
+        </div>
+    </>
+);


### PR DESCRIPTION
# General summary

Add a `fullWidth` prop on `Button` to make it as big as available

# Screenshots

![image](https://user-images.githubusercontent.com/1261213/140321279-3983defd-04e9-490b-bce5-862773118824.png)

<details>
<summary>Bonus: added stories for all button/icon button variations</summary>

![html_id=lumx-components-button-button--button-variations](https://user-images.githubusercontent.com/939567/140771764-77fc454a-e70d-4719-b3db-c96ec4addc2f.png)

![html_id=lumx-components-button-button--icon-button-variations](https://user-images.githubusercontent.com/939567/140771981-ffc6f5c3-0fdb-4570-b316-f456fd39be0d.png)


</details>

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [X] (if has style) Add `need: review-integration` label
-   [X] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [X] (if has react) Check through the [react dev check list]
-   [X] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
