### PR TITLE
fix(thumbnail): fix original aspect ratio on ios safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         -   The tooltip hides when loosing focus on the anchor.
         -   The tooltip hides when the escape key is pressed.
 
+### Fixed
+
+-   Thumbnail: fix image original aspect ratio on ios safari.
+
 ## [2.2.3][] - 2022-02-07
 
 ### Added

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -39,11 +39,14 @@
 
     &__image {
         display: block;
-        width: fit-content;
         max-width: 100%;
-        height: fit-content;
         max-height: 100%;
         font-size: 0;
+
+        &--has-defined-size {
+            width: fit-content;
+            height: fit-content;
+        }
     }
 
     &__background,

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -188,7 +188,13 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
                         ...focusPointStyle,
                     }}
                     ref={mergeRefs(setImgElement, propImgRef)}
-                    className={classNames(`${CLASSNAME}__image`, isLoading && `${CLASSNAME}__image--is-loading`)}
+                    className={classNames(
+                        handleBasicClasses({
+                            prefix: `${CLASSNAME}__image`,
+                            isLoading,
+                            hasDefinedSize: Boolean(imgProps?.height && imgProps.width),
+                        }),
+                    )}
                     crossOrigin={crossOrigin}
                     src={image}
                     alt={alt}


### PR DESCRIPTION
# General summary

Fix height/width ratio on aspect ratio original on iOS Safari

# Screenshots
| Before | After |
| --- | --- |
| ![IMG_1852](https://user-images.githubusercontent.com/939567/155327152-651206ea-ec6c-4462-bfe6-180da75ca705.PNG) | ![IMG_1851](https://user-images.githubusercontent.com/939567/155327158-9c4c4b15-4a1c-485c-b90b-d553755222b0.PNG) |


