### PR TITLE
Revert: thumbnail, avatar, userblock improved link a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Reverted a11y link improvements (`linkAs` and `linkProps`) on Thumbnail, Avatar and UserBlock introduced in v2.1.5 that introduced a regression on the Thumbnail style.
+
 ## [2.1.8][] - 2021-12-10
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -103,9 +103,8 @@
 /* Thumbnail states
    ========================================================================== */
 
-.#{$lumx-base-prefix}-thumbnail--is-clickable {
+.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
     position: relative;
-    display: block;
     cursor: pointer;
 
     &::after {
@@ -120,8 +119,7 @@
         pointer-events: none;
     }
 
-    &:hover::after,
-    &:focus::after {
+    &:hover::after {
         @include lumx-state(lumx-base-const('state', 'HOVER'), lumx-base-const('emphasis', 'LOW'), 'dark');
     }
 
@@ -130,19 +128,19 @@
     }
 }
 
-.#{$lumx-base-prefix}-thumbnail--variant-rounded.#{$lumx-base-prefix}-thumbnail--is-clickable {
+.#{$lumx-base-prefix}-thumbnail--variant-rounded.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
     &[data-focus-visible-added]::after {
         border-radius: var(--lumx-border-radius);
     }
 }
 
-.#{$lumx-base-prefix}-thumbnail--theme-light.#{$lumx-base-prefix}-thumbnail--is-clickable {
+.#{$lumx-base-prefix}-thumbnail--theme-light.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
     &[data-focus-visible-added]::after {
         @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'dark');
     }
 }
 
-.#{$lumx-base-prefix}-thumbnail--theme-dark.#{$lumx-base-prefix}-thumbnail--is-clickable {
+.#{$lumx-base-prefix}-thumbnail--theme-dark.#{$lumx-base-prefix}-thumbnail[tabindex='0'] {
     &[data-focus-visible-added]::after {
         @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'light');
     }

--- a/packages/lumx-core/src/scss/components/user-block/_index.scss
+++ b/packages/lumx-core/src/scss/components/user-block/_index.scss
@@ -49,7 +49,7 @@
             color: lumx-color-variant('light', 'N');
         }
 
-        &--is-clickable {
+        &[tabindex='0'] {
             #{$self}--theme-light & {
                 @include lumx-link('dark');
             }

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -36,10 +36,6 @@ export interface AvatarProps extends GenericProps {
         ThumbnailProps,
         'image' | 'alt' | 'size' | 'theme' | 'align' | 'fillHeight' | 'variant' | 'aspectRatio'
     >;
-    /** Props to pass to the link wrapping the thumbnail. */
-    linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
-    /** Custom react component for the link (can be used to inject react router Link). */
-    linkAs?: 'a' | any;
 }
 
 /**
@@ -79,8 +75,6 @@ export const Avatar: Comp<AvatarProps, HTMLDivElement> = forwardRef((props, ref)
         size,
         theme,
         thumbnailProps,
-        linkProps,
-        linkAs,
         ...forwardedProps
     } = props;
 
@@ -91,8 +85,6 @@ export const Avatar: Comp<AvatarProps, HTMLDivElement> = forwardRef((props, ref)
             className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, size, theme }))}
         >
             <Thumbnail
-                linkProps={linkProps}
-                linkAs={linkAs}
                 className={`${CLASSNAME}__thumbnail`}
                 onClick={onClick}
                 onKeyPress={onKeyPress}

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -18,33 +18,12 @@ import { boolean, select, text } from '@storybook/addon-knobs';
 import { enumKnob } from '@lumx/react/stories/knobs/enumKnob';
 import { focusKnob } from '@lumx/react/stories/knobs/focusKnob';
 import { sizeKnob } from '@lumx/react/stories/knobs/sizeKnob';
-import classNames from 'classnames';
 
 export default { title: 'LumX components/thumbnail/Thumbnail' };
 
 export const Default = () => <Thumbnail alt="Image alt text" image={imageKnob()} size={Size.xxl} />;
 
 export const Clickable = () => <Thumbnail alt="Click me" image={imageKnob()} size={Size.xxl} onClick={console.log} />;
-
-export const ClickableLink = () => (
-    <Thumbnail alt="Click me" image={imageKnob()} size={Size.xxl} linkProps={{ href: 'https://google.fr' }} />
-);
-
-const CustomLinkComponent = (props: any) => (
-    <a {...props} className={classNames('custom-link-component', props.className)}>
-        {props.children}
-    </a>
-);
-
-export const ClickableCustomLink = () => (
-    <Thumbnail
-        alt="Click me"
-        image={imageKnob()}
-        size={Size.xxl}
-        linkAs={CustomLinkComponent}
-        linkProps={{ href: 'https://google.fr', className: 'custom-class-name' }}
-    />
-);
 
 export const DefaultFallback = () => <Thumbnail alt="foo" image="foo" />;
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.test.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.test.tsx
@@ -5,16 +5,7 @@ import 'jest-enzyme';
 import { commonTestsSuite, itShouldRenderStories } from '@lumx/react/testing/utils';
 
 import { Thumbnail, ThumbnailProps } from './Thumbnail';
-import {
-    Clickable,
-    ClickableCustomLink,
-    ClickableLink,
-    CustomFallback,
-    Default,
-    DefaultFallback,
-    IconFallback,
-    WithBadge,
-} from './Thumbnail.stories';
+import { Clickable, CustomFallback, Default, DefaultFallback, IconFallback, WithBadge } from './Thumbnail.stories';
 
 const CLASSNAME = Thumbnail.className as string;
 
@@ -31,16 +22,7 @@ describe(`<${Thumbnail.displayName}>`, () => {
     // 1. Test render via snapshot.
     describe('Snapshots and structure', () => {
         itShouldRenderStories(
-            {
-                Default,
-                Clickable,
-                ClickableLink,
-                ClickableCustomLink,
-                DefaultFallback,
-                CustomFallback,
-                IconFallback,
-                WithBadge,
-            },
+            { Default, Clickable, DefaultFallback, CustomFallback, IconFallback, WithBadge },
             Thumbnail,
         );
     });

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -20,6 +20,7 @@ import { isInternetExplorer } from '@lumx/react/utils/isInternetExplorer';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { useFocusPoint } from '@lumx/react/components/thumbnail/useFocusPoint';
 import { useImageLoad } from '@lumx/react/components/thumbnail/useImageLoad';
+import { useClickable } from '@lumx/react/components/thumbnail/useClickable';
 import { FocusPoint, ThumbnailSize, ThumbnailVariant } from './types';
 
 type ImgHTMLProps = ImgHTMLAttributes<HTMLImageElement>;
@@ -62,10 +63,6 @@ export interface ThumbnailProps extends GenericProps {
     theme?: Theme;
     /** Variant of the component. */
     variant?: ThumbnailVariant;
-    /** Props to pass to the link wrapping the thumbnail. */
-    linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
-    /** Custom react component for the link (can be used to inject react router Link). */
-    linkAs?: 'a' | any;
 }
 
 /**
@@ -112,8 +109,6 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
         size,
         theme,
         variant,
-        linkProps,
-        linkAs,
         ...forwardedProps
     } = props;
     const imgRef = useRef<HTMLImageElement>(null);
@@ -124,44 +119,24 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
     const isLoading = loadingState === 'isLoading';
 
     const [wrapper, setWrapper] = useState<HTMLElement>();
-
-    const isLink = Boolean(linkProps?.href || linkAs);
-    const isButton = !!forwardedProps.onClick;
-    const isClickable = isButton || isLink;
-
-    let Wrapper: any = 'div';
-    const wrapperProps = { ...forwardedProps };
-    if (isLink) {
-        Wrapper = linkAs || 'a';
-        Object.assign(wrapperProps, linkProps);
-    } else if (isButton) {
-        Wrapper = 'button';
-    }
+    const wrapperProps: any = {
+        ...forwardedProps,
+        ref: mergeRefs(setWrapper, ref),
+        className: classNames(
+            className,
+            handleBasicClasses({ align, aspectRatio, prefix: CLASSNAME, size, theme, variant, hasBadge: !!badge }),
+            isLoading && wrapper?.getBoundingClientRect()?.height && 'lumx-color-background-dark-L6',
+            fillHeight && `${CLASSNAME}--fill-height`,
+        ),
+        // Handle clickable Thumbnail a11y.
+        ...useClickable(props),
+    };
 
     // Update img style according to focus point and aspect ratio.
     const style = useFocusPoint({ image, focusPoint, aspectRatio, imgRef, loadingState, wrapper });
 
     return (
-        <Wrapper
-            {...wrapperProps}
-            ref={mergeRefs(setWrapper, ref) as any}
-            className={classNames(
-                linkProps?.className,
-                className,
-                handleBasicClasses({
-                    align,
-                    aspectRatio,
-                    prefix: CLASSNAME,
-                    size,
-                    theme,
-                    variant,
-                    isClickable,
-                    hasBadge: !!badge,
-                }),
-                isLoading && wrapper?.getBoundingClientRect()?.height && 'lumx-color-background-dark-L6',
-                fillHeight && `${CLASSNAME}--fill-height`,
-            )}
-        >
+        <div {...wrapperProps}>
             <div
                 className={`${CLASSNAME}__background`}
                 style={{
@@ -194,7 +169,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
                 ))}
             {badge &&
                 React.cloneElement(badge, { className: classNames(`${CLASSNAME}__badge`, badge.props.className) })}
-        </Wrapper>
+        </div>
     );
 });
 Thumbnail.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
+++ b/packages/lumx-react/src/components/thumbnail/__snapshots__/Thumbnail.test.tsx.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Thumbnail> Snapshots and structure should render story 'Clickable' 1`] = `
-<button
-  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--is-clickable"
+<div
+  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light"
   onClick={[Function]}
+  onKeyPress={[Function]}
+  role="button"
+  tabIndex={0}
 >
   <div
     className="lumx-thumbnail__background"
@@ -22,57 +25,7 @@ exports[`<Thumbnail> Snapshots and structure should render story 'Clickable' 1`]
       style={Object {}}
     />
   </div>
-</button>
-`;
-
-exports[`<Thumbnail> Snapshots and structure should render story 'ClickableCustomLink' 1`] = `
-<CustomLinkComponent
-  className="custom-class-name lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--is-clickable"
-  href="https://google.fr"
->
-  <div
-    className="lumx-thumbnail__background"
-    style={
-      Object {
-        "display": undefined,
-        "visibility": "hidden",
-      }
-    }
-  >
-    <img
-      alt="Click me"
-      className="lumx-thumbnail__image"
-      loading="lazy"
-      src="/demo-assets/landscape1.jpg"
-      style={Object {}}
-    />
-  </div>
-</CustomLinkComponent>
-`;
-
-exports[`<Thumbnail> Snapshots and structure should render story 'ClickableLink' 1`] = `
-<a
-  className="lumx-thumbnail lumx-thumbnail--size-xxl lumx-thumbnail--theme-light lumx-thumbnail--is-clickable"
-  href="https://google.fr"
->
-  <div
-    className="lumx-thumbnail__background"
-    style={
-      Object {
-        "display": undefined,
-        "visibility": "hidden",
-      }
-    }
-  >
-    <img
-      alt="Click me"
-      className="lumx-thumbnail__image"
-      loading="lazy"
-      src="/demo-assets/landscape1.jpg"
-      style={Object {}}
-    />
-  </div>
-</a>
+</div>
 `;
 
 exports[`<Thumbnail> Snapshots and structure should render story 'CustomFallback' 1`] = `

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -6,12 +6,11 @@ import { UserBlock } from './UserBlock';
 
 export default { title: 'LumX components/user-block/UserBlock' };
 
-export const Sizes = ({ theme }: any) => {
+export const Sizes = () => {
     const logAction = (action: string) => () => console.log(action);
     return [Size.s, Size.m, Size.l].map((size: any) => (
         <div className="demo-grid" key={size}>
             <UserBlock
-                theme={theme}
                 name="Emmitt O. Lum"
                 fields={['Creative developer', 'Denpasar']}
                 avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
@@ -24,31 +23,11 @@ export const Sizes = ({ theme }: any) => {
     ));
 };
 
-export const WithLinks = ({ theme }: any) => {
-    const logAction = (action: string) => () => console.log(action);
-    return [Size.s, Size.m, Size.l].map((size: any) => (
-        <div className="demo-grid" key={size}>
-            <UserBlock
-                theme={theme}
-                name="Emmitt O. Lum"
-                linkProps={{ href: 'https://www.lumapps.com', target: '_blank' }}
-                fields={['Creative developer', 'Denpasar']}
-                avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
-                size={size}
-                onMouseEnter={logAction('Mouse entered')}
-                onMouseLeave={logAction('Mouse left')}
-                onClick={logAction('UserBlock clicked')}
-            />
-        </div>
-    ));
-};
-
-export const WithBadge = ({ theme }: any) => {
+export const WithBadge = () => {
     const logAction = (action: string) => () => console.log(action);
     return (
         <div className="demo-grid">
             <UserBlock
-                theme={theme}
                 name="Emmitt O. Lum"
                 fields={['Creative developer', 'Denpasar']}
                 avatarProps={{
@@ -63,19 +42,19 @@ export const WithBadge = ({ theme }: any) => {
                 size={Size.m}
                 onMouseEnter={logAction('Mouse entered')}
                 onMouseLeave={logAction('Mouse left')}
+                onClick={logAction('UserBlock clicked')}
             />
         </div>
     );
 };
 
-export const InList = ({ theme }: any) => {
+export const InList = () => {
     const logAction = (action: string) => () => console.log(action);
     return (
         <div className="demo-grid">
             <List itemPadding={Size.big}>
                 <ListItem className="lumx-color-background-dark-L6" size={Size.big}>
                     <UserBlock
-                        theme={theme}
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
                         avatarProps={{
@@ -95,7 +74,6 @@ export const InList = ({ theme }: any) => {
                 </ListItem>
                 <ListItem className="lumx-color-background-dark-L6" size={Size.big}>
                     <UserBlock
-                        theme={theme}
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
                         avatarProps={{
@@ -115,7 +93,6 @@ export const InList = ({ theme }: any) => {
                 </ListItem>
                 <ListItem className="lumx-color-background-dark-L6" size={Size.big}>
                     <UserBlock
-                        theme={theme}
                         name="Emmitt O. Lum"
                         fields={['Creative developer', 'Denpasar']}
                         avatarProps={{

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -31,10 +31,7 @@ export const WithLinks = ({ theme }: any) => {
             <UserBlock
                 theme={theme}
                 name="Emmitt O. Lum"
-                linkProps={{
-                    href: 'https://www.lumapps.com',
-                    target: '_blank',
-                }}
+                linkProps={{ href: 'https://www.lumapps.com', target: '_blank' }}
                 fields={['Creative developer', 'Denpasar']}
                 avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
                 size={size}

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -146,7 +146,6 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
         >
             {avatarProps && (
                 <Avatar
-                    linkAs={linkAs}
                     linkProps={linkProps}
                     {...avatarProps}
                     className={classNames(`${CLASSNAME}__avatar`, avatarProps.className)}

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -5,8 +5,6 @@ import classNames from 'classnames';
 import { Avatar, Orientation, Size, Theme } from '@lumx/react';
 
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
-import { isEmpty } from 'lodash';
-import { renderLink } from '@lumx/react/utils/renderLink';
 import { AvatarProps } from '../avatar/Avatar';
 
 /**
@@ -20,10 +18,6 @@ export type UserBlockSize = Extract<Size, 's' | 'm' | 'l'>;
 export interface UserBlockProps extends GenericProps {
     /** Props to pass to the avatar. */
     avatarProps?: AvatarProps;
-    /** Props to pass to the link wrapping the avatar thumbnail. */
-    linkProps?: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
-    /** Custom react component for the link (can be used to inject react router Link). */
-    linkAs?: 'a' | any;
     /** Simple action toolbar content. */
     simpleAction?: ReactNode;
     /** Multiple action toolbar content. */
@@ -86,8 +80,6 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
         simpleAction,
         size,
         theme,
-        linkProps,
-        linkAs,
         ...forwardedProps
     } = props;
     let componentSize = size;
@@ -99,29 +91,12 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
 
     const shouldDisplayActions: boolean = orientation === Orientation.vertical;
 
-    const isLink = Boolean(linkProps?.href || linkAs);
-    const isClickable = !!onClick || isLink;
-
-    const nameBlock: ReactNode = React.useMemo(() => {
-        if (isEmpty(name)) {
-            return null;
-        }
-        const nameClassName = classNames(
-            handleBasicClasses({ prefix: `${CLASSNAME}__name`, isClickable }),
-            isLink && linkProps?.className,
-        );
-        if (isLink) {
-            return renderLink({ ...linkProps, linkAs, className: nameClassName }, name);
-        }
-        if (onClick) {
-            return (
-                <button onClick={onClick} type="button" className={nameClassName}>
-                    {name}
-                </button>
-            );
-        }
-        return <span className={nameClassName}>{name}</span>;
-    }, [isClickable, isLink, linkAs, linkProps, name, onClick]);
+    const nameBlock: ReactNode = name && (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-tabindex,jsx-a11y/no-static-element-interactions
+        <span className={`${CLASSNAME}__name`} onClick={onClick} tabIndex={onClick ? 0 : -1}>
+            {name}
+        </span>
+    );
 
     const fieldsBlock: ReactNode = fields && componentSize !== Size.s && (
         <div className={`${CLASSNAME}__fields`}>
@@ -139,20 +114,21 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
             {...forwardedProps}
             className={classNames(
                 className,
-                handleBasicClasses({ prefix: CLASSNAME, orientation, size: componentSize, theme, isClickable }),
+                handleBasicClasses({ prefix: CLASSNAME, orientation, size: componentSize, theme }),
             )}
             onMouseLeave={onMouseLeave}
             onMouseEnter={onMouseEnter}
         >
             {avatarProps && (
-                <Avatar
-                    linkProps={linkProps}
-                    {...avatarProps}
-                    className={classNames(`${CLASSNAME}__avatar`, avatarProps.className)}
-                    size={componentSize}
-                    onClick={onClick}
-                    theme={theme}
-                />
+                <div className={`${CLASSNAME}__avatar`}>
+                    <Avatar
+                        {...avatarProps}
+                        size={componentSize}
+                        onClick={onClick}
+                        tabIndex={onClick ? 0 : -1}
+                        theme={theme}
+                    />
+                </div>
             )}
             {(fields || name) && (
                 <div className={`${CLASSNAME}__wrapper`}>

--- a/packages/lumx-react/src/components/user-block/__snapshots__/UserBlock.test.tsx.snap
+++ b/packages/lumx-react/src/components/user-block/__snapshots__/UserBlock.test.tsx.snap
@@ -3,37 +3,41 @@
 exports[`<UserBlock> Snapshots and structure should render story 'InList' 1`] = `
 Array [
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <Avatar
-      alt="Avatar"
-      badge={
-        <Badge
-          color="blue"
-        >
-          <Icon
-            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-          />
-        </Badge>
-      }
+    <div
       className="lumx-user-block__avatar"
-      image="/demo-assets/avatar1.jpg"
-      onClick={[Function]}
-      size="m"
-      theme="light"
-    />
+    >
+      <Avatar
+        alt="Avatar"
+        badge={
+          <Badge
+            color="blue"
+          >
+            <Icon
+              icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+            />
+          </Badge>
+        }
+        image="/demo-assets/avatar1.jpg"
+        onClick={[Function]}
+        size="m"
+        tabIndex={0}
+        theme="light"
+      />
+    </div>
     <div
       className="lumx-user-block__wrapper"
     >
-      <button
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+      <span
+        className="lumx-user-block__name"
         onClick={[Function]}
-        type="button"
+        tabIndex={0}
       >
         Emmitt O. Lum
-      </button>
+      </span>
       <div
         className="lumx-user-block__fields"
       >
@@ -53,37 +57,41 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <Avatar
-      alt="Avatar"
-      badge={
-        <Badge
-          color="blue"
-        >
-          <Icon
-            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-          />
-        </Badge>
-      }
+    <div
       className="lumx-user-block__avatar"
-      image="/demo-assets/avatar2.jpg"
-      onClick={[Function]}
-      size="m"
-      theme="light"
-    />
+    >
+      <Avatar
+        alt="Avatar"
+        badge={
+          <Badge
+            color="blue"
+          >
+            <Icon
+              icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+            />
+          </Badge>
+        }
+        image="/demo-assets/avatar2.jpg"
+        onClick={[Function]}
+        size="m"
+        tabIndex={0}
+        theme="light"
+      />
+    </div>
     <div
       className="lumx-user-block__wrapper"
     >
-      <button
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+      <span
+        className="lumx-user-block__name"
         onClick={[Function]}
-        type="button"
+        tabIndex={0}
       >
         Emmitt O. Lum
-      </button>
+      </span>
       <div
         className="lumx-user-block__fields"
       >
@@ -103,37 +111,41 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <Avatar
-      alt="Avatar"
-      badge={
-        <Badge
-          color="blue"
-        >
-          <Icon
-            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-          />
-        </Badge>
-      }
+    <div
       className="lumx-user-block__avatar"
-      image="/demo-assets/avatar3.jpg"
-      onClick={[Function]}
-      size="m"
-      theme="light"
-    />
+    >
+      <Avatar
+        alt="Avatar"
+        badge={
+          <Badge
+            color="blue"
+          >
+            <Icon
+              icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+            />
+          </Badge>
+        }
+        image="/demo-assets/avatar3.jpg"
+        onClick={[Function]}
+        size="m"
+        tabIndex={0}
+        theme="light"
+      />
+    </div>
     <div
       className="lumx-user-block__wrapper"
     >
-      <button
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+      <span
+        className="lumx-user-block__name"
         onClick={[Function]}
-        type="button"
+        tabIndex={0}
       >
         Emmitt O. Lum
-      </button>
+      </span>
       <div
         className="lumx-user-block__fields"
       >
@@ -158,53 +170,61 @@ Array [
 exports[`<UserBlock> Snapshots and structure should render story 'Sizes' 1`] = `
 Array [
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-s lumx-user-block--theme-light lumx-user-block--is-clickable"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-s lumx-user-block--theme-light"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <Avatar
-      alt="Avatar"
+    <div
       className="lumx-user-block__avatar"
-      image="/demo-assets/avatar1.jpg"
-      onClick={[Function]}
-      size="s"
-      theme="light"
-    />
+    >
+      <Avatar
+        alt="Avatar"
+        image="/demo-assets/avatar1.jpg"
+        onClick={[Function]}
+        size="s"
+        tabIndex={0}
+        theme="light"
+      />
+    </div>
     <div
       className="lumx-user-block__wrapper"
     >
-      <button
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+      <span
+        className="lumx-user-block__name"
         onClick={[Function]}
-        type="button"
+        tabIndex={0}
       >
         Emmitt O. Lum
-      </button>
+      </span>
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <Avatar
-      alt="Avatar"
+    <div
       className="lumx-user-block__avatar"
-      image="/demo-assets/avatar1.jpg"
-      onClick={[Function]}
-      size="m"
-      theme="light"
-    />
+    >
+      <Avatar
+        alt="Avatar"
+        image="/demo-assets/avatar1.jpg"
+        onClick={[Function]}
+        size="m"
+        tabIndex={0}
+        theme="light"
+      />
+    </div>
     <div
       className="lumx-user-block__wrapper"
     >
-      <button
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+      <span
+        className="lumx-user-block__name"
         onClick={[Function]}
-        type="button"
+        tabIndex={0}
       >
         Emmitt O. Lum
-      </button>
+      </span>
       <div
         className="lumx-user-block__fields"
       >
@@ -224,28 +244,32 @@ Array [
     </div>
   </div>,
   <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-l lumx-user-block--theme-light lumx-user-block--is-clickable"
+    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-l lumx-user-block--theme-light"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <Avatar
-      alt="Avatar"
+    <div
       className="lumx-user-block__avatar"
-      image="/demo-assets/avatar1.jpg"
-      onClick={[Function]}
-      size="l"
-      theme="light"
-    />
+    >
+      <Avatar
+        alt="Avatar"
+        image="/demo-assets/avatar1.jpg"
+        onClick={[Function]}
+        size="l"
+        tabIndex={0}
+        theme="light"
+      />
+    </div>
     <div
       className="lumx-user-block__wrapper"
     >
-      <button
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
+      <span
+        className="lumx-user-block__name"
         onClick={[Function]}
-        type="button"
+        tabIndex={0}
       >
         Emmitt O. Lum
-      </button>
+      </span>
       <div
         className="lumx-user-block__fields"
       >
@@ -273,27 +297,34 @@ exports[`<UserBlock> Snapshots and structure should render story 'WithBadge' 1`]
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
-  <Avatar
-    alt="Avatar"
-    badge={
-      <Badge
-        color="blue"
-      >
-        <Icon
-          icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
-        />
-      </Badge>
-    }
+  <div
     className="lumx-user-block__avatar"
-    image="/demo-assets/avatar1.jpg"
-    size="m"
-    theme="light"
-  />
+  >
+    <Avatar
+      alt="Avatar"
+      badge={
+        <Badge
+          color="blue"
+        >
+          <Icon
+            icon="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+          />
+        </Badge>
+      }
+      image="/demo-assets/avatar1.jpg"
+      onClick={[Function]}
+      size="m"
+      tabIndex={0}
+      theme="light"
+    />
+  </div>
   <div
     className="lumx-user-block__wrapper"
   >
     <span
       className="lumx-user-block__name"
+      onClick={[Function]}
+      tabIndex={0}
     >
       Emmitt O. Lum
     </span>
@@ -315,134 +346,4 @@ exports[`<UserBlock> Snapshots and structure should render story 'WithBadge' 1`]
     </div>
   </div>
 </div>
-`;
-
-exports[`<UserBlock> Snapshots and structure should render story 'WithLinks' 1`] = `
-Array [
-  <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-s lumx-user-block--theme-light lumx-user-block--is-clickable"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
-    <Avatar
-      alt="Avatar"
-      className="lumx-user-block__avatar"
-      image="/demo-assets/avatar1.jpg"
-      linkProps={
-        Object {
-          "href": "https://www.lumapps.com",
-          "target": "_blank",
-        }
-      }
-      onClick={[Function]}
-      size="s"
-      theme="light"
-    />
-    <div
-      className="lumx-user-block__wrapper"
-    >
-      <a
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
-        href="https://www.lumapps.com"
-        target="_blank"
-      >
-        Emmitt O. Lum
-      </a>
-    </div>
-  </div>,
-  <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-m lumx-user-block--theme-light lumx-user-block--is-clickable"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
-    <Avatar
-      alt="Avatar"
-      className="lumx-user-block__avatar"
-      image="/demo-assets/avatar1.jpg"
-      linkProps={
-        Object {
-          "href": "https://www.lumapps.com",
-          "target": "_blank",
-        }
-      }
-      onClick={[Function]}
-      size="m"
-      theme="light"
-    />
-    <div
-      className="lumx-user-block__wrapper"
-    >
-      <a
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
-        href="https://www.lumapps.com"
-        target="_blank"
-      >
-        Emmitt O. Lum
-      </a>
-      <div
-        className="lumx-user-block__fields"
-      >
-        <span
-          className="lumx-user-block__field"
-          key="0"
-        >
-          Creative developer
-        </span>
-        <span
-          className="lumx-user-block__field"
-          key="1"
-        >
-          Denpasar
-        </span>
-      </div>
-    </div>
-  </div>,
-  <div
-    className="lumx-user-block lumx-user-block--orientation-horizontal lumx-user-block--size-l lumx-user-block--theme-light lumx-user-block--is-clickable"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
-    <Avatar
-      alt="Avatar"
-      className="lumx-user-block__avatar"
-      image="/demo-assets/avatar1.jpg"
-      linkProps={
-        Object {
-          "href": "https://www.lumapps.com",
-          "target": "_blank",
-        }
-      }
-      onClick={[Function]}
-      size="l"
-      theme="light"
-    />
-    <div
-      className="lumx-user-block__wrapper"
-    >
-      <a
-        className="lumx-user-block__name lumx-user-block__name--is-clickable"
-        href="https://www.lumapps.com"
-        target="_blank"
-      >
-        Emmitt O. Lum
-      </a>
-      <div
-        className="lumx-user-block__fields"
-      >
-        <span
-          className="lumx-user-block__field"
-          key="0"
-        >
-          Creative developer
-        </span>
-        <span
-          className="lumx-user-block__field"
-          key="1"
-        >
-          Denpasar
-        </span>
-      </div>
-    </div>
-  </div>,
-]
 `;


### PR DESCRIPTION
- Revert "fix(user-block): fix linkAs on Avatar"
- Revert "feat(thumbnail): fix thumbnail avatar and userblock a11y"

Reverts https://github.com/lumapps/design-system/pull/736
Reverts https://github.com/lumapps/design-system/pull/744

Changes on the Thumbnail markup (use of `<button>`) is breaking the style in specific use case so we are reverting these changes temporarly to [rework the Thumbnail style](https://github.com/lumapps/design-system/pull/713).

