### PR TITLE
chore(select): fix select vertical margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   CommentBlock: Move the comment date to below comment text and add a tooltip to display the full date with the added `fullDate` prop;
 
+### Fixed
+
+-   Select: fix chip vertical margin calculation.
+
 ## [2.2.12][] - 2022-03-24
 
 ### Added

--- a/packages/lumx-core/src/scss/components/text-field/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_mixins.scss
@@ -160,7 +160,7 @@
     flex: 1 1 auto;
     flex-wrap: wrap;
     align-items: center;
-    margin: calc((var(--lumx-text-field-input-min-height) - (var(--lumx-size-s) - 6px)) / 2) 0;
+    margin: calc((var(--lumx-text-field-input-min-height) - var(--lumx-size-s) - 6px) / 2) 0;
 
     .#{$lumx-base-prefix}-chip {
         margin: $lumx-chip-group-spacing 0;


### PR DESCRIPTION
# General summary

Fix select vertical margin calculation


In v2.2.12 https://5fbfb1d508c0520021560f10-mtwabgggwo.chromatic.com/?path=/story/lumx-components-select-select-multiple--default-select-multiple

![2022-04-04-153057_690x89_scrot](https://user-images.githubusercontent.com/939567/161554903-04c69115-0e07-4f27-831a-60d9e1bf1f23.png)

With this PR https://5fbfb1d508c0520021560f10-bihmedrrjf.chromatic.com/?path=/story/lumx-components-select-select-multiple--default-select-multiple

![2022-04-04-153050_696x87_scrot](https://user-images.githubusercontent.com/939567/161554961-58b3d951-8675-4fd8-853b-131f1006f8d2.png)

