### PR TITLE
chore(comment-block): change date position and add tooltip for date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   CommentBlock: Move the comment date to below comment text and add a tooltip to display the full date with the added `fullDate` prop;
+
 ## [2.2.12][] - 2022-03-24
 
 ### Added

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
@@ -10,10 +10,10 @@ export const WithHeaderActions = ({ theme }: any) => (
     <CommentBlock
         hasActions
         actions={[
-            <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+            <Button key="button0" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                 24 likes
             </Button>,
-            <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+            <Button key="button1" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
                 Reply
             </Button>,
         ]}
@@ -23,6 +23,8 @@ export const WithHeaderActions = ({ theme }: any) => (
         fullDate="Monday, March 30, 2021 at 4:06 PM"
         name="Emmitt O. Lum"
         text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
-        headerActions={<IconButton label="Actions" icon={mdiDotsHorizontal} emphasis={Emphasis.low} size={Size.s} />}
+        headerActions={
+            <IconButton label="Actions" icon={mdiDotsHorizontal} theme={theme} emphasis={Emphasis.low} size={Size.s} />
+        }
     />
 );

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.stories.tsx
@@ -19,7 +19,8 @@ export const WithHeaderActions = ({ theme }: any) => (
         ]}
         theme={theme}
         avatarProps={{ image: avatarImageKnob(), alt: 'Avatar' }}
-        date="4 hours ago"
+        date="5 days"
+        fullDate="Monday, March 30, 2021 at 4:06 PM"
         name="Emmitt O. Lum"
         text="All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation."
         headerActions={<IconButton label="Actions" icon={mdiDotsHorizontal} emphasis={Emphasis.low} size={Size.s} />}

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -2,7 +2,7 @@ import React, { Children, forwardRef, KeyboardEvent, KeyboardEventHandler, React
 
 import classNames from 'classnames';
 
-import { Avatar, Size, Theme } from '@lumx/react';
+import { Avatar, Size, Theme, Tooltip } from '@lumx/react';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses, ValueOf } from '@lumx/react/utils';
 
 import isFunction from 'lodash/isFunction';
@@ -27,8 +27,10 @@ export interface CommentBlockProps extends GenericProps {
     avatarProps: AvatarProps;
     /** Comment block replies. */
     children?: ReactNode;
-    /** Comment date. */
+    /** Comment date with the minimal timestamp informations (xx minutes, x hours, yesterday, 6 days, Month Day, Month Day Year)*/
     date: string;
+    /** Comment date with the full timestamp informations (day, month, year, time) */
+    fullDate?: string;
     /** Whether the component has actions to display or not. */
     hasActions?: boolean;
     /** Action toolbar header content. */
@@ -85,6 +87,7 @@ export const CommentBlock: Comp<CommentBlockProps, HTMLDivElement> = forwardRef(
         children,
         className,
         date,
+        fullDate,
         hasActions,
         headerActions,
         isOpen,
@@ -146,11 +149,18 @@ export const CommentBlock: Comp<CommentBlockProps, HTMLDivElement> = forwardRef(
                             >
                                 {name}
                             </span>
-                            {date && <span className={`${CLASSNAME}__date`}>{date}</span>}
                             {headerActions && <span className={`${CLASSNAME}__header-actions`}>{headerActions}</span>}
                         </div>
 
                         <div className={`${CLASSNAME}__text`}>{text}</div>
+                        {date &&
+                            (fullDate ? (
+                                <Tooltip label={fullDate} placement="top">
+                                    <span className={`${CLASSNAME}__date`}>{date}</span>
+                                </Tooltip>
+                            ) : (
+                                <span className={`${CLASSNAME}__date`}>{date}</span>
+                            ))}
                     </div>
                     {hasActions && <div className={`${CLASSNAME}__actions`}>{actions}</div>}
                 </div>

--- a/packages/lumx-react/src/components/comment-block/__snapshots__/CommentBlock.test.tsx.snap
+++ b/packages/lumx-react/src/components/comment-block/__snapshots__/CommentBlock.test.tsx.snap
@@ -37,11 +37,6 @@ exports[`<CommentBlock> Snapshots and structure should render story 'WithHeaderA
             Emmitt O. Lum
           </span>
           <span
-            className="lumx-comment-block__date"
-          >
-            4 hours ago
-          </span>
-          <span
             className="lumx-comment-block__header-actions"
           >
             <IconButton
@@ -58,6 +53,16 @@ exports[`<CommentBlock> Snapshots and structure should render story 'WithHeaderA
         >
           All the rumors have finally died down and many skeptics have tightened their lips, the iPod does support video format now on its fifth generation.
         </div>
+        <Tooltip
+          label="Monday, March 30, 2021 at 4:06 PM"
+          placement="top"
+        >
+          <span
+            className="lumx-comment-block__date"
+          >
+            5 days
+          </span>
+        </Tooltip>
       </div>
       <div
         className="lumx-comment-block__actions"

--- a/packages/site-demo/content/product/components/comment-block/react/default.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/default.tsx
@@ -6,10 +6,10 @@ export const App = ({ theme }: any) => (
     <CommentBlock
         hasActions
         actions={[
-            <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+            <Button key="button0" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                 24 likes
             </Button>,
-            <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+            <Button key="button1" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
                 Reply
             </Button>,
         ]}

--- a/packages/site-demo/content/product/components/comment-block/react/relevant.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/relevant.tsx
@@ -7,10 +7,10 @@ export const App = ({ theme }: any) => (
         hasActions
         isRelevant
         actions={[
-            <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+            <Button key="button0" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                 24 likes
             </Button>,
-            <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+            <Button key="button1" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
                 Reply
             </Button>,
         ]}

--- a/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
+++ b/packages/site-demo/content/product/components/comment-block/react/threaded.tsx
@@ -8,10 +8,10 @@ export const App = ({ theme }: any) => (
             hasActions
             isOpen
             actions={[
-                <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                <Button key="button0" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                     24 likes
                 </Button>,
-                <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+                <Button key="button1" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
                     2 replies
                 </Button>,
             ]}
@@ -24,7 +24,7 @@ export const App = ({ theme }: any) => (
             <CommentBlock
                 hasActions
                 actions={
-                    <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                    <Button theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                         24 likes
                     </Button>
                 }
@@ -37,7 +37,7 @@ export const App = ({ theme }: any) => (
             <CommentBlock
                 hasActions
                 actions={
-                    <Button emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                    <Button theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                         16 likes
                     </Button>
                 }
@@ -52,10 +52,10 @@ export const App = ({ theme }: any) => (
         <CommentBlock
             hasActions
             actions={[
-                <Button key="button0" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
+                <Button key="button0" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiHeart}>
                     24 likes
                 </Button>,
-                <Button key="button1" emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
+                <Button key="button1" theme={theme} emphasis={Emphasis.low} size={Size.s} leftIcon={mdiReply}>
                     2 replies
                 </Button>,
             ]}


### PR DESCRIPTION
# General summary

Move the block comment date to below comment text and add a tooltip to display the new full date prop because the date will used the new timestamp format displaying the minimal information needed according to the current date
<!-- Please describe the PR content -->

# Screenshots
![image](https://user-images.githubusercontent.com/11031685/162394264-c645613a-0412-4e7b-8c4e-4938114cdc0a.png)
<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [x] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
