### PR TITLE
feat(flexbox): add tiny size to flexbox gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `gap` defaults to `big`
 -   GenericBlock: remove sections ("figure", "content" and "actions") if empty.
 -   GenericBlock: prevent overflow by default.
+-   FlexBox: add `tiny` to the possible `gap` sizes.
 
 ## [2.2.22][] - 2022-07-25
 

--- a/packages/lumx-core/src/scss/components/flex-box/_index.scss
+++ b/packages/lumx-core/src/scss/components/flex-box/_index.scss
@@ -95,6 +95,10 @@
 /* Gap
    ========================================================================== */
 
+.#{$lumx-base-prefix}-flex-box--gap-tiny {
+    gap: $lumx-spacing-unit-tiny;
+}
+
 .#{$lumx-base-prefix}-flex-box--gap-regular {
     gap: $lumx-spacing-unit;
 }

--- a/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
@@ -18,7 +18,7 @@ const flexViewKnobConfigs: Array<
     ['fillSpace', boolean],
     ['noShrink', boolean],
     ['wrap', boolean],
-    ['gap', select, [DEFAULT_PROPS.gap, Size.regular, Size.medium, Size.big, Size.huge]],
+    ['gap', select, [DEFAULT_PROPS.gap, Size.tiny, Size.regular, Size.medium, Size.big, Size.huge]],
     ['hAlign', select, [DEFAULT_PROPS.hAlign, Alignment.center, Alignment.top, Alignment.bottom]],
     ['vAlign', select, [DEFAULT_PROPS.vAlign, Alignment.center, Alignment.right, Alignment.left]],
     ['orientation', select, [undefined, Orientation.horizontal, Orientation.vertical]],

--- a/packages/lumx-react/src/components/flex-box/FlexBox.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.tsx
@@ -6,7 +6,7 @@ import React, { forwardRef, ReactNode } from 'react';
 import { Size } from '..';
 
 export type MarginAutoAlignment = Extract<Alignment, 'top' | 'bottom' | 'right' | 'left'>;
-export type GapSize = Extract<Size, 'regular' | 'medium' | 'big' | 'huge'>;
+export type GapSize = Extract<Size, 'tiny' | 'regular' | 'medium' | 'big' | 'huge'>;
 
 /**
  * Defines the props of the component.


### PR DESCRIPTION
# General summary

FlexBox: add `tiny` to the possible `gap` sizes.