### PR TITLE
chore: improve component prop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Thumbnail: broaden `badge` prop TS type from `ReactElement` to `ReactElement | Falsy`.
+
 ## [2.2.21][] - 2022-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Thumbnail: broaden `badge` prop TS type from `ReactElement` to `ReactElement | Falsy`.
+-   Dialog: broaden `contentRef` prop TS type from `RefObject` to `Ref`.
+-   TextField: broaden `inputRef` prop TS type from `RefObject` to `Ref`.
+-   Autocomplete: broaden `inputRef` prop TS type from `RefObject` to `Ref`.
 
 ## [2.2.21][] - 2022-07-04
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef, ReactNode, RefObject, SyntheticEvent, useRef } from 'react';
+import React, { forwardRef, ReactNode, SyntheticEvent, useRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Dropdown, IconButtonProps, Offset, Placement, TextField, Theme } from '@lumx/react';
+import { Dropdown, IconButtonProps, Offset, Placement, TextField, TextFieldProps, Theme } from '@lumx/react';
 
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
@@ -29,7 +29,7 @@ export interface AutocompleteProps extends GenericProps {
      * Reference to the <input> or <textarea> element.
      * @see {@link TextFieldProps#inputRef}
      */
-    inputRef?: RefObject<HTMLInputElement>;
+    inputRef?: TextFieldProps['inputRef'];
     /**
      * The offset that will be applied to the Dropdown position.
      * @see {@link DropdownProps#offset}
@@ -244,7 +244,7 @@ export const Autocomplete: Comp<AutocompleteProps, HTMLDivElement> = forwardRef(
                 hasError={hasError}
                 helper={helper}
                 icon={icon}
-                inputRef={mergeRefs(inputAnchorRef, inputRef) as any}
+                inputRef={mergeRefs(inputAnchorRef as React.RefObject<HTMLInputElement>, inputRef)}
                 clearButtonProps={clearButtonProps}
                 isDisabled={isDisabled}
                 isRequired={isRequired}

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, { Children, forwardRef, ReactElement, ReactNode, RefObject, useMemo, useRef, useState } from 'react';
+import React, { Children, forwardRef, ReactElement, ReactNode, Ref, RefObject, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import classNames from 'classnames';
@@ -42,7 +42,7 @@ export interface DialogProps extends GenericProps {
     /** Reference to the parent element that triggered modal opening (will get back focus on close). */
     parentElement?: RefObject<HTMLElement>;
     /** Reference to the dialog content element. */
-    contentRef?: RefObject<HTMLDivElement>;
+    contentRef?: Ref<HTMLDivElement>;
     /** Reference to the of the element that should get the focus when the dialogs opens. By default, the first child will take focus. */
     focusElement?: RefObject<HTMLElement>;
     /** Whether to keep the dialog open on clickaway or escape press. */

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -3,7 +3,7 @@ import React, { cloneElement, forwardRef, useMemo, useRef } from 'react';
 import classNames from 'classnames';
 
 import { List, ListProps } from '@lumx/react/components/list/List';
-import { Offset, Placement, Popover } from '@lumx/react/components/popover/Popover';
+import { Offset, Placement, Popover, PopoverProps } from '@lumx/react/components/popover/Popover';
 import { useInfiniteScroll } from '@lumx/react/hooks/useInfiniteScroll';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
 
@@ -11,10 +11,11 @@ import { Comp, GenericProps, getRootClassName, handleBasicClasses, isComponent }
  * Defines the props of the component.
  */
 export interface DropdownProps extends GenericProps {
-    /** Reference to the element around which the dropdown is placed.
+    /**
+     * Reference to the element around which the dropdown is placed.
      * @see {@link PopoverProps#anchorRef}
      */
-    anchorRef: React.RefObject<HTMLElement>;
+    anchorRef: PopoverProps['anchorRef'];
     /** Dropdown content. */
     children: React.ReactNode;
     /**

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ReactNode, RefObject, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, ReactNode, Ref, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 import get from 'lodash/get';
@@ -33,7 +33,7 @@ export interface TextFieldProps extends GenericProps {
     /** Native input id property (generated if not provided to link the label element). */
     id?: string;
     /** Reference to the <input> or <textarea> element. */
-    inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
+    inputRef?: Ref<HTMLInputElement | HTMLTextAreaElement>;
     /** Whether the component is disabled or not. */
     isDisabled?: boolean;
     /** Whether the component is required or not. */
@@ -53,7 +53,7 @@ export interface TextFieldProps extends GenericProps {
     /** Placeholder text. */
     placeholder?: string;
     /** Reference to the wrapper. */
-    textFieldRef?: RefObject<HTMLDivElement>;
+    textFieldRef?: Ref<HTMLDivElement>;
     /** Theme adapting the component to light or dark background. */
     theme?: Theme;
     /** Value. */
@@ -139,7 +139,7 @@ const useComputeNumberOfRows = (
 
 interface InputNativeProps {
     id?: string;
-    inputRef?: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>;
+    inputRef?: TextFieldProps['inputRef'];
     isDisabled?: boolean;
     isRequired?: boolean;
     multiline?: boolean;

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 
 import { AspectRatio, HorizontalAlignment, Icon, Size, Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, Falsy, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
 
 import { mdiImageBroken } from '@lumx/icons';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
@@ -34,7 +34,7 @@ export interface ThumbnailProps extends GenericProps {
     /** Image aspect ratio. */
     aspectRatio?: AspectRatio;
     /** Badge. */
-    badge?: ReactElement;
+    badge?: ReactElement | Falsy;
     /** Image cross origin resource policy. */
     crossOrigin?: ImgHTMLProps['crossOrigin'];
     /** Fallback icon (SVG path) or react node when image fails to load. */


### PR DESCRIPTION
Minor TS type improvements to broaden prop types making them usable on more use cases. 
**Their is no functional change**

-   Thumbnail: broaden `badge` prop TS type from `ReactElement` to `ReactElement | Falsy`.
   Useful to display badge conditionally (ex: ` <Thumbnail badge={icon && <Badge>...`)
-   Dialog: broaden `contentRef` prop TS type from `RefObject` to `Ref`.
-   TextField: broaden `inputRef` prop TS type from `RefObject` to `Ref`.
-   Autocomplete: broaden `inputRef` prop TS type from `RefObject` to `Ref`.