### PR TITLE
[a11y] Add linkProps to Thumbnail/Avatar/UserBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+-   Thumbnail: Added `linkProps` prop to allow the user to turn a thumbnail into an accessible link.
+-   Thumbnail: Added `linkAs` prop into this new prop, to customize the link component.
+-   Avatar: Added a `linkProps` and `linkAs` props which will be passed to the Thumbnail child.
+-   UserBlock: Added a `linkProps` and `linkAs` props which will be passed to the Thumbnail child and used to wrap the username.
+
 ## [2.1.4][] - 2021-11-25
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -103,8 +103,9 @@
 /* Thumbnail states
    ========================================================================== */
 
-.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
+.#{$lumx-base-prefix}-thumbnail--is-clickable {
     position: relative;
+    display: block;
     cursor: pointer;
 
     &::after {
@@ -119,7 +120,8 @@
         pointer-events: none;
     }
 
-    &:hover::after {
+    &:hover::after,
+    &:focus::after {
         @include lumx-state(lumx-base-const('state', 'HOVER'), lumx-base-const('emphasis', 'LOW'), 'dark');
     }
 
@@ -128,19 +130,19 @@
     }
 }
 
-.#{$lumx-base-prefix}-thumbnail--variant-rounded.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
+.#{$lumx-base-prefix}-thumbnail--variant-rounded.#{$lumx-base-prefix}-thumbnail--is-clickable {
     &[data-focus-visible-added]::after {
         border-radius: var(--lumx-border-radius);
     }
 }
 
-.#{$lumx-base-prefix}-thumbnail--theme-light.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
+.#{$lumx-base-prefix}-thumbnail--theme-light.#{$lumx-base-prefix}-thumbnail--is-clickable {
     &[data-focus-visible-added]::after {
         @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'dark');
     }
 }
 
-.#{$lumx-base-prefix}-thumbnail--theme-dark.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
+.#{$lumx-base-prefix}-thumbnail--theme-dark.#{$lumx-base-prefix}-thumbnail--is-clickable {
     &[data-focus-visible-added]::after {
         @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'light');
     }

--- a/packages/lumx-core/src/scss/components/user-block/_index.scss
+++ b/packages/lumx-core/src/scss/components/user-block/_index.scss
@@ -49,7 +49,7 @@
             color: lumx-color-variant('light', 'N');
         }
 
-        &[tabindex='0'] {
+        &--is-clickable {
             #{$self}--theme-light & {
                 @include lumx-link('dark');
             }

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -36,6 +36,10 @@ export interface AvatarProps extends GenericProps {
         ThumbnailProps,
         'image' | 'alt' | 'size' | 'theme' | 'align' | 'fillHeight' | 'variant' | 'aspectRatio'
     >;
+    /** Props to pass to the link wrapping the thumbnail. */
+    linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+    /** Custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
 }
 
 /**
@@ -75,6 +79,8 @@ export const Avatar: Comp<AvatarProps, HTMLDivElement> = forwardRef((props, ref)
         size,
         theme,
         thumbnailProps,
+        linkProps,
+        linkAs,
         ...forwardedProps
     } = props;
 
@@ -85,6 +91,8 @@ export const Avatar: Comp<AvatarProps, HTMLDivElement> = forwardRef((props, ref)
             className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, size, theme }))}
         >
             <Thumbnail
+                linkProps={linkProps}
+                linkAs={linkAs}
                 className={`${CLASSNAME}__thumbnail`}
                 onClick={onClick}
                 onKeyPress={onKeyPress}

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -18,12 +18,33 @@ import { boolean, select, text } from '@storybook/addon-knobs';
 import { enumKnob } from '@lumx/react/stories/knobs/enumKnob';
 import { focusKnob } from '@lumx/react/stories/knobs/focusKnob';
 import { sizeKnob } from '@lumx/react/stories/knobs/sizeKnob';
+import classNames from 'classnames';
 
 export default { title: 'LumX components/thumbnail/Thumbnail' };
 
 export const Default = () => <Thumbnail alt="Image alt text" image={imageKnob()} size={Size.xxl} />;
 
 export const Clickable = () => <Thumbnail alt="Click me" image={imageKnob()} size={Size.xxl} onClick={console.log} />;
+
+export const ClickableLink = () => (
+    <Thumbnail alt="Click me" image={imageKnob()} size={Size.xxl} linkProps={{ href: 'https://google.fr' }} />
+);
+
+const CustomLinkComponent = (props: any) => (
+    <a {...props} className={classNames('custom-link-component', props.className)}>
+        {props.children}
+    </a>
+);
+
+export const ClickableCustomLink = () => (
+    <Thumbnail
+        alt="Click me"
+        image={imageKnob()}
+        size={Size.xxl}
+        linkAs={CustomLinkComponent}
+        linkProps={{ href: 'https://google.fr', className: 'custom-class-name' }}
+    />
+);
 
 export const DefaultFallback = () => <Thumbnail alt="foo" image="foo" />;
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.test.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.test.tsx
@@ -5,7 +5,16 @@ import 'jest-enzyme';
 import { commonTestsSuite, itShouldRenderStories } from '@lumx/react/testing/utils';
 
 import { Thumbnail, ThumbnailProps } from './Thumbnail';
-import { Clickable, CustomFallback, Default, DefaultFallback, IconFallback, WithBadge } from './Thumbnail.stories';
+import {
+    Clickable,
+    ClickableCustomLink,
+    ClickableLink,
+    CustomFallback,
+    Default,
+    DefaultFallback,
+    IconFallback,
+    WithBadge,
+} from './Thumbnail.stories';
 
 const CLASSNAME = Thumbnail.className as string;
 
@@ -22,7 +31,16 @@ describe(`<${Thumbnail.displayName}>`, () => {
     // 1. Test render via snapshot.
     describe('Snapshots and structure', () => {
         itShouldRenderStories(
-            { Default, Clickable, DefaultFallback, CustomFallback, IconFallback, WithBadge },
+            {
+                Default,
+                Clickable,
+                ClickableLink,
+                ClickableCustomLink,
+                DefaultFallback,
+                CustomFallback,
+                IconFallback,
+                WithBadge,
+            },
             Thumbnail,
         );
     });

--- a/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
+++ b/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
@@ -1,12 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Thumbnail> Snapshots and structure should render story 'Clickable' 1`] = `
-<div
-  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light"
+<button
+  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--is-clickable"
   onClick={[Function]}
-  onKeyPress={[Function]}
-  role="button"
-  tabIndex={0}
 >
   <div
     className="lumx-thumbnail__background"
@@ -25,7 +22,57 @@ exports[`<Thumbnail> Snapshots and structure should render story 'Clickable' 1`]
       style={Object {}}
     />
   </div>
-</div>
+</button>
+`;
+
+exports[`<Thumbnail> Snapshots and structure should render story 'ClickableCustomLink' 1`] = `
+<CustomLinkComponent
+  className="custom-class-name lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--is-clickable"
+  href="https://google.fr"
+>
+  <div
+    className="lumx-thumbnail__background"
+    style={
+      Object {
+        "display": undefined,
+        "visibility": "hidden",
+      }
+    }
+  >
+    <img
+      alt="Click me"
+      className="lumx-thumbnail__image"
+      loading="lazy"
+      src="landscape1.jpg"
+      style={Object {}}
+    />
+  </div>
+</CustomLinkComponent>
+`;
+
+exports[`<Thumbnail> Snapshots and structure should render story 'ClickableLink' 1`] = `
+<a
+  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--is-clickable"
+  href="https://google.fr"
+>
+  <div
+    className="lumx-thumbnail__background"
+    style={
+      Object {
+        "display": undefined,
+        "visibility": "hidden",
+      }
+    }
+  >
+    <img
+      alt="Click me"
+      className="lumx-thumbnail__image"
+      loading="lazy"
+      src="landscape1.jpg"
+      style={Object {}}
+    />
+  </div>
+</a>
 `;
 
 exports[`<Thumbnail> Snapshots and structure should render story 'CustomFallback' 1`] = `

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -6,11 +6,12 @@ import { UserBlock } from './UserBlock';
 
 export default { title: 'LumX components/user-block/UserBlock' };
 
-export const Sizes = () => {
+export const Sizes = ({ theme }: any) => {
     const logAction = (action: string) => () => console.log(action);
     return [Size.s, Size.m, Size.l].map((size: any) => (
         <div className="demo-grid" key={size}>
             <UserBlock
+                theme={theme}
                 name="Emmitt O. Lum"
                 fields={['Creative developer', 'Denpasar']}
                 avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
@@ -23,11 +24,31 @@ export const Sizes = () => {
     ));
 };
 
-export const WithBadge = () => {
+export const WithLinks = ({ theme }: any) => {
+    const logAction = (action: string) => () => console.log(action);
+    return [Size.s, Size.m, Size.l].map((size: any) => (
+        <div className="demo-grid" key={size}>
+            <UserBlock
+                theme={theme}
+                name="Emmitt O. Lum"
+                linkProps={{ href: 'https://www.lumapps.com', target: '_blank' }}
+                fields={['Creative developer', 'Denpasar']}
+                avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
+                size={size}
+                onMouseEnter={logAction('Mouse entered')}
+                onMouseLeave={logAction('Mouse left')}
+                onClick={logAction('UserBlock clicked')}
+            />
+        </div>
+    ));
+};
+
+export const WithBadge = ({ theme }: any) => {
     const logAction = (action: string) => () => console.log(action);
     return (
         <div className="demo-grid">
             <UserBlock
+                theme={theme}
                 name="Emmitt O. Lum"
                 fields={['Creative developer', 'Denpasar']}
                 avatarProps={{
@@ -42,19 +63,19 @@ export const WithBadge = () => {
                 size={Size.m}
                 onMouseEnter={logAction('Mouse entered')}
                 onMouseLeave={logAction('Mouse left')}
-                onClick={logAction('UserBlock clicked')}
             />
         </div>
     );
 };
 
-export const InList = () => {
+export const InList = ({ theme }: any) => {
     const logAction = (action: string) => () => console.log(action);
     return (
         <div className="demo-grid">
             <List itemPadding={Size.big}>
                 <ListItem className="lumx-color-background-dark-L6" size={Size.big}>
                     <UserBlock
+                        theme={theme}
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
                         avatarProps={{
@@ -74,6 +95,7 @@ export const InList = () => {
                 </ListItem>
                 <ListItem className="lumx-color-background-dark-L6" size={Size.big}>
                     <UserBlock
+                        theme={theme}
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
                         avatarProps={{
@@ -93,6 +115,7 @@ export const InList = () => {
                 </ListItem>
                 <ListItem className="lumx-color-background-dark-L6" size={Size.big}>
                     <UserBlock
+                        theme={theme}
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
                         avatarProps={{

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames';
 import { Avatar, Orientation, Size, Theme } from '@lumx/react';
 
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { isEmpty } from 'lodash';
+import { renderLink } from '@lumx/react/utils/renderLink';
 import { AvatarProps } from '../avatar/Avatar';
 
 /**
@@ -18,6 +20,10 @@ export type UserBlockSize = Extract<Size, 's' | 'm' | 'l'>;
 export interface UserBlockProps extends GenericProps {
     /** Props to pass to the avatar. */
     avatarProps?: AvatarProps;
+    /** Props to pass to the link wrapping the avatar thumbnail. */
+    linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
+    /** Custom react component for the link (can be used to inject react router Link). */
+    linkAs?: 'a' | any;
     /** Simple action toolbar content. */
     simpleAction?: ReactNode;
     /** Multiple action toolbar content. */
@@ -80,6 +86,8 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
         simpleAction,
         size,
         theme,
+        linkProps,
+        linkAs,
         ...forwardedProps
     } = props;
     let componentSize = size;
@@ -91,12 +99,29 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
 
     const shouldDisplayActions: boolean = orientation === Orientation.vertical;
 
-    const nameBlock: ReactNode = name && (
-        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-tabindex,jsx-a11y/no-static-element-interactions
-        <span className={`${CLASSNAME}__name`} onClick={onClick} tabIndex={onClick ? 0 : -1}>
-            {name}
-        </span>
-    );
+    const isLink = Boolean(linkProps?.href || linkAs);
+    const isClickable = !!onClick || isLink;
+
+    const nameBlock: ReactNode = React.useMemo(() => {
+        if (isEmpty(name)) {
+            return null;
+        }
+        const nameClassName = classNames(
+            handleBasicClasses({ prefix: `${CLASSNAME}__name`, isClickable }),
+            isLink && linkProps?.className,
+        );
+        if (isLink) {
+            return renderLink({ ...linkProps, linkAs, className: nameClassName }, name);
+        }
+        if (onClick) {
+            return (
+                <button onClick={onClick} type="button" className={nameClassName}>
+                    {name}
+                </button>
+            );
+        }
+        return <span className={nameClassName}>{name}</span>;
+    }, [isClickable, isLink, linkAs, linkProps, name, onClick]);
 
     const fieldsBlock: ReactNode = fields && componentSize !== Size.s && (
         <div className={`${CLASSNAME}__fields`}>
@@ -114,21 +139,20 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
             {...forwardedProps}
             className={classNames(
                 className,
-                handleBasicClasses({ prefix: CLASSNAME, orientation, size: componentSize, theme }),
+                handleBasicClasses({ prefix: CLASSNAME, orientation, size: componentSize, theme, isClickable }),
             )}
             onMouseLeave={onMouseLeave}
             onMouseEnter={onMouseEnter}
         >
             {avatarProps && (
-                <div className={`${CLASSNAME}__avatar`}>
-                    <Avatar
-                        {...avatarProps}
-                        size={componentSize}
-                        onClick={onClick}
-                        tabIndex={onClick ? 0 : -1}
-                        theme={theme}
-                    />
-                </div>
+                <Avatar
+                    linkProps={linkProps}
+                    {...avatarProps}
+                    className={classNames(`${CLASSNAME}__avatar`, avatarProps.className)}
+                    size={componentSize}
+                    onClick={onClick}
+                    theme={theme}
+                />
             )}
             {(fields || name) && (
                 <div className={`${CLASSNAME}__wrapper`}>

--- a/packages/lumx-react/src/components/user-block/__snapshots__/UserBlock.test.tsx.snap
+++ b/packages/lumx-react/src/components/user-block/__snapshots__/UserBlock.test.tsx.snap
@@ -3,41 +3,37 @@
 exports[`<UserBlock> Snapshots and structure should render story 'InList' 1`] = `
 Array [
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <div
+    <Avatar
+      alt="Avatar"
+      badge={
+        <Badge
+          color="blue"
+        >
+          <Icon
+            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+          />
+        </Badge>
+      }
       className="lumx-user-block__avatar"
-    >
-      <Avatar
-        alt="Avatar"
-        badge={
-          <Badge
-            color="blue"
-          >
-            <Icon
-              icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-            />
-          </Badge>
-        }
-        image="avatar1.jpg"
-        onClick={[Function]}
-        size="m"
-        tabIndex={0}
-        theme="light"
-      />
-    </div>
+      image="avatar1.jpg"
+      onClick={[Function]}
+      size="m"
+      theme="light"
+    />
     <div
       className="lumx-user-block__wrapper"
     >
-      <span
-        className="lumx-user-block__name"
+      <button
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
         onClick={[Function]}
-        tabIndex={0}
+        type="button"
       >
         Emmitt O. Lum
-      </span>
+      </button>
       <div
         className="lumx-user-block__fields"
       >
@@ -57,41 +53,37 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <div
+    <Avatar
+      alt="Avatar"
+      badge={
+        <Badge
+          color="blue"
+        >
+          <Icon
+            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+          />
+        </Badge>
+      }
       className="lumx-user-block__avatar"
-    >
-      <Avatar
-        alt="Avatar"
-        badge={
-          <Badge
-            color="blue"
-          >
-            <Icon
-              icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-            />
-          </Badge>
-        }
-        image="avatar2.jpg"
-        onClick={[Function]}
-        size="m"
-        tabIndex={0}
-        theme="light"
-      />
-    </div>
+      image="avatar2.jpg"
+      onClick={[Function]}
+      size="m"
+      theme="light"
+    />
     <div
       className="lumx-user-block__wrapper"
     >
-      <span
-        className="lumx-user-block__name"
+      <button
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
         onClick={[Function]}
-        tabIndex={0}
+        type="button"
       >
         Emmitt O. Lum
-      </span>
+      </button>
       <div
         className="lumx-user-block__fields"
       >
@@ -111,41 +103,37 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <div
+    <Avatar
+      alt="Avatar"
+      badge={
+        <Badge
+          color="blue"
+        >
+          <Icon
+            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+          />
+        </Badge>
+      }
       className="lumx-user-block__avatar"
-    >
-      <Avatar
-        alt="Avatar"
-        badge={
-          <Badge
-            color="blue"
-          >
-            <Icon
-              icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-            />
-          </Badge>
-        }
-        image="avatar3.jpg"
-        onClick={[Function]}
-        size="m"
-        tabIndex={0}
-        theme="light"
-      />
-    </div>
+      image="avatar3.jpg"
+      onClick={[Function]}
+      size="m"
+      theme="light"
+    />
     <div
       className="lumx-user-block__wrapper"
     >
-      <span
-        className="lumx-user-block__name"
+      <button
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
         onClick={[Function]}
-        tabIndex={0}
+        type="button"
       >
         Emmitt O. Lum
-      </span>
+      </button>
       <div
         className="lumx-user-block__fields"
       >
@@ -170,61 +158,53 @@ Array [
 exports[`<UserBlock> Snapshots and structure should render story 'Sizes' 1`] = `
 Array [
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-s lumx-user-block--theme-light"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-s lumx-user-block--theme-light lumx-user-block--is-clickable"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <div
+    <Avatar
+      alt="Avatar"
       className="lumx-user-block__avatar"
-    >
-      <Avatar
-        alt="Avatar"
-        image="avatar1.jpg"
-        onClick={[Function]}
-        size="s"
-        tabIndex={0}
-        theme="light"
-      />
-    </div>
+      image="avatar1.jpg"
+      onClick={[Function]}
+      size="s"
+      theme="light"
+    />
     <div
       className="lumx-user-block__wrapper"
     >
-      <span
-        className="lumx-user-block__name"
+      <button
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
         onClick={[Function]}
-        tabIndex={0}
+        type="button"
       >
         Emmitt O. Lum
-      </span>
+      </button>
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <div
+    <Avatar
+      alt="Avatar"
       className="lumx-user-block__avatar"
-    >
-      <Avatar
-        alt="Avatar"
-        image="avatar1.jpg"
-        onClick={[Function]}
-        size="m"
-        tabIndex={0}
-        theme="light"
-      />
-    </div>
+      image="avatar1.jpg"
+      onClick={[Function]}
+      size="m"
+      theme="light"
+    />
     <div
       className="lumx-user-block__wrapper"
     >
-      <span
-        className="lumx-user-block__name"
+      <button
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
         onClick={[Function]}
-        tabIndex={0}
+        type="button"
       >
         Emmitt O. Lum
-      </span>
+      </button>
       <div
         className="lumx-user-block__fields"
       >
@@ -244,32 +224,28 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-l lumx-user-block--theme-light"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-l lumx-user-block--theme-light lumx-user-block--is-clickable"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <div
+    <Avatar
+      alt="Avatar"
       className="lumx-user-block__avatar"
-    >
-      <Avatar
-        alt="Avatar"
-        image="avatar1.jpg"
-        onClick={[Function]}
-        size="l"
-        tabIndex={0}
-        theme="light"
-      />
-    </div>
+      image="avatar1.jpg"
+      onClick={[Function]}
+      size="l"
+      theme="light"
+    />
     <div
       className="lumx-user-block__wrapper"
     >
-      <span
-        className="lumx-user-block__name"
+      <button
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
         onClick={[Function]}
-        tabIndex={0}
+        type="button"
       >
         Emmitt O. Lum
-      </span>
+      </button>
       <div
         className="lumx-user-block__fields"
       >
@@ -297,34 +273,27 @@ exports[`<UserBlock> Snapshots and structure should render story 'WithBadge' 1`]
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
-  <div
+  <Avatar
+    alt="Avatar"
+    badge={
+      <Badge
+        color="blue"
+      >
+        <Icon
+          icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+        />
+      </Badge>
+    }
     className="lumx-user-block__avatar"
-  >
-    <Avatar
-      alt="Avatar"
-      badge={
-        <Badge
-          color="blue"
-        >
-          <Icon
-            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-          />
-        </Badge>
-      }
-      image="avatar1.jpg"
-      onClick={[Function]}
-      size="m"
-      tabIndex={0}
-      theme="light"
-    />
-  </div>
+    image="avatar1.jpg"
+    size="m"
+    theme="light"
+  />
   <div
     className="lumx-user-block__wrapper"
   >
     <span
       className="lumx-user-block__name"
-      onClick={[Function]}
-      tabIndex={0}
     >
       Emmitt O. Lum
     </span>
@@ -346,4 +315,134 @@ exports[`<UserBlock> Snapshots and structure should render story 'WithBadge' 1`]
     </div>
   </div>
 </div>
+`;
+
+exports[`<UserBlock> Snapshots and structure should render story 'WithLinks' 1`] = `
+Array [
+  <div
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-s lumx-user-block--theme-light lumx-user-block--is-clickable"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <Avatar
+      alt="Avatar"
+      className="lumx-user-block__avatar"
+      image="avatar1.jpg"
+      linkProps={
+        Object {
+          "href": "https://www.lumapps.com",
+          "target": "_blank",
+        }
+      }
+      onClick={[Function]}
+      size="s"
+      theme="light"
+    />
+    <div
+      className="lumx-user-block__wrapper"
+    >
+      <a
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+        href="https://www.lumapps.com"
+        target="_blank"
+      >
+        Emmitt O. Lum
+      </a>
+    </div>
+  </div>,
+  <div
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <Avatar
+      alt="Avatar"
+      className="lumx-user-block__avatar"
+      image="avatar1.jpg"
+      linkProps={
+        Object {
+          "href": "https://www.lumapps.com",
+          "target": "_blank",
+        }
+      }
+      onClick={[Function]}
+      size="m"
+      theme="light"
+    />
+    <div
+      className="lumx-user-block__wrapper"
+    >
+      <a
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+        href="https://www.lumapps.com"
+        target="_blank"
+      >
+        Emmitt O. Lum
+      </a>
+      <div
+        className="lumx-user-block__fields"
+      >
+        <span
+          className="lumx-user-block__field"
+          key="0"
+        >
+          Creative developer
+        </span>
+        <span
+          className="lumx-user-block__field"
+          key="1"
+        >
+          Denpasar
+        </span>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-l lumx-user-block--theme-light lumx-user-block--is-clickable"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <Avatar
+      alt="Avatar"
+      className="lumx-user-block__avatar"
+      image="avatar1.jpg"
+      linkProps={
+        Object {
+          "href": "https://www.lumapps.com",
+          "target": "_blank",
+        }
+      }
+      onClick={[Function]}
+      size="l"
+      theme="light"
+    />
+    <div
+      className="lumx-user-block__wrapper"
+    >
+      <a
+        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+        href="https://www.lumapps.com"
+        target="_blank"
+      >
+        Emmitt O. Lum
+      </a>
+      <div
+        className="lumx-user-block__fields"
+      >
+        <span
+          className="lumx-user-block__field"
+          key="0"
+        >
+          Creative developer
+        </span>
+        <span
+          className="lumx-user-block__field"
+          key="1"
+        >
+          Denpasar
+        </span>
+      </div>
+    </div>
+  </div>,
+]
 `;


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->
This PR aims to resolve accessibility issues on UserBlock components. We needed to let Thumbnail handle the clickable behaviour. 
Also add a `linkProps` prop to UserBlock, Avatar and Thumbnail, in order to handle accessible links, before we were forced to use `onClick` which is not good for accessibility.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
