### PR TITLE
docs(skeleton): fixed broken links

### DIFF
--- a/packages/site-demo/content/product/components/skeleton/index.mdx
+++ b/packages/site-demo/content/product/components/skeleton/index.mdx
@@ -1,12 +1,12 @@
 # Skeleton
 
-**Skeleton are primitives shapes which mimic a piece of content in a recognizable way. It communicate [loading states](/product/foundations/loading-state).**
+**Skeleton are primitives shapes which mimic a piece of content in a recognizable way. It communicate [loading states](/product/patterns/loading-state).**
 
 There are three variants: `circle`, `rectangular`, `typography`. When designing loading states with skeletons, use a combination of variants that best mimic the replaced content.
 
 ## Circle
 
-Use circle skeletons to mimic components like [avatar](/product/components/avatar/), [icon](/product/components/icon). Respect at best the size of replaced element using the T-shirt [sizes](/product/foundations/sizes).
+Use circle skeletons to mimic components like [avatar](/product/components/avatar/), [icon](/product/components/icon). Respect at best the size of replaced element using the T-shirt [sizes](/product/foundations/size).
 
 <DemoBlock demo="circle" orientation="horizontal" withThemeSwitcher />
 


### PR DESCRIPTION
# General summary

Fixed some broken link on skeleton demo page

# Screenshots

![Capture d’écran 2022-05-06 à 11 58 36](https://user-images.githubusercontent.com/15898440/167110485-dd80474f-03ee-47c1-ad88-73d8982c586c.png)

