### PR TITLE
chore(icons): build module for better tree shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   GenericBlock: remove sections ("figure", "content" and "actions") if empty.
 -   GenericBlock: prevent overflow by default.
 -   FlexBox: add `tiny` to the possible `gap` sizes.
+-   @lumx/icons: inline mdi icon import in the ESM module for better tree shaking.
 
 ## [2.2.22][] - 2022-07-25
 

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -7,6 +7,13 @@
         "@mdi/font": "5.8.55",
         "@mdi/js": "5.8.55"
     },
+    "devDependencies": {
+        "@rollup/plugin-node-resolve": "9.0.0",
+        "rollup": "2.26.10",
+        "rollup-plugin-babel": "^4.4.0",
+        "rollup-plugin-cleaner": "^1.0.0",
+        "rollup-plugin-copy": "^3.3.0"
+    },
     "description": "LumX icons",
     "engines": {
         "node": ">= 12.0.0",
@@ -19,6 +26,13 @@
     "repository": {
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"
+    },
+    "publishConfig": {
+        "directory": "dist"
+    },
+    "scripts": {
+        "build": "rollup -c",
+        "prepublishOnly": "yarn build"
     },
     "sideEffects": false,
     "version": "2.2.22"

--- a/packages/lumx-icons/rollup.config.js
+++ b/packages/lumx-icons/rollup.config.js
@@ -1,0 +1,42 @@
+import path from 'path';
+import glob from 'glob';
+import resolve from '@rollup/plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
+import copy from 'rollup-plugin-copy';
+import cleaner from 'rollup-plugin-cleaner';
+
+import pkg from './package.json';
+
+const CONFIGS = require('../../configs');
+
+const DIST_PATH = path.resolve(__dirname, pkg.publishConfig.directory);
+export const extensions = ['.js'];
+
+export default {
+    input: 'index.js',
+    output: {
+        format: 'esm',
+        sourcemap: true,
+        dir: DIST_PATH,
+    },
+    plugins: [
+        /** Clean dist dir */
+        cleaner({ targets: [DIST_PATH] }),
+        /** Resolve source files. */
+        resolve({ browser: true, extensions }),
+        /** Transpile JS. */
+        babel({
+            extensions,
+            exclude: /node_modules/,
+            plugins: CONFIGS.babel.plugins,
+            presets: [
+                ['@babel/preset-env', { targets: 'defaults' }],
+            ],
+        }),
+        /** Copy additional files to dist. */
+        copy({
+            targets: glob.sync('*(package.json|*.js|*.d.ts|*.scss|*.md)')
+                .map(file => ({ src: path.join(__dirname, file), dest: DIST_PATH })),
+        }),
+    ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4907,6 +4907,11 @@ __metadata:
   dependencies:
     "@mdi/font": 5.8.55
     "@mdi/js": 5.8.55
+    "@rollup/plugin-node-resolve": 9.0.0
+    rollup: 2.26.10
+    rollup-plugin-babel: ^4.4.0
+    rollup-plugin-cleaner: ^1.0.0
+    rollup-plugin-copy: ^3.3.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
# General summary

Add a build step to the `@lumx/icons` to flatten all icons from mdi into one ESM module so tree shaking can be more effective