### PR TITLE
fix/thumbnail small image with size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fixed Tooltip with target element using a function ref instead of object ref.
+-   Thumbnail: fix smaller image than the `size` prop.
 
 ## [2.2.0][] - 2022-01-21
 

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -79,13 +79,6 @@
     }
 }
 
-.#{$lumx-base-prefix}-thumbnail[class*='#{$lumx-base-prefix}-thumbnail--size-'] {
-    .#{$lumx-base-prefix}-thumbnail__background,
-    .#{$lumx-base-prefix}-thumbnail__image {
-        width: 100%;
-    }
-}
-
 /* Thumbnail aspect ratio
    ========================================================================== */
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -275,11 +275,13 @@ export const Vertical = () => (
             <Thumbnail alt="" aspectRatio="vertical" image={IMAGES.portrait1s200} size="xxl" />
         </FlexBox>
         <h2>With size & smaller image & fill height</h2>
+        <small>Unsupported use case (use ratio free with fill height)</small>
         <FlexBox orientation="horizontal" vAlign="center" gap="huge">
             <Thumbnail alt="" aspectRatio="vertical" image={IMAGES.landscape1s200} size="xxl" fillHeight />
             <Thumbnail alt="" aspectRatio="vertical" image={IMAGES.portrait1s200} size="xxl" fillHeight />
         </FlexBox>
         <h2>Constrained parent size & smaller image & fill height</h2>
+        <small>Unsupported use case (use ratio free with fill height)</small>
         <FlexBox orientation="horizontal" vAlign="center" gap="huge">
             <div className="parent" style={{ width: 220 }}>
                 <Thumbnail alt="" aspectRatio="vertical" image={IMAGES.landscape1s200} fillHeight />
@@ -329,11 +331,13 @@ export const Wide = () => (
             <Thumbnail alt="" aspectRatio="wide" image={IMAGES.portrait1s200} size="xxl" />
         </FlexBox>
         <h2>With size & smaller image & fill height</h2>
+        <small>Unsupported use case (use ratio free with fill height)</small>
         <FlexBox orientation="horizontal" vAlign="center" gap="huge">
             <Thumbnail alt="" aspectRatio="wide" image={IMAGES.landscape1s200} size="xxl" fillHeight />
             <Thumbnail alt="" aspectRatio="wide" image={IMAGES.portrait1s200} size="xxl" fillHeight />
         </FlexBox>
         <h2>Constrained parent size & smaller image & fill height</h2>
+        <small>Unsupported use case (use ratio free with fill height)</small>
         <FlexBox orientation="horizontal" vAlign="center" gap="huge">
             <div className="parent" style={{ width: 220 }}>
                 <Thumbnail alt="" aspectRatio="wide" image={IMAGES.landscape1s200} fillHeight />
@@ -383,11 +387,13 @@ export const Square = () => (
             <Thumbnail alt="" aspectRatio="square" image={IMAGES.portrait1s200} size="xxl" />
         </FlexBox>
         <h2>With size & smaller image & fill height</h2>
+        <small>Unsupported use case (use ratio free with fill height)</small>
         <FlexBox orientation="horizontal" vAlign="center" gap="huge">
             <Thumbnail alt="" aspectRatio="square" image={IMAGES.landscape1s200} size="xxl" fillHeight />
             <Thumbnail alt="" aspectRatio="square" image={IMAGES.portrait1s200} size="xxl" fillHeight />
         </FlexBox>
         <h2>Constrained parent size & smaller image & fill height</h2>
+        <small>Unsupported use case (use ratio free with fill height)</small>
         <FlexBox orientation="horizontal" vAlign="center" gap="huge">
             <div className="parent" style={{ width: 220 }}>
                 <Thumbnail alt="" aspectRatio="square" image={IMAGES.landscape1s200} fillHeight />

--- a/packages/lumx-react/src/stories/generated/Badge/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/Badge/Demos.stories.tsx
@@ -3,6 +3,7 @@
  */
 export default { title: 'LumX components/badge/Badge Demos' };
 
+export { App as Colors } from './colors';
 export { App as Icon } from './icon';
 export { App as Label } from './label';
 export { App as Thumbnail } from './thumbnail';

--- a/packages/lumx-react/src/stories/generated/Badge/colors.tsx
+++ b/packages/lumx-react/src/stories/generated/Badge/colors.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/badge/react/colors.tsx

--- a/packages/lumx-react/src/stories/generated/Flag/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/Flag/Demos.stories.tsx
@@ -1,0 +1,6 @@
+/**
+ * File generated when storybook is started. Do not edit directly!
+ */
+export default { title: 'LumX components/flag/Flag Demos' };
+
+export { App as Flag } from './flag';

--- a/packages/lumx-react/src/stories/generated/Flag/flag.tsx
+++ b/packages/lumx-react/src/stories/generated/Flag/flag.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/flag/react/flag.tsx


### PR DESCRIPTION
- fix(thumbnail): fix image smaller than the `size`
- chore(thumbnail): minor stories update

Image smaller than the given size prop were stretching to fill the size of the thumbnail but they should not