### PR TITLE
chore(data-table): remove bind-html to avoid security issues

### DIFF
--- a/packages/lumx-angularjs/src/components/data-table/data-table.html
+++ b/packages/lumx-angularjs/src/components/data-table/data-table.html
@@ -48,7 +48,7 @@
 
                 <lx-table-cell-body ng-repeat="th in lx.thead">
                     <span ng-if="!th.format">{{ tr[th.name] }}</span>
-                    <div ng-bind-html="lx.$sce.trustAsHtml(th.format(tr))" ng-if="th.format"></div>
+                    <div ng-bind-html="th.format(tr)" ng-if="th.format"></div>
                 </lx-table-cell-body>
             </lx-table-row>
         </lx-table-body>


### PR DESCRIPTION
# General summary
In order to avoid security issues, this PR aims to remove the `bind-html` in the data-table component.
<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
