### PR TITLE
fix(icon-button): simplify typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed `IconButton` typing by making both `icon` and `image` props conditional.
+    This fixes an issue that would occur when extending the interface and forwarding parent props to a children `IconButton`.
+
 ## [2.1.1][] - 2021-10-28
 
 ### Added

--- a/packages/lumx-react/src/components/button/IconButton.test.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.test.tsx
@@ -4,6 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
+import { mdiClose } from '@lumx/icons';
 
 import { IconButton, IconButtonProps } from './IconButton';
 
@@ -43,6 +44,14 @@ describe(`<${IconButton.displayName}>`, () => {
 
         it('should render icon button with an image', () => {
             const { buttonRoot, icon, img, wrapper } = setup({ image: 'http://foo.com' });
+            expect(wrapper).toMatchSnapshot();
+            expect(buttonRoot).toExist();
+            expect(icon).not.toExist();
+            expect(img).toExist();
+        });
+
+        it('should render icon button with an image if both props are set', () => {
+            const { buttonRoot, icon, img, wrapper } = setup({ image: 'http://foo.com', icon: mdiClose });
             expect(wrapper).toMatchSnapshot();
             expect(buttonRoot).toExist();
             expect(icon).not.toExist();

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -4,27 +4,17 @@ import { Emphasis, Icon, Size, Theme, Tooltip, TooltipProps } from '@lumx/react'
 import { BaseButtonProps, ButtonRoot } from '@lumx/react/components/button/ButtonRoot';
 import { Comp, getRootClassName } from '@lumx/react/utils';
 
-/** Either icon or image prop must be defined */
-type ImageOrIconType =
-    /** Svg path type icon */
-    | {
-          /**
-           * Icon SVG path (recommended over an image).
-           */
-          icon: string;
-          image?: undefined;
-      }
-    /** Image url type icon */
-    | {
-          /**
-           * Image URL (use icon SVG path when possible).
-           */
-          image: string;
-          icon?: undefined;
-      };
-
-/** Props common to icon and image type icon. */
-export interface IconButtonBaseProps {
+export interface IconButtonProps extends BaseButtonProps {
+    /**
+     * Icon (SVG path).
+     * If `image` is also set, `image` will be used instead.
+     */
+    icon?: string;
+    /**
+     * Image (image url).
+     * Has priority over `icon`.
+     */
+    image?: string;
     /**
      * Label text (required for a11y purpose).
      * If you really don't want an aria-label, you can set an empty label (this is not recommended).
@@ -38,11 +28,6 @@ export interface IconButtonBaseProps {
     /** Whether the tooltip should be hidden or not. */
     hideTooltip?: boolean;
 }
-
-/**
- * Defines the props of the component.
- */
-export type IconButtonProps = IconButtonBaseProps & ImageOrIconType & BaseButtonProps;
 
 /**
  * Component display name.

--- a/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
@@ -67,3 +67,22 @@ exports[`<IconButton> Snapshots and structure should render icon button with an 
   </ButtonRoot>
 </Tooltip>
 `;
+
+exports[`<IconButton> Snapshots and structure should render icon button with an image if both props are set 1`] = `
+<Tooltip
+  delay={500}
+  placement="bottom"
+>
+  <ButtonRoot
+    emphasis="high"
+    size="m"
+    theme="light"
+    variant="icon"
+  >
+    <img
+      alt=""
+      src="http://foo.com"
+    />
+  </ButtonRoot>
+</Tooltip>
+`;


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->
 Fixed `IconButton` typing by making both `icon` and `image` props conditional.
 This fixes an issue that would occur when extending the interface and forwarding parent props to a children `IconButton`.

# Screenshots
![image](https://user-images.githubusercontent.com/7147342/140752289-d6c9932b-8b91-40d8-9b2a-021b6a7afbb9.png)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
