### PR TITLE
docs(flag): added documentation page

### DIFF
--- a/packages/site-demo/content/product/components/flag/index.mdx
+++ b/packages/site-demo/content/product/components/flag/index.mdx
@@ -1,0 +1,11 @@
+# Flag
+
+**Flag display distinct attributes or number. They are not interactive.**
+
+Use flags to display short to middle length info like label, status, states in lists, tables.
+
+<DemoBlock orientation="horizontal" demo="flag" />
+
+### Properties
+
+<PropTable component="Flag" />

--- a/packages/site-demo/content/product/components/flag/index.mdx
+++ b/packages/site-demo/content/product/components/flag/index.mdx
@@ -2,7 +2,7 @@
 
 **Flag display distinct attributes or number. They are not interactive.**
 
-Use flags to display short to middle length info like label, status, states in lists, tables.
+Use flags to display short to middle length pieces of info like labels, status, states in lists and tables.
 
 <DemoBlock orientation="horizontal" demo="flag" />
 

--- a/packages/site-demo/content/product/components/flag/react/flag.tsx
+++ b/packages/site-demo/content/product/components/flag/react/flag.tsx
@@ -1,0 +1,13 @@
+import { mdiHeart } from '@lumx/icons';
+import { Flag, ColorPalette } from '@lumx/react';
+import React from 'react';
+
+export const App = ({ theme }: any) => (
+    <>
+        <Flag color={ColorPalette.blue} icon={mdiHeart} label="blue" theme={theme} />
+        <Flag color={ColorPalette.dark} icon={mdiHeart} label="dark" theme={theme} />
+        <Flag color={ColorPalette.green} icon={mdiHeart} label="green" theme={theme} />
+        <Flag color={ColorPalette.red} icon={mdiHeart} label="red" theme={theme} />
+        <Flag color={ColorPalette.yellow} icon={mdiHeart} label="yellow" theme={theme} />
+    </>
+);


### PR DESCRIPTION
# General summary

Documentation page for `flag` component
 
# Screenshots
![Capture d’écran 2022-01-25 à 08 37 09](https://user-images.githubusercontent.com/15898440/150932241-edeb8efd-bb69-46f3-8fa0-cddb808cd05a.png)


