### PR TITLE
chore(slideshow): fix hidden slide when using groupBy

### DIFF
--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -218,6 +218,10 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
         };
     }, [autoPlay, element]);
 
+    // Start index and end index of visible slides.
+    const startIndexVisible = currentIndex * (groupBy as number);
+    const endIndexVisible = startIndexVisible + (groupBy as number);
+
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     return (
         <section
@@ -240,13 +244,13 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
                 <div className={`${CLASSNAME}__wrapper`} style={wrapperStyle}>
                     {React.Children.map(children, (child: React.ReactNode, index: number) => {
                         if (React.isValidElement(child)) {
-                            const isCurrentlyNotVisible = index !== currentIndex;
+                            const isCurrentlyVisible = index >= startIndexVisible && index <= endIndexVisible;
 
                             return React.cloneElement(child, {
-                                style: isCurrentlyNotVisible
+                                style: !isCurrentlyVisible
                                     ? { visibility: 'hidden', ...(child.props.style || {}) }
                                     : child.props.style || {},
-                                'aria-hidden': isCurrentlyNotVisible,
+                                'aria-hidden': !isCurrentlyVisible,
                             });
                         }
 

--- a/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
+++ b/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
@@ -47,13 +47,9 @@ Array [
           />
         </SlideshowItem>
         <SlideshowItem
-          aria-hidden={true}
+          aria-hidden={false}
           key=".$/demo-assets/landscape1-s200.jpg-1"
-          style={
-            Object {
-              "visibility": "hidden",
-            }
-          }
+          style={Object {}}
         >
           <ImageBlock
             align="left"


### PR DESCRIPTION
# General summary

The addition of the `visibility: 'hidden'` style on slide was not aware of the `groupBy` option and thus slides where not all showing as expected when grouping slides.

