### PR TITLE
chore(flexbox): add as prop to cutomize component render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   FlexBox: add `as` prop to customize the root element component render.
+-   GenericBlock: add `as` prop to customize the root, the figure, the content and actions elements component render.
+
 ## [3.0.2][] - 2022-09-23
 
 ### Added

--- a/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.stories.tsx
@@ -235,3 +235,11 @@ export const Distribution = () => (
         <Button>Button 3</Button>
     </FlexBox>
 );
+
+export const CustomizeElement = () => (
+    <FlexBox as="header" orientation="horizontal" gap="regular">
+        <div>Element 1</div>
+        <div>Element 2</div>
+        <div>Element 2</div>
+    </FlexBox>
+);

--- a/packages/lumx-react/src/components/flex-box/FlexBox.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.tsx
@@ -15,6 +15,8 @@ export type FlexHorizontalAlignment = HorizontalAlignment | SpaceAlignment;
  * Defines the props of the component.
  */
 export interface FlexBoxProps extends GenericProps {
+    /** Customize the root element. */
+    as?: React.ElementType;
     /** Children elements. */
     children?: ReactNode;
     /** Whether the "content filling space" is enabled or not. */
@@ -54,6 +56,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 export const FlexBox: Comp<FlexBoxProps, HTMLDivElement> = forwardRef((props, ref) => {
     const {
+        as: Component = 'div',
         children,
         className,
         fillSpace,
@@ -68,7 +71,7 @@ export const FlexBox: Comp<FlexBoxProps, HTMLDivElement> = forwardRef((props, re
     } = props;
 
     return (
-        <div
+        <Component
             ref={ref}
             {...forwardedProps}
             className={classNames(
@@ -87,7 +90,7 @@ export const FlexBox: Comp<FlexBoxProps, HTMLDivElement> = forwardRef((props, re
             )}
         >
             {children}
-        </div>
+        </Component>
     );
 });
 FlexBox.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/flex-box/__snapshots__/FlexBox.test.tsx.snap
+++ b/packages/lumx-react/src/components/flex-box/__snapshots__/FlexBox.test.tsx.snap
@@ -75,6 +75,22 @@ exports[`<FlexBox> Snapshots and structure should render story 'Distribution' 1`
 </div>
 `;
 
+exports[`<FlexBox> Snapshots and structure should render story 'CustomizeElement' 1`] = `
+<header
+  className="lumx-flex-box lumx-flex-box--orientation-horizontal lumx-flex-box--gap-regular"
+>
+  <div>
+    Element 1
+  </div>
+  <div>
+    Element 2
+  </div>
+  <div>
+    Element 2
+  </div>
+</header>
+`;
+
 exports[`<FlexBox> Snapshots and structure should render story 'Flex' 1`] = `
 Array [
   <div

--- a/packages/lumx-react/src/components/generic-block/GenericBlock.stories.jsx
+++ b/packages/lumx-react/src/components/generic-block/GenericBlock.stories.jsx
@@ -1,6 +1,7 @@
+import { IMAGES } from '@lumx/react/stories/knobs/image';
 import React from 'react';
 import { mdiPencil } from '@lumx/icons';
-import { GenericBlock, Button, Icon, Size } from '@lumx/react';
+import { GenericBlock, Button, Icon, Size, Thumbnail } from '@lumx/react';
 
 export default { title: 'LumX components/generic-block/GenericBlock' };
 
@@ -104,3 +105,24 @@ export const GapSizes = ({ theme }) =>
             </GenericBlock.Actions>
         </GenericBlock>
     ));
+
+export const AsAFigure = () => (
+    <GenericBlock as="figure" orientation="vertical" style={{ width: '150px' }}>
+        <GenericBlock.Figure>
+            <Thumbnail alt="" image={IMAGES.portrait1s200} aspectRatio="horizontal" />
+        </GenericBlock.Figure>
+        <GenericBlock.Content as="figcaption">Rocky mountain landscape</GenericBlock.Content>
+    </GenericBlock>
+);
+
+export const AsAnArticle = () => (
+    <GenericBlock as="article" orientation="horizontal">
+        <GenericBlock.Figure>
+            <Thumbnail alt="" size="xl" image={IMAGES.portrait1s200} aspectRatio="horizontal" />
+        </GenericBlock.Figure>
+        <GenericBlock.Content>
+            <h2>Article title</h2>
+            <p>Article description...</p>
+        </GenericBlock.Content>
+    </GenericBlock>
+);


### PR DESCRIPTION
# General summary

-   FlexBox: add `as` prop to customize the root element component render.
-   GenericBlock: add `as` prop to customize the root, the figure, the content and actions elements component render.
