### PR TITLE
fix(tooltip): fix tooltip on element using function ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   UserBlock: Added a `linkProps` and `linkAs` props which will be passed to the Thumbnail child and used to wrap the username.
 -   UserBlock: Added a `nameProps` props which will be passed to the name block.
 
+### Fixed
+
+-   Fixed Tooltip with target element using a function ref instead of object ref.
+
 ## [2.2.0][] - 2022-01-21
 
 ### Changed

--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -76,13 +76,16 @@ export const EmptyTooltip = () => (
 );
 
 export const TooltipWithDropdown = () => {
-    const buttonRef = useRef(null);
+    const [button, setButton] = useState<HTMLElement | null>(null);
+    const [isOpen, setOpen] = useState(false);
     return (
         <>
-            <Tooltip label="Tooltip">
-                <Button ref={buttonRef}>Anchor</Button>
+            <Tooltip label={!isOpen && 'Tooltip'} placement="top">
+                <Button ref={setButton} onClick={() => setOpen((o) => !o)}>
+                    Anchor
+                </Button>
             </Tooltip>
-            <Dropdown anchorRef={buttonRef} isOpen>
+            <Dropdown anchorRef={{ current: button }} isOpen={isOpen}>
                 Dropdown
             </Dropdown>
         </>

--- a/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
+++ b/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
@@ -28,9 +28,7 @@ export const useInjectTooltipRef = (
             get(children, 'props.isDisabled') !== true
         ) {
             const element = children as any;
-            if (element.ref) {
-                setAnchorElement(element.ref.current);
-            }
+
             return cloneElement(element, {
                 ...element.props,
                 ...ariaProps,


### PR DESCRIPTION
# General summary

Fix tooltip on element using function ref instead of object ref (createRef/useRef)
