### PR TITLE
docs(toolbar): added file list toolbar example

### DIFF
--- a/packages/site-demo/content/product/components/toolbar/index.mdx
+++ b/packages/site-demo/content/product/components/toolbar/index.mdx
@@ -24,6 +24,10 @@ A toolbar has three sections. An optional contextual icon button and a title on 
 
 <DemoBlock demo="back" />
 
+### File list widget
+
+<DemoBlock demo="file-widget" />
+
 ### Properties
 
 <PropTable component="Toolbar" />

--- a/packages/site-demo/content/product/components/toolbar/react/file-widget.tsx
+++ b/packages/site-demo/content/product/components/toolbar/react/file-widget.tsx
@@ -1,0 +1,36 @@
+import { mdiChevronLeft, mdiMagnify, mdiOpenInNew, mdiSort } from '@lumx/icons';
+
+import { Alignment, Button, Emphasis, FlexBox, IconButton, Orientation, TextField, Toolbar, Size } from '@lumx/react';
+
+import classNames from 'classnames';
+import React, { useState } from 'react';
+
+export const App = ({ theme }: any) => {
+    const [value, setValue] = useState('');
+
+    return (
+        <Toolbar
+            before={<IconButton label="Previous" emphasis={Emphasis.low} theme={theme} icon={mdiChevronLeft} />}
+            label={
+                <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center} gap={Size.regular}>
+                    <span
+                        className={classNames(
+                            'lumx-typography-title',
+                            theme === 'light' ? 'lumx-color-font-dark-N' : 'lumx-color-font-light-N',
+                        )}
+                    >
+                        Folder name
+                    </span>
+                    <IconButton label="Previous" emphasis={Emphasis.low} theme={theme} icon={mdiOpenInNew} />
+                </FlexBox>
+            }
+            after={
+                <FlexBox orientation={Orientation.horizontal} hAlign={Alignment.center} gap={Size.regular}>
+                    <TextField value={value} onChange={setValue} icon={mdiMagnify} theme={theme} />
+                    <IconButton label="Grid" emphasis={Emphasis.low} theme={theme} icon={mdiSort} />
+                    <Button theme={theme}>New</Button>
+                </FlexBox>
+            }
+        />
+    );
+};

--- a/packages/site-demo/src/style/layout/main/_main.scss
+++ b/packages/site-demo/src/style/layout/main/_main.scss
@@ -8,7 +8,7 @@
 
     &__wrapper {
         position: relative;
-        width: 800px;
+        max-width: 800px;
         margin: 0 auto;
     }
 }


### PR DESCRIPTION
# General summary

Added a demo block for illustrating file list widget toolbar example

# Screenshots

<img width="975" alt="Capture d’écran 2022-03-21 à 11 31 01" src="https://user-images.githubusercontent.com/15898440/159243973-24e21f80-b85e-42c7-a686-a4fe775fa0f6.png">