### PR TITLE
feat(tooltip): improve tooltip activation on touch devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Tooltip: rework of the activation method to fit more devices
+    -   On device with touch screen:
+        -   The Tooltip shows when the tooltip's anchor is pressed for more than 250 ms (long press).
+            This disables the default anchor's `click`/`touchend` event.
+        -   The tooltip hides 3 seconds after the long press is ended.
+        -   The tooltip is not activated on a short `click`/`tap`.
+    -   On devices supporting pointer hovering:
+        -   The tooltip shows when hovering (500 ms delay).
+        -   The tooltip hides when moving the pointer outside the anchor or clicking the anchor.
+    -   On every device:
+        -   The tooltip shows when focusing the anchor.
+        -   The tooltip hides when loosing focus on the anchor.
+        -   The tooltip hides when the escape key is pressed.
+
 ## [2.2.3][] - 2022-02-07
 
 ### Added

--- a/packages/lumx-core/src/js/constants/index.ts
+++ b/packages/lumx-core/src/js/constants/index.ts
@@ -14,3 +14,21 @@ export * from './keycodes';
  */
 export const DIALOG_TRANSITION_DURATION = 400;
 export const NOTIFICATION_TRANSITION_DURATION = 200;
+
+/**
+ * Delay on hover after which we open or close the tooltip.
+ * Only applies to devices supporting pointer hover.
+ */
+export const TOOLTIP_HOVER_DELAY = {
+    open: 500,
+    close: 0,
+};
+
+/**
+ * Delay on long press after which we open or close the tooltip.
+ * Only applies to devices not supporting pointer hover.
+ */
+export const TOOLTIP_LONG_PRESS_DELAY = {
+    open: 250,
+    close: 3000,
+};

--- a/packages/lumx-core/src/scss/components/tooltip/_index.scss
+++ b/packages/lumx-core/src/scss/components/tooltip/_index.scss
@@ -78,3 +78,10 @@
         line-height: $lumx-tooltip-line-height;
     }
 }
+
+.#{$lumx-base-prefix}-tooltip-anchor-wrapper {
+    width: fit-content;
+    // Prevent text selection on mobile device that would hinder long press.
+    -webkit-touch-callout: none;
+    user-select: none;
+}

--- a/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/lumx-react/src/components/button/__snapshots__/IconButton.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`<IconButton> Props should forward any CSS class 1`] = `
 <Tooltip
-  delay={500}
   placement="bottom"
 >
   <ButtonRoot
@@ -19,7 +18,6 @@ exports[`<IconButton> Props should forward any CSS class 1`] = `
 
 exports[`<IconButton> Props should use default props 1`] = `
 <Tooltip
-  delay={500}
   placement="bottom"
 >
   <ButtonRoot
@@ -35,7 +33,6 @@ exports[`<IconButton> Props should use default props 1`] = `
 
 exports[`<IconButton> Snapshots and structure should render icon button 1`] = `
 <Tooltip
-  delay={500}
   placement="bottom"
 >
   <ButtonRoot
@@ -51,7 +48,6 @@ exports[`<IconButton> Snapshots and structure should render icon button 1`] = `
 
 exports[`<IconButton> Snapshots and structure should render icon button with an image 1`] = `
 <Tooltip
-  delay={500}
   placement="bottom"
 >
   <ButtonRoot
@@ -70,7 +66,6 @@ exports[`<IconButton> Snapshots and structure should render icon button with an 
 
 exports[`<IconButton> Snapshots and structure should render icon button with an image if both props are set 1`] = `
 <Tooltip
-  delay={500}
   placement="bottom"
 >
   <ButtonRoot

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -49,7 +49,6 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * Component default props.
  */
 const DEFAULT_PROPS: Partial<TooltipProps> = {
-    delay: 500,
     placement: Placement.BOTTOM,
 };
 
@@ -90,7 +89,7 @@ export const Tooltip: Comp<TooltipProps, HTMLDivElement> = forwardRef((props, re
     });
 
     const position = attributes?.popper?.['data-popper-placement'] ?? placement;
-    const isOpen = useTooltipOpen(delay as number, anchorElement) || forceOpen;
+    const isOpen = useTooltipOpen(delay, anchorElement) || forceOpen;
     const wrappedChildren = useInjectTooltipRef(children, setAnchorElement, isOpen as boolean, id);
 
     return (

--- a/packages/lumx-react/src/constants.ts
+++ b/packages/lumx-react/src/constants.ts
@@ -1,4 +1,10 @@
-export { CSS_PREFIX, DIALOG_TRANSITION_DURATION, NOTIFICATION_TRANSITION_DURATION } from '@lumx/core/js/constants';
+export {
+    CSS_PREFIX,
+    DIALOG_TRANSITION_DURATION,
+    NOTIFICATION_TRANSITION_DURATION,
+    TOOLTIP_HOVER_DELAY,
+    TOOLTIP_LONG_PRESS_DELAY,
+} from '@lumx/core/js/constants';
 
 /**
  * Optional global `window` instance (not defined when running SSR).

--- a/packages/lumx-react/src/utils/browserDoesNotSupportHover.test.js
+++ b/packages/lumx-react/src/utils/browserDoesNotSupportHover.test.js
@@ -1,0 +1,24 @@
+import { browserDoesNotSupportHover } from '@lumx/react/utils/browserDoesNotSupportHover';
+
+const originalMatchMedia = global.matchMedia;
+
+describe('browserDoesNotSupportHover', () => {
+    afterAll(() => {
+        global.matchMedia = originalMatchMedia;
+    });
+
+    it('should return `false` on browsers that do not support matchMedia', () => {
+        global.matchMedia = undefined;
+        expect(browserDoesNotSupportHover()).toBe(false);
+    });
+
+    it('should return `false` on browsers that support matchMedia and does support hover', () => {
+        global.matchMedia = () => ({ matches: false });
+        expect(browserDoesNotSupportHover()).toBe(false);
+    });
+
+    it('should return `true` on browsers that support matchMedia and does not support hover', () => {
+        global.matchMedia = () => ({ matches: true });
+        expect(browserDoesNotSupportHover()).toBe(true);
+    });
+});

--- a/packages/lumx-react/src/utils/browserDoesNotSupportHover.ts
+++ b/packages/lumx-react/src/utils/browserDoesNotSupportHover.ts
@@ -1,0 +1,2 @@
+/** Return true if the browser does not support pointer hover */
+export const browserDoesNotSupportHover = (): boolean => !!window.matchMedia?.('(hover: none)').matches;


### PR DESCRIPTION
# General summary


## Tooltip: rework of the activation method to fit more devices
-   On device with touch screen:
    -   The Tooltip shows when the tooltip's anchor is pressed for more than 250 ms (long press).
        This disables the default anchor's `click`/`touchend` event.
    -   The tooltip hides 3 seconds after the long press is ended.
    -   The tooltip is not activated on a short `click`/`tap`.
 -   On devices supporting pointer hovering:
     -   The tooltip shows when hovering the anchor (500 ms delay).
     -   The tooltip hides when moving the pointer outside the anchor or clicking the anchor.
 -   On every device:
     -   The tooltip shows when focusing the anchor.
     -   The tooltip hides when loosing focus on the anchor.
     -   The tooltip hides when the escape key is pressed.

# Screenshots

On desktop 

https://user-images.githubusercontent.com/939567/153460473-d16c7151-30ed-4507-befa-eb80911234c5.mp4 

On mobile

https://user-images.githubusercontent.com/939567/153460476-84a1c03a-cc57-4916-9da0-11f71310a55d.mp4


