### PR TITLE
chore(select-multiple): forward props to wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added forwarded props to the `SelectMultiple` component.
+
 ## [2.2.15][] - 2022-04-14
 
 ### Fixed

--- a/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
@@ -46,6 +46,8 @@ const setup = (props: SetupProps = {}, shallowRendering = true) => {
             (n: ShallowWrapper | ReactWrapper) => n.name() === 'InputHelper' && n.prop('kind') === Kind.info,
         ),
         input: wrapper.find('#select-uid:not(SelectMultipleField)').first(),
+        chip: wrapper.find('Chip'),
+        inputWrapper: wrapper.find('.lumx-select__wrapper'),
         props,
         wrapper,
     };
@@ -187,6 +189,29 @@ describe(`<SelectMultiple>`, () => {
 
             expect(error).toExist();
             expect(helper).toExist();
+        });
+
+        it('should have a data-id as prop', () => {
+            const { inputWrapper } = setup(
+                {
+                    'data-id': 'select',
+                },
+                false,
+            );
+
+            expect(inputWrapper.prop('data-id')).toEqual('select');
+        });
+
+        it('should have a data-id as prop with Chip variant', () => {
+            const { chip } = setup(
+                {
+                    'data-id': 'select',
+                    variant: SelectVariant.chip,
+                },
+                false,
+            );
+
+            expect(chip.prop('data-id')).toEqual('select');
         });
     });
 

--- a/packages/lumx-react/src/components/select/SelectMultiple.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.tsx
@@ -73,6 +73,7 @@ export const SelectMultipleField: React.FC<SelectMultipleProps> = ({
     theme,
     value,
     variant,
+    ...forwardedProps
 }) => (
     <>
         {variant === SelectVariant.input && (
@@ -99,6 +100,7 @@ export const SelectMultipleField: React.FC<SelectMultipleProps> = ({
                     onKeyDown={handleKeyboardNav}
                     tabIndex={isDisabled ? undefined : 0}
                     aria-disabled={isDisabled || undefined}
+                    {...forwardedProps}
                 >
                     <div className={`${CLASSNAME}__chips`}>
                         {!isEmpty &&
@@ -139,6 +141,7 @@ export const SelectMultipleField: React.FC<SelectMultipleProps> = ({
                 onClick={onInputClick}
                 ref={anchorRef as RefObject<HTMLAnchorElement>}
                 theme={theme}
+                {...forwardedProps}
             >
                 {isEmpty && <span>{label}</span>}
 


### PR DESCRIPTION
# General summary

Forward props to the wrapper component of the SelectMultiple.
This can be useful to add additionnal data such as `data-id`.

# Check list

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
