### PR TITLE
docs(typography): added custom styles and LumApps theme info

### DIFF
--- a/packages/site-demo/content/product/foundations/typography/index.mdx
+++ b/packages/site-demo/content/product/foundations/typography/index.mdx
@@ -1,14 +1,51 @@
 # Typography
 
-**Use typography to create clear hierarchies, organize information, and guide users.**
+**Use typography to create clear visual hierarchies, organize information, and guide users.**
 
 ## Typefaces
 
-The design system uses the open-source typeface Roboto. It can be accessed and downloaded from this <a href="https://fonts.google.com/specimen/Roboto" target="_blank">Google font page</a>.
+The default font vary with the theme used.
+
+- With Material theme the design system uses the open-source typeface Roboto. It can be accessed and downloaded from <a href="https://fonts.google.com/specimen/Roboto" target="_blank">Google font</a>.
+
+- Without Material theme, the design system intentionaly uses default systems fonts, avoiding unecessary weight, loading time plus benefiting native system fonts accessibility.
+
+### Fonts by system
+
+<table style="text-align: left; width: 100%">
+    <thead>
+        <tr>
+            <th>System</th>
+            <th>Font</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><strong>Windows</strong></td>
+            <td>Segoe UI</td>
+        </tr>
+        <tr>
+            <td><strong>Mac OSX</strong></td>
+            <td>SF Pro</td>
+        </tr>
+        <tr>
+            <td><strong>Linux</strong></td>
+            <td>Ubuntu</td>
+        </tr>
+        <tr>
+            <td><strong>Chrome OS</strong></td>
+            <td>Roboto</td>
+        </tr>
+    </tbody>
+</table>
 
 ## Styles
 
-Selecting the appropriate type style is determined by layout or template structure. Layouts may have several levels of architecture or areas that require varying typographic hierarchies. Using the right type styles helps manage the display of content, keeping it useful, simple, and effective.
+Selecting appropriate text styles is determined by layout structure. Layouts may have several levels of architecture or areas that require varying typographic hierarchies. Using the right text styles helps manage the display of content, keeping it useful, simple, and effective.
+
+### Basic styles
+
+Basic text styles are default choice for any piece of UI. They are consistent throughout the whole interface and cannot be customized further than the font family choice.
 
 <DemoBlock>
 <h1 className="lumx-typography-display1">Display 1</h1>
@@ -20,4 +57,37 @@ Selecting the appropriate type style is determined by layout or template structu
 <p className="lumx-typography-body1">Body 1 Hundreds of thousands with pretty stories for which there's little good evidence billions upon billions culture science from which we spring? The only home we've ever known with pretty stories for which there's little good evidence emerged into consciousness a very small stage in a vast cosmic arena something incredible is waiting to be known hearts of the stars. Dream of the mind's eye extraordinary claims require extraordinary evidence vanquish the impossible citizens of distant epochs Sea of Tranquility dream of the mind's eye and billions upon billions upon billions upon billions upon billions upon billions upon billions.</p>
 <p className="lumx-typography-caption">Caption</p>
 <p className="lumx-typography-overline">Overline</p>
+</DemoBlock>
+
+### Custom styles
+
+Custom styles are only available when Material theme is not used.
+Custom text styles are overrideable by customization:
+
+- font-family
+- size
+- weight
+- style
+- line-height
+
+Use them in pieces of UI that need to reflect an identity (usually widgets or pages). They’re the same app-wide by default but the customization can be made with context: targeting a specific piece of UI like a specific widget in a specific page.
+
+<DemoBlock>
+<h1 className="lumx-typography-custom-title1">Title1</h1>
+<h2 className="lumx-typography-custom-title2">Title2</h2>
+<h3 className="lumx-typography-custom-title3">Title3</h3>
+<h4 className="lumx-typography-custom-title4">Title4</h4>
+<h5 className="lumx-typography-custom-title5">Title5</h5>
+<h6 className="lumx-typography-custom-title6">Title6</h6>
+<p className="lumx-typography-custom-intro">Intro</p>
+<p className="lumx-typography-custom-body-large">Body large</p>
+<p className="lumx-typography-custom-body">Body</p>
+<p className="lumx-typography-custom-quote">Quote</p>
+<p className="lumx-typography-custom-publish-info">Publish info</p>
+{/*
+<p className="lumx-typography-custom-tag">Tag</p>
+<p className="lumx-typography-custom-metadata">metadata</p>
+<p className="lumx-typography-custom-button-size-m">Button m</p>
+<p className="lumx-typography-custom-button-size-s">Button s</p>
+*/}
 </DemoBlock>

--- a/packages/site-demo/src/components/layout/MainContent/MainContent.scss
+++ b/packages/site-demo/src/components/layout/MainContent/MainContent.scss
@@ -28,6 +28,10 @@
         }
 
         & > h3 {
+            @include lumx-typography(title);
+        }
+
+        & > h4 {
             @include lumx-typography(subtitle2);
         }
 


### PR DESCRIPTION
# General summary

Info on custom text styles available when Material theme is not used

# Screenshots
<img width="900" alt="Capture d’écran 2022-03-28 à 18 01 08" src="https://user-images.githubusercontent.com/15898440/160439652-5838b8fb-7b10-431b-9338-d47911140033.png">
<img width="861" alt="Capture d’écran 2022-03-28 à 18 01 14" src="https://user-images.githubusercontent.com/15898440/160439664-4cc2faa9-92d1-4c8f-99d3-025b6ae683c2.png">
