### PR TITLE
feat(component): create generic block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   LinkPreview: added `linkAs` prop to customize link component.
 -   LinkPreview: added `titleHeading` prop to customize the title heading tag.
 -   Select & SelectMultiple: add `icon` props
+-   New `GenericBlock` component
 
 ### Fixed
 

--- a/packages/lumx-react/src/components/generic-block/GenericBlock.stories.tsx
+++ b/packages/lumx-react/src/components/generic-block/GenericBlock.stories.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { mdiPencil } from '@lumx/icons';
+import { GenericBlock, Button, Icon, Size, Orientation, Alignment } from '@lumx/react';
+
+export default { title: 'LumX components/generic-block/GenericBlock' };
+
+export const Horizontal = ({ theme }: any) => (
+    <GenericBlock
+        orientation={Orientation.horizontal}
+        figure={<Icon icon={mdiPencil} size={Size.m} />}
+        actionsProps={{
+            style: { border: '1px solid red' },
+        }}
+        figureProps={{
+            style: { border: '1px solid red' },
+        }}
+        contentProps={{
+            style: { border: '1px solid red' },
+        }}
+        actions={<Button theme={theme}>Button</Button>}
+    >
+        Content
+    </GenericBlock>
+);
+
+export const HorizontalWithAlignment = ({ theme }: any) => (
+    <GenericBlock
+        orientation={Orientation.horizontal}
+        figure={<Icon icon={mdiPencil} size={Size.m} />}
+        actionsProps={{
+            fillSpace: true,
+            style: { border: '1px solid red' },
+            vAlign: 'center',
+        }}
+        figureProps={{
+            style: { border: '1px solid red' },
+        }}
+        contentProps={{
+            style: { border: '1px solid red' },
+        }}
+        actions={<Button theme={theme}>Centered button</Button>}
+    >
+        Content
+    </GenericBlock>
+);
+
+export const HorizontalTop = ({ theme }: any) => (
+    <GenericBlock
+        orientation={Orientation.horizontal}
+        hAlign={Alignment.top}
+        figure={<Icon icon={mdiPencil} size={Size.m} />}
+        actionsProps={{
+            style: { border: '1px solid red' },
+        }}
+        figureProps={{
+            style: { border: '1px solid red' },
+        }}
+        contentProps={{
+            style: { border: '1px solid red' },
+        }}
+        actions={<Button theme={theme}>Centered button</Button>}
+    >
+        Content
+    </GenericBlock>
+);
+
+export const Vertical = ({ theme }: any) => (
+    <GenericBlock
+        orientation={Orientation.vertical}
+        figure={<Icon icon={mdiPencil} size={Size.m} />}
+        actionsProps={{
+            fillSpace: true,
+            style: { border: '1px solid red' },
+        }}
+        figureProps={{
+            style: { border: '1px solid red' },
+        }}
+        contentProps={{
+            style: { border: '1px solid red' },
+        }}
+        actions={<Button theme={theme}>Button</Button>}
+    >
+        Content
+    </GenericBlock>
+);
+
+export const GapSizes = ({ theme }: any) => (
+    <>
+        <GenericBlock
+            orientation={Orientation.vertical}
+            figure={<Icon icon={mdiPencil} size={Size.m} />}
+            gap={Size.regular}
+            style={{ marginBottom: 40 }}
+            actionsProps={{
+                style: { border: '1px solid red' },
+            }}
+            figureProps={{
+                style: { border: '1px solid red' },
+            }}
+            contentProps={{
+                style: { border: '1px solid red' },
+            }}
+            actions={<Button theme={theme}>Button</Button>}
+        >
+            <h2>Small gap size</h2>
+            <p>For small blocks</p>
+        </GenericBlock>
+
+        <GenericBlock
+            orientation={Orientation.vertical}
+            figure={<Icon icon={mdiPencil} size={Size.m} />}
+            gap={Size.big}
+            style={{ marginBottom: 40 }}
+            actionsProps={{
+                style: { border: '1px solid red' },
+            }}
+            figureProps={{
+                style: { border: '1px solid red' },
+            }}
+            contentProps={{
+                style: { border: '1px solid red' },
+            }}
+            actions={<Button theme={theme}>Button</Button>}
+        >
+            <h2>Medium gap size</h2>
+            <p>For medium blocks</p>
+        </GenericBlock>
+
+        <GenericBlock
+            orientation={Orientation.vertical}
+            figure={<Icon icon={mdiPencil} size={Size.m} />}
+            gap={Size.huge}
+            style={{ marginBottom: 40 }}
+            actionsProps={{
+                style: { border: '1px solid red' },
+            }}
+            figureProps={{
+                style: { border: '1px solid red' },
+            }}
+            contentProps={{
+                style: { border: '1px solid red' },
+            }}
+            actions={<Button theme={theme}>Button</Button>}
+        >
+            <h2>Big gap size</h2>
+            <p>For large blocks</p>
+        </GenericBlock>
+    </>
+);

--- a/packages/lumx-react/src/components/generic-block/GenericBlock.test.tsx
+++ b/packages/lumx-react/src/components/generic-block/GenericBlock.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import 'jest-enzyme';
+import { commonTestsSuite, itShouldRenderStories } from '@lumx/react/testing/utils';
+
+import { GenericBlock, GenericBlockProps } from './GenericBlock';
+import * as stories from '../../stories/generated/GenericBlock/Demos.stories';
+
+const CLASSNAME = GenericBlock.className as string;
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ */
+const setup = (props: Partial<GenericBlockProps> = {}, shallowRendering = true) => {
+    const renderer: any = shallowRendering ? shallow : mount;
+    const wrapper: any = renderer(<GenericBlock {...(props as any)} />);
+    return { props, wrapper };
+};
+
+describe(`<${GenericBlock.displayName}>`, () => {
+    // 1. Test render via snapshot.
+    describe('Snapshots and structure', () => {
+        itShouldRenderStories(stories, GenericBlock);
+    });
+
+    // Common tests suite.
+    commonTestsSuite(setup, { className: 'wrapper', prop: 'wrapper' }, { className: CLASSNAME });
+});

--- a/packages/lumx-react/src/components/generic-block/GenericBlock.tsx
+++ b/packages/lumx-react/src/components/generic-block/GenericBlock.tsx
@@ -1,0 +1,120 @@
+import React, { forwardRef, ReactNode } from 'react';
+import classNames from 'classnames';
+import { Comp, getRootClassName } from '@lumx/react/utils';
+import { Orientation, Size, FlexBox, FlexBoxProps, Alignment, HorizontalAlignment } from '@lumx/react';
+
+export interface GenericBlockProps extends FlexBoxProps {
+    /** Component to use as visual element. */
+    figure?: ReactNode;
+    /** Actions to set after the main content. */
+    actions?: ReactNode;
+    /** Main content to display */
+    children: ReactNode;
+    /** Orientation of the 3 sections */
+    orientation?: FlexBoxProps['orientation'];
+    /** Horizontal alignment. */
+    hAlign?: FlexBoxProps['hAlign'];
+    /** Vertical alignment. */
+    vAlign?: FlexBoxProps['vAlign'];
+    /**
+     * The props to forward to the content.
+     * By default, the content will have the same alignment as wrapper.
+     */
+    contentProps?: Omit<FlexBoxProps, 'children'>;
+    /** props to forward to the actions element. */
+    actionsProps?: Omit<FlexBoxProps, 'children'>;
+    /** props to forward to the figure element. */
+    figureProps?: Omit<FlexBoxProps, 'children'>;
+}
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'GenericBlock';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
+
+/**
+ * Component default props.
+ */
+const DEFAULT_PROPS: Partial<GenericBlockProps> = {
+    gap: Size.regular,
+    orientation: Orientation.vertical,
+    hAlign: Alignment.center,
+    vAlign: Alignment.center,
+};
+
+/**
+ * The GenericBlock is a layout component made of 3 sections that can be
+ * displayed either horizontally of vertically with the same gap between each section.
+ *
+ * The sections are:
+ * * (Optional) `Figure` => A visual element to display before the main content.
+ * * (Required) `Content` => The main content displayed
+ * * (Optional) `Actions` => One or more actions to set after the element.
+ *
+ * @see https://www.figma.com/file/lzzrQmsfaXRaOyRfoEogPZ/DS%3A-playground?node-id=1%3A4076
+ */
+export const GenericBlock: Comp<GenericBlockProps, HTMLDivElement> = forwardRef((props, ref) => {
+    const {
+        className,
+        figure,
+        figureProps,
+        children,
+        actions,
+        actionsProps,
+        gap,
+        orientation,
+        contentProps,
+        ...forwardedProps
+    } = props;
+
+    let actionsVAlign: HorizontalAlignment = Alignment.center;
+    if (orientation === Orientation.horizontal) {
+        actionsVAlign = Alignment.right;
+    }
+    let contentVAlign: HorizontalAlignment = Alignment.center;
+    if (orientation === Orientation.horizontal) {
+        contentVAlign = Alignment.left;
+    }
+
+    return (
+        <FlexBox
+            ref={ref}
+            className={classNames(className, CLASSNAME)}
+            gap={gap}
+            orientation={orientation}
+            {...forwardedProps}
+        >
+            <FlexBox {...figureProps} className={classNames(figureProps?.className, `${CLASSNAME}__figure`)}>
+                {figure}
+            </FlexBox>
+
+            {children && (
+                <FlexBox
+                    orientation={Orientation.vertical}
+                    fillSpace
+                    vAlign={contentVAlign}
+                    {...contentProps}
+                    className={classNames(contentProps?.className, `${CLASSNAME}__content`)}
+                >
+                    {children}
+                </FlexBox>
+            )}
+
+            <FlexBox
+                vAlign={actionsVAlign}
+                {...actionsProps}
+                className={classNames(actionsProps?.className, `${CLASSNAME}__actions`)}
+            >
+                {actions}
+            </FlexBox>
+        </FlexBox>
+    );
+});
+GenericBlock.displayName = COMPONENT_NAME;
+GenericBlock.className = CLASSNAME;
+GenericBlock.defaultProps = DEFAULT_PROPS;

--- a/packages/lumx-react/src/components/generic-block/__snapshots__/GenericBlock.test.tsx.snap
+++ b/packages/lumx-react/src/components/generic-block/__snapshots__/GenericBlock.test.tsx.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<GenericBlock> Snapshots and structure should render story 'Default' 1`] = `
+Array [
+  <FlexBox
+    className="lumx-generic-block"
+    gap="regular"
+    hAlign="center"
+    orientation="vertical"
+    vAlign="center"
+  >
+    <FlexBox
+      className="lumx-generic-block__figure"
+    >
+      <Avatar
+        alt=""
+        image="/demo-assets/persona.png"
+        size="m"
+        theme="light"
+      />
+    </FlexBox>
+    <FlexBox
+      className="lumx-generic-block__content"
+      fillSpace={true}
+      orientation="vertical"
+      vAlign="center"
+    >
+      <h2>
+        Content title
+      </h2>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rhoncus libero aliquet pharetra luctus. Fusce nisl turpis, posuere ac tellus at, euismod vulputate libero...
+      </p>
+    </FlexBox>
+    <FlexBox
+      className="lumx-generic-block__actions"
+      vAlign="center"
+    >
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
+        Actions
+      </Button>
+    </FlexBox>
+  </FlexBox>,
+  <FlexBox
+    className="lumx-generic-block"
+    gap="regular"
+    hAlign="center"
+    orientation="horizontal"
+    vAlign="center"
+  >
+    <FlexBox
+      className="lumx-generic-block__figure"
+    >
+      <Avatar
+        alt=""
+        image="/demo-assets/persona.png"
+        size="m"
+        theme="light"
+      />
+    </FlexBox>
+    <FlexBox
+      className="lumx-generic-block__content"
+      fillSpace={true}
+      orientation="vertical"
+      vAlign="left"
+    >
+      <h2>
+        Content title
+      </h2>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rhoncus libero aliquet pharetra luctus. Fusce nisl turpis, posuere ac tellus at, euismod vulputate libero...
+      </p>
+    </FlexBox>
+    <FlexBox
+      className="lumx-generic-block__actions"
+      vAlign="right"
+    >
+      <Button
+        emphasis="high"
+        size="m"
+        theme="light"
+      >
+        Actions
+      </Button>
+    </FlexBox>
+  </FlexBox>,
+]
+`;

--- a/packages/lumx-react/src/components/generic-block/index.ts
+++ b/packages/lumx-react/src/components/generic-block/index.ts
@@ -1,0 +1,1 @@
+export * from './GenericBlock';

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -15,6 +15,7 @@ export * from './components/dropdown';
 export * from './components/expansion-panel';
 export * from './components/flag';
 export * from './components/flex-box';
+export * from './components/generic-block';
 export * from './components/grid';
 export * from './components/icon';
 export * from './components/image-block';

--- a/packages/lumx-react/src/stories/generated/GenericBlock/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/GenericBlock/Demos.stories.tsx
@@ -1,0 +1,6 @@
+/**
+ * File generated when storybook is started. Do not edit directly!
+ */
+export default { title: 'LumX components/generic-block/GenericBlock Demos' };
+
+export { App as Default } from './default';

--- a/packages/lumx-react/src/stories/generated/GenericBlock/default.tsx
+++ b/packages/lumx-react/src/stories/generated/GenericBlock/default.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/generic-block/react/default.tsx

--- a/packages/site-demo/content/product/components/generic-block/index.mdx
+++ b/packages/site-demo/content/product/components/generic-block/index.mdx
@@ -1,0 +1,10 @@
+
+# GenericBlock
+
+## Default
+
+<DemoBlock demo="default" withThemeSwitcher />
+
+### Properties
+
+<PropTable component="GenericBlock" />

--- a/packages/site-demo/content/product/components/generic-block/react/default.tsx
+++ b/packages/site-demo/content/product/components/generic-block/react/default.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { GenericBlock, Avatar, Button, Size, Orientation } from '@lumx/react';
+
+export const App = ({ theme }: any) => (
+    <>
+        <GenericBlock
+            theme={theme}
+            figure={<Avatar theme={theme} image="/demo-assets/persona.png" alt="" size={Size.m} />}
+            actions={<Button theme={theme}>Actions</Button>}
+        >
+            <h2>Content title</h2>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rhoncus libero aliquet pharetra luctus.
+                Fusce nisl turpis, posuere ac tellus at, euismod vulputate libero...
+            </p>
+        </GenericBlock>
+
+        <GenericBlock
+            theme={theme}
+            orientation={Orientation.horizontal}
+            figure={<Avatar theme={theme} image="/demo-assets/persona.png" alt="" size={Size.m} />}
+            actions={<Button theme={theme}>Actions</Button>}
+        >
+            <h2>Content title</h2>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rhoncus libero aliquet pharetra luctus.
+                Fusce nisl turpis, posuere ac tellus at, euismod vulputate libero...
+            </p>
+        </GenericBlock>
+    </>
+);


### PR DESCRIPTION
# General summary

Creating the `GenericBlock` component providing a reusable layout for the common pattern of "blocks" (site block, user block, etc.)
