### PR TITLE
chore(doc): improve class name forwarding documentation

### DIFF
--- a/packages/lumx-react/src/components/button/Button.test.tsx
+++ b/packages/lumx-react/src/components/button/Button.test.tsx
@@ -110,7 +110,7 @@ describe(`<${Button.displayName}>`, () => {
         });
 
         it('should forward any CSS class', () => {
-            const props: Partial<ButtonProps> = {
+            const props = {
                 className: 'component component--is-tested',
             };
             const { wrapper, buttonRoot } = setup(props);

--- a/packages/lumx-react/src/components/button/IconButton.test.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.test.tsx
@@ -73,7 +73,7 @@ describe(`<${IconButton.displayName}>`, () => {
         });
 
         it('should forward any CSS class', () => {
-            const props: Partial<IconButtonProps> = {
+            const props = {
                 className: 'component component--is-tested',
             };
             const { wrapper, buttonRoot } = setup(props);

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -11,8 +11,6 @@ export interface SlidesProps extends GenericProps {
     activeIndex: number;
     /** slides id to be added to the wrapper */
     id?: string;
-    /** custom classname */
-    className?: string;
     /** custom theme */
     theme?: Theme;
     /** Whether the automatic rotation of the slideshow is enabled or not. */

--- a/packages/lumx-react/src/testing/utils/commonTestsSuite.ts
+++ b/packages/lumx-react/src/testing/utils/commonTestsSuite.ts
@@ -47,8 +47,8 @@ export function commonTestsSuite(
                 const wrappersToTest = isArray(tests.className)
                     ? tests.className
                     : [tests.className as string, tests.className as string];
-                expect(wrappers[wrappersToTest[0]]).toHaveClassName(params.className);
-                expect(wrappers[wrappersToTest[1]]).toHaveClassName(modifiedProps.className);
+                expect(wrappers[wrappersToTest[0]]).toHaveClassName(params.className as string);
+                expect(wrappers[wrappersToTest[1]]).toHaveClassName(modifiedProps.className as string);
             });
         }
 

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -39,8 +39,11 @@ export type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
  */
 export interface GenericProps {
     /**
+     * Class name forwarded to the root element of the component.
+     */
+    className?: string;
+    /**
      * Any prop (particularly any supported prop for a HTML element).
-     * E.g. classNames, onClick, disabled, ...
      */
     [propName: string]: any;
 }


### PR DESCRIPTION
Document class name forwarding across all components

All component having `className` forwarding now have their props extend the `HasClassName` interface on which the `className` prop is documented with JSDoc.

On the documentation site, the `className` prop will show in all component prop tables