### PR TITLE
chore(slideshow): added play buttton and other enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Slideshow Controls: Added Play/Pause Button and added focus styles to bullets.
+
+### Fixed
+
+-   Slideshow: slides no longer appear as blank while transitioning.
+
 ## [2.2.8][] - 2022-03-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Slideshow Controls: Added Play/Pause Button and added focus styles to bullets.
+-   Slideshow Controls: Added Play/Pause Button and added focus styles to bullets. Allow to pass in a label for each bullet.
 
 ### Fixed
 

--- a/packages/lumx-core/src/js/constants/index.ts
+++ b/packages/lumx-core/src/js/constants/index.ts
@@ -14,6 +14,7 @@ export * from './keycodes';
  */
 export const DIALOG_TRANSITION_DURATION = 400;
 export const NOTIFICATION_TRANSITION_DURATION = 200;
+export const SLIDESHOW_TRANSITION_DURATION = 5000;
 
 /**
  * Delay on hover after which we open or close the tooltip.

--- a/packages/lumx-core/src/scss/components/slideshow/_index.scss
+++ b/packages/lumx-core/src/scss/components/slideshow/_index.scss
@@ -81,9 +81,11 @@
         display: flex;
         align-items: center;
         transition: transform $lumx-slideshow-transition-duration;
+        padding: 4px 0;
     }
 
     &__pagination-item {
+        $item: &;
         width: 8px;
         height: 8px;
         flex-shrink: 0;
@@ -102,18 +104,34 @@
         #{$self}--theme-light & {
             background-color: lumx-color-variant('dark', 'L4');
 
+            &[data-focus-visible-added]{
+                @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'dark');
+            }
+
             &:hover,
             &--is-active {
                 background-color: lumx-color-variant('primary', 'N');
+
+                &[data-focus-visible-added]{
+                    @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'primary');
+                }
             }
         }
 
         #{$self}--theme-dark & {
             background-color: lumx-color-variant('light', 'L4');
 
+            &[data-focus-visible-added]{
+                @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'light');
+            }
+
             &:hover,
             &--is-active {
                 background-color: lumx-color-variant('light', 'N');
+
+                &[data-focus-visible-added]{
+                    @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'light');
+                }
             }
         }
 

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -3,11 +3,41 @@ import React, { CSSProperties, forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
-import { Comp, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+import { Theme } from '@lumx/react';
 
-export interface SlidesProps {
-
+export interface SlidesProps extends GenericProps {
+    /** current slide active */
+    activeIndex?: number;
+    /** slides id to be added to the wrapper */
+    id?: string;
+    /** callback to set a reference to the slideshow */
+    setSlideshow: (slideshow: HTMLDivElement | undefined) => void;
+    /** custom classname */
+    className?: string;
+    /** custom theme */
+    theme?: Theme;
+    /** Whether the automatic rotation of the slideshow is enabled or not. */
+    autoPlay?: boolean;
+    /** Whether the image has to fill its container height or not. */
+    fillHeight?: boolean;
+    /** Number of slides to group together. */
+    groupBy?: number;
+    /** Interval between each slide when automatic rotation is enabled. */
+    interval?: number;
+    /** whether the slides are currently playing or not */
+    isAutoPlaying?: boolean;
+    /** id to be passed in into the slides */
+    slidesId?: string;
+    /** callback to change whether the slideshow is playing or not */
+    setIsAutoPlaying: (isAutoPlaying: boolean) => void;
+    /** starting visible index */
+    startIndexVisible: number;
+    /** ending visible index */
+    endIndexVisible: number;
+    /** component to be rendered after the slides */
+    afterSlides?: React.ReactNode;
 }
 
 /**
@@ -30,7 +60,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
 export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
     const {
         activeIndex,
-        slideshowId,
+        id,
         setSlideshow,
         className,
         theme,
@@ -38,12 +68,13 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
         groupBy,
         isAutoPlaying,
         autoPlay,
-        slideshowSlidesId,
+        slidesId,
         setIsAutoPlaying,
         startIndexVisible,
         endIndexVisible,
         children,
         afterSlides,
+        interval,
         ...forwardedProps
     } = props;
     // Inline style of wrapper element.
@@ -52,7 +83,7 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     return (
         <section
-            id={slideshowId}
+            id={id}
             ref={mergeRefs(ref, setSlideshow)}
             {...forwardedProps}
             className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }), {
@@ -63,7 +94,7 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
             aria-live={isAutoPlaying ? 'off' : 'polite'}
         >
             <div
-                id={slideshowSlidesId}
+                id={slidesId}
                 className={`${CLASSNAME}__slides`}
                 onMouseEnter={() => setIsAutoPlaying(false)}
                 onMouseLeave={() => setIsAutoPlaying(Boolean(autoPlay))}
@@ -71,13 +102,11 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
                 <div className={`${CLASSNAME}__wrapper`} style={wrapperStyle}>
                     {React.Children.map(children, (child: React.ReactNode, index: number) => {
                         if (React.isValidElement(child)) {
-                            const isCurrentlyVisible = index >= startIndexVisible && index <= endIndexVisible;
+                            const isCurrentlyVisible = index >= startIndexVisible && index < endIndexVisible;
 
                             return React.cloneElement(child, {
-                                style: !isCurrentlyVisible
-                                    ? { visibility: 'hidden', ...(child.props.style || {}) }
-                                    : child.props.style || {},
-                                'aria-hidden': !isCurrentlyVisible,
+                                isCurrentlyVisible,
+                                interval,
                             });
                         }
 
@@ -90,3 +119,6 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
         </section>
     );
 });
+
+Slides.displayName = COMPONENT_NAME;
+Slides.className = CLASSNAME;

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 
 import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
-import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { Theme } from '@lumx/react';
 
 export interface SlidesProps extends GenericProps {
@@ -12,8 +11,6 @@ export interface SlidesProps extends GenericProps {
     activeIndex?: number;
     /** slides id to be added to the wrapper */
     id?: string;
-    /** callback to set a reference to the slideshow */
-    setSlideshow: (slideshow: HTMLDivElement | undefined) => void;
     /** custom classname */
     className?: string;
     /** custom theme */
@@ -24,8 +21,6 @@ export interface SlidesProps extends GenericProps {
     fillHeight?: boolean;
     /** Number of slides to group together. */
     groupBy?: number;
-    /** Interval between each slide when automatic rotation is enabled. */
-    interval?: number;
     /** whether the slides are currently playing or not */
     isAutoPlaying?: boolean;
     /** id to be passed in into the slides */
@@ -61,7 +56,6 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
     const {
         activeIndex,
         id,
-        setSlideshow,
         className,
         theme,
         fillHeight,
@@ -74,30 +68,28 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
         endIndexVisible,
         children,
         afterSlides,
-        interval,
         ...forwardedProps
     } = props;
     // Inline style of wrapper element.
     const wrapperStyle: CSSProperties = { transform: `translateX(-${FULL_WIDTH_PERCENT * activeIndex}%)` };
 
-    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     return (
         <section
             id={id}
-            ref={mergeRefs(ref, setSlideshow)}
+            ref={ref}
             {...forwardedProps}
             className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }), {
                 [`${CLASSNAME}--fill-height`]: fillHeight,
                 [`${CLASSNAME}--group-by-${groupBy}`]: Boolean(groupBy),
             })}
             aria-roledescription="carousel"
-            aria-live={isAutoPlaying ? 'off' : 'polite'}
         >
             <div
                 id={slidesId}
                 className={`${CLASSNAME}__slides`}
                 onMouseEnter={() => setIsAutoPlaying(false)}
                 onMouseLeave={() => setIsAutoPlaying(Boolean(autoPlay))}
+                aria-live={isAutoPlaying ? 'off' : 'polite'}
             >
                 <div className={`${CLASSNAME}__wrapper`} style={wrapperStyle}>
                     {React.Children.map(children, (child: React.ReactNode, index: number) => {
@@ -106,7 +98,6 @@ export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
 
                             return React.cloneElement(child, {
                                 isCurrentlyVisible,
-                                interval,
                             });
                         }
 

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -1,0 +1,92 @@
+import React, { CSSProperties, forwardRef } from 'react';
+
+import classNames from 'classnames';
+
+import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
+import { Comp, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+
+export interface SlidesProps {
+
+}
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'Slideshow';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
+
+/**
+ * Slides component.
+ *
+ * @param  props Component props.
+ * @param  ref   Component ref.
+ * @return React element.
+ */
+export const Slides: Comp<any, HTMLDivElement> = forwardRef((props, ref) => {
+    const {
+        activeIndex,
+        slideshowId,
+        setSlideshow,
+        className,
+        theme,
+        fillHeight,
+        groupBy,
+        isAutoPlaying,
+        autoPlay,
+        slideshowSlidesId,
+        setIsAutoPlaying,
+        startIndexVisible,
+        endIndexVisible,
+        children,
+        afterSlides,
+        ...forwardedProps
+    } = props;
+    // Inline style of wrapper element.
+    const wrapperStyle: CSSProperties = { transform: `translateX(-${FULL_WIDTH_PERCENT * activeIndex}%)` };
+
+    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+    return (
+        <section
+            id={slideshowId}
+            ref={mergeRefs(ref, setSlideshow)}
+            {...forwardedProps}
+            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }), {
+                [`${CLASSNAME}--fill-height`]: fillHeight,
+                [`${CLASSNAME}--group-by-${groupBy}`]: Boolean(groupBy),
+            })}
+            aria-roledescription="carousel"
+            aria-live={isAutoPlaying ? 'off' : 'polite'}
+        >
+            <div
+                id={slideshowSlidesId}
+                className={`${CLASSNAME}__slides`}
+                onMouseEnter={() => setIsAutoPlaying(false)}
+                onMouseLeave={() => setIsAutoPlaying(Boolean(autoPlay))}
+            >
+                <div className={`${CLASSNAME}__wrapper`} style={wrapperStyle}>
+                    {React.Children.map(children, (child: React.ReactNode, index: number) => {
+                        if (React.isValidElement(child)) {
+                            const isCurrentlyVisible = index >= startIndexVisible && index <= endIndexVisible;
+
+                            return React.cloneElement(child, {
+                                style: !isCurrentlyVisible
+                                    ? { visibility: 'hidden', ...(child.props.style || {}) }
+                                    : child.props.style || {},
+                                'aria-hidden': !isCurrentlyVisible,
+                            });
+                        }
+
+                        return null;
+                    })}
+                </div>
+            </div>
+
+            {afterSlides}
+        </section>
+    );
+});

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -40,6 +40,40 @@ export const Simple = ({ theme }: any) => {
     );
 };
 
+export const SimpleWithAutoPlay = ({ theme }: any) => {
+    const images = thumbnailsKnob(6);
+    const activeIndex = number('Active index', 0);
+    const groupBy = number('Group by', 1);
+    const interval = number('Autoplay interval (in milliseconds)', 1000);
+
+    return (
+        <Slideshow
+            activeIndex={activeIndex}
+            autoPlay
+            interval={interval}
+            slideshowControlsProps={{
+                nextButtonProps: { label: 'Next' },
+                previousButtonProps: { label: 'Previous' },
+                playButtonProps: { label: 'Play/Pause' },
+            }}
+            theme={theme}
+            groupBy={groupBy}
+            style={{ width: '50%' }}
+        >
+            {images.map(({ image, alt }, index) => (
+                <SlideshowItem key={`${image}-${index}`}>
+                    <ImageBlock
+                        thumbnailProps={{ aspectRatio: AspectRatio.horizontal, loading: 'eager' }}
+                        image={image}
+                        alt={alt}
+                        theme={theme}
+                    />
+                </SlideshowItem>
+            ))}
+        </Slideshow>
+    );
+};
+
 export const ResponsiveSlideShowSwipe = () => {
     const slides = range(3);
     return (

--- a/packages/lumx-react/src/components/slideshow/Slideshow.test.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.test.tsx
@@ -35,5 +35,5 @@ describe(`<${Slideshow.displayName}>`, () => {
     });
 
     // Common tests suite.
-    commonTestsSuite(setup, { className: 'wrapper', prop: 'wrapper' }, { className: CLASSNAME });
+    commonTestsSuite(setup, { prop: 'wrapper' }, { className: CLASSNAME });
 });

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -1,12 +1,8 @@
-import React, { CSSProperties, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 
-import classNames from 'classnames';
-
-import { SlideshowControls, SlideshowControlsProps, Theme } from '@lumx/react';
+import { SlideshowControls, SlideshowControlsProps, Theme, Slides } from '@lumx/react';
 import { DEFAULT_OPTIONS } from '@lumx/react/hooks/useSlideshowControls';
-import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
-import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+import { Comp, GenericProps, getRootClassName } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
@@ -24,16 +20,16 @@ export interface SlideshowProps extends GenericProps {
     interval?: number;
     /** Props to pass to the slideshow controls (minus those already set by the Slideshow props). */
     slideshowControlsProps?: Pick<SlideshowControlsProps, 'nextButtonProps' | 'previousButtonProps'> &
-        Omit<
-            SlideshowControlsProps,
-            | 'activeIndex'
-            | 'onPaginationClick'
-            | 'onNextClick'
-            | 'onPreviousClick'
-            | 'slidesCount'
-            | 'parentRef'
-            | 'theme'
-        >;
+    Omit<
+        SlideshowControlsProps,
+        | 'activeIndex'
+        | 'onPaginationClick'
+        | 'onNextClick'
+        | 'onPreviousClick'
+        | 'slidesCount'
+        | 'parentRef'
+        | 'theme'
+    >;
     /** Theme adapting the component to light or dark background. */
     theme?: Theme;
     /** Callback when slide changes */
@@ -114,47 +110,24 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
         slidesId,
     });
 
-    // Inline style of wrapper element.
-    const wrapperStyle: CSSProperties = { transform: `translateX(-${FULL_WIDTH_PERCENT * currentIndex}%)` };
-
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     return (
-        <section
-            id={slideshowId}
-            ref={mergeRefs(ref, setSlideshow)}
-            {...forwardedProps}
-            className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, theme }), {
-                [`${CLASSNAME}--fill-height`]: fillHeight,
-                [`${CLASSNAME}--group-by-${groupBy}`]: Boolean(groupBy),
-            })}
-            aria-roledescription="carousel"
-            aria-live={isAutoPlaying ? 'off' : 'polite'}
-        >
-            <div
-                id={slideshowSlidesId}
-                className={`${CLASSNAME}__slides`}
-                onMouseEnter={() => setIsAutoPlaying(false)}
-                onMouseLeave={() => setIsAutoPlaying(Boolean(autoPlay))}
-            >
-                <div className={`${CLASSNAME}__wrapper`} style={wrapperStyle}>
-                    {React.Children.map(children, (child: React.ReactNode, index: number) => {
-                        if (React.isValidElement(child)) {
-                            const isCurrentlyVisible = index >= startIndexVisible && index <= endIndexVisible;
-
-                            return React.cloneElement(child, {
-                                style: !isCurrentlyVisible
-                                    ? { visibility: 'hidden', ...(child.props.style || {}) }
-                                    : child.props.style || {},
-                                'aria-hidden': !isCurrentlyVisible,
-                            });
-                        }
-
-                        return null;
-                    })}
-                </div>
-            </div>
-
-            {slideshowControlsProps && slidesCount > 1 && (
+        <Slides
+            activeIndex={currentIndex}
+            slideshowId={slideshowId}
+            setSlideshow={setSlideshow}
+            className={className}
+            theme={theme}
+            fillHeight={fillHeight}
+            groupBy={groupBy}
+            isAutoPlaying={isAutoPlaying}
+            autoPlay={autoPlay}
+            slideshowSlidesId={slideshowSlidesId}
+            setIsAutoPlaying={setIsAutoPlaying}
+            startIndexVisible={startIndexVisible}
+            endIndexVisible={endIndexVisible}
+            children={children}
+            afterSlides={slideshowControlsProps && slidesCount > 1 ? (
                 <div className={`${CLASSNAME}__controls`}>
                     <SlideshowControls
                         {...slideshowControlsProps}
@@ -175,8 +148,9 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
                         }}
                     />
                 </div>
-            )}
-        </section>
+            ) : undefined}
+            {...forwardedProps}
+        />
     );
 });
 

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -4,6 +4,7 @@ import { SlideshowControls, SlideshowControlsProps, Theme, Slides, SlidesProps }
 import { DEFAULT_OPTIONS } from '@lumx/react/hooks/useSlideshowControls';
 import { Comp, GenericProps } from '@lumx/react/utils';
 import { useFocusWithin } from '@lumx/react/hooks/useFocusWithin';
+import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 /**
  * Defines the props of the component.
@@ -12,15 +13,7 @@ export interface SlideshowProps
     extends GenericProps,
         Pick<
             SlidesProps,
-            | 'activeIndex'
-            | 'autoPlay'
-            | 'fillHeight'
-            | 'slidesId'
-            | 'id'
-            | 'theme'
-            | 'fillHeight'
-            | 'groupBy'
-            | 'interval'
+            'activeIndex' | 'autoPlay' | 'fillHeight' | 'slidesId' | 'id' | 'theme' | 'fillHeight' | 'groupBy'
         > {
     /** Interval between each slide when automatic rotation is enabled. */
     interval?: number;
@@ -110,12 +103,10 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
         onFocusOut: startAutoPlay,
     });
 
-    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     return (
         <Slides
             activeIndex={currentIndex}
             id={slideshowId}
-            setSlideshow={setSlideshow}
             className={className}
             theme={theme}
             fillHeight={fillHeight}
@@ -127,7 +118,7 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
             startIndexVisible={startIndexVisible}
             endIndexVisible={endIndexVisible}
             interval={interval}
-            ref={ref}
+            ref={mergeRefs(ref, setSlideshow)}
             afterSlides={
                 slideshowControlsProps && slidesCount > 1 ? (
                     <div className={`${Slides.className}__controls`}>

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
@@ -70,7 +70,7 @@ export const ControllingSlideshow = ({ theme }: any) => {
         <Slides
             activeIndex={currentIndex}
             id={slideshowId}
-            setSlideshow={setSlideshow}
+            ref={setSlideshow}
             theme={theme}
             isAutoPlaying={isAutoPlaying}
             autoPlay
@@ -98,6 +98,7 @@ export const ControllingSlideshow = ({ theme }: any) => {
                             'aria-controls': slideshowSlidesId,
                             onClick: () => setIsForcePaused(!isForcePaused),
                         }}
+                        paginationItemLabel={(index) => `Slide ${index}`}
                     />
                 </div>
             }

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { AspectRatio, ImageBlock, Slideshow, SlideshowControls, SlideshowItem } from '@lumx/react';
+import { AspectRatio, ImageBlock, Slides, SlideshowControls, SlideshowItem } from '@lumx/react';
 import { thumbnailsKnob } from '@lumx/react/stories/knobs/thumbnailsKnob';
+import { useFocusWithin } from '@lumx/react/hooks/useFocusWithin';
 
 export default { title: 'LumX components/slideshow/Slideshow controls' };
 
@@ -30,53 +31,87 @@ export const Simple = () => {
 };
 
 export const ControllingSlideshow = ({ theme }: any) => {
-    const items = thumbnailsKnob(6);
-    const slideshowStyle = {
-        width: '50%',
-    };
+    const images = thumbnailsKnob(6);
 
     const {
-        activeIndex,
-        setActiveIndex,
+        activeIndex: currentIndex,
+        slideshowId,
+        setSlideshow,
+        isAutoPlaying,
+        slideshowSlidesId,
+        setIsAutoPlaying,
+        startIndexVisible,
+        endIndexVisible,
+        slidesCount,
         onNextClick,
-        onPreviousClick,
         onPaginationClick,
+        onPreviousClick,
+        slideshow,
+        isForcePaused,
+        setIsForcePaused,
+        stopAutoPlay,
+        startAutoPlay,
     } = SlideshowControls.useSlideshowControls({
+        activeIndex: 0,
+        defaultActiveIndex: 0,
+        autoPlay: true,
         itemsCount: 6,
+        groupBy: 1,
     });
 
+    useFocusWithin({
+        element: slideshow,
+        onFocusIn: stopAutoPlay,
+        onFocusOut: startAutoPlay,
+    });
+
+    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     return (
-        <div style={{ height: 400, width: 500, position: 'relative' }}>
-            <Slideshow
-                activeIndex={activeIndex}
-                theme={theme}
-                autoPlay
-                groupBy={1}
-                style={slideshowStyle}
-                onChange={setActiveIndex}
-            >
-                {items.map(({ image, alt }) => (
-                    <SlideshowItem key={image}>
-                        <ImageBlock
-                            image={image}
-                            alt={alt}
-                            thumbnailProps={{ aspectRatio: AspectRatio.vertical }}
-                            theme={theme}
-                        />
-                    </SlideshowItem>
-                ))}
-            </Slideshow>
-            <div style={{ position: 'absolute', bottom: 0, right: -24 }}>
-                <SlideshowControls
-                    activeIndex={activeIndex}
-                    slidesCount={items.length}
-                    onNextClick={onNextClick}
-                    onPreviousClick={onPreviousClick}
-                    onPaginationClick={onPaginationClick}
-                    nextButtonProps={{ label: 'Next' }}
-                    previousButtonProps={{ label: 'Previous' }}
-                />
-            </div>
-        </div>
+        <Slides
+            activeIndex={currentIndex}
+            id={slideshowId}
+            setSlideshow={setSlideshow}
+            theme={theme}
+            isAutoPlaying={isAutoPlaying}
+            autoPlay
+            slidesId={slideshowSlidesId}
+            setIsAutoPlaying={setIsAutoPlaying}
+            startIndexVisible={startIndexVisible}
+            endIndexVisible={endIndexVisible}
+            groupBy={1}
+            style={{ width: '50%' }}
+            afterSlides={
+                <div className={`${Slides.className}__controls`}>
+                    <SlideshowControls
+                        activeIndex={currentIndex}
+                        onPaginationClick={onPaginationClick}
+                        onNextClick={onNextClick}
+                        onPreviousClick={onPreviousClick}
+                        slidesCount={slidesCount}
+                        parentRef={slideshow}
+                        theme={theme}
+                        isAutoPlaying={isAutoPlaying}
+                        nextButtonProps={{ label: 'Next', 'aria-controls': slideshowSlidesId }}
+                        previousButtonProps={{ label: 'Previous', 'aria-controls': slideshowSlidesId }}
+                        playButtonProps={{
+                            label: 'Play/Pause',
+                            'aria-controls': slideshowSlidesId,
+                            onClick: () => setIsForcePaused(!isForcePaused),
+                        }}
+                    />
+                </div>
+            }
+        >
+            {images.map(({ image, alt }, index) => (
+                <SlideshowItem key={`${image}-${index}`}>
+                    <ImageBlock
+                        thumbnailProps={{ aspectRatio: AspectRatio.horizontal, loading: 'eager' }}
+                        image={image}
+                        alt={alt}
+                        theme={theme}
+                    />
+                </SlideshowItem>
+            ))}
+        </Slides>
     );
 };

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -158,14 +158,15 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
                 </div>
             </div>
 
-            {playButtonProps ?
+            {playButtonProps ? (
                 <IconButton
                     {...playButtonProps}
                     icon={isAutoPlaying ? mdiPauseCircleOutline : mdiPlayCircleOutline}
                     className={`${CLASSNAME}__play`}
                     color={theme === Theme.dark ? 'light' : 'dark'}
+                    emphasis={Emphasis.low}
                 />
-            : null}
+            ) : null}
 
             <IconButton
                 {...nextButtonProps}

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -40,6 +40,8 @@ export interface SlideshowControlsProps extends GenericProps {
     onPreviousClick?(loopback?: boolean): void;
     /** whether the slideshow is currently playing */
     isAutoPlaying?: boolean;
+    /** function to be executed in order to retrieve the label for the pagination item */
+    paginationItemLabel?: (index: number) => string;
     /** Props to pass to the lay button (minus those already set by the SlideshowControls props). */
     playButtonProps?: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
@@ -84,6 +86,7 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
         theme,
         isAutoPlaying = false,
         playButtonProps,
+        paginationItemLabel,
         ...forwardedProps
     } = props;
 
@@ -137,7 +140,6 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
                                 const isActive = activeIndex === index;
                                 const isOutRange = index < visibleRange.min || index > visibleRange.max;
                                 return (
-                                    // eslint-disable-next-line jsx-a11y/control-has-associated-label
                                     <button
                                         className={classNames(
                                             handleBasicClasses({
@@ -150,10 +152,22 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
                                         key={index}
                                         type="button"
                                         onClick={() => onPaginationClick?.(index)}
+                                        {...{
+                                            'aria-label': paginationItemLabel
+                                                ? paginationItemLabel(index)
+                                                : `${index + 1} / ${slidesCount}`,
+                                        }}
                                     />
                                 );
                             }),
-                        [slidesCount, visibleRange.min, visibleRange.max, activeIndex, onPaginationClick],
+                        [
+                            slidesCount,
+                            visibleRange.min,
+                            visibleRange.max,
+                            activeIndex,
+                            paginationItemLabel,
+                            onPaginationClick,
+                        ],
                     )}
                 </div>
             </div>

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, RefObject, useCallback, useMemo } from 'react';
 import classNames from 'classnames';
 import range from 'lodash/range';
 
-import { mdiChevronLeft, mdiChevronRight } from '@lumx/icons';
+import { mdiChevronLeft, mdiChevronRight, mdiPlayCircleOutline, mdiPauseCircleOutline } from '@lumx/icons';
 import { Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 import { WINDOW } from '@lumx/react/constants';
@@ -38,6 +38,11 @@ export interface SlideshowControlsProps extends GenericProps {
     onPaginationClick?(index: number): void;
     /** On previous button click callback. */
     onPreviousClick?(loopback?: boolean): void;
+    /** whether the slideshow is currently playing */
+    isAutoPlaying?: boolean;
+    /** Props to pass to the lay button (minus those already set by the SlideshowControls props). */
+    playButtonProps?: Pick<IconButtonProps, 'label'> &
+        Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
 }
 
 /**
@@ -77,6 +82,8 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
         previousButtonProps,
         slidesCount,
         theme,
+        isAutoPlaying = false,
+        playButtonProps,
         ...forwardedProps
     } = props;
 
@@ -150,6 +157,16 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
                     )}
                 </div>
             </div>
+
+            {playButtonProps ?
+                <IconButton
+                    {...playButtonProps}
+                    icon={isAutoPlaying ? mdiPauseCircleOutline : mdiPlayCircleOutline}
+                    className={`${CLASSNAME}__play`}
+                    color={theme === Theme.dark ? 'light' : 'dark'}
+                />
+            : null}
+
             <IconButton
                 {...nextButtonProps}
                 icon={mdiChevronRight}

--- a/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
@@ -1,13 +1,22 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import classNames from 'classnames';
 
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
+import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
+
+import { AUTOPLAY_DEFAULT_INTERVAL } from '@lumx/react/components/slideshow/constants';
+
 /**
  * Defines the props of the component.
  */
-export type SlideshowItemProps = GenericProps;
+export interface SlideshowItemProps extends GenericProps {
+    /** whether the slideshow item is currently visible */
+    isCurrentlyVisible?: boolean;
+    /** interval in which slides are automatically shown */
+    interval?: number;
+}
 
 /**
  * Component display name.
@@ -27,7 +36,18 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * @return React element.
  */
 export const SlideshowItem: Comp<SlideshowItemProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const { className, children, ...forwardedProps } = props;
+    const {
+        className,
+        children,
+        isCurrentlyVisible = false,
+        interval = AUTOPLAY_DEFAULT_INTERVAL,
+        ...forwardedProps
+    } = props;
+    const [isVisible, setIsVisible] = useState<boolean>(isCurrentlyVisible);
+
+    useDelayedVisibility(isCurrentlyVisible, interval, (isNowVisible) => {
+        setIsVisible(isNowVisible);
+    });
 
     return (
         <div
@@ -41,6 +61,8 @@ export const SlideshowItem: Comp<SlideshowItemProps, HTMLDivElement> = forwardRe
             aria-roledescription="slide"
             role="group"
             {...forwardedProps}
+            style={!isVisible ? { visibility: 'hidden', ...(forwardedProps.style || {}) } : forwardedProps.style || {}}
+            aria-hidden={!isVisible}
         >
             {children}
         </div>

--- a/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
@@ -6,7 +6,7 @@ import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/
 
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
 
-import { AUTOPLAY_DEFAULT_INTERVAL } from '@lumx/react/components/slideshow/constants';
+import { SLIDESHOW_TRANSITION_DURATION } from '@lumx/core/js/constants';
 
 /**
  * Defines the props of the component.
@@ -36,16 +36,10 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  * @return React element.
  */
 export const SlideshowItem: Comp<SlideshowItemProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const {
-        className,
-        children,
-        isCurrentlyVisible = false,
-        interval = AUTOPLAY_DEFAULT_INTERVAL,
-        ...forwardedProps
-    } = props;
+    const { className, children, isCurrentlyVisible = false, ...forwardedProps } = props;
     const [isVisible, setIsVisible] = useState<boolean>(isCurrentlyVisible);
 
-    useDelayedVisibility(isCurrentlyVisible, interval, (isNowVisible) => {
+    useDelayedVisibility(isCurrentlyVisible, SLIDESHOW_TRANSITION_DURATION, (isNowVisible) => {
         setIsVisible(isNowVisible);
     });
 

--- a/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
+++ b/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
@@ -2,262 +2,155 @@
 
 exports[`<Slideshow> Snapshots and structure should render story 'Simple' 1`] = `
 Array [
-  <section
-    aria-live="polite"
-    aria-roledescription="carousel"
-    className="lumx-slideshow lumx-slideshow--theme-light lumx-slideshow--group-by-1"
+  <Slideshow
+    activeIndex={0}
+    afterSlides={
+      <div
+        className="lumx-slideshow__controls"
+      >
+        <SlideshowControls
+          activeIndex={0}
+          isAutoPlaying={false}
+          nextButtonProps={
+            Object {
+              "aria-controls": "slideshow-slides2",
+              "label": "Next",
+            }
+          }
+          onNextClick={[Function]}
+          onPaginationClick={[Function]}
+          onPreviousClick={[Function]}
+          previousButtonProps={
+            Object {
+              "aria-controls": "slideshow-slides2",
+              "label": "Previous",
+            }
+          }
+          slidesCount={6}
+          theme="light"
+        />
+      </div>
+    }
+    autoPlay={false}
+    endIndexVisible={1}
+    groupBy={1}
     id="slideshow1"
+    interval={1000}
+    isAutoPlaying={false}
+    setIsAutoPlaying={[Function]}
+    setSlideshow={[Function]}
+    slidesId="slideshow-slides2"
+    startIndexVisible={0}
     style={
       Object {
         "width": "50%",
       }
     }
+    theme="light"
   >
-    <div
-      className="lumx-slideshow__slides"
-      id="slideshow-slides2"
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
+    <SlideshowItem
+      key="/demo-assets/landscape1.jpg-0"
     >
-      <div
-        className="lumx-slideshow__wrapper"
-        style={
-          Object {
-            "transform": "translateX(-0%)",
-          }
-        }
-      >
-        <SlideshowItem
-          aria-hidden={false}
-          key=".$/demo-assets/landscape1.jpg-0"
-          style={Object {}}
-        >
-          <ImageBlock
-            align="left"
-            alt="Image 1"
-            captionPosition="below"
-            image="/demo-assets/landscape1.jpg"
-            theme="light"
-            thumbnailProps={
-              Object {
-                "aspectRatio": "horizontal",
-                "loading": "eager",
-              }
-            }
-          />
-        </SlideshowItem>
-        <SlideshowItem
-          aria-hidden={false}
-          key=".$/demo-assets/landscape1-s200.jpg-1"
-          style={Object {}}
-        >
-          <ImageBlock
-            align="left"
-            alt="Image 2"
-            captionPosition="below"
-            image="/demo-assets/landscape1-s200.jpg"
-            theme="light"
-            thumbnailProps={
-              Object {
-                "aspectRatio": "horizontal",
-                "loading": "eager",
-              }
-            }
-          />
-        </SlideshowItem>
-        <SlideshowItem
-          aria-hidden={true}
-          key=".$/demo-assets/landscape2.jpg-2"
-          style={
-            Object {
-              "visibility": "hidden",
-            }
-          }
-        >
-          <ImageBlock
-            align="left"
-            alt="Image 3"
-            captionPosition="below"
-            image="/demo-assets/landscape2.jpg"
-            theme="light"
-            thumbnailProps={
-              Object {
-                "aspectRatio": "horizontal",
-                "loading": "eager",
-              }
-            }
-          />
-        </SlideshowItem>
-        <SlideshowItem
-          aria-hidden={true}
-          key=".$/demo-assets/landscape3.jpg-3"
-          style={
-            Object {
-              "visibility": "hidden",
-            }
-          }
-        >
-          <ImageBlock
-            align="left"
-            alt="Image 4"
-            captionPosition="below"
-            image="/demo-assets/landscape3.jpg"
-            theme="light"
-            thumbnailProps={
-              Object {
-                "aspectRatio": "horizontal",
-                "loading": "eager",
-              }
-            }
-          />
-        </SlideshowItem>
-        <SlideshowItem
-          aria-hidden={true}
-          key=".$/demo-assets/portrait1.jpg-4"
-          style={
-            Object {
-              "visibility": "hidden",
-            }
-          }
-        >
-          <ImageBlock
-            align="left"
-            alt="Image 5"
-            captionPosition="below"
-            image="/demo-assets/portrait1.jpg"
-            theme="light"
-            thumbnailProps={
-              Object {
-                "aspectRatio": "horizontal",
-                "loading": "eager",
-              }
-            }
-          />
-        </SlideshowItem>
-        <SlideshowItem
-          aria-hidden={true}
-          key=".$/demo-assets/portrait1-s200.jpg-5"
-          style={
-            Object {
-              "visibility": "hidden",
-            }
-          }
-        >
-          <ImageBlock
-            align="left"
-            alt="Image 6"
-            captionPosition="below"
-            image="/demo-assets/portrait1-s200.jpg"
-            theme="light"
-            thumbnailProps={
-              Object {
-                "aspectRatio": "horizontal",
-                "loading": "eager",
-              }
-            }
-          />
-        </SlideshowItem>
-      </div>
-    </div>
-    <div
-      className="lumx-slideshow__controls"
-    >
-      <SlideshowControls
-        activeIndex={0}
-        nextButtonProps={
-          Object {
-            "aria-controls": "slideshow-slides2",
-            "label": "Next",
-          }
-        }
-        onNextClick={[Function]}
-        onPaginationClick={[Function]}
-        onPreviousClick={[Function]}
-        previousButtonProps={
-          Object {
-            "aria-controls": "slideshow-slides2",
-            "label": "Previous",
-          }
-        }
-        slidesCount={6}
+      <ImageBlock
+        align="left"
+        alt="Image 1"
+        captionPosition="below"
+        image="/demo-assets/landscape1.jpg"
         theme="light"
-      />
-    </div>
-  </section>,
-  <div
-    className="lumx-slideshow-controls lumx-slideshow-controls--theme-light lumx-slideshow-controls--has-infinite-pagination"
-  >
-    <IconButton
-      aria-controls="slideshow-slides4"
-      className="lumx-slideshow-controls__navigation"
-      color="dark"
-      emphasis="low"
-      icon="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
-      label="Previous"
-      onClick={[Function]}
-      size="m"
-      theme="light"
-    />
-    <div
-      className="lumx-slideshow-controls__pagination"
-    >
-      <div
-        className="lumx-slideshow-controls__pagination-items"
-        style={
+        thumbnailProps={
           Object {
-            "transform": "translateX(-0px)",
+            "aspectRatio": "horizontal",
+            "loading": "eager",
           }
         }
-      >
-        <button
-          className="lumx-slideshow-controls__pagination-item lumx-slideshow-controls__pagination-item--is-active"
-          key="0"
-          onClick={[Function]}
-          type="button"
-        />
-        <button
-          className="lumx-slideshow-controls__pagination-item"
-          key="1"
-          onClick={[Function]}
-          type="button"
-        />
-        <button
-          className="lumx-slideshow-controls__pagination-item"
-          key="2"
-          onClick={[Function]}
-          type="button"
-        />
-        <button
-          className="lumx-slideshow-controls__pagination-item"
-          key="3"
-          onClick={[Function]}
-          type="button"
-        />
-        <button
-          className="lumx-slideshow-controls__pagination-item lumx-slideshow-controls__pagination-item--is-on-edge"
-          key="4"
-          onClick={[Function]}
-          type="button"
-        />
-        <button
-          className="lumx-slideshow-controls__pagination-item lumx-slideshow-controls__pagination-item--is-out-range"
-          key="5"
-          onClick={[Function]}
-          type="button"
-        />
-      </div>
-    </div>
-    <IconButton
-      aria-controls="slideshow-slides4"
-      className="lumx-slideshow-controls__navigation"
-      color="dark"
-      emphasis="low"
-      icon="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-      label="Next"
-      onClick={[Function]}
-      size="m"
-      theme="light"
-    />
-  </div>,
+      />
+    </SlideshowItem>
+    <SlideshowItem
+      key="/demo-assets/landscape1-s200.jpg-1"
+    >
+      <ImageBlock
+        align="left"
+        alt="Image 2"
+        captionPosition="below"
+        image="/demo-assets/landscape1-s200.jpg"
+        theme="light"
+        thumbnailProps={
+          Object {
+            "aspectRatio": "horizontal",
+            "loading": "eager",
+          }
+        }
+      />
+    </SlideshowItem>
+    <SlideshowItem
+      key="/demo-assets/landscape2.jpg-2"
+    >
+      <ImageBlock
+        align="left"
+        alt="Image 3"
+        captionPosition="below"
+        image="/demo-assets/landscape2.jpg"
+        theme="light"
+        thumbnailProps={
+          Object {
+            "aspectRatio": "horizontal",
+            "loading": "eager",
+          }
+        }
+      />
+    </SlideshowItem>
+    <SlideshowItem
+      key="/demo-assets/landscape3.jpg-3"
+    >
+      <ImageBlock
+        align="left"
+        alt="Image 4"
+        captionPosition="below"
+        image="/demo-assets/landscape3.jpg"
+        theme="light"
+        thumbnailProps={
+          Object {
+            "aspectRatio": "horizontal",
+            "loading": "eager",
+          }
+        }
+      />
+    </SlideshowItem>
+    <SlideshowItem
+      key="/demo-assets/portrait1.jpg-4"
+    >
+      <ImageBlock
+        align="left"
+        alt="Image 5"
+        captionPosition="below"
+        image="/demo-assets/portrait1.jpg"
+        theme="light"
+        thumbnailProps={
+          Object {
+            "aspectRatio": "horizontal",
+            "loading": "eager",
+          }
+        }
+      />
+    </SlideshowItem>
+    <SlideshowItem
+      key="/demo-assets/portrait1-s200.jpg-5"
+    >
+      <ImageBlock
+        align="left"
+        alt="Image 6"
+        captionPosition="below"
+        image="/demo-assets/portrait1-s200.jpg"
+        theme="light"
+        thumbnailProps={
+          Object {
+            "aspectRatio": "horizontal",
+            "loading": "eager",
+          }
+        }
+      />
+    </SlideshowItem>
+  </Slideshow>,
+  null,
 ]
 `;

--- a/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
+++ b/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
@@ -38,7 +38,6 @@ Array [
     interval={1000}
     isAutoPlaying={false}
     setIsAutoPlaying={[Function]}
-    setSlideshow={[Function]}
     slidesId="slideshow-slides2"
     startIndexVisible={0}
     style={

--- a/packages/lumx-react/src/components/slideshow/index.ts
+++ b/packages/lumx-react/src/components/slideshow/index.ts
@@ -1,3 +1,4 @@
 export * from './Slideshow';
 export * from './SlideshowItem';
 export * from './SlideshowControls';
+export * from './Slides';

--- a/packages/lumx-react/src/hooks/useFocusWithin.ts
+++ b/packages/lumx-react/src/hooks/useFocusWithin.ts
@@ -26,7 +26,7 @@ export const useFocusWithin = ({ element, onFocusIn, onFocusOut }: UseFocusWithi
             if (element) {
                 element.removeEventListener('focusin', onFocusIn);
 
-                element.addEventListener('focusout', onFocusOut);
+                element.removeEventListener('focusout', onFocusOut);
             }
         };
     }, [onFocusIn, element, onFocusOut]);

--- a/packages/lumx-react/src/hooks/useSlideshowControls.ts
+++ b/packages/lumx-react/src/hooks/useSlideshowControls.ts
@@ -4,8 +4,6 @@ import { useInterval } from '@lumx/react/hooks/useInterval';
 import uniqueId from 'lodash/uniqueId';
 import { AUTOPLAY_DEFAULT_INTERVAL } from '@lumx/react/components/slideshow/constants';
 
-import { useFocusWithin } from './useFocusWithin';
-
 export interface UseSlideshowControlsOptions {
     /** default active index to be displayed */
     defaultActiveIndex?: number;
@@ -52,12 +50,16 @@ export interface UseSlideshowControls {
     onPaginationClick: (index: number) => void;
     /** whether the slideshow is autoplaying or not */
     isAutoPlaying: boolean;
+    isForcePaused: boolean;
+    setIsForcePaused: (isForcePaused: boolean) => void;
     /** callback to change whether the slideshow is autoplaying or not */
     setIsAutoPlaying: (isAutoPlaying: boolean) => void;
     /** current active slide index  */
     activeIndex: number;
     /** set the current index as the active one */
     setActiveIndex: (index: number) => void;
+    stopAutoPlay: () => void;
+    startAutoPlay: () => void;
 }
 
 export const DEFAULT_OPTIONS: Partial<UseSlideshowControlsOptions> = {
@@ -122,8 +124,11 @@ export const useSlideshowControls = ({
 
     // Auto play
     const [isAutoPlaying, setIsAutoPlaying] = useState(Boolean(autoPlay));
+    const [isForcePaused, setIsForcePaused] = useState(false);
+
+    const isSlideshowAutoPlaying = isForcePaused ? false : isAutoPlaying;
     // Start
-    useInterval(goToNextSlide, isAutoPlaying && slidesCount > 1 ? (interval as number) : null);
+    useInterval(goToNextSlide, isSlideshowAutoPlaying && slidesCount > 1 ? (interval as number) : null);
 
     // Reset current index if it become invalid.
     useEffect(() => {
@@ -184,11 +189,15 @@ export const useSlideshowControls = ({
         setIsAutoPlaying(false);
     };
 
-    useFocusWithin({
-        element,
-        onFocusIn: stopAutoPlay,
-        onFocusOut: startAutoPlay,
-    });
+    const forcePause = (isPaused: boolean) => {
+        setIsForcePaused(isPaused);
+
+        if (isPaused) {
+            stopAutoPlay();
+        } else {
+            startAutoPlay();
+        }
+    };
 
     // Start index and end index of visible slides.
     const startIndexVisible = currentIndex * (groupBy as number);
@@ -204,10 +213,14 @@ export const useSlideshowControls = ({
         onPreviousClick,
         onNextClick,
         onPaginationClick,
-        isAutoPlaying,
+        isAutoPlaying: isSlideshowAutoPlaying,
         setIsAutoPlaying,
         activeIndex: currentIndex,
         slidesCount,
         setActiveIndex: setCurrentIndex,
+        startAutoPlay,
+        stopAutoPlay,
+        isForcePaused,
+        setIsForcePaused: forcePause,
     };
 };

--- a/packages/lumx-react/src/hooks/useSlideshowControls.ts
+++ b/packages/lumx-react/src/hooks/useSlideshowControls.ts
@@ -50,7 +50,9 @@ export interface UseSlideshowControls {
     onPaginationClick: (index: number) => void;
     /** whether the slideshow is autoplaying or not */
     isAutoPlaying: boolean;
+    /** whether the slideshow was force paused or not */
     isForcePaused: boolean;
+    /** callback to enable/disable the force pause feature */
     setIsForcePaused: (isForcePaused: boolean) => void;
     /** callback to change whether the slideshow is autoplaying or not */
     setIsAutoPlaying: (isAutoPlaying: boolean) => void;
@@ -58,7 +60,9 @@ export interface UseSlideshowControls {
     activeIndex: number;
     /** set the current index as the active one */
     setActiveIndex: (index: number) => void;
+    /** callback that stops the auto play */
     stopAutoPlay: () => void;
+    /** callback that starts the auto play */
     startAutoPlay: () => void;
 }
 


### PR DESCRIPTION
# General summary
This PR adds the following enhancements to the Slideshow component:
- Adds the Play/Pause button
- Adds focus to the bullets
- Refactors the slideshow component in order to avoid multiple hooks managing the same state
- Fixes an issue when the slide would go blank while transitioning.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
