### PR TITLE
fix(textfield): show maxlength counter  when there is no label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Textfield: show the maxlength counter on textfields with no label
+
 ## [2.1.6][] - 2021-12-03
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/text-field/_index.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_index.scss
@@ -39,7 +39,7 @@
         display: flex;
         flex-shrink: 0;
         align-items: center;
-        margin-left: $lumx-spacing-unit;
+        margin-left: auto;
 
         span {
             font-size: var(--lumx-material-text-field-header-label-font-size);

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -137,3 +137,33 @@ export const WithAfterElement = ({ theme }: any) => {
         />
     );
 };
+
+export const WithMaxLengthNoLabel = ({ theme }: any) => {
+    const [value, onChange] = React.useState('Value');
+    const multiline = boolean('Multiline', true);
+    const minimumRows = number('Minimum number of rows', 2, { min: 0, max: 100 });
+    const isClearable = boolean('Clearable', true);
+    const hasError = boolean('Has error', true);
+    return (
+        <TextField
+            value={value}
+            placeholder={text('Placeholder', 'Placeholder')}
+            theme={theme}
+            onChange={onChange}
+            multiline={multiline}
+            minimumRows={minimumRows}
+            hasError={hasError}
+            maxLength={200}
+            clearButtonProps={isClearable ? { label: 'Clear' } : undefined}
+            helper={<span>{text('Helper', 'Helper')}</span>}
+            afterElement={
+                <IconButton
+                    label="foo"
+                    emphasis={emphasis('Button emphasis', Emphasis.medium, 'After element')}
+                    size={buttonSize('Button size', Size.s, 'After element')}
+                    icon={mdiTranslate}
+                />
+            }
+        />
+    );
+};

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -307,16 +307,18 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
                 }),
             )}
         >
-            {label && (
+            {(label || maxLength) && (
                 <div className={`${CLASSNAME}__header`}>
-                    <InputLabel
-                        htmlFor={textFieldId}
-                        className={`${CLASSNAME}__label`}
-                        isRequired={isRequired}
-                        theme={theme}
-                    >
-                        {label}
-                    </InputLabel>
+                    {label && (
+                        <InputLabel
+                            htmlFor={textFieldId}
+                            className={`${CLASSNAME}__label`}
+                            isRequired={isRequired}
+                            theme={theme}
+                        >
+                            {label}
+                        </InputLabel>
+                    )}
 
                     {maxLength && (
                         <div className={`${CLASSNAME}__char-counter`}>


### PR DESCRIPTION
CMS-2064

# General summary

<!-- Please describe the PR content -->
When a textfield has a max content but no label, the counter was not shown. I changed the conditions in order to show the counter even when there is no label. I also added a story in order to test the behavior, and changed some style.
# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
