### PR TITLE
chore(focus-trap): fix & improve the focus trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Dialog & Lightbox: fixed focus trap not working when closing and reopening the same component.
 -   Dialog & Lightbox & DatePickerField: fixed focus trap on nested components.
 -   Dialog & Lightbox & Popover: fixed 'Escape' key to close nested components.
+-   DatePickerField: fix focus element when opened and re-opened.
 
 ## [2.2.19][] - 2022-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   LinkPreview: Improve accessibility on thumbnail link, remove redundant links in focus order and improve tag semantics.
 -   Dialog & Lightbox: fixed focus trap not working when closing and reopening the same component.
+-   Dialog & Lightbox & DatePickerField: fixed focus trap on nested components.
 
 ## [2.2.19][] - 2022-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   LinkPreview: Improve accessibility on thumbnail link, remove redundant links in focus order and improve tag semantics.
+-   Dialog & Lightbox: fixed focus trap not working when closing and reopening the same component.
 
 ## [2.2.19][] - 2022-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   LinkPreview: Improve accessibility on thumbnail link, remove redundant links in focus order and improve tag semantics.
 -   Dialog & Lightbox: fixed focus trap not working when closing and reopening the same component.
 -   Dialog & Lightbox & DatePickerField: fixed focus trap on nested components.
+-   Dialog & Lightbox & Popover: fixed 'Escape' key to close nested components.
 
 ## [2.2.19][] - 2022-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   LinkPreview: added `titleHeading` prop to customize the title heading tag.
 -   Select & SelectMultiple: add `icon` props
 -   New `GenericBlock` component
+-   Popover: focus first focusable element in anchor OR anchor on close.
 
 ### Fixed
 

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -62,7 +62,7 @@ export const DatePickerField: Comp<DatePickerFieldProps, HTMLDivElement> = forwa
         value,
         ...forwardedProps
     } = props;
-    const wrapperRef = useRef(null);
+    const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(null);
     const anchorRef = useRef(null);
 
     const [isOpen, setIsOpen] = useState(false);
@@ -83,8 +83,8 @@ export const DatePickerField: Comp<DatePickerFieldProps, HTMLDivElement> = forwa
     };
 
     // Handle focus trap.
-    const todayOrSelectedDateRef = useRef<HTMLButtonElement>(null);
-    useFocusTrap(isOpen && todayOrSelectedDateRef.current && wrapperRef.current, todayOrSelectedDateRef.current);
+    const [todayOrSelectedDate, setTodayOrSelectedDate] = useState<HTMLButtonElement | null>(null);
+    useFocusTrap(isOpen && wrapperElement, todayOrSelectedDate);
 
     const onTextFieldChange = (textFieldValue: string, textFieldName?: string, event?: SyntheticEvent) => {
         if (!textFieldValue) {
@@ -121,19 +121,18 @@ export const DatePickerField: Comp<DatePickerFieldProps, HTMLDivElement> = forwa
                     closeOnClickAway
                     closeOnEscape
                 >
-                    <div ref={wrapperRef}>
-                        <DatePicker
-                            locale={locale}
-                            maxDate={maxDate}
-                            minDate={minDate}
-                            value={value}
-                            onChange={onDatePickerChange}
-                            todayOrSelectedDateRef={todayOrSelectedDateRef}
-                            defaultMonth={defaultMonth}
-                            nextButtonProps={nextButtonProps}
-                            previousButtonProps={previousButtonProps}
-                        />
-                    </div>
+                    <DatePicker
+                        ref={setWrapperElement}
+                        locale={locale}
+                        maxDate={maxDate}
+                        minDate={minDate}
+                        value={value}
+                        onChange={onDatePickerChange}
+                        todayOrSelectedDateRef={setTodayOrSelectedDate}
+                        defaultMonth={defaultMonth}
+                        nextButtonProps={nextButtonProps}
+                        previousButtonProps={previousButtonProps}
+                    />
                 </Popover>
             ) : null}
         </>

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -84,7 +84,7 @@ export const DatePickerField: Comp<DatePickerFieldProps, HTMLDivElement> = forwa
 
     // Handle focus trap.
     const todayOrSelectedDateRef = useRef<HTMLButtonElement>(null);
-    useFocusTrap(todayOrSelectedDateRef.current && wrapperRef.current, todayOrSelectedDateRef.current);
+    useFocusTrap(isOpen && todayOrSelectedDateRef.current && wrapperRef.current, todayOrSelectedDateRef.current);
 
     const onTextFieldChange = (textFieldValue: string, textFieldName?: string, event?: SyntheticEvent) => {
         if (!textFieldValue) {

--- a/packages/lumx-react/src/components/date-picker/types.ts
+++ b/packages/lumx-react/src/components/date-picker/types.ts
@@ -1,6 +1,6 @@
 import { IconButtonProps } from '@lumx/react';
 import { GenericProps } from '@lumx/react/utils';
-import { RefObject } from 'react';
+import { Ref } from 'react';
 
 /**
  * Defines the props of the component.
@@ -20,7 +20,7 @@ export interface DatePickerProps extends GenericProps {
     previousButtonProps: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
     /** Reference to the <button> element corresponding to the current date or the selected date. */
-    todayOrSelectedDateRef?: RefObject<HTMLButtonElement>;
+    todayOrSelectedDateRef?: Ref<HTMLButtonElement>;
     /** Currently selected date. */
     value: Date | undefined;
     /** On change callback. */

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -1,3 +1,4 @@
+import noop from 'lodash/noop';
 import { mdiClose } from '@lumx/icons';
 import {
     AlertDialog,
@@ -303,7 +304,7 @@ export const DialogFocusTrap = ({ theme }: any) => {
     const [date, setDate] = useState<Date | undefined>(new Date('2020-05-18'));
 
     const datePickerDialogButtonRef = useRef<HTMLButtonElement>(null);
-    const [isDatePickerDialogOpen, closeDatePickerDialogOpen, openDatePickerDialogOpen] = useBooleanState(false);
+    const [isDatePickerDialogOpen, closeDatePickerDialog, openDatePickerDialog] = useBooleanState(false);
 
     return (
         <>
@@ -339,13 +340,13 @@ export const DialogFocusTrap = ({ theme }: any) => {
                     />
 
                     <FlexBox orientation="horizontal" hAlign="bottom" gap="regular">
-                        <Button ref={datePickerDialogButtonRef} onClick={openDatePickerDialogOpen}>
+                        <Button ref={datePickerDialogButtonRef} onClick={openDatePickerDialog}>
                             Open date picker
                         </Button>
                         <Dialog
                             isOpen={isDatePickerDialogOpen}
                             parentElement={datePickerDialogButtonRef}
-                            onClose={closeDatePickerDialogOpen}
+                            onClose={closeDatePickerDialog}
                         >
                             <header>
                                 <Toolbar
@@ -354,7 +355,7 @@ export const DialogFocusTrap = ({ theme }: any) => {
                                         <IconButton
                                             label="Close"
                                             icon={mdiClose}
-                                            onClick={closeDialog}
+                                            onClick={closeDatePickerDialog}
                                             emphasis={Emphasis.low}
                                         />
                                     }
@@ -370,6 +371,17 @@ export const DialogFocusTrap = ({ theme }: any) => {
                                     value={date}
                                     nextButtonProps={{ label: 'Next month' }}
                                     previousButtonProps={{ label: 'Previous month' }}
+                                />
+                                <DatePickerField
+                                    locale="fr"
+                                    label="Start date"
+                                    placeholder="Pick a date"
+                                    theme={theme}
+                                    onChange={noop}
+                                    value={undefined}
+                                    nextButtonProps={{ label: 'Next month' }}
+                                    previousButtonProps={{ label: 'Previous month' }}
+                                    defaultMonth={new Date('2020-05-18')}
                                 />
                             </div>
                         </Dialog>

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -17,7 +17,8 @@ import {
 } from '@lumx/react';
 import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
 import { select } from '@storybook/addon-knobs';
-import React, { RefObject, useRef, useState } from 'react';
+import React, { RefObject, useCallback, useRef, useState } from 'react';
+import { useBooleanState } from '@lumx/react/hooks/useBooleanState';
 import { Dialog, DialogSizes } from './Dialog';
 import { loremIpsum } from '../../stories/knobs/lorem';
 import { chromaticForceScreenSize } from '../../stories/chromaticForceScreenSize';
@@ -43,8 +44,8 @@ const footer = <footer className="lumx-spacing-padding">Dialog footer</footer>;
 function useOpenButton(theme: Theme, defaultState = true) {
     const buttonRef = useRef() as RefObject<HTMLButtonElement>;
     const [isOpen, setOpen] = useState(defaultState);
-    const openDialog = () => setOpen(true);
-    const closeDialog = () => setOpen(false);
+    const openDialog = useCallback(() => setOpen(true), []);
+    const closeDialog = useCallback(() => setOpen(false), []);
 
     return {
         button: (
@@ -301,6 +302,9 @@ export const DialogFocusTrap = ({ theme }: any) => {
     };
     const [date, setDate] = useState<Date | undefined>(new Date('2020-05-18'));
 
+    const datePickerDialogButtonRef = useRef<HTMLButtonElement>(null);
+    const [isDatePickerDialogOpen, closeDatePickerDialogOpen, openDatePickerDialogOpen] = useBooleanState(false);
+
     return (
         <>
             {button}
@@ -335,16 +339,40 @@ export const DialogFocusTrap = ({ theme }: any) => {
                     />
 
                     <FlexBox orientation="horizontal" hAlign="bottom" gap="regular">
-                        <DatePickerField
-                            locale="fr"
-                            label="Start date"
-                            placeholder="Pick a date"
-                            theme={theme}
-                            onChange={setDate}
-                            value={date}
-                            nextButtonProps={{ label: 'Next month' }}
-                            previousButtonProps={{ label: 'Previous month' }}
-                        />
+                        <Button ref={datePickerDialogButtonRef} onClick={openDatePickerDialogOpen}>
+                            Open date picker
+                        </Button>
+                        <Dialog
+                            isOpen={isDatePickerDialogOpen}
+                            parentElement={datePickerDialogButtonRef}
+                            onClose={closeDatePickerDialogOpen}
+                        >
+                            <header>
+                                <Toolbar
+                                    label={<h1 className="lumx-typography-title">Date picker</h1>}
+                                    after={
+                                        <IconButton
+                                            label="Close"
+                                            icon={mdiClose}
+                                            onClick={closeDialog}
+                                            emphasis={Emphasis.low}
+                                        />
+                                    }
+                                />
+                            </header>
+                            <div className="lumx-spacing-padding">
+                                <DatePickerField
+                                    locale="fr"
+                                    label="Start date"
+                                    placeholder="Pick a date"
+                                    theme={theme}
+                                    onChange={setDate}
+                                    value={date}
+                                    nextButtonProps={{ label: 'Next month' }}
+                                    previousButtonProps={{ label: 'Previous month' }}
+                                />
+                            </div>
+                        </Dialog>
 
                         <Select
                             className="lumx-spacing-margin-left-huge"

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -142,7 +142,7 @@ export const Dialog: Comp<DialogProps, HTMLDivElement> = forwardRef((props, ref)
     const localContentRef = useRef<HTMLDivElement>(null);
     // Handle focus trap.
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useFocusTrap(wrapperRef.current, focusElement?.current);
+    useFocusTrap(isOpen && wrapperRef.current, focusElement?.current);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useDisableBodyScroll(isOpen && localContentRef.current);

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -80,23 +80,84 @@ exports[`<Dialog> Snapshots and structure should render story DialogFocusTrap 1`
         hAlign="bottom"
         orientation="horizontal"
       >
-        <DatePickerField
-          label="Start date"
-          locale="fr"
-          nextButtonProps={
+        <Button
+          emphasis="high"
+          onClick={[Function]}
+          size="m"
+          theme="light"
+        >
+          Open date picker
+        </Button>
+        <Dialog
+          isOpen={false}
+          onClose={[Function]}
+          parentElement={
             Object {
-              "label": "Next month",
+              "current": null,
             }
           }
-          onChange={[Function]}
-          placeholder="Pick a date"
-          previousButtonProps={
-            Object {
-              "label": "Previous month",
-            }
-          }
-          value={2020-05-18T00:00:00.000Z}
-        />
+          size="big"
+        >
+          <header>
+            <Toolbar
+              after={
+                <IconButton
+                  emphasis="low"
+                  icon="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+                  label="Close"
+                  onClick={[Function]}
+                  size="m"
+                  theme="light"
+                />
+              }
+              label={
+                <h1
+                  className="lumx-typography-title"
+                >
+                  Date picker
+                </h1>
+              }
+            />
+          </header>
+          <div
+            className="lumx-spacing-padding"
+          >
+            <DatePickerField
+              label="Start date"
+              locale="fr"
+              nextButtonProps={
+                Object {
+                  "label": "Next month",
+                }
+              }
+              onChange={[Function]}
+              placeholder="Pick a date"
+              previousButtonProps={
+                Object {
+                  "label": "Previous month",
+                }
+              }
+              value={2020-05-18T00:00:00.000Z}
+            />
+            <DatePickerField
+              defaultMonth={2020-05-18T00:00:00.000Z}
+              label="Start date"
+              locale="fr"
+              nextButtonProps={
+                Object {
+                  "label": "Next month",
+                }
+              }
+              onChange={[Function]}
+              placeholder="Pick a date"
+              previousButtonProps={
+                Object {
+                  "label": "Previous month",
+                }
+              }
+            />
+          </div>
+        </Dialog>
         <Select
           className="lumx-spacing-margin-left-huge"
           isOpen={false}

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -87,7 +87,7 @@ export const Lightbox: Comp<LightboxProps, HTMLDivElement> = forwardRef((props, 
 
     // Handle focus trap.
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useFocusTrap(wrapperRef.current, childrenRef.current?.firstChild);
+    useFocusTrap(isOpen && wrapperRef.current, childrenRef.current?.firstChild);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const previousOpen = useRef(isOpen);

--- a/packages/lumx-react/src/hooks/useCallbackOnEscape.ts
+++ b/packages/lumx-react/src/hooks/useCallbackOnEscape.ts
@@ -1,25 +1,54 @@
 import { DOCUMENT } from '@lumx/react/constants';
 import { Callback, onEscapePressed } from '@lumx/react/utils';
 import { useEffect } from 'react';
+import last from 'lodash/last';
+import pull from 'lodash/pull';
+
+type Listener = { enable(): void; disable(): void };
 
 /**
- * Triggers a callback when the escape key is pressed.
+ * List of all listeners.
+ */
+const LISTENERS: Listener[] = [];
+
+/**
+ * Register a global listener on 'Escape' key pressed.
+ *
+ * If multiple listener are registered, only the last one is maintained. When a listener is unregistered, the previous
+ * one gets activated again.
  *
  * @param callback      Callback
  * @param closeOnEscape Disables the hook when false
- * @param rootElement   Element on which to listen the escape key
  */
-export function useCallbackOnEscape(
-    callback: Callback | undefined,
-    closeOnEscape = true,
-    rootElement = DOCUMENT?.body,
-) {
+export function useCallbackOnEscape(callback: Callback | undefined, closeOnEscape = true) {
     useEffect(() => {
-        if (closeOnEscape && callback && rootElement) {
-            const onKeyDown = onEscapePressed(callback);
-            rootElement.addEventListener('keydown', onKeyDown);
-            return () => rootElement.removeEventListener('keydown', onKeyDown);
+        const rootElement = DOCUMENT?.body;
+        if (!closeOnEscape || !callback || !rootElement) {
+            return undefined;
         }
-        return undefined;
-    }, [callback, closeOnEscape, rootElement]);
+        const onKeyDown = onEscapePressed(callback);
+
+        const listener: Listener = {
+            enable: () => rootElement.addEventListener('keydown', onKeyDown),
+            disable: () => rootElement.removeEventListener('keydown', onKeyDown),
+        };
+
+        // SETUP:
+        // Disable previous listener.
+        last(LISTENERS)?.disable();
+        // Keep track of current listener.
+        LISTENERS.push(listener);
+        // Enable current listener.
+        listener.enable();
+
+        // TEARDOWN:
+        return () => {
+            // Disable current listener.
+            listener.disable();
+            // Remove current listener.
+            pull(LISTENERS, listener);
+            // Enable previous listener.
+            last(LISTENERS)?.enable();
+        };
+    }, [callback, closeOnEscape]);
 }

--- a/packages/lumx-react/src/hooks/useCallbackOnEscape.ts
+++ b/packages/lumx-react/src/hooks/useCallbackOnEscape.ts
@@ -1,15 +1,9 @@
 import { DOCUMENT } from '@lumx/react/constants';
 import { Callback, onEscapePressed } from '@lumx/react/utils';
 import { useEffect } from 'react';
-import last from 'lodash/last';
-import pull from 'lodash/pull';
+import { Listener, makeListenerTowerContext } from '@lumx/react/utils/makeListenerTowerContext';
 
-type Listener = { enable(): void; disable(): void };
-
-/**
- * List of all listeners.
- */
-const LISTENERS: Listener[] = [];
+const LISTENERS = makeListenerTowerContext();
 
 /**
  * Register a global listener on 'Escape' key pressed.
@@ -33,22 +27,7 @@ export function useCallbackOnEscape(callback: Callback | undefined, closeOnEscap
             disable: () => rootElement.removeEventListener('keydown', onKeyDown),
         };
 
-        // SETUP:
-        // Disable previous listener.
-        last(LISTENERS)?.disable();
-        // Keep track of current listener.
-        LISTENERS.push(listener);
-        // Enable current listener.
-        listener.enable();
-
-        // TEARDOWN:
-        return () => {
-            // Disable current listener.
-            listener.disable();
-            // Remove current listener.
-            pull(LISTENERS, listener);
-            // Enable previous listener.
-            last(LISTENERS)?.enable();
-        };
+        LISTENERS.register(listener);
+        return () => LISTENERS.unregister(listener);
     }, [callback, closeOnEscape]);
 }

--- a/packages/lumx-react/src/hooks/useFocusTrap.ts
+++ b/packages/lumx-react/src/hooks/useFocusTrap.ts
@@ -1,69 +1,105 @@
 import { useEffect } from 'react';
+import last from 'lodash/last';
+import pull from 'lodash/pull';
 
 import { DOCUMENT } from '@lumx/react/constants';
 import { getFirstAndLastFocusable } from '@lumx/react/utils/focus/getFirstAndLastFocusable';
 import { Falsy } from '@lumx/react/utils';
 
+type Listener = { enable(): void; disable(): void };
+
 /**
- * Add a key down event handler to the given root element (document.body by default) to trap the move of focus
- * (TAB and SHIFT-TAB keys) inside the given focusZoneElement.
- * Will focus the given focus element when activating the focus trap.
+ * List of all focus traps.
+ */
+const FOCUS_TRAPS: Listener[] = [];
+
+/**
+ * Trap 'Tab' focus switch inside the `focusZoneElement`.
+ *
+ * If multiple focus trap are activated, only the last one is maintained and when a focus trap closes, the previous one
+ * gets activated again.
  *
  * @param focusZoneElement The element in which to trap the focus.
- * @param focusElement     The element to focus when the focus trap is activated.
- * @param rootElement      The element on which the key down event will be placed.
+ * @param focusElement     The element to focus when the focus trap is activated (otherwise the first focusable element
+ *                         will be focused).
  */
-export function useFocusTrap(
-    focusZoneElement: HTMLElement | Falsy,
-    focusElement?: HTMLElement | null,
-    rootElement = DOCUMENT?.body,
-): void {
+export function useFocusTrap(focusZoneElement: HTMLElement | Falsy, focusElement?: HTMLElement | null): void {
     useEffect(() => {
-        if (rootElement && focusZoneElement) {
-            (document.activeElement as HTMLElement)?.blur();
-            if (focusElement) {
-                focusElement.focus();
+        // Body element can be undefined in SSR context.
+        const rootElement = DOCUMENT?.body;
+
+        if (!rootElement || !focusZoneElement) {
+            return undefined;
+        }
+
+        // Trap 'Tab' key down focus switch into the focus zone.
+        const trapTabFocusInFocusZone = (evt: KeyboardEvent) => {
+            const { key } = evt;
+            if (key !== 'Tab') {
+                return;
+            }
+            const focusable = getFirstAndLastFocusable(focusZoneElement);
+
+            // Prevent focus switch if no focusable available.
+            if (!focusable.first) {
+                evt.preventDefault();
+                return;
             }
 
-            const onKeyDown = (evt: KeyboardEvent) => {
-                const { key } = evt;
-                if (key !== 'Tab') {
-                    return;
-                }
-                const focusable = getFirstAndLastFocusable(focusZoneElement);
+            if (
+                // No previous focus
+                !document.activeElement ||
+                // Previous focus is at the end of the focus zone.
+                (!evt.shiftKey && document.activeElement === focusable.last) ||
+                // Previous focus is outside the focus zone
+                !focusZoneElement.contains(document.activeElement)
+            ) {
+                focusable.first.focus();
+                evt.preventDefault();
+                return;
+            }
 
-                // Prevent focus switch if no focusable available.
-                if (!focusable.first) {
-                    evt.preventDefault();
-                    return;
-                }
+            if (
+                // Focus order reversed
+                evt.shiftKey &&
+                // Previous focus is at the start of the focus zone.
+                document.activeElement === focusable.first
+            ) {
+                focusable.last.focus();
+                evt.preventDefault();
+            }
+        };
 
-                if (
-                    // No previous focus
-                    !document.activeElement ||
-                    // Previous focus is at the end of the focus zone.
-                    (!evt.shiftKey && document.activeElement === focusable.last) ||
-                    // Previous focus is outside the focus zone
-                    !focusZoneElement.contains(document.activeElement)
-                ) {
-                    focusable.first.focus();
-                    evt.preventDefault();
-                    return;
-                }
+        const focusTrap: Listener = {
+            enable: () => rootElement.addEventListener('keydown', trapTabFocusInFocusZone),
+            disable: () => rootElement.removeEventListener('keydown', trapTabFocusInFocusZone),
+        };
 
-                if (
-                    // Focus order reversed
-                    evt.shiftKey &&
-                    // Previous focus is at the start of the focus zone.
-                    document.activeElement === focusable.first
-                ) {
-                    focusable.last.focus();
-                    evt.preventDefault();
-                }
-            };
-            rootElement.addEventListener('keydown', onKeyDown);
-            return () => rootElement.removeEventListener('keydown', onKeyDown);
+        // SETUP:
+
+        if (focusElement && focusZoneElement.contains(focusElement)) {
+            // Focus the given element.
+            focusElement.focus();
+        } else {
+            // Focus the first focusable element in the zone.
+            getFirstAndLastFocusable(focusZoneElement).first?.focus();
         }
-        return undefined;
-    }, [focusElement, focusZoneElement, rootElement]);
+
+        // Disable previous focus trap.
+        last(FOCUS_TRAPS)?.disable();
+        // Keep track of current focus trap.
+        FOCUS_TRAPS.push(focusTrap);
+        // Enable current focus trap.
+        focusTrap.enable();
+
+        // TEARDOWN:
+        return () => {
+            // Disable current focus trap.
+            focusTrap.disable();
+            // Remove current focus trap.
+            pull(FOCUS_TRAPS, focusTrap);
+            // Enable previous focus trap.
+            last(FOCUS_TRAPS)?.enable();
+        };
+    }, [focusElement, focusZoneElement]);
 }

--- a/packages/lumx-react/src/hooks/useFocusTrap.ts
+++ b/packages/lumx-react/src/hooks/useFocusTrap.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { DOCUMENT } from '@lumx/react/constants';
 import { getFirstAndLastFocusable } from '@lumx/react/utils/focus/getFirstAndLastFocusable';
+import { Falsy } from '@lumx/react/utils';
 
 /**
  * Add a key down event handler to the given root element (document.body by default) to trap the move of focus
@@ -13,7 +14,7 @@ import { getFirstAndLastFocusable } from '@lumx/react/utils/focus/getFirstAndLas
  * @param rootElement      The element on which the key down event will be placed.
  */
 export function useFocusTrap(
-    focusZoneElement: HTMLElement | null,
+    focusZoneElement: HTMLElement | Falsy,
     focusElement?: HTMLElement | null,
     rootElement = DOCUMENT?.body,
 ): void {

--- a/packages/lumx-react/src/utils/makeListenerTowerContext.ts
+++ b/packages/lumx-react/src/utils/makeListenerTowerContext.ts
@@ -1,0 +1,32 @@
+import last from 'lodash/last';
+import pull from 'lodash/pull';
+
+export type Listener = { enable(): void; disable(): void };
+
+/**
+ * Keep track of listeners, only the last registered listener gets activated at any point (previously registered
+ * listener are disabled).
+ * When a listener gets unregistered, the previously registered listener gets enabled again.
+ */
+export function makeListenerTowerContext() {
+    const LISTENERS: Listener[] = [];
+
+    return {
+        register(listener: Listener) {
+            // Disable previous listener.
+            last(LISTENERS)?.disable();
+            // Keep track of current listener.
+            LISTENERS.push(listener);
+            // Enable current listener.
+            listener.enable();
+        },
+        unregister(listener: Listener) {
+            // Disable current listener.
+            listener.disable();
+            // Remove current listener.
+            pull(LISTENERS, listener);
+            // Enable previous listener.
+            last(LISTENERS)?.enable();
+        },
+    };
+}


### PR DESCRIPTION
- fix(focus-trap): fix reset focus trap
- fix(focus-trap): fix nested focus traps
- fix(focus-trap): fix close nested components on escape key pressed
- chore(popover): focus first focusable element inside anchor on close
- fix(date-picker-field): fixed focus element on open

# Test

Scenario:
1. Go to the story ["Dialog Focus Trap"](https://5fbfb1d508c0520021560f10-enyqcdxplj.chromatic.com/?path=/story/lumx-components-dialog-dialog--dialog-focus-trap)
1. Navigate with `Tab` to the "Open date picker" button
1. Open by pressing `Enter`
1. Navigate with `Tab` to the date picker field
1. Open by pressing `Enter`
1. Navigate dates with `Tab` (this navigation could be improved upon)
1. Close the date picker with `Escape`
1. Close the date picker dialog with `Escape`
1. Close the main dialog with `Escape`

Additional checks 
- Navigating with `Tab` or `shift+Tab` should be confined to the dialog/date-picker
- Closing a dialog/date-picker should focus the activating element (button or date-picker field)
- Opening a dialog/date-picker should focus an element by default

