### PR TITLE
Docs/badge : added section about colors

### DIFF
--- a/packages/site-demo/content/product/components/badge/index.mdx
+++ b/packages/site-demo/content/product/components/badge/index.mdx
@@ -17,7 +17,7 @@ Badges with icon are often used to display states, status or activities.
 
 ## Thumbnail
 
-Badges with thumbnail are often used to display custom logos.
+Badges with thumbnail are often used to display custom logos images.
 
 <DemoBlock orientation="horizontal" demo="thumbnail" />
 

--- a/packages/site-demo/content/product/components/badge/index.mdx
+++ b/packages/site-demo/content/product/components/badge/index.mdx
@@ -21,6 +21,11 @@ Badges with thumbnail are often used to display custom logos.
 
 <DemoBlock orientation="horizontal" demo="thumbnail" />
 
+## Colors
+**Blue** badges are often used as an accent visual, **Green** to emphasize succes, **Yellow** to emphasize warnings, **Red** to emphasize alerts and **Dark** as a neutral visual.
+
+<DemoBlock orientation="horizontal" demo="colors" />
+
 ### Properties
 
 <PropTable component="Badge" />

--- a/packages/site-demo/content/product/components/badge/react/colors.tsx
+++ b/packages/site-demo/content/product/components/badge/react/colors.tsx
@@ -1,0 +1,28 @@
+import { mdiAccount, mdiAlertCircle, mdiCheck, mdiClose, mdiStar } from '@lumx/icons';
+
+import { Badge, ColorPalette, Icon } from '@lumx/react';
+import React from 'react';
+
+export const App = () => (
+    <>
+        <Badge color={ColorPalette.blue}>
+            <Icon icon={mdiStar} />
+        </Badge>
+
+        <Badge color={ColorPalette.green}>
+            <Icon icon={mdiCheck} />
+        </Badge>
+
+        <Badge color={ColorPalette.yellow}>
+            <Icon icon={mdiAlertCircle} />
+        </Badge>
+
+        <Badge color={ColorPalette.red}>
+            <Icon icon={mdiClose} />
+        </Badge>
+
+        <Badge color={ColorPalette.dark}>
+            <Icon icon={mdiAccount} />
+        </Badge>
+    </>
+);


### PR DESCRIPTION
# General summary

A new section about color usage for badges and a demo block according.

# Screenshots
<img width="897" alt="Capture d’écran 2022-01-04 à 11 29 26" src="https://user-images.githubusercontent.com/15898440/148045839-6cc52001-b389-4858-a654-45d639c13b5a.png">
