### PR TITLE
chore(icons): bundle both CJS and ESM module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   @lumx/icons: provide both CJS and ESM module for better tooling compatibility.
+
 ## [2.2.24][] - 2022-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.25][] - 2022-08-04
+
 ### Changed
 
 -   @lumx/icons: provide both CJS and ESM module for better tooling compatibility.
@@ -1551,3 +1553,5 @@ _Failed released_
 [2.2.23]: https://github.com/lumapps/design-system/tree/v2.2.23
 [unreleased]: https://github.com/lumapps/design-system/compare/v2.2.24...HEAD
 [2.2.24]: https://github.com/lumapps/design-system/tree/v2.2.24
+[unreleased]: https://github.com/lumapps/design-system/compare/v2.2.25...HEAD
+[2.2.25]: https://github.com/lumapps/design-system/tree/v2.2.25

--- a/dev-packages/eslint-plugin-lumapps/package.json
+++ b/dev-packages/eslint-plugin-lumapps/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eslint-plugin-lumapps",
     "private": true,
-    "version": "2.2.24",
+    "version": "2.2.25",
     "license": "MIT",
     "main": "index.js"
 }

--- a/dev-packages/ga-remove-label/package.json
+++ b/dev-packages/ga-remove-label/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumapps/ga-remove-label",
   "private": true,
-  "version": "2.2.24",
+  "version": "2.2.25",
   "description": "Github action for removing a label",
   "main": "index.js",
   "license": "MIT",

--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,7 @@
             "message": "chore(release): release %s"
         }
     },
-    "version": "2.2.24",
+    "version": "2.2.25",
     "useWorkspaces": true,
     "npmClient": "yarn"
 }

--- a/packages/lumx-angularjs/package.json
+++ b/packages/lumx-angularjs/package.json
@@ -6,8 +6,8 @@
         "url": "https://github.com/lumapps/design-system/issues"
     },
     "dependencies": {
-        "@lumx/core": "^2.2.24",
-        "@lumx/icons": "^2.2.24",
+        "@lumx/core": "^2.2.25",
+        "@lumx/icons": "^2.2.25",
         "focus-visible": "^5.0.2",
         "lodash": "4.17.21",
         "popper.js": "^1.16.0"
@@ -40,7 +40,7 @@
         "prepare": "install-peers || exit 0",
         "prepublishOnly": "yarn build"
     },
-    "version": "2.2.24",
+    "version": "2.2.25",
     "devDependencies": {
         "@babel/core": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/packages/lumx-core/package.json
+++ b/packages/lumx-core/package.json
@@ -42,7 +42,7 @@
         "version": "yarn version-changelog ../../CHANGELOG.md && yarn changelog-verify ../../CHANGELOG.md && git add ../../CHANGELOG.md"
     },
     "sideEffects": false,
-    "version": "2.2.24",
+    "version": "2.2.25",
     "devDependencies": {
         "@babel/core": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -21,7 +21,8 @@
         "yarn": ">= 1.3.0"
     },
     "license": "MIT",
-    "main": "index.js",
+    "main": "cjs/index.js",
+    "module": "index.js",
     "name": "@lumx/icons",
     "repository": {
         "type": "git",

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -36,5 +36,5 @@
         "prepublishOnly": "yarn build"
     },
     "sideEffects": false,
-    "version": "2.2.24"
+    "version": "2.2.25"
 }

--- a/packages/lumx-icons/rollup.config.js
+++ b/packages/lumx-icons/rollup.config.js
@@ -14,11 +14,20 @@ export const extensions = ['.js'];
 
 export default {
     input: 'index.js',
-    output: {
-        format: 'esm',
-        sourcemap: true,
-        dir: DIST_PATH,
-    },
+    output: [
+        // ESM version
+        {
+            format: 'esm',
+            sourcemap: true,
+            dir: DIST_PATH,
+        },
+        // CommonJS version
+        {
+            format: 'cjs',
+            sourcemap: true,
+            dir: path.join(DIST_PATH, 'cjs'),
+        },
+    ],
     plugins: [
         /** Clean dist dir */
         cleaner({ targets: [DIST_PATH] }),

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -7,8 +7,8 @@
     },
     "dependencies": {
         "@juggle/resize-observer": "^3.2.0",
-        "@lumx/core": "^2.2.24",
-        "@lumx/icons": "^2.2.24",
+        "@lumx/core": "^2.2.25",
+        "@lumx/icons": "^2.2.25",
         "@popperjs/core": "^2.5.4",
         "body-scroll-lock": "^3.1.5",
         "classnames": "^2.2.6",
@@ -120,5 +120,5 @@
         "build:storybook": "cd storybook && ./build"
     },
     "sideEffects": false,
-    "version": "2.2.24"
+    "version": "2.2.25"
 }

--- a/packages/site-demo/package.json
+++ b/packages/site-demo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lumx-site-demo",
-    "version": "2.2.24",
+    "version": "2.2.25",
     "private": true,
     "description": "The official LumApps Design System (LumX) demo site",
     "bugs": {
@@ -20,10 +20,10 @@
         "start": "NODE_OPTIONS=--no-warnings gatsby develop"
     },
     "dependencies": {
-        "@lumx/angularjs": "^2.2.24",
-        "@lumx/core": "^2.2.24",
-        "@lumx/icons": "^2.2.24",
-        "@lumx/react": "^2.2.24",
+        "@lumx/angularjs": "^2.2.25",
+        "@lumx/core": "^2.2.25",
+        "@lumx/icons": "^2.2.25",
+        "@lumx/react": "^2.2.25",
         "@mdx-js/mdx": "^1.6.19",
         "@mdx-js/react": "^1.6.19",
         "@reach/router": "^1.2.1",

--- a/packages/yo-generators/package.json
+++ b/packages/yo-generators/package.json
@@ -12,5 +12,5 @@
     "main": "generators/index.js",
     "name": "generator-lumx-component",
     "private": true,
-    "version": "2.2.24"
+    "version": "2.2.25"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,7 +4815,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumx/angularjs@^2.2.24, @lumx/angularjs@workspace:packages/lumx-angularjs":
+"@lumx/angularjs@^2.2.25, @lumx/angularjs@workspace:packages/lumx-angularjs":
   version: 0.0.0-use.local
   resolution: "@lumx/angularjs@workspace:packages/lumx-angularjs"
   dependencies:
@@ -4828,8 +4828,8 @@ __metadata:
     "@babel/plugin-proposal-private-property-in-object": ^7.16.0
     "@babel/preset-env": ^7.8.3
     "@babel/preset-typescript": ^7.12.7
-    "@lumx/core": ^2.2.24
-    "@lumx/icons": ^2.2.24
+    "@lumx/core": ^2.2.25
+    "@lumx/icons": ^2.2.25
     babel-plugin-angularjs-annotate: ^0.10.0
     clean-webpack-plugin: ^3.0.0
     copy-webpack-plugin: ^5.1.1
@@ -4854,7 +4854,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumx/core@^2.2.24, @lumx/core@workspace:packages/lumx-core":
+"@lumx/core@^2.2.25, @lumx/core@workspace:packages/lumx-core":
   version: 0.0.0-use.local
   resolution: "@lumx/core@workspace:packages/lumx-core"
   dependencies:
@@ -4901,7 +4901,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumx/icons@^2.2.24, @lumx/icons@workspace:packages/lumx-icons":
+"@lumx/icons@^2.2.25, @lumx/icons@workspace:packages/lumx-icons":
   version: 0.0.0-use.local
   resolution: "@lumx/icons@workspace:packages/lumx-icons"
   dependencies:
@@ -4953,7 +4953,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumx/react@^2.2.24, @lumx/react@workspace:packages/lumx-react":
+"@lumx/react@^2.2.25, @lumx/react@workspace:packages/lumx-react":
   version: 0.0.0-use.local
   resolution: "@lumx/react@workspace:packages/lumx-react"
   dependencies:
@@ -4969,8 +4969,8 @@ __metadata:
     "@babel/preset-react": ^7.8.3
     "@babel/preset-typescript": ^7.12.7
     "@juggle/resize-observer": ^3.2.0
-    "@lumx/core": ^2.2.24
-    "@lumx/icons": ^2.2.24
+    "@lumx/core": ^2.2.25
+    "@lumx/icons": ^2.2.25
     "@popperjs/core": ^2.5.4
     "@rollup/plugin-commonjs": ^15.0.0
     "@rollup/plugin-node-resolve": 9.0.0
@@ -20873,10 +20873,10 @@ fsevents@~2.1.2:
   version: 0.0.0-use.local
   resolution: "lumx-site-demo@workspace:packages/site-demo"
   dependencies:
-    "@lumx/angularjs": ^2.2.24
-    "@lumx/core": ^2.2.24
-    "@lumx/icons": ^2.2.24
-    "@lumx/react": ^2.2.24
+    "@lumx/angularjs": ^2.2.25
+    "@lumx/core": ^2.2.25
+    "@lumx/icons": ^2.2.25
+    "@lumx/react": ^2.2.25
     "@mdx-js/mdx": ^1.6.19
     "@mdx-js/react": ^1.6.19
     "@reach/router": ^1.2.1


### PR DESCRIPTION
# General summary

Current ESM version of `@lumw/icons` can have trouble being processed by Jest (compiling with babel in `NODE_ENV=test` [triggers an `Infinite cycle detected` error](https://github.com/babel/babel/blob/e498bee10f0123bb208baa228ce6417542a2c3c4/packages/babel-traverse/src/context.js#L56)) 

To counter that, we'll export both an ESM version for build tools and better tree shaking and a CJS version for Jest tests.

