### PR TITLE
chore(doc): factorize components theme prop documentation

### DIFF
--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -2,9 +2,9 @@ import React, { forwardRef, ReactNode, SyntheticEvent, useRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Dropdown, IconButtonProps, Offset, Placement, TextField, TextFieldProps, Theme } from '@lumx/react';
+import { Dropdown, IconButtonProps, Offset, Placement, TextField, TextFieldProps } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
@@ -12,7 +12,7 @@ import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 /**
  * Defines the props of the component.
  */
-export interface AutocompleteProps extends GenericProps {
+export interface AutocompleteProps extends GenericProps, HasTheme {
     /**
      * Whether the suggestions list should display anchored to the input or to the wrapper.
      * @see {@link DropdownProps#anchorToInput}
@@ -94,8 +94,6 @@ export interface AutocompleteProps extends GenericProps {
      * @see {@link TextFieldProps#placeholder}
      */
     placeholder?: string;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** List of suggestions to display during autocomplete. */
     children: React.ReactNode;
     /**

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { AspectRatio, Size, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Avatar sizes.
@@ -14,7 +14,7 @@ export type AvatarSize = Extract<Size, 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl'>;
 /**
  * Defines the props of the component.
  */
-export interface AvatarProps extends GenericProps {
+export interface AvatarProps extends GenericProps, HasTheme {
     /** Action toolbar content. */
     actions?: ReactNode;
     /** Image alternative text. */
@@ -33,8 +33,6 @@ export interface AvatarProps extends GenericProps {
     onKeyPress?: KeyboardEventHandler<HTMLDivElement>;
     /** Size variant. */
     size?: AvatarSize;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Props to pass to the thumbnail (minus those already set by the Avatar props). */
     thumbnailProps?: Omit<
         ThumbnailProps,

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 
 import { Color, ColorPalette, Emphasis, Size, Theme } from '@lumx/react';
 import { CSS_PREFIX } from '@lumx/react/constants';
-import { Comp, GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 type HTMLButtonProps = DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
@@ -18,7 +18,8 @@ export type ButtonSize = Extract<Size, 's' | 'm'>;
 
 export interface BaseButtonProps
     extends GenericProps,
-        Pick<AriaAttributes, 'aria-expanded' | 'aria-haspopup' | 'aria-pressed' | 'aria-label'> {
+        Pick<AriaAttributes, 'aria-expanded' | 'aria-haspopup' | 'aria-pressed' | 'aria-label'>,
+        HasTheme {
     /** Color variant. */
     color?: Color;
     /** Emphasis variant. */
@@ -37,8 +38,6 @@ export interface BaseButtonProps
     size?: ButtonSize;
     /** Native anchor target property. */
     target?: '_self' | '_blank' | '_parent' | '_top';
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Native button type. */
     type?: HTMLButtonProps['type'];
     /** Custom react component for the link (can be used to inject react router Link). */

--- a/packages/lumx-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.tsx
@@ -6,12 +6,12 @@ import { uid } from 'uid';
 import { mdiCheck } from '@lumx/icons';
 
 import { Icon, InputHelper, InputLabel, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface CheckboxProps extends GenericProps {
+export interface CheckboxProps extends GenericProps, HasTheme {
     /** Helper text. */
     helper?: string;
     /** Native input id property. */
@@ -26,8 +26,6 @@ export interface CheckboxProps extends GenericProps {
     label?: ReactNode;
     /** Native input name property. */
     name?: string;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Native input value property. */
     value?: string;
     /** On change callback. */

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -1,7 +1,7 @@
 import { Color, ColorPalette, Size, Theme } from '@lumx/react';
 import { useStopPropagation } from '@lumx/react/hooks/useStopPropagation';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, onEnterPressed } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, onEnterPressed } from '@lumx/react/utils';
 
 import classNames from 'classnames';
 
@@ -16,7 +16,7 @@ type ChipSize = Extract<Size, 's' | 'm'>;
 /**
  * Defines the props of the component.
  */
-export interface ChipProps extends GenericProps {
+export interface ChipProps extends GenericProps, HasTheme {
     /** A component to be rendered after the content. */
     after?: ReactNode;
     /** A component to be rendered before the content. */
@@ -33,8 +33,6 @@ export interface ChipProps extends GenericProps {
     isSelected?: boolean;
     /** Size variant. */
     size?: ChipSize;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** On "after" element clicked callback. */
     onAfterClick?: MouseEventHandler;
     /** On "before" element clicked callback. */

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -3,7 +3,7 @@ import React, { Children, forwardRef, KeyboardEvent, KeyboardEventHandler, React
 import classNames from 'classnames';
 
 import { Avatar, Size, Theme, Tooltip } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
 
 import isFunction from 'lodash/isFunction';
 import { AvatarProps } from '../avatar/Avatar';
@@ -20,7 +20,7 @@ export type CommentBlockVariant = ValueOf<typeof CommentBlockVariant>;
 /**
  * Defines the props of the component.
  */
-export interface CommentBlockProps extends GenericProps {
+export interface CommentBlockProps extends GenericProps, HasTheme {
     /** Action toolbar content. */
     actions?: ReactNode;
     /** Props to pass to the avatar. */
@@ -49,8 +49,6 @@ export interface CommentBlockProps extends GenericProps {
     onMouseLeave?(): void;
     /** Comment content. */
     text: ReactNode | string;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Comment variant. */
     variant?: CommentBlockVariant;
 }

--- a/packages/lumx-react/src/components/divider/Divider.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.tsx
@@ -3,15 +3,12 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface DividerProps extends GenericProps {
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
-}
+export interface DividerProps extends GenericProps, HasTheme {}
 
 /**
  * Component display name.

--- a/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
+++ b/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
@@ -4,15 +4,12 @@ import classNames from 'classnames';
 
 import { mdiDragVertical } from '@lumx/icons';
 import { ColorPalette, Icon, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface DragHandleProps extends GenericProps {
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
-}
+export interface DragHandleProps extends GenericProps, HasTheme {}
 
 /**
  * Component display name.

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -15,6 +15,7 @@ import {
     GenericProps,
     getRootClassName,
     handleBasicClasses,
+    HasTheme,
     isComponent,
     partitionMulti,
 } from '@lumx/react/utils';
@@ -22,7 +23,7 @@ import {
 /**
  * Defines the props of the component.
  */
-export interface ExpansionPanelProps extends GenericProps {
+export interface ExpansionPanelProps extends GenericProps, HasTheme {
     /** Whether the expansion panel has a background. */
     hasBackground?: boolean;
     /** Whether the header has a divider. */
@@ -31,8 +32,6 @@ export interface ExpansionPanelProps extends GenericProps {
     isOpen?: boolean;
     /** Label text (overwritten if a `<header>` is provided in the children). */
     label?: string;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** On open callback. */
     onOpen?: Callback;
     /** On close callback. */

--- a/packages/lumx-react/src/components/flag/Flag.tsx
+++ b/packages/lumx-react/src/components/flag/Flag.tsx
@@ -2,11 +2,9 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { ColorPalette, Icon, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
-export interface FlagProps extends GenericProps {
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
+export interface FlagProps extends GenericProps, HasTheme {
     /** Color of the component. */
     color?: ColorPalette;
     /** Icon to use before the label. */

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { Color, ColorPalette, ColorVariant, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import { mdiAlertCircle } from '@lumx/icons';
 
 export type IconSizes = Extract<Size, 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl'>;
@@ -11,7 +11,7 @@ export type IconSizes = Extract<Size, 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'x
 /**
  * Defines the props of the component.
  */
-export interface IconProps extends GenericProps {
+export interface IconProps extends GenericProps, HasTheme {
     /** Color variant. */
     color?: Color;
     /** Lightened or darkened variant of the selected icon color. */
@@ -25,8 +25,6 @@ export interface IconProps extends GenericProps {
     icon: string;
     /** Size variant. */
     size?: IconSizes;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Sets an alternative text on the svg. Will set an `img` role to the svg. */
     alt?: string;
 }

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -6,7 +6,7 @@ import isObject from 'lodash/isObject';
 
 import { Alignment, HorizontalAlignment, Size, Theme, Thumbnail } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
 import { ThumbnailProps } from '../thumbnail/Thumbnail';
 
 /**
@@ -26,7 +26,7 @@ export type ImageBlockSize = Extract<Size, 'xl' | 'xxl'>;
 /**
  * Defines the props of the component.
  */
-export interface ImageBlockProps extends GenericProps {
+export interface ImageBlockProps extends GenericProps, HasTheme {
     /** Action toolbar content. */
     actions?: ReactNode;
     /** Alignment. */
@@ -47,8 +47,6 @@ export interface ImageBlockProps extends GenericProps {
     size?: ImageBlockSize;
     /** Tag content. */
     tags?: ReactNode;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Props to pass to the thumbnail (minus those already set by the ImageBlock props). */
     thumbnailProps?: Omit<ThumbnailProps, 'image' | 'size' | 'theme' | 'align' | 'fillHeight'>;
     /** Image title to display in the caption. */

--- a/packages/lumx-react/src/components/input-helper/InputHelper.tsx
+++ b/packages/lumx-react/src/components/input-helper/InputHelper.tsx
@@ -1,5 +1,5 @@
 import { Kind, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import classNames from 'classnames';
 import React, { forwardRef, ReactNode } from 'react';
 
@@ -8,13 +8,11 @@ import { INPUT_HELPER_CONFIGURATION } from './constants';
 /**
  * Defines the props of the component.
  */
-export interface InputHelperProps extends GenericProps {
+export interface InputHelperProps extends GenericProps, HasTheme {
     /** Helper content. */
     children: string | ReactNode;
     /** Helper variant. */
     kind?: Kind;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
 }
 
 /**

--- a/packages/lumx-react/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-react/src/components/input-label/InputLabel.tsx
@@ -1,20 +1,18 @@
 import { Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import classNames from 'classnames';
 import React, { forwardRef, ReactNode } from 'react';
 
 /**
  * Defines the props of the component.
  */
-export interface InputLabelProps extends GenericProps {
+export interface InputLabelProps extends GenericProps, HasTheme {
     /** Label content. */
     children: string | ReactNode;
     /** Native htmlFor property. */
     htmlFor: string;
     /** Whether the component is required or not. */
     isRequired?: boolean;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
 }
 
 /**

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 import { createPortal } from 'react-dom';
 
 import { mdiClose } from '@lumx/icons';
-import { ColorPalette, Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
+import { ColorPalette, Emphasis, IconButton, IconButtonProps } from '@lumx/react';
 import { DOCUMENT } from '@lumx/react/constants';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
@@ -20,7 +20,7 @@ const LIGHTBOX_TRANSITION_DURATION = 400;
 /**
  * Defines the props of the component.
  */
-export interface LightboxProps extends GenericProps {
+export interface LightboxProps extends GenericProps, HasTheme {
     /** Props to pass to the close button (minus those already set by the Lightbox props). */
     closeButtonProps?: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
@@ -30,8 +30,6 @@ export interface LightboxProps extends GenericProps {
     parentElement: RefObject<any>;
     /** Whether to keep the dialog open on clickaway or escape press. */
     preventAutoClose?: boolean;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Z-axis position. */
     zIndex?: number;
     /** On close callback. */

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
@@ -14,12 +14,12 @@ import {
     ThumbnailProps,
 } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HeadingElement } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HeadingElement, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface LinkPreviewProps extends GenericProps {
+export interface LinkPreviewProps extends GenericProps, HasTheme {
     /** Description. */
     description?: string;
     /** Link URL. */
@@ -30,8 +30,6 @@ export interface LinkPreviewProps extends GenericProps {
     linkProps?: Omit<LinkProps, 'color' | 'colorVariant' | 'href' | 'target'>;
     /** Size variant. */
     size?: Extract<Size, 'regular' | 'big'>;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Thumbnail for the link preview. */
     thumbnailProps?: ThumbnailProps;
     /** Title. */

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -1,16 +1,14 @@
 import React, { forwardRef, MouseEventHandler, useMemo } from 'react';
 
 import { Alignment, AspectRatio, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import classNames from 'classnames';
 import take from 'lodash/take';
 
 /**
  * Defines the props of the component.
  */
-export interface MosaicProps extends GenericProps {
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
+export interface MosaicProps extends GenericProps, HasTheme {
     /** Thumbnails. */
     thumbnails: ThumbnailProps[];
     /** On image click callback. */

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -9,22 +9,20 @@ import { Button, Emphasis, Icon, Kind, Size, Theme } from '@lumx/react';
 
 import { DOCUMENT, NOTIFICATION_TRANSITION_DURATION } from '@lumx/react/constants';
 import { NOTIFICATION_CONFIGURATION } from '@lumx/react/components/notification/constants';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
 
 /**
  * Defines the props of the component.
  */
-export interface NotificationProps extends GenericProps {
+export interface NotificationProps extends GenericProps, HasTheme {
     /** Action button label. */
     actionLabel?: string;
     /** Content. */
     content?: React.ReactNode;
     /** Whether the component is open or not. */
     isOpen?: boolean;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Notification type. */
     type?: Kind;
     /** Z-axis position. */

--- a/packages/lumx-react/src/components/post-block/PostBlock.tsx
+++ b/packages/lumx-react/src/components/post-block/PostBlock.tsx
@@ -6,12 +6,12 @@ import isObject from 'lodash/isObject';
 
 import { Orientation, Theme, Thumbnail, ThumbnailProps, ThumbnailVariant } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface PostBlockProps extends GenericProps {
+export interface PostBlockProps extends GenericProps, HasTheme {
     /** Action toolbar content. */
     actions?: ReactNode;
     /** Attachment content. */
@@ -26,8 +26,6 @@ export interface PostBlockProps extends GenericProps {
     tags?: ReactNode;
     /** Content (string, or sanitized html). */
     text?: string | { __html: string };
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Thumbnail. */
     thumbnailProps?: ThumbnailProps;
     /** Title. */

--- a/packages/lumx-react/src/components/progress/Progress.tsx
+++ b/packages/lumx-react/src/components/progress/Progress.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
 
 /**
  * Progress variants.
@@ -15,9 +15,7 @@ export type ProgressVariant = ValueOf<typeof ProgressVariant>;
 /**
  * Defines the props of the component.
  */
-export interface ProgressProps extends GenericProps {
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
+export interface ProgressProps extends GenericProps, HasTheme {
     /** Progress variant. */
     variant?: ProgressVariant;
 }

--- a/packages/lumx-react/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.tsx
@@ -5,12 +5,12 @@ import { uid } from 'uid';
 
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface RadioButtonProps extends GenericProps {
+export interface RadioButtonProps extends GenericProps, HasTheme {
     /** Helper text. */
     helper?: string;
     /** Native input id property. */
@@ -25,8 +25,6 @@ export interface RadioButtonProps extends GenericProps {
     label?: ReactNode;
     /** Native input name property. */
     name?: string;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Native input value property. */
     value?: string;
     /** On change callback. */

--- a/packages/lumx-react/src/components/select/constants.ts
+++ b/packages/lumx-react/src/components/select/constants.ts
@@ -1,6 +1,5 @@
 import { IconButtonProps } from '@lumx/react';
-import { Theme } from '@lumx/react/components';
-import { GenericProps, ValueOf } from '@lumx/react/utils';
+import { GenericProps, HasTheme, ValueOf } from '@lumx/react/utils';
 import { ReactNode, SyntheticEvent } from 'react';
 
 /**
@@ -9,7 +8,7 @@ import { ReactNode, SyntheticEvent } from 'react';
 export const SelectVariant = { input: 'input', chip: 'chip' } as const;
 export type SelectVariant = ValueOf<typeof SelectVariant>;
 
-export interface CoreSelectProps extends GenericProps {
+export interface CoreSelectProps extends GenericProps, HasTheme {
     /** Props to pass to the clear button (minus those already set by the Select props). If not specified, the button won't be displayed. */
     clearButtonProps?: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
@@ -35,8 +34,6 @@ export interface CoreSelectProps extends GenericProps {
     label?: string;
     /** Placeholder input text. */
     placeholder?: string;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Select variant. */
     variant?: SelectVariant;
     /** On clear callback. */

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
@@ -4,16 +4,14 @@ import classNames from 'classnames';
 
 import { SideNavigationItem, Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, isComponent } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface SideNavigationProps extends GenericProps {
+export interface SideNavigationProps extends GenericProps, HasTheme {
     /** SideNavigationItem elements. */
     children: ReactNode;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
 }
 
 /**

--- a/packages/lumx-react/src/components/skeleton/SkeletonCircle.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonCircle.tsx
@@ -2,16 +2,14 @@ import classNames from 'classnames';
 import React, { forwardRef } from 'react';
 
 import { GlobalSize, Theme, ColorPalette } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface SkeletonCircleProps extends GenericProps {
+export interface SkeletonCircleProps extends GenericProps, HasTheme {
     /** Size variant. */
     size: GlobalSize;
-    /** Theme. */
-    theme?: Theme;
     /** The color of the skeleton. */
     color?: ColorPalette;
 }

--- a/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, { forwardRef } from 'react';
 
 import { AspectRatio, GlobalSize, Theme, ColorPalette } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
 
 /**
  * Skeleton variants.
@@ -13,13 +13,11 @@ export type SkeletonRectangleVariant = ValueOf<typeof SkeletonRectangleVariant>;
 /**
  * Defines the props of the component.
  */
-export interface SkeletonRectangleProps extends GenericProps {
+export interface SkeletonRectangleProps extends GenericProps, HasTheme {
     /** Aspect ratio (use with width and not height). */
     aspectRatio?: Extract<AspectRatio, 'square' | 'horizontal' | 'vertical' | 'wide'>;
     /** Height size. */
     height?: GlobalSize;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Border variant. */
     variant?: SkeletonRectangleVariant;
     /** Width size. */

--- a/packages/lumx-react/src/components/skeleton/SkeletonTypography.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonTypography.tsx
@@ -2,14 +2,12 @@ import classNames from 'classnames';
 import React, { CSSProperties, forwardRef } from 'react';
 
 import { Theme, TypographyInterface, ColorPalette } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface SkeletonTypographyProps extends GenericProps {
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
+export interface SkeletonTypographyProps extends GenericProps, HasTheme {
     /** Typography variant. */
     typography: TypographyInterface;
     /** Width CSS property. */

--- a/packages/lumx-react/src/components/slider/Slider.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import useEventCallback from '@lumx/react/hooks/useEventCallback';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 import { uid } from 'uid';
 import { clamp } from '@lumx/react/utils/clamp';
@@ -14,7 +14,7 @@ import { clamp } from '@lumx/react/utils/clamp';
 /**
  * Defines the props of the component.
  */
-export interface SliderProps extends GenericProps {
+export interface SliderProps extends GenericProps, HasTheme {
     /** Helper text. */
     helper?: string;
     /** Whether the min and max labels should be hidden or not. */
@@ -33,8 +33,6 @@ export interface SliderProps extends GenericProps {
     precision?: number;
     /** Range step value. */
     steps?: number;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Selected ranged value. */
     value: number;
     /** On change callback. */

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -3,16 +3,13 @@ import React, { CSSProperties, forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
-import { Theme } from '@lumx/react';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
-export interface SlidesProps extends GenericProps {
+export interface SlidesProps extends GenericProps, HasTheme {
     /** current slide active */
     activeIndex: number;
     /** slides id to be added to the wrapper */
     id?: string;
-    /** custom theme */
-    theme?: Theme;
     /** Whether the automatic rotation of the slideshow is enabled or not. */
     autoPlay?: boolean;
     /** Whether the image has to fill its container height or not. */

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -5,7 +5,7 @@ import range from 'lodash/range';
 
 import { mdiChevronLeft, mdiChevronRight, mdiPlayCircleOutline, mdiPauseCircleOutline } from '@lumx/icons';
 import { Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import { WINDOW } from '@lumx/react/constants';
 import { useSlideshowControls, DEFAULT_OPTIONS } from '@lumx/react/hooks/useSlideshowControls';
 
@@ -17,7 +17,7 @@ import { usePaginationVisibleRange } from './usePaginationVisibleRange';
 /**
  * Defines the props of the component.
  */
-export interface SlideshowControlsProps extends GenericProps {
+export interface SlideshowControlsProps extends GenericProps, HasTheme {
     /** Index of the current slide. */
     activeIndex?: number;
     /** Props to pass to the next button (minus those already set by the SlideshowControls props). */
@@ -30,8 +30,6 @@ export interface SlideshowControlsProps extends GenericProps {
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
     /** Number of slides. */
     slidesCount: number;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** On next button click callback. */
     onNextClick?(loopback?: boolean): void;
     /** On pagination change callback. */

--- a/packages/lumx-react/src/components/switch/Switch.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.tsx
@@ -7,12 +7,12 @@ import isEmpty from 'lodash/isEmpty';
 
 import { Alignment, InputHelper, InputLabel, Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface SwitchProps extends GenericProps {
+export interface SwitchProps extends GenericProps, HasTheme {
     /** Helper text. */
     helper?: string;
     /** Whether it is checked or not. */
@@ -23,8 +23,6 @@ export interface SwitchProps extends GenericProps {
     name?: string;
     /** Position of the switch relative to the label. */
     position?: Extract<Alignment, 'right' | 'left'>;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Native input value property. */
     value?: string;
     /** On change callback. */

--- a/packages/lumx-react/src/components/table/Table.tsx
+++ b/packages/lumx-react/src/components/table/Table.tsx
@@ -4,18 +4,16 @@ import classNames from 'classnames';
 
 import { Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 /**
  * Defines the props of the component.
  */
-export interface TableProps extends GenericProps {
+export interface TableProps extends GenericProps, HasTheme {
     /** Whether the table has checkbox or thumbnail on first cell or not. */
     hasBefore?: boolean;
     /** Whether the table has dividers or not. */
     hasDividers?: boolean;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
 }
 
 /**

--- a/packages/lumx-react/src/components/tabs/TabList.tsx
+++ b/packages/lumx-react/src/components/tabs/TabList.tsx
@@ -1,6 +1,6 @@
 import { Alignment, Theme } from '@lumx/react';
 import { CSS_PREFIX } from '@lumx/react/constants';
-import { Comp, GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import classNames from 'classnames';
@@ -15,7 +15,7 @@ export enum TabListLayout {
 /**
  * Defines the props of the component.
  */
-export interface TabListProps extends GenericProps {
+export interface TabListProps extends GenericProps, HasTheme {
     /** ARIA label (purpose of the set of tabs). */
     ['aria-label']: string;
     /** Tab list. */
@@ -24,8 +24,6 @@ export interface TabListProps extends GenericProps {
     layout?: TabListLayout;
     /** Position of the tabs in the list (requires 'clustered' layout). */
     position?: Alignment;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
 }
 
 /**

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -6,13 +6,13 @@ import { uid } from 'uid';
 
 import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from '@lumx/icons';
 import { Emphasis, Icon, IconButton, IconButtonProps, InputHelper, InputLabel, Kind, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 /**
  * Defines the props of the component.
  */
-export interface TextFieldProps extends GenericProps {
+export interface TextFieldProps extends GenericProps, HasTheme {
     /** Chip Group to be rendered before the main text input. */
     chips?: HTMLElement | ReactNode;
     /** Props to pass to the clear button (minus those already set by the TextField props). If not specified, the button won't be displayed. */
@@ -54,8 +54,6 @@ export interface TextFieldProps extends GenericProps {
     placeholder?: string;
     /** Reference to the wrapper. */
     textFieldRef?: Ref<HTMLDivElement>;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Value. */
     value?: string;
     /** On blur callback. */

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 
 import { AspectRatio, HorizontalAlignment, Icon, Size, Theme } from '@lumx/react';
 
-import { Comp, Falsy, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, Falsy, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 import { mdiImageBroken } from '@lumx/icons';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
@@ -26,7 +26,7 @@ type ImgHTMLProps = ImgHTMLAttributes<HTMLImageElement>;
 /**
  * Defines the props of the component.
  */
-export interface ThumbnailProps extends GenericProps {
+export interface ThumbnailProps extends GenericProps, HasTheme {
     /** Alignment of the thumbnail in it's parent (requires flex parent). */
     align?: HorizontalAlignment;
     /** Image alternative text. */
@@ -59,8 +59,6 @@ export interface ThumbnailProps extends GenericProps {
     onClick?: MouseEventHandler<HTMLDivElement>;
     /** On key press callback. */
     onKeyPress?: KeyboardEventHandler<HTMLDivElement>;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Variant of the component. */
     variant?: ThumbnailVariant;
     /** Props to pass to the link wrapping the thumbnail. */

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, MouseEventHandler } from 'react';
 import classNames from 'classnames';
 
 import { AspectRatio, Icon, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
 
 /**
  * Uploader variants.
@@ -23,7 +23,7 @@ export type UploaderSize = Extract<Size, 'xl' | 'xxl'>;
 /**
  * Defines the props of the component.
  */
-export interface UploaderProps extends GenericProps {
+export interface UploaderProps extends GenericProps, HasTheme {
     /** Image aspect ratio. */
     aspectRatio?: AspectRatio;
     /** Icon (SVG path). */
@@ -32,8 +32,6 @@ export interface UploaderProps extends GenericProps {
     label?: string;
     /** Size variant. */
     size?: UploaderSize;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** Variant. */
     variant?: UploaderVariant;
     /** On click callback. */

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import set from 'lodash/set';
 
 import { Avatar, ColorPalette, Link, Orientation, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
 
 import { AvatarProps } from '../avatar/Avatar';
 
@@ -16,7 +16,7 @@ export type UserBlockSize = Extract<Size, 's' | 'm' | 'l'>;
 /**
  * Defines the props of the component.
  */
-export interface UserBlockProps extends GenericProps {
+export interface UserBlockProps extends GenericProps, HasTheme {
     /** Props to pass to the avatar. */
     avatarProps?: Omit<AvatarProps, 'alt'>;
     /** Additional fields used to describe the user. */
@@ -37,8 +37,6 @@ export interface UserBlockProps extends GenericProps {
     simpleAction?: ReactNode;
     /** Size variant. */
     size?: UserBlockSize;
-    /** Theme adapting the component to light or dark background. */
-    theme?: Theme;
     /** On click callback. */
     onClick?(): void;
     /** On mouse enter callback. */

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 import { ReactElement, ReactNode, Ref } from 'react';
+import { Theme } from '@lumx/react';
 
 /** Get types of the values of a record. */
 export type ValueOf<T extends Record<any, any>> = T[keyof T];
@@ -33,6 +34,13 @@ export type Comp<P, T = HTMLElement> = {
 
 /** Union type of all heading elements */
 export type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export interface HasTheme {
+    /**
+     * Theme adapting the component to light or dark background.
+     */
+    theme?: Theme;
+}
 
 /**
  * Define a generic props types.


### PR DESCRIPTION

Factorize theme prop documentation across components

All component having `theme` props extend the `HasTheme` interface on which the `theme` prop is documented with JSDoc.

On the documentation site, the `theme` prop will show in all component prop tables
