### PR TITLE
Fix/userblock-linkas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Textfield: show the maxlength counter on textfields with no label
+-   Textfield: show the maxlength counter on textfields with no label.
+-   UserBlock : Pass `linkAs` prop to Avatar child.
 
 ## [2.1.6][] - 2021-12-03
 

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -31,7 +31,10 @@ export const WithLinks = ({ theme }: any) => {
             <UserBlock
                 theme={theme}
                 name="Emmitt O. Lum"
-                linkProps={{ href: 'https://www.lumapps.com', target: '_blank' }}
+                linkProps={{
+                    href: 'https://www.lumapps.com',
+                    target: '_blank',
+                }}
                 fields={['Creative developer', 'Denpasar']}
                 avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
                 size={size}

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -146,6 +146,7 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
         >
             {avatarProps && (
                 <Avatar
+                    linkAs={linkAs}
                     linkProps={linkProps}
                     {...avatarProps}
                     className={classNames(`${CLASSNAME}__avatar`, avatarProps.className)}


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->
The UserBlock `linkAs` prop was not passed to the Avatar, making the avatar unclickable when using a custom link.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
