### PR TITLE
chore(a11y): fix focus trap not ignoring disabled elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Dialog & Lightbox: fixed focus trap on disabled elements and protect against focus breaking out.
+
 ## [2.2.16][] - 2022-04-20
 
 ### Added

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -333,7 +333,7 @@ export const DialogWithFocusableElements = ({ theme }: any) => {
                         label="Checkbox input"
                     />
 
-                    <FlexBox orientation="horizontal">
+                    <FlexBox orientation="horizontal" hAlign="bottom" gap="regular">
                         <DatePickerField
                             locale="fr"
                             label="Start date"
@@ -366,6 +366,8 @@ export const DialogWithFocusableElements = ({ theme }: any) => {
                                 ))}
                             </List>
                         </Select>
+
+                        <Button isDisabled>Disabled button (focus ignored)</Button>
                     </FlexBox>
 
                     {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -152,6 +152,8 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithFocusabl
         theme="light"
       />
       <FlexBox
+        gap="regular"
+        hAlign="bottom"
         orientation="horizontal"
       >
         <DatePickerField
@@ -210,6 +212,14 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithFocusabl
             </ListItem>
           </List>
         </Select>
+        <Button
+          emphasis="high"
+          isDisabled={true}
+          size="m"
+          theme="light"
+        >
+          Disabled button (focus ignored)
+        </Button>
       </FlexBox>
       <div
         tabIndex={0}


### PR DESCRIPTION
# General summary

2 focus trap issues fixed in this PR:
- Having disabled elements inside dialogs and lightbox could break the focus trap.
- Also coming in focus from outside the browser window could escape the focus trap.

# Test

Test on storybook: https://5fbfb1d508c0520021560f10-xzwarxjqom.chromatic.com/iframe.html?id=lumx-components-dialog-dialog--dialog-with-focusable-elements&args=&viewMode=story
The dialog should trap the focus
- Using Tab or using shift+Tab should circle through all focusable elemnts in the dialog without leaving the dialog
- Starting the focus in the browser search bar and focusing in the window should focus inside the dialog

