### PR TITLE
chore(icon): add alt attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Icon: Add `alt` attribute to set an alternative text to the icon. If defined, `role="img"` will also be applied to `svg` element.
+If undefined, `aria-hidden=true` will be applied to `svg` element.
+
 ### Changed
 
 -   @lumx/core: all CSS `:hover` style are now disable on devices that do not support pointer hover.

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -27,6 +27,8 @@ export interface IconProps extends GenericProps {
     size?: IconSizes;
     /** Theme adapting the component to light or dark background. */
     theme?: Theme;
+    /** Sets an alternative text on the svg. Will set an `img` role to the svg. */
+    alt?: string;
 }
 
 /**
@@ -52,7 +54,7 @@ const DEFAULT_PROPS: Partial<IconProps> = {};
  * @return React element.
  */
 export const Icon: Comp<IconProps, HTMLElement> = forwardRef((props, ref) => {
-    const { className, color, colorVariant, hasShape, icon, size, theme, ...forwardedProps } = props;
+    const { className, color, colorVariant, hasShape, icon, size, theme, alt, ...forwardedProps } = props;
 
     let iconColor;
     let iconColorVariant;
@@ -110,7 +112,9 @@ export const Icon: Comp<IconProps, HTMLElement> = forwardRef((props, ref) => {
             )}
         >
             <svg
-                aria-hidden="true"
+                aria-hidden={alt ? undefined : 'true'}
+                role={alt ? 'img' : undefined}
+                aria-label={alt}
                 height="1em"
                 preserveAspectRatio="xMidYMid meet"
                 style={{ verticalAlign: '-0.125em' }}


### PR DESCRIPTION
# General summary

Add alt attribute to svg element.

If set, the svg element will have a `role="img"` attribute added to it + `aria-label={alt}`
If omitted, the svg keeps a `aria-hidden="true"` attribute.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

# Check list

<!-- Add/Remove/Update the following check list depending on your submission -->

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
