### PR TITLE
fix(list-item): improve a11y on button vs link behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `ListItem`: Added `isDisabled` prop to disable a clickable list item.
+-   `ListItem`: improve a11y keyboard activation on button list item.
 
 ## [2.1.2][] - 2021-11-10
 

--- a/packages/lumx-core/src/js/utils.ts
+++ b/packages/lumx-core/src/js/utils.ts
@@ -277,3 +277,20 @@ export function onEscapePressed<E extends KeyboardEvent | React.KeyboardEvent>(
         handler(evt);
     };
 }
+
+/**
+ * Handle button key pressed (Enter + Space).
+ *
+ * @param  handler The handler to call.
+ * @return The decorated function.
+ */
+export function onButtonPressed<E extends KeyboardEvent | React.KeyboardEvent>(
+    handler: KeyboardEventHandler<E>,
+): KeyboardEventHandler<E> {
+    return (evt) => {
+        if (evt.key !== 'Enter' && evt.key !== ' ') {
+            return;
+        }
+        handler(evt);
+    };
+}

--- a/packages/lumx-react/src/components/list/List.stories.tsx
+++ b/packages/lumx-react/src/components/list/List.stories.tsx
@@ -47,7 +47,10 @@ export const KeyboardNavigation = () => {
                     <ListSubheader>Header</ListSubheader>
                 </>
                 <ListItem linkProps={{ href: '#' }} isDisabled>
-                    Link item 3
+                    Disabled link item
+                </ListItem>
+                <ListItem onItemSelected={action('onItemSelected')} isDisabled>
+                    Disabled button item
                 </ListItem>
                 <CustomListItem />
                 {[

--- a/packages/lumx-react/src/components/list/ListItem.stories.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.stories.tsx
@@ -2,15 +2,34 @@ import React from 'react';
 
 import { Size } from '@lumx/react';
 import { select, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import { ListItem } from './ListItem';
 
 export default { title: 'LumX components/list/ListItem' };
 
-export const Default = ({ theme }: any) => <ListItem theme={theme}>{text('text', 'Text')}</ListItem>;
+export const NonClickable = ({ theme }: any) => <ListItem theme={theme}>{text('text', 'Text')}</ListItem>;
 
-export const Disabled = ({ theme }: any) => (
+export const Link = ({ theme }: any) => (
+    <ListItem theme={theme} linkProps={{ href: '#' }}>
+        {text('text', 'Text')}
+    </ListItem>
+);
+
+export const Button = ({ theme }: any) => (
+    <ListItem theme={theme} onItemSelected={action('onItemSelected')}>
+        {text('text', 'Text')}
+    </ListItem>
+);
+
+export const LinkDisabled = ({ theme }: any) => (
     <ListItem theme={theme} linkProps={{ href: '#' }} isDisabled>
+        {text('text', 'Text')}
+    </ListItem>
+);
+
+export const ButtonDisabled = ({ theme }: any) => (
+    <ListItem theme={theme} onItemSelected={action('onItemSelected')} isDisabled>
         {text('text', 'Text')}
     </ListItem>
 );
@@ -34,10 +53,10 @@ export const Sizes = ({ theme }: any) => (
 );
 
 const CustomLink: React.FC = ({ children, ...props }) =>
-    React.createElement('a', { ...props, style: { color: 'red' } }, children);
+    React.createElement('a', { ...props, style: { color: 'red' }, href: 'http://google.com' }, children);
 
 export const WithCustomLink = ({ theme }: any) => (
-    <ListItem theme={theme} linkAs={CustomLink} linkProps={{ href: 'http://google.com' }}>
+    <ListItem theme={theme} linkAs={CustomLink}>
         My custom link
     </ListItem>
 );

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -4,7 +4,14 @@ import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
 import { ListProps, Size } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import {
+    Comp,
+    GenericProps,
+    getRootClassName,
+    handleBasicClasses,
+    onEnterPressed,
+    onButtonPressed,
+} from '@lumx/react/utils';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 export type ListItemSize = Extract<Size, 'tiny' | 'regular' | 'big' | 'huge'>;
@@ -88,9 +95,13 @@ export const ListItem: Comp<ListItemProps, HTMLLIElement> = forwardRef((props, r
         size,
         ...forwardedProps
     } = props;
-    const onKeyDown = useMemo(() => (onItemSelected ? onEnterPressed(onItemSelected as any) : undefined), [
-        onItemSelected,
-    ]);
+
+    const role = linkAs || linkProps.href ? 'link' : 'button';
+    const onKeyDown = useMemo(() => {
+        if (onItemSelected && role === 'link') return onEnterPressed(onItemSelected as any);
+        if (onItemSelected && role === 'button') return onButtonPressed(onItemSelected as any);
+        return undefined;
+    }, [role, onItemSelected]);
 
     const content = (
         <>
@@ -117,8 +128,8 @@ export const ListItem: Comp<ListItemProps, HTMLLIElement> = forwardRef((props, r
                 renderLink(
                     {
                         linkAs,
-                        tabIndex: 0,
-                        role: onItemSelected ? 'button' : undefined,
+                        tabIndex: !isDisabled && role === 'button' ? 0 : undefined,
+                        role,
                         'aria-disabled': isDisabled,
                         ...linkProps,
                         href: isDisabled ? undefined : linkProps.href,

--- a/packages/lumx-react/src/components/list/__snapshots__/List.test.tsx.snap
+++ b/packages/lumx-react/src/components/list/__snapshots__/List.test.tsx.snap
@@ -139,14 +139,22 @@ exports[`<List> Snapshots and structure should render story 'KeyboardNavigation'
     }
     size="regular"
   >
-    Link item 3
+    Disabled link item
+  </ListItem>
+  <ListItem
+    isDisabled={true}
+    key=".5"
+    onItemSelected={[Function]}
+    size="regular"
+  >
+    Disabled button item
   </ListItem>
   <CustomListItem
-    key=".5"
+    key=".6"
   />
   <ListItem
     isHighlighted={false}
-    key=".6:$1"
+    key=".7:$1"
     linkProps={
       Object {
         "href": "#",

--- a/packages/lumx-react/src/components/list/__snapshots__/ListItem.test.tsx.snap
+++ b/packages/lumx-react/src/components/list/__snapshots__/ListItem.test.tsx.snap
@@ -1,29 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ListItem> Snapshots and structure should render story 'Default' 1`] = `
+exports[`<ListItem> Snapshots and structure should render story 'Button' 1`] = `
 <li
   className="lumx-list-item lumx-list-item--size-regular"
 >
-  <div
-    className="lumx-list-item__wrapper"
+  <a
+    className="lumx-list-item__link"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex={0}
   >
     <div
       className="lumx-list-item__content"
     >
       Text
     </div>
-  </div>
+  </a>
 </li>
 `;
 
-exports[`<ListItem> Snapshots and structure should render story 'Disabled' 1`] = `
+exports[`<ListItem> Snapshots and structure should render story 'ButtonDisabled' 1`] = `
 <li
   className="lumx-list-item lumx-list-item--size-regular"
 >
   <a
     aria-disabled={true}
     className="lumx-list-item__link lumx-list-item__link--is-disabled"
-    tabIndex={0}
+    onKeyDown={[Function]}
+    role="button"
   >
     <div
       className="lumx-list-item__content"
@@ -41,7 +46,7 @@ exports[`<ListItem> Snapshots and structure should render story 'Highlighted' 1`
   <a
     className="lumx-list-item__link lumx-list-item__link--is-highlighted"
     href="#"
-    tabIndex={0}
+    role="link"
   >
     <div
       className="lumx-list-item__content"
@@ -52,6 +57,58 @@ exports[`<ListItem> Snapshots and structure should render story 'Highlighted' 1`
 </li>
 `;
 
+exports[`<ListItem> Snapshots and structure should render story 'Link' 1`] = `
+<li
+  className="lumx-list-item lumx-list-item--size-regular"
+>
+  <a
+    className="lumx-list-item__link"
+    href="#"
+    role="link"
+  >
+    <div
+      className="lumx-list-item__content"
+    >
+      Text
+    </div>
+  </a>
+</li>
+`;
+
+exports[`<ListItem> Snapshots and structure should render story 'LinkDisabled' 1`] = `
+<li
+  className="lumx-list-item lumx-list-item--size-regular"
+>
+  <a
+    aria-disabled={true}
+    className="lumx-list-item__link lumx-list-item__link--is-disabled"
+    role="link"
+  >
+    <div
+      className="lumx-list-item__content"
+    >
+      Text
+    </div>
+  </a>
+</li>
+`;
+
+exports[`<ListItem> Snapshots and structure should render story 'NonClickable' 1`] = `
+<li
+  className="lumx-list-item lumx-list-item--size-regular"
+>
+  <div
+    className="lumx-list-item__wrapper"
+  >
+    <div
+      className="lumx-list-item__content"
+    >
+      Text
+    </div>
+  </div>
+</li>
+`;
+
 exports[`<ListItem> Snapshots and structure should render story 'Selected' 1`] = `
 <li
   className="lumx-list-item lumx-list-item--size-regular"
@@ -59,7 +116,7 @@ exports[`<ListItem> Snapshots and structure should render story 'Selected' 1`] =
   <a
     className="lumx-list-item__link lumx-list-item__link--is-selected"
     href="#"
-    tabIndex={0}
+    role="link"
   >
     <div
       className="lumx-list-item__content"
@@ -90,16 +147,14 @@ exports[`<ListItem> Snapshots and structure should render story 'WithCustomLink'
 <li
   className="lumx-list-item lumx-list-item--size-regular"
 >
-  <CustomLink
-    className="lumx-list-item__link"
-    href="http://google.com"
-    tabIndex={0}
+  <div
+    className="lumx-list-item__wrapper"
   >
     <div
       className="lumx-list-item__content"
     >
       My custom link
     </div>
-  </CustomLink>
+  </div>
 </li>
 `;


### PR DESCRIPTION
# General summary

Improve a11y role and keyboard activation on link list item (with `linkProps.href` or `linkAs` prop) and button list item (with `onItemSelected` prop)
