### PR TITLE
feat(side-nav): add closeMode to hide or unmount children when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Tooltip: clear pending timers when the component unmounts
 
+### Added
+
+-   SideNavigationItem: added `closeMode` to `"unmount"` or `"hide"` children when the item is closed.
+
 ## [2.2.17][] - 2022-04-28
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/side-navigation/_index.scss
+++ b/packages/lumx-core/src/scss/components/side-navigation/_index.scss
@@ -51,6 +51,10 @@
     &__children {
         @include lumx-side-navigation-children;
     }
+
+    &:not(#{$self}--is-open) #{$self}__children {
+        display: none;
+    }
 }
 
 /* Item link states

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.stories.tsx
@@ -163,3 +163,29 @@ export const With3LevelsAndMultiActions = () => {
         </SideNavigation>
     );
 };
+
+/** Using closeMode="hide" keeps children in DOM on close */
+export const CloseModeHide = () => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const toggleL1 = () => setIsOpen(!isOpen);
+
+    return (
+        <SideNavigation>
+            <SideNavigationItem
+                closeMode="hide"
+                label="Level 1"
+                emphasis={Emphasis.high}
+                isOpen={isOpen}
+                onClick={toggleL1}
+                toggleButtonProps={{ label: 'Toggle' }}
+            >
+                <SideNavigationItem
+                    closeMode="hide"
+                    label="Level 2"
+                    emphasis={Emphasis.medium}
+                    toggleButtonProps={{ label: 'Toggle' }}
+                />
+            </SideNavigationItem>
+        </SideNavigation>
+    );
+};

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
+import without from 'lodash/without';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
 import { getBasicClass } from '@lumx/react/utils';
@@ -51,12 +52,27 @@ describe(`<${SideNavigationItem.displayName}>`, () => {
             expect(root).toHaveClassName(CLASSNAME);
         });
 
-        it('should render correctly with splitted actions', () => {
+        it('should render correctly with split actions', () => {
             const { root, wrapper } = setup({ linkProps: { href: 'http://toto.com' }, onClick: () => null });
             expect(wrapper).toMatchSnapshot();
 
             expect(root).toExist();
             expect(root).toHaveClassName(CLASSNAME);
+        });
+
+        it('should unmount children by default when closed', () => {
+            const { children } = setup({
+                children: <SideNavigationItem label="Child 1" toggleButtonProps={{ label: 'Toggle' }} />,
+            });
+            expect(children).not.toExist();
+        });
+
+        it('should keep children in DOM when closed and with closeMode="hide"', () => {
+            const { children } = setup({
+                closeMode: 'hide',
+                children: <SideNavigationItem key="1" label="Child 1" toggleButtonProps={{ label: 'Toggle' }} />,
+            });
+            expect(children).toExist();
         });
     });
 
@@ -67,7 +83,8 @@ describe(`<${SideNavigationItem.displayName}>`, () => {
         it('should use default props', () => {
             const { root } = setup();
 
-            for (const prop of Object.keys(DEFAULT_PROPS)) {
+            const propNames = without(Object.keys(DEFAULT_PROPS), 'closeMode');
+            for (const prop of propNames) {
                 const className = getBasicClass({ prefix: CLASSNAME, type: prop, value: DEFAULT_PROPS[prop] });
                 if (className) {
                     expect(root).toHaveClassName(className);

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -41,6 +41,11 @@ export interface SideNavigationItemProps extends GenericProps {
     /** Props to pass to the toggle button (minus those already set by the SideNavigationItem props). */
     toggleButtonProps: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color' | 'size'>;
+    /**
+     * Choose how the children are hidden when closed
+     * ('hide' keeps the children in DOM but hide them, 'unmount' remove the children from the DOM).
+     */
+    closeMode?: 'hide' | 'unmount';
     /** On action button click callback. */
     onActionClick?(evt: React.MouseEvent): void;
     /** On click callback. */
@@ -62,6 +67,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 const DEFAULT_PROPS: Partial<SideNavigationItemProps> = {
     emphasis: Emphasis.high,
+    closeMode: 'unmount',
 };
 
 /**
@@ -85,12 +91,14 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
         onActionClick,
         onClick,
         toggleButtonProps,
+        closeMode = 'unmount',
         ...forwardedProps
     } = props;
 
     const content = children && Children.toArray(children).filter(isComponent(SideNavigationItem));
     const hasContent = !isEmpty(content);
     const shouldSplitActions = Boolean(onActionClick);
+    const showChildren = hasContent && isOpen;
 
     return (
         <li
@@ -100,7 +108,7 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
                 className,
                 handleBasicClasses({
                     emphasis,
-                    isOpen,
+                    isOpen: showChildren,
                     isSelected,
                     prefix: CLASSNAME,
                 }),
@@ -151,7 +159,7 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
                 )
             )}
 
-            {hasContent && isOpen && <ul className={`${CLASSNAME}__children`}>{content}</ul>}
+            {(closeMode === 'hide' || showChildren) && <ul className={`${CLASSNAME}__children`}>{content}</ul>}
         </li>
     );
 });

--- a/packages/lumx-react/src/components/side-navigation/__snapshots__/SideNavigationItem.test.tsx.snap
+++ b/packages/lumx-react/src/components/side-navigation/__snapshots__/SideNavigationItem.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<SideNavigationItem> Snapshots and structure should render correctly 1`
 </li>
 `;
 
-exports[`<SideNavigationItem> Snapshots and structure should render correctly with splitted actions 1`] = `
+exports[`<SideNavigationItem> Snapshots and structure should render correctly with split actions 1`] = `
 <li
   className="lumx-side-navigation-item lumx-side-navigation-item--emphasis-high"
 >

--- a/packages/site-demo/gatsby-config.js
+++ b/packages/site-demo/gatsby-config.js
@@ -8,7 +8,6 @@ module.exports = {
         description: packageJson.description,
         version: packageJson.version,
     },
-    pathPrefix: '__PATH_PREFIX__',
     plugins: [
         // Inject path prefix at runtime (detected with a RegExp pattern).
         {

--- a/packages/site-demo/package.json
+++ b/packages/site-demo/package.json
@@ -16,7 +16,7 @@
     },
     "scripts": {
         "clean": "NODE_OPTIONS=--no-warnings gatsby clean",
-        "build": "NODE_OPTIONS=--no-warnings gatsby build --prefix-paths",
+        "build": "NODE_OPTIONS=--no-warnings gatsby build",
         "start": "NODE_OPTIONS=--no-warnings gatsby develop"
     },
     "dependencies": {


### PR DESCRIPTION
# General summary

- SideNavigationItem: added `closeMode` to `"unmount"` or `"hide"` children when the item is closed.
- Improve demo site side navigation SSR (nav fully generated in HTML now)
- Improve demo site side navigation automatically opening and closing sections on navigation (also scrolling the nav to put the current page link in the viewport)

Test on storybook
- Check side nav items open/close like before
- Check side nav items with `closeMode=hide` open/close keeping the children in the DOM