### PR TITLE
feat(text-field): add `afterElement` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `Button`: Added `fullWidth` prop to match the parent width when possible.
+-   `TextField`: Added `afterElement` prop to add a custom element at the end of the text field.
 
 ## [2.1.1][] - 2021-10-28
 

--- a/packages/lumx-core/src/scss/components/text-field/_index.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_index.scss
@@ -144,7 +144,8 @@
         }
     }
 
-    &__input-clear {
+    &__input-clear,
+    &__after-element {
         @include lumx-text-field-input-clear;
     }
 

--- a/packages/lumx-core/src/scss/components/text-field/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_mixins.scss
@@ -144,11 +144,15 @@
 
 @mixin lumx-text-field-input-clear() {
     flex-shrink: 0;
-    margin-top: calc(
-        var(--lumx-text-field-wrapper-padding-vertical) +
-            ((var(--lumx-material-text-field-input-content-line-height) - (var(--lumx-button-height) / 1.5)) / 2)
-    );
-    margin-left: $lumx-spacing-unit / 2;
+    margin:
+        // vertical
+        calc(
+            var(--lumx-text-field-wrapper-padding-vertical) +
+                ((var(--lumx-material-text-field-input-content-line-height) - (var(--lumx-button-height) / 1.5)) / 2)
+        )
+        // horizontal
+        $lumx-spacing-unit / 2;
+    margin-right: 0;
 }
 
 @mixin lumx-text-field-chips() {

--- a/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
@@ -1,6 +1,6 @@
 import { mdiDelete, mdiEye, mdiPencil, mdiStar } from '@lumx/icons';
 import { AvatarSize, Badge, ColorPalette, Emphasis, Icon, IconButton, Size } from '@lumx/react';
-import { AVATAR_IMAGES, avatarImageKnob, PORTRAIT_IMAGES } from '@lumx/react/stories/knobs';
+import { AVATAR_IMAGES, avatarImageKnob, PORTRAIT_IMAGES } from '@lumx/react/stories/knobs/image';
 import { select } from '@storybook/addon-knobs';
 import React from 'react';
 

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -1,7 +1,9 @@
 import React, { Fragment } from 'react';
 import { mdiSend } from '@lumx/icons';
-import { Button, ColorPalette, Emphasis, IconButton, Size } from '@lumx/react';
-import { squareImageKnob } from '@lumx/react/stories/knobs';
+import { Button, ColorPalette, IconButton } from '@lumx/react';
+import { squareImageKnob } from '@lumx/react/stories/knobs/image';
+import { buttonSize } from '@lumx/react/stories/knobs/buttonKnob';
+import { emphasis } from '@lumx/react/stories/knobs/emphasisKnob';
 import { boolean, select, text } from '@storybook/addon-knobs';
 
 export default { title: 'LumX components/button/Button' };
@@ -11,11 +13,11 @@ const DEFAULT_PROPS = Button.defaultProps as any;
 export const SimpleButton = ({ theme }: any) => {
     return (
         <Button
-            emphasis={select('Emphasis', Emphasis, DEFAULT_PROPS.emphasis)}
+            emphasis={emphasis('Emphasis', DEFAULT_PROPS.emphasis)}
             theme={theme}
             rightIcon={select('Right icon', { none: undefined, mdiSend }, undefined)}
             leftIcon={select('Left icon', { none: undefined, mdiSend }, undefined)}
-            size={select('Size', [Size.m, Size.s], DEFAULT_PROPS.size)}
+            size={buttonSize()}
             isSelected={boolean('isSelected', Boolean(DEFAULT_PROPS.isSelected))}
             isDisabled={boolean('isDisabled', Boolean(DEFAULT_PROPS.isDisabled))}
             color={select('color', ColorPalette, DEFAULT_PROPS.color)}
@@ -43,9 +45,9 @@ export const IconButtonWithImage = ({ theme }: any) => (
             theme={theme}
             label="Image label"
             image={squareImageKnob()}
-            size={select('Size', [Size.m, Size.s], DEFAULT_PROPS.size)}
+            size={buttonSize()}
             hasBackground={boolean('Has background', false)}
-            emphasis={select('Emphasis', Emphasis, DEFAULT_PROPS.emphasis)}
+            emphasis={emphasis('Emphasis', DEFAULT_PROPS.emphasis)}
             color={select('color', ColorPalette, DEFAULT_PROPS.color)}
         />
     </div>

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mdiDotsHorizontal, mdiHeart, mdiReply } from '@lumx/icons';
 import { Button, CommentBlock, Emphasis, Size } from '@lumx/react';
 import { IconButton } from '@lumx/react/components/button/IconButton';
-import { avatarImageKnob } from '@lumx/react/stories/knobs';
+import { avatarImageKnob } from '@lumx/react/stories/knobs/image';
 
 export default { title: 'LumX components/comment-block/CommentBlock' };
 

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -17,7 +17,7 @@ import {
 import { select } from '@storybook/addon-knobs';
 import React, { RefObject, useRef, useState } from 'react';
 import { Dialog, DialogSizes } from './Dialog';
-import { loremIpsum } from '../../stories/knobs';
+import { loremIpsum } from '../../stories/knobs/lorem';
 
 export default {
     title: 'LumX components/dialog/Dialog',

--- a/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
@@ -1,4 +1,4 @@
-import { LANDSCAPE_IMAGES, landscapeImageKnob } from '@lumx/react/stories/knobs';
+import { LANDSCAPE_IMAGES, landscapeImageKnob } from '@lumx/react/stories/knobs/image';
 import React from 'react';
 
 import { Alignment, AspectRatio, Chip, ChipGroup, ImageBlock, Size } from '@lumx/react';

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.stories.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.stories.tsx
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import { landscapeImageKnob, portraitImageKnob } from '@lumx/react/stories/knobs';
+import { landscapeImageKnob, portraitImageKnob } from '@lumx/react/stories/knobs/image';
 import { text } from '@storybook/addon-knobs';
 import React from 'react';
 import { Size } from '..';

--- a/packages/lumx-react/src/components/skeleton/SkeletonRectangle.stories.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonRectangle.stories.tsx
@@ -12,7 +12,7 @@ import {
     Thumbnail,
     ColorPalette,
 } from '@lumx/react';
-import { imageKnob } from '@lumx/react/stories/knobs';
+import { imageKnob } from '@lumx/react/stories/knobs/image';
 
 export default { title: 'LumX components/skeleton/Skeleton' };
 

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -1,90 +1,87 @@
-import { TextField } from '@lumx/react';
-import { text } from '@storybook/addon-knobs';
-import noop from 'lodash/noop';
 import React from 'react';
+import { mdiTranslate } from '@lumx/icons/';
+import { Emphasis, IconButton, Size, TextField } from '@lumx/react';
+import { boolean, number, text } from '@storybook/addon-knobs';
+import { buttonSize } from '@lumx/react/stories/knobs/buttonKnob';
+import { emphasis } from '@lumx/react/stories/knobs/emphasisKnob';
 
 export default { title: 'LumX components/text-field/TextField' };
 
-/**
- * TextField story
- * @return simple TextField.
- */
-export const SimpleTextField = ({ theme }: any) => (
-    <TextField
-        value={text('Value', 'myvalue')}
-        label={text('Label', 'I am the label')}
-        placeholder={text('Placeholder', 'ex: A value')}
-        theme={theme}
-        onChange={noop}
-    />
-);
-
-export const SimpleTextNumberField = ({ theme }: any) => (
-    <TextField
-        value={text('Value', '2')}
-        label={text('Label', 'I am the label')}
-        placeholder={text('Placeholder', 'ex: A value')}
-        theme={theme}
-        onChange={noop}
-        type="number"
-    />
-);
-
-export const TextFieldWithHelp = ({ theme }: any) => (
-    <TextField
-        value={text('Value', 'myvalue')}
-        label={text('Label', 'I am the label')}
-        placeholder={text('Placeholder', 'ex: A value')}
-        theme={theme}
-        onChange={noop}
-        helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
-    />
-);
-
-export const TextFieldWithError = ({ theme }: any) => (
-    <TextField
-        value={text('Value', 'myvalue')}
-        label={text('Label', 'I am the label')}
-        placeholder={text('Placeholder', 'ex: A value')}
-        theme={theme}
-        onChange={noop}
-        helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
-        hasError
-        error={
-            <span>
-                You must provide <strong>something</strong>
-            </span>
-        }
-    />
-);
-
-export const TextArea = ({ theme }: any) => {
-    const [value, setValue] = React.useState('my value');
+export const TextField_ = ({ theme }: any) => {
+    const [value, onChange] = React.useState('Value');
     return (
         <TextField
             value={value}
-            label={text('Label', 'I am the label')}
-            placeholder={text('Placeholder', 'ex: A value')}
-            multiline
-            minimumRows={1}
+            onChange={onChange}
+            label={text('Label', 'Label')}
+            placeholder={text('Placeholder', 'Placeholder')}
             theme={theme}
-            onChange={setValue}
-            helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
         />
     );
 };
-export const TextAreaWith2Lines = ({ theme }: any) => {
-    const [value, setValue] = React.useState('the value');
+
+export const Clearable = ({ theme }: any) => {
+    const [value, onChange] = React.useState('Value');
     return (
         <TextField
             value={value}
-            label={text('Label', 'I am the label')}
-            placeholder={text('Placeholder', 'ex: A value')}
+            onChange={onChange}
+            label={text('Label', 'Label')}
+            clearButtonProps={{ label: 'Clear' }}
+            theme={theme}
+        />
+    );
+};
+
+export const States = ({ theme }: any) => {
+    const [value1, onChange1] = React.useState('Value');
+    const [value2, onChange2] = React.useState('Value');
+    return (
+        <>
+            <TextField
+                label="Has error"
+                hasError
+                error="Error message"
+                theme={theme}
+                value={value1}
+                onChange={onChange1}
+            />
+            <TextField label="Is valid" isValid theme={theme} value={value2} onChange={onChange2} />
+        </>
+    );
+};
+
+export const NumberField = ({ theme }: any) => {
+    const [value, onChange] = React.useState('0');
+    return <TextField value={value} onChange={onChange} label={text('Label', 'Label')} theme={theme} type="number" />;
+};
+
+export const WithHelper = ({ theme }: any) => {
+    const [value, onChange] = React.useState('Value');
+    return (
+        <TextField
+            value={value}
+            onChange={onChange}
+            label={text('Label', 'Label')}
+            placeholder={text('Placeholder', 'Placeholder')}
+            theme={theme}
+            helper={<span>{text('Helper', 'Helper')}</span>}
+        />
+    );
+};
+
+export const TextArea = ({ theme }: any) => {
+    const [value, setValue] = React.useState('Value');
+    return (
+        <TextField
+            value={value}
+            label={text('Label', 'Label')}
+            placeholder={text('Placeholder', 'Placeholder')}
             multiline
-            minimumRows={2}
+            minimumRows={number('Minimum number of rows', 1, { min: 0, max: 100 })}
             theme={theme}
             onChange={setValue}
-            helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
+            helper={<span>{text('Helper', 'Helper')}</span>}
         />
     );
 };
@@ -99,26 +96,44 @@ text`;
     return (
         <TextField
             value={value}
-            label={text('Label', 'I am the label')}
-            placeholder={text('Placeholder', 'ex: A value')}
+            label={text('Label', 'Label')}
+            placeholder={text('Placeholder', 'Placeholder')}
             multiline
-            minimumRows={2}
+            minimumRows={number('Minimum number of rows', 2, { min: 0, max: 100 })}
             theme={theme}
             onChange={setValue}
-            helper={<span>{text('Helper', 'ex: toto@acme.com')}</span>}
+            helper={<span>{text('Helper', 'Helper')}</span>}
         />
     );
 };
 
-// Even with value set programmatically, the number of rows should be updated
-export const TextAreaWithKnobValue = ({ theme }: any) => (
-    <TextField
-        value={text('Value', 'myvalue')}
-        label={text('Label', 'I am the label')}
-        placeholder={text('Placeholder', 'ex: A value')}
-        multiline
-        minimumRows={1}
-        theme={theme}
-        onChange={noop}
-    />
-);
+export const WithAfterElement = ({ theme }: any) => {
+    const [value, onChange] = React.useState('Value');
+    const multiline = boolean('Multiline', true);
+    const minimumRows = number('Minimum number of rows', 2, { min: 0, max: 100 });
+    const isClearable = boolean('Clearable', true);
+    const hasError = boolean('Has error', true);
+    return (
+        <TextField
+            value={value}
+            label={text('Label', 'Label')}
+            placeholder={text('Placeholder', 'Placeholder')}
+            theme={theme}
+            onChange={onChange}
+            multiline={multiline}
+            minimumRows={minimumRows}
+            hasError={hasError}
+            maxLength={200}
+            clearButtonProps={isClearable ? { label: 'Clear' } : undefined}
+            helper={<span>{text('Helper', 'Helper')}</span>}
+            afterElement={
+                <IconButton
+                    label="foo"
+                    emphasis={emphasis('Button emphasis', Emphasis.medium, 'After element')}
+                    size={buttonSize('Button size', Size.s, 'After element')}
+                    icon={mdiTranslate}
+                />
+            }
+        />
+    );
+};

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -24,6 +24,8 @@ export interface TextFieldProps extends GenericProps {
     forceFocusStyle?: boolean;
     /** Whether the text field is displayed with error style or not. */
     hasError?: boolean;
+    /** Additional element to put at the end of the text field. */
+    afterElement?: ReactNode;
     /** Helper text. */
     helper?: string | ReactNode;
     /** Icon (SVG path). */
@@ -259,6 +261,7 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
         theme,
         type,
         value,
+        afterElement,
         ...forwardedProps
     } = props;
     const textFieldId = useMemo(() => id || `text-field-${uid()}`, [id]);
@@ -405,6 +408,8 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
                         type="button"
                     />
                 )}
+
+                {afterElement && <div className={`${CLASSNAME}__after-element`}>{afterElement}</div>}
             </div>
 
             {hasError && error && (

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -12,7 +12,7 @@ import {
     Thumbnail,
     ThumbnailVariant,
 } from '@lumx/react';
-import { imageKnob, IMAGES } from '@lumx/react/stories/knobs';
+import { imageKnob, IMAGES } from '@lumx/react/stories/knobs/image';
 import { htmlDecode } from '@lumx/react/utils/htmlDecode';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { enumKnob } from '@lumx/react/stories/knobs/enumKnob';

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -1,6 +1,6 @@
 import { mdiStar } from '@lumx/icons';
 import { Badge, ColorPalette, Icon, List, ListItem, Size } from '@lumx/react';
-import { AVATAR_IMAGES, avatarImageKnob } from '@lumx/react/stories/knobs';
+import { AVATAR_IMAGES, avatarImageKnob } from '@lumx/react/stories/knobs/image';
 import React from 'react';
 import { UserBlock } from './UserBlock';
 

--- a/packages/lumx-react/src/stories/knobs/buttonKnob.ts
+++ b/packages/lumx-react/src/stories/knobs/buttonKnob.ts
@@ -1,0 +1,9 @@
+import { Button, ButtonProps, Size } from '@lumx/react';
+import { select } from '@storybook/addon-knobs';
+import { ButtonSize } from '@lumx/react/components/button/ButtonRoot';
+
+export const buttonSize = (
+    name = 'Size',
+    value: ButtonSize = Button.defaultProps?.size as any,
+    groupId: string | undefined = undefined,
+): ButtonProps['size'] => select(name, [Size.m, Size.s], value, groupId);

--- a/packages/lumx-react/src/stories/knobs/emphasisKnob.ts
+++ b/packages/lumx-react/src/stories/knobs/emphasisKnob.ts
@@ -1,0 +1,8 @@
+import { Emphasis } from '@lumx/react';
+import { select } from '@storybook/addon-knobs';
+
+export const emphasis = (
+    name = 'Emphasis',
+    value: Emphasis = Emphasis.high,
+    groupId: string | undefined = undefined,
+): Emphasis => select(name, Emphasis, value, groupId);

--- a/packages/lumx-react/src/stories/knobs/index.ts
+++ b/packages/lumx-react/src/stories/knobs/index.ts
@@ -1,2 +1,0 @@
-export * from './image';
-export * from './lorem';


### PR DESCRIPTION
# General summary

Add an `afterElement` prop on the `TextField` to add custom elements at the end of a textfield.

https://www.figma.com/file/oBsCET5MB3dQMDkBAc214t/DS%3A-LumApps?node-id=1853%3A27

# Screenshots

| Material theme | Lumapps theme |
| --- | --- |
| ![localhost_9000_iframe html_id=lumx-components-text-field-textfield--with-after-element](https://user-images.githubusercontent.com/939567/140938712-d5bb544b-281c-445b-acae-96e7c5f622d1.png) | ![localhost_9000_iframe html_id=lumx-components-text-field-textfield--with-after-element (1)](https://user-images.githubusercontent.com/939567/140938721-4b24075d-5cc7-45bf-a599-6b46d54dffb5.png) |

