### PR TITLE
chore(tooltip): remove unecessary set state on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Icon: better `dark` theme on icon with shape.
 -   List: Removed default `tabIndex={0}`.
+-   Tooltip: Removed unecessary set state on unmount causing warnings in React dev tools.
 
 ## [2.2.11][] - 2022-03-17
 

--- a/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
+++ b/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
@@ -103,7 +103,6 @@ export function useTooltipOpen(delay: number | undefined, anchorElement: HTMLEle
             for (const [node, eventType, evenHandler] of events) {
                 node.removeEventListener(eventType, evenHandler);
             }
-            closeImmediately();
         };
     }, [anchorElement, delay]);
 


### PR DESCRIPTION
# General summary

Removed unecessary closing of tooltip (react set state) on unmount that can cause warnings in the React dev tools
