### PR TITLE
feat(icon): add dark theme compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Icon: better `dark` theme on icon with shape.
+
 ## [2.2.11][] - 2022-03-17
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/icon/_index.scss
+++ b/packages/lumx-core/src/scss/components/icon/_index.scss
@@ -82,12 +82,22 @@
         }
 
         &.#{$lumx-base-prefix}-icon--has-shape {
-            @include lumx-icon-color($color-key, true);
+            @include lumx-icon-color($color-key, true, lumx-base-const('theme', 'LIGHT'));
+
+            &.#{$lumx-base-prefix}-icon--theme-dark {
+                @include lumx-icon-color($color-key, true, lumx-base-const('theme', 'DARK'));
+            }
         }
     }
 
     @each $color-variant in $lumx-color-variants {
         .#{$lumx-base-prefix}-icon--color-#{$color-key}.#{$lumx-base-prefix}-icon--color-variant-#{$color-variant} {
+            @if $color-key == 'yellow' {
+                &.#{$lumx-base-prefix}-icon--has-shape {
+                    color: lumx-color-variant('dark', 'L1');
+                }
+            }
+
             color: lumx-color-variant($color-key, $color-variant);
         }
     }

--- a/packages/lumx-core/src/scss/components/icon/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/icon/_mixins.scss
@@ -11,9 +11,18 @@
     }
 }
 
-@mixin lumx-icon-color($color, $has-shape: false) {
+@mixin lumx-icon-color($color, $has-shape: false, $theme: light) {
     @if $has-shape == true {
-        background-color: lumx-color-variant($color, 'L6');
+        $base-color: lumx-color-variant($color, 'L6');
+
+        @if $theme == lumx-base-const('theme', 'DARK') and $color != 'light' {
+            // adds a white background for dark theme
+            background-color: lumx-color-variant('light', 'N');
+            // Custom color is set as a background gradient to be on top of background-color
+            background-image: linear-gradient(to right, $base-color, $base-color);
+        } @else {
+            background-color: $base-color;
+        }
 
         @if $color == 'yellow' {
             color: lumx-color-variant('dark', 'L1');

--- a/packages/lumx-react/src/components/icon/Icon.stories.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { mdiEmail } from '@lumx/icons';
-import { ColorPalette, FlexBox, Icon, IconSizes, Size } from '@lumx/react';
+import { ColorPalette, ColorVariant, FlexBox, Icon, IconSizes, Size } from '@lumx/react';
 import { Orientation } from '..';
 
-export default { title: 'LumX components/icon/Icon' };
+export default { title: 'LumX components/icon/Icon', parameters: { hasGreyBackground: true } };
 
 const iconSizes: Array<IconSizes | undefined> = [
     undefined,
@@ -16,42 +16,61 @@ const iconSizes: Array<IconSizes | undefined> = [
     Size.xl,
     Size.xxl,
 ];
-const iconColors = [undefined, ...Object.values(ColorPalette)];
-const iconShapes = [false, true];
 
-export const AllIcon = ({ theme }: any) => {
+const TemplateSizeVariants = ({ hasShape, theme }: any) => (
+    <FlexBox orientation={Orientation.horizontal}>
+        {iconSizes.map((size) => (
+            <FlexBox fillSpace key={`${size}`}>
+                <h2>Size: {size || 'undefined'}</h2>
+                <Icon icon={mdiEmail} size={size} hasShape={hasShape} theme={theme} />
+            </FlexBox>
+        ))}
+    </FlexBox>
+);
+
+export const AllSize = ({ theme }: any) => TemplateSizeVariants({ theme });
+
+export const AllSizeWithShape = ({ theme }: any) => TemplateSizeVariants({ theme, hasShape: true });
+
+const TemplateColorVariants = ({ hasShape, theme }: any) => {
+    const withUndefined = (a: any) => [undefined].concat(Object.values(a));
     return (
-        <>
-            {iconShapes.map((hasShape) => {
-                return (
-                    <>
-                        <h1>{`With shape: ${hasShape}`}</h1>
-                        {iconSizes.map((size) => {
-                            return (
+        <FlexBox orientation={Orientation.horizontal}>
+            {withUndefined(ColorPalette).map((color) => (
+                <FlexBox fillSpace key={`${color}`}>
+                    <small key={`${color}`}>Color: {color || 'undefined'}</small>
+                    <br />
+                    {withUndefined(Object.values(ColorVariant).reverse()).map((colorVariant) => (
+                        <Fragment key={`${colorVariant}`}>
+                            {!colorVariant && (
                                 <>
-                                    <h2>{`Size: ${size}`}</h2>
-                                    <FlexBox orientation={Orientation.horizontal}>
-                                        {iconColors.map((color) => {
-                                            return (
-                                                <FlexBox fillSpace key={color}>
-                                                    {`Color: ${color}`}
-                                                    <Icon
-                                                        hasShape={hasShape}
-                                                        icon={mdiEmail}
-                                                        color={color}
-                                                        size={size}
-                                                        theme={theme}
-                                                    />
-                                                </FlexBox>
-                                            );
-                                        })}
-                                    </FlexBox>
+                                    <small>No theme</small>
+                                    <Icon
+                                        icon={mdiEmail}
+                                        color={color}
+                                        colorVariant={colorVariant}
+                                        size="m"
+                                        hasShape={hasShape}
+                                    />
                                 </>
-                            );
-                        })}
-                    </>
-                );
-            })}
-        </>
+                            )}
+                            <small>Variant: {colorVariant || 'undefined'}</small>
+                            <Icon
+                                icon={mdiEmail}
+                                color={color}
+                                colorVariant={colorVariant}
+                                size="m"
+                                theme={theme}
+                                hasShape={hasShape}
+                            />
+                        </Fragment>
+                    ))}
+                </FlexBox>
+            ))}
+        </FlexBox>
     );
 };
+
+export const AllColors = ({ theme }: any) => TemplateColorVariants({ theme });
+
+export const AllColorsWithShape = ({ theme }: any) => TemplateColorVariants({ theme, hasShape: true });

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -19,8 +19,8 @@ export interface IconProps extends GenericProps {
     /** Whether the icon has a shape. */
     hasShape?: boolean;
     /**
-     * Icon (SVG path).draw code (`d` property of the `<path>` SVG element).
-     * @see {@link https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths}
+     * Icon (SVG path) draw code (`d` property of the `<path>` SVG element).
+     * See https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths
      */
     icon: string;
     /** Size variant. */
@@ -56,35 +56,25 @@ const DEFAULT_PROPS: Partial<IconProps> = {};
 export const Icon: Comp<IconProps, HTMLElement> = forwardRef((props, ref) => {
     const { className, color, colorVariant, hasShape, icon, size, theme, alt, ...forwardedProps } = props;
 
-    let iconColor;
-    let iconColorVariant;
-    if (color) {
-        iconColor = color;
-        iconColorVariant = colorVariant;
-    } else if (theme) {
-        iconColor = theme === Theme.light ? ColorPalette.dark : ColorPalette.light;
-
-        if (colorVariant) {
-            iconColorVariant = colorVariant;
-        } else {
-            iconColorVariant = Theme.light ? 'L1' : 'N';
-        }
-    } else if (hasShape) {
-        iconColor = ColorPalette.dark;
+    // Color
+    let iconColor = color;
+    if (!iconColor && (hasShape || theme)) {
+        iconColor = theme === Theme.dark ? ColorPalette.light : ColorPalette.dark;
     }
 
-    let iconSize;
-    if (size) {
-        if (hasShape) {
-            if (size === Size.xxs || size === Size.xs) {
-                iconSize = Size.s;
-            } else if (size === Size.xxl) {
-                iconSize = Size.xl;
-            } else {
-                iconSize = size;
-            }
-        } else {
-            iconSize = size;
+    // Color variant
+    let iconColorVariant = colorVariant;
+    if (!iconColorVariant && hasShape && iconColor === ColorPalette.dark) {
+        iconColorVariant = 'L2';
+    }
+
+    // Size
+    let iconSize = size;
+    if (size && hasShape) {
+        if (size === Size.xxs || size === Size.xs) {
+            iconSize = Size.s;
+        } else if (size === Size.xxl) {
+            iconSize = Size.xl;
         }
     } else if (hasShape) {
         iconSize = Size.m;
@@ -101,6 +91,7 @@ export const Icon: Comp<IconProps, HTMLElement> = forwardRef((props, ref) => {
                     colorVariant: iconColorVariant,
                     hasShape,
                     prefix: CLASSNAME,
+                    theme,
                     size: iconSize,
                 }),
                 !hasShape && `${CLASSNAME}--no-shape`,

--- a/packages/lumx-react/storybook/story-block/StoryBlock.tsx
+++ b/packages/lumx-react/storybook/story-block/StoryBlock.tsx
@@ -29,7 +29,7 @@ export const StoryBlock: React.FC<StoryBlockProps> = (props) => {
     if (isChromatic()) return <Story />;
 
     return (
-        <div className={classNames(CLASSNAME, `${CLASSNAME}--theme-${theme}`)}>
+        <div className={classNames(CLASSNAME, context.parameters.hasGreyBackground && `${CLASSNAME}--has-grey-background`, `${CLASSNAME}--theme-${theme}`)}>
             <div className={`${CLASSNAME}__toolbar`}>
                 <Switch
                     className="dark-theme-switcher"

--- a/packages/lumx-react/storybook/story-block/index.scss
+++ b/packages/lumx-react/storybook/story-block/index.scss
@@ -2,6 +2,18 @@
 @import '~@lumx/core/src/scss/core';
 
 .story-block {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow: auto;
+    padding: 1rem;
+
+    &--has-grey-background:not(&--theme-dark) {
+        background: lightgray;
+    }
+
     &--theme-dark {
         background: lumx-color-variant('dark', 'N');
         color: lumx-color-variant('light', 'N');

--- a/packages/site-demo/content/product/components/icon/index.mdx
+++ b/packages/site-demo/content/product/components/icon/index.mdx
@@ -14,18 +14,22 @@ Check [size foundations](/product/foundations/size) for more details.
 
 Display a raw icon. Often used nested in other components.
 
-<DemoBlock orientation="horizontal" demo="simple" />
+<DemoBlock orientation="horizontal" demo="simple" withThemeSwitcher />
 
 ### Shape
 
 Display an icon with a shape. Often used as small illustrations.
 
-<DemoBlock orientation="horizontal" demo="shape" />
+<DemoBlock orientation="horizontal" demo="shape" withThemeSwitcher />
 
 ## Colors
 
-Color availables: `blue`, `green`, `yellow`, `red`, `dark` and `light`.
-`blue` is oftenly used as an accent visual, `green` to emphasize succes, `yellow` to emphasize warnings, `red` to emphasize alerts and `dark` or `light` as a neutral visual.
+Colors available: `blue`, `green`, `yellow`, `red`, `dark` and `light`.
+`blue` is often used as an accent visual, `green` to emphasize success, `yellow` to emphasize warnings, `red` to emphasize alerts and `dark` or `light` as a neutral visual.
 See [foundation colors](/product/foundations/color) for more details.
 
-<DemoBlock orientation="horizontal" demo="colors" />
+<DemoBlock orientation="horizontal" demo="colors" withThemeSwitcher/>
+
+### Properties
+
+<PropTable component="Icon" />

--- a/packages/site-demo/content/product/components/icon/react/colors.tsx
+++ b/packages/site-demo/content/product/components/icon/react/colors.tsx
@@ -2,16 +2,18 @@ import { mdiAlert, mdiAlertCircle, mdiArrowRight, mdiBullhorn, mdiCheck, mdiMess
 import { ColorPalette, Icon, Size } from '@lumx/react';
 import React from 'react';
 
-export const App = () => (
+export const App = ({ theme }: any) => (
     <>
         <Icon icon={mdiArrowRight} size={Size.s} color={ColorPalette.blue} />
         <Icon icon={mdiCheck} size={Size.s} color={ColorPalette.green} />
         <Icon icon={mdiAlertCircle} size={Size.s} color={ColorPalette.yellow} />
         <Icon icon={mdiAlert} size={Size.s} color={ColorPalette.red} />
-        <Icon icon={mdiBullhorn} size={Size.m} color={ColorPalette.blue} hasShape />
-        <Icon icon={mdiAlertCircle} size={Size.m} color={ColorPalette.yellow} hasShape />
-        <Icon icon={mdiAlert} size={Size.m} color={ColorPalette.red} hasShape />
-        <Icon icon={mdiCheck} size={Size.m} color={ColorPalette.green} hasShape />
-        <Icon icon={mdiMessageText} size={Size.m} hasShape />
+        <Icon icon={mdiBullhorn} size={Size.m} color={ColorPalette.blue} theme={theme} hasShape />
+        <Icon icon={mdiAlertCircle} size={Size.m} color={ColorPalette.yellow} theme={theme} hasShape />
+        <Icon icon={mdiAlert} size={Size.m} theme={theme} color={ColorPalette.red} hasShape />
+        <Icon icon={mdiCheck} size={Size.m} theme={theme} color={ColorPalette.green} hasShape />
+        <Icon icon={mdiMessageText} size={Size.m} color={ColorPalette.dark} theme={theme} hasShape />
+        <span className={theme === 'dark' ? 'lumx-color-font-light-N' : ''}>Without color:</span>
+        <Icon icon={mdiMessageText} size={Size.m} theme={theme} hasShape />
     </>
 );

--- a/packages/site-demo/content/product/components/icon/react/shape.tsx
+++ b/packages/site-demo/content/product/components/icon/react/shape.tsx
@@ -2,11 +2,11 @@ import { mdiMessageTextOutline } from '@lumx/icons';
 import { Icon, Size } from '@lumx/react';
 import React from 'react';
 
-export const App = () => (
+export const App = ({ theme }: any) => (
     <>
-        <Icon icon={mdiMessageTextOutline} size={Size.s} hasShape />
-        <Icon icon={mdiMessageTextOutline} size={Size.m} hasShape />
-        <Icon icon={mdiMessageTextOutline} size={Size.l} hasShape />
-        <Icon icon={mdiMessageTextOutline} size={Size.xl} hasShape />
+        <Icon icon={mdiMessageTextOutline} size={Size.s} hasShape theme={theme} />
+        <Icon icon={mdiMessageTextOutline} size={Size.m} hasShape theme={theme} />
+        <Icon icon={mdiMessageTextOutline} size={Size.l} hasShape theme={theme} />
+        <Icon icon={mdiMessageTextOutline} size={Size.xl} hasShape theme={theme} />
     </>
 );

--- a/packages/site-demo/content/product/components/icon/react/simple.tsx
+++ b/packages/site-demo/content/product/components/icon/react/simple.tsx
@@ -2,13 +2,13 @@ import { mdiEmail } from '@lumx/icons';
 import { Icon, Size } from '@lumx/react';
 import React from 'react';
 
-export const App = () => (
+export const App = ({ theme }: any) => (
     <>
-        <Icon icon={mdiEmail} size={Size.xxs} />
-        <Icon icon={mdiEmail} size={Size.xs} />
-        <Icon icon={mdiEmail} size={Size.s} />
-        <Icon icon={mdiEmail} size={Size.m} />
-        <Icon icon={mdiEmail} size={Size.l} />
-        <Icon icon={mdiEmail} size={Size.xl} />
+        <Icon icon={mdiEmail} size={Size.xxs} theme={theme} />
+        <Icon icon={mdiEmail} size={Size.xs} theme={theme} />
+        <Icon icon={mdiEmail} size={Size.s} theme={theme} />
+        <Icon icon={mdiEmail} size={Size.m} theme={theme} />
+        <Icon icon={mdiEmail} size={Size.l} theme={theme} />
+        <Icon icon={mdiEmail} size={Size.xl} theme={theme} />
     </>
 );


### PR DESCRIPTION
# General summary

Icon component do not currently support dark theme, this work is my attempt to make icon with "hasShape" parameter supports dark theme.

# Screenshots

What I'm trying to achieve:
<img width="554" alt="Capture d’écran 2022-03-16 à 10 35 52" src="https://user-images.githubusercontent.com/15898440/158560509-c2cfb199-7ad3-4ab9-8a81-3791494ed1f7.png">

I'm available to discuss the case.