### PR TITLE
fix(thumbnail): fix shift calculation when focusY is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   FlexBox: add `tiny` to the possible `gap` sizes.
 -   @lumx/icons: inline mdi icon import in the ESM module for better tree shaking.
 
+### Fixed
+
+-   Thumbnail: fix a bug on focus shift calculation caused when focusPoint is equals to 0 and the image size equals the container size.
+
+
 ## [2.2.22][] - 2022-07-25
 
 ### Changed

--- a/packages/lumx-react/src/components/thumbnail/useFocusPointStyle.test.ts
+++ b/packages/lumx-react/src/components/thumbnail/useFocusPointStyle.test.ts
@@ -1,0 +1,92 @@
+import { shiftPosition } from './useFocusPointStyle';
+
+describe('shiftPosition', () => {
+    it('should always return 0% if the imageSize fits the containerSize', () => {
+        expect(
+            shiftPosition({
+                scale: 1.5,
+                focusPoint: 0,
+                imageSize: 1000,
+                containerSize: 1000,
+            }),
+        ).toEqual(0);
+        expect(
+            shiftPosition({
+                scale: 1,
+                focusPoint: 0.27,
+                imageSize: 1000,
+                containerSize: 1000,
+            }),
+        ).toEqual(0);
+        expect(
+            shiftPosition({
+                scale: 3,
+                focusPoint: 0.5,
+                imageSize: 1000,
+                containerSize: 1000,
+            }),
+        ).toEqual(0);
+        expect(
+            shiftPosition({
+                scale: 2.4,
+                focusPoint: 1,
+                imageSize: 1000,
+                containerSize: 1000,
+            }),
+        ).toEqual(0);
+    });
+
+    describe('with bigger side than container ', () => {
+        // This use case will come, for example, if you have an image in width 100%
+        // but the image after being resized to keep the ratio is higher than the container.
+        // Then we are calculating the y shift.
+
+        const image = { width: 1000, height: 1200 };
+        const container = { width: 1000, height: 300 };
+        // scale is always the minimum scale ratio. Here imagewidth/containerwidth.
+        const scale = image.width / container.width; // 1
+        it('should return 0% if focusPoint equals 0', () => {
+            expect(
+                shiftPosition({
+                    scale,
+                    focusPoint: 0,
+                    imageSize: image.height,
+                    containerSize: container.height,
+                }),
+            ).toEqual(0);
+        });
+
+        it('should return 100% if focusPoint equals 1', () => {
+            expect(
+                shiftPosition({
+                    scale,
+                    focusPoint: 1,
+                    imageSize: image.height,
+                    containerSize: container.height,
+                }),
+            ).toEqual(100);
+        });
+
+        it('should return 50% if focusPoint equals 0.5', () => {
+            expect(
+                shiftPosition({
+                    scale,
+                    focusPoint: 0.5,
+                    imageSize: image.height,
+                    containerSize: container.height,
+                }),
+            ).toEqual(50);
+        });
+
+        it('should return 16% if focusPoint equals 0.25', () => {
+            expect(
+                shiftPosition({
+                    scale,
+                    focusPoint: 0.25,
+                    imageSize: image.height,
+                    containerSize: container.height,
+                }),
+            ).toEqual(16);
+        });
+    });
+});

--- a/packages/lumx-react/src/components/thumbnail/useFocusPointStyle.tsx
+++ b/packages/lumx-react/src/components/thumbnail/useFocusPointStyle.tsx
@@ -3,11 +3,24 @@ import { AspectRatio } from '@lumx/react/components';
 import { ThumbnailProps } from '@lumx/react/components/thumbnail/Thumbnail';
 
 // Calculate shift to center the focus point in the container.
-function shiftPosition(scale: number, focusPoint: number, imageSize: number, containerSize: number) {
+export function shiftPosition({
+    scale,
+    focusPoint,
+    imageSize,
+    containerSize,
+}: {
+    scale: number;
+    focusPoint: number;
+    imageSize: number;
+    containerSize: number;
+}) {
+    if (imageSize === containerSize) return 0;
     const scaledSize = imageSize / scale;
+
     const scaledFocusHeight = focusPoint * scaledSize;
     const startFocus = scaledFocusHeight - containerSize / 2;
     const shift = startFocus / (scaledSize - containerSize);
+
     return Math.floor(Math.max(Math.min(shift, 1), 0) * 100);
 }
 
@@ -73,14 +86,23 @@ export const useFocusPointStyle = (
 
         // Focus Y relative to the top (instead of the center)
         const focusPointFromTop = Math.abs((focusPoint?.y || 0) - 1) / 2;
-        const y = shiftPosition(scale, focusPointFromTop, imageSize.height, containerSize.height);
+        const y = shiftPosition({
+            scale,
+            focusPoint: focusPointFromTop,
+            imageSize: imageSize.height,
+            containerSize: containerSize.height,
+        });
 
         // Focus X relative to the left (instead of the center)
         const focusPointFromLeft = Math.abs((focusPoint?.x || 0) + 1) / 2;
-        const x = shiftPosition(scale, focusPointFromLeft, imageSize.width, containerSize.width);
+        const x = shiftPosition({
+            scale,
+            focusPoint: focusPointFromLeft,
+            imageSize: imageSize.width,
+            containerSize: containerSize.width,
+        });
 
         const objectPosition = `${x}% ${y}%`;
-
         // Update only if needed.
         setStyle((oldStyle) => (oldStyle.objectPosition === objectPosition ? oldStyle : { objectPosition }));
     }, [aspectRatio, containerSize, element, focusPoint?.x, focusPoint?.y, image, imageSize]);


### PR DESCRIPTION
# General summary

When the container and the image size were equal, it caused a division by 0. 
It wasn't a big problem when the focusPoint is not equal to 0, because the result of a `x/0 === Infinity` if x !== 0, so it was translated to 100%. But `0/0 === NaN`, so when the focusPoint is 0, the computed CSS was invalid, so the focus point was not applied. 

Now we just early return a 0 if `containerSize === imageSize`. 
This PR also adds some tests on this function.
 
<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
