### PR TITLE
docs(form-validation): fix wrong text and image

### DIFF
--- a/packages/site-demo/content/product/patterns/form-validation/index.mdx
+++ b/packages/site-demo/content/product/patterns/form-validation/index.mdx
@@ -73,9 +73,15 @@ Error messages must be displayed inline with erroneous fields. If an error occur
 
 ## Stepper buttons behavior
 
-<img src="assets/inline-validation.png" width="100%" />
+<img src="assets/stepper-behavior1.png" width="100%" />
 
-The NEXT stepper button is disabled as long as the mandatory fields haven’t been completed, or present errors.
+<img src="assets/stepper-behavior2.png" width="100%" />
+
+The "Next" stepper button is *disabled* as long as the mandatory fields haven’t been completed or present errors.
+
+<img src="assets/stepper-behavior3.png" width="100%" />
+
+The "Next" stepper button is *enabled* when all the mandatory fields have been completed and do not present errors.
 
 ## Optional vs. mandatory fields
 


### PR DESCRIPTION
# General summary

Fix wrong images and text for Stepper behavior section

# Screenshots
<img width="1115" alt="Capture d’écran 2022-01-06 à 15 29 55" src="https://user-images.githubusercontent.com/15898440/148398506-d830a943-2653-4c84-9b67-f1f2efcc21e5.png">

