### PR TITLE
fix(slideshow): improve accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   New `Heading` component. The component comes with a `HeadingProvider` that allows the `Heading` component to automatically use the correct heading level depending on the nested providers.
 -   New `useHeadingLevel` hook to get the current heading level.
 
+### Changed
+
+- SlideshowControls: The bullets now use the "roving tab index" pattern to have only the current slide focusable and navigate using the left/right arrows.
+
 ### Fixed
 
 - Slideshow: Avoid slides that are not displayed to be focusable and read by a screen reader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Slideshow: Improve accessibility by adding `tablist` / `tab` roles to slideshow pagination and `tabpanel` role to slide groups. These elements are linked together using `aria-controls` attribute.
+- Slideshow: Added the `slideGroupLabel` prop to set a label on each slide groups. The prop should be a function that receives the group position starting from 1 and the total number of groups.
+- Slideshow: Slides grouped together are now wrapper inside individual divs.
+- SlideshowControls: Added the `paginationItemProps` prop to set custom props to each pagination item. The prop should be a function that receives the item index.
 - SlideshowControls: The bullets now use the "roving tab index" pattern to have only the current slide focusable and navigate using the left/right arrows.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   New `Heading` component. The component comes with a `HeadingProvider` that allows the `Heading` component to automatically use the correct heading level depending on the nested providers.
 -   New `useHeadingLevel` hook to get the current heading level.
 
+### Fixed
+
+- Slideshow: Avoid slides that are not displayed to be focusable and read by a screen reader.
+
 ## [3.0.1][] - 2022-09-21
 
 ### Changed

--- a/packages/lumx-core/src/js/constants/index.ts
+++ b/packages/lumx-core/src/js/constants/index.ts
@@ -33,3 +33,12 @@ export const TOOLTIP_LONG_PRESS_DELAY = {
     open: 250,
     close: 3000,
 };
+
+/**
+ * List of elements that receives focus and can be interacted with.
+ */
+export const INTERACTIVE_ELEMENTS = ['a', 'button', 'select', 'input', 'textarea', '[tabindex="0"]'];
+/**
+ * List of elements that receives focus and can be interacted, as a string.
+ */
+export const INTERACTIVE_ELEMENTS_STRING = INTERACTIVE_ELEMENTS.join(',');

--- a/packages/lumx-core/src/js/constants/index.ts
+++ b/packages/lumx-core/src/js/constants/index.ts
@@ -33,12 +33,3 @@ export const TOOLTIP_LONG_PRESS_DELAY = {
     open: 250,
     close: 3000,
 };
-
-/**
- * List of elements that receives focus and can be interacted with.
- */
-export const INTERACTIVE_ELEMENTS = ['a', 'button', 'select', 'input', 'textarea', '[tabindex="0"]'];
-/**
- * List of elements that receives focus and can be interacted, as a string.
- */
-export const INTERACTIVE_ELEMENTS_STRING = INTERACTIVE_ELEMENTS.join(',');

--- a/packages/lumx-core/src/scss/components/slideshow/_index.scss
+++ b/packages/lumx-core/src/scss/components/slideshow/_index.scss
@@ -49,6 +49,21 @@
     }
 }
 
+/* Slideshow item group
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-slideshow-item-group {
+    display: flex;
+    overflow: hidden;
+    max-width: 100%;
+    flex: 0 0 100%;
+
+    .#{$lumx-base-prefix}-slideshow--fill-height & {
+        min-height: 0;
+        flex: 1 1 100%;
+    }
+}
+
 /* Slideshow item
    ========================================================================== */
 
@@ -58,6 +73,7 @@
     }
 }
 
+
 @for $i from 1 through 12 {
     .#{$lumx-base-prefix}-slideshow--group-by-#{$i} .#{$lumx-base-prefix}-slideshow-item {
         flex: 0 0 #{math.div(100, $i) + "%"};
@@ -65,7 +81,6 @@
         overflow: hidden;
     }
 }
-
 /* Slideshow controls
    ========================================================================== */
 

--- a/packages/lumx-core/src/scss/components/slideshow/_index.scss
+++ b/packages/lumx-core/src/scss/components/slideshow/_index.scss
@@ -57,11 +57,6 @@
     overflow: hidden;
     max-width: 100%;
     flex: 0 0 100%;
-
-    .#{$lumx-base-prefix}-slideshow--fill-height & {
-        min-height: 0;
-        flex: 1 1 100%;
-    }
 }
 
 /* Slideshow item

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { useSlideFocusManagement } from './useSlideFocusManagement';
 
 export interface SlidesProps extends GenericProps, HasTheme {
     /** current slide active */
@@ -58,6 +59,10 @@ export const Slides: Comp<SlidesProps, HTMLDivElement> = forwardRef((props, ref)
         afterSlides,
         ...forwardedProps
     } = props;
+    const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+    useSlideFocusManagement({ wrapperRef, activeIndex, groupBy });
+
     // Inline style of wrapper element.
     const wrapperStyle: CSSProperties = { transform: `translateX(-${FULL_WIDTH_PERCENT * activeIndex}%)` };
 
@@ -77,9 +82,13 @@ export const Slides: Comp<SlidesProps, HTMLDivElement> = forwardRef((props, ref)
                 className={`${CLASSNAME}__slides`}
                 onMouseEnter={toggleAutoPlay}
                 onMouseLeave={toggleAutoPlay}
-                aria-live={isAutoPlaying ? 'off' : 'polite'}
             >
-                <div className={`${CLASSNAME}__wrapper`} style={wrapperStyle}>
+                <div
+                    ref={wrapperRef}
+                    className={classNames(`${CLASSNAME}__wrapper`)}
+                    style={wrapperStyle}
+                    aria-live={isAutoPlaying ? 'off' : 'polite'}
+                >
                     {children}
                 </div>
             </div>

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -44,7 +44,7 @@ const COMPONENT_NAME = 'Slideshow';
 /**
  * Component default class name and class prefix.
  */
-export const CLASSNAME = getRootClassName(COMPONENT_NAME);
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
 /**
  * Slides component.
@@ -77,10 +77,10 @@ export const Slides: Comp<SlidesProps, HTMLDivElement> = forwardRef((props, ref)
     // Inline style of wrapper element.
     const wrapperStyle: CSSProperties = { transform: `translateX(-${FULL_WIDTH_PERCENT * activeIndex}%)` };
 
-    const groups = React.useMemo(
-        () => (groupBy && groupBy > 1 ? chunk(Children.toArray(children), groupBy) : [children]),
-        [children, groupBy],
-    );
+    const groups = React.useMemo(() => {
+        const childrenArray = Children.toArray(children);
+        return groupBy && groupBy > 1 ? chunk(childrenArray, groupBy) : childrenArray;
+    }, [children, groupBy]);
 
     return (
         <section

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 
 import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
 import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
-import { useSlideFocusManagement } from './useSlideFocusManagement';
 import { buildSlideShowGroupId, SlideshowItemGroup } from './SlideshowItemGroup';
 
 export interface SlidesProps extends GenericProps, HasTheme {
@@ -71,8 +70,8 @@ export const Slides: Comp<SlidesProps, HTMLDivElement> = forwardRef((props, ref)
         ...forwardedProps
     } = props;
     const wrapperRef = React.useRef<HTMLDivElement>(null);
-
-    useSlideFocusManagement({ wrapperRef, activeIndex, groupBy });
+    const startIndexVisible = activeIndex;
+    const endIndexVisible = startIndexVisible + 1;
 
     // Inline style of wrapper element.
     const wrapperStyle: CSSProperties = { transform: `translateX(-${FULL_WIDTH_PERCENT * activeIndex}%)` };
@@ -107,6 +106,7 @@ export const Slides: Comp<SlidesProps, HTMLDivElement> = forwardRef((props, ref)
                             id={slidesId && buildSlideShowGroupId(slidesId, index)}
                             role={hasControls ? 'tabpanel' : 'group'}
                             label={slideGroupLabel ? slideGroupLabel(index + 1, groups.length) : undefined}
+                            isDisplayed={index >= startIndexVisible && index < endIndexVisible}
                         >
                             {group}
                         </SlideshowItemGroup>

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -29,7 +29,7 @@ export const Simple = ({ theme }: any) => {
             slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
         >
             {images.map(({ image, alt }, index) => (
-                <SlideshowItem key={`${image}-${index}`} aria-label={`${index + 1} of ${images.length}`}>
+                <SlideshowItem key={`${image}-${index}`}>
                     <ImageBlock
                         thumbnailProps={{ aspectRatio: AspectRatio.horizontal, loading: 'eager' }}
                         image={image}
@@ -65,7 +65,7 @@ export const SimpleWithAutoPlay = ({ theme }: any) => {
             slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
         >
             {images.map(({ image, alt }, index) => (
-                <SlideshowItem key={`${image}-${index}`} aria-label={`${index + 1} of ${images.length}`}>
+                <SlideshowItem key={`${image}-${index}`}>
                     <ImageBlock
                         thumbnailProps={{ aspectRatio: AspectRatio.horizontal, loading: 'eager' }}
                         image={image}

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -178,27 +178,35 @@ export const WithComplexContent = () => (
             nextButtonProps: { label: 'Next' },
             previousButtonProps: { label: 'Previous' },
             playButtonProps: { label: 'Play/Pause' },
-            paginationItemProps: (index) => ({ 'aria-label': `Slide ${index + 1}` }),
+            paginationItemProps: (index) => ({ label: `Slide ${index + 1}` }),
         }}
-        autoPlay
         slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
     >
-        {slides.map((slide) => (
-            <SlideshowItem key={slide.id}>
-                <a href={slide.link}>
-                    <img src={slide.src} alt={slide.alt} />
-                </a>
-                <FlexBox orientation={Orientation.vertical}>
-                    <h3>
-                        <a href={slide.link}>{slide.title}</a>
-                        {/* Add a non focusable element to test that it stays that way after a page change. */}
-                        <button type="button" tabIndex={-1} aria-hidden="true">
-                            Not focusable
-                        </button>
-                    </h3>
-                    {slide.subtitle && <p>{slide.subtitle}</p>}
-                </FlexBox>
-            </SlideshowItem>
-        ))}
+        {range(number('Slides', 6)).map((nb) => {
+            const slide = slides[nb % slides.length];
+
+            return (
+                <SlideshowItem key={slide.id}>
+                    <a href={slide.link}>
+                        <ImageBlock
+                            thumbnailProps={{ aspectRatio: AspectRatio.horizontal, loading: 'eager' }}
+                            image={slide.src}
+                            alt={slide.alt}
+                        />
+                    </a>
+                    <FlexBox orientation={Orientation.vertical}>
+                        <h3>
+                            <a href={slide.link}>{slide.title}</a>
+                            {/* Add a non focusable element to test that it stays that way after a page change. */}
+                            <button type="button" tabIndex={-1} aria-hidden="true">
+                                Not focusable
+                            </button>
+                            <button type="button">Focusable</button>
+                        </h3>
+                        {slide.subtitle && <p>{slide.subtitle}</p>}
+                    </FlexBox>
+                </SlideshowItem>
+            );
+        })}
     </Slideshow>
 );

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -26,6 +26,7 @@ export const Simple = ({ theme }: any) => {
             theme={theme}
             groupBy={groupBy}
             style={{ width: '50%' }}
+            slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
         >
             {images.map(({ image, alt }, index) => (
                 <SlideshowItem key={`${image}-${index}`} aria-label={`${index + 1} of ${images.length}`}>
@@ -61,6 +62,7 @@ export const SimpleWithAutoPlay = ({ theme }: any) => {
             theme={theme}
             groupBy={groupBy}
             style={{ width: '50%' }}
+            slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
         >
             {images.map(({ image, alt }, index) => (
                 <SlideshowItem key={`${image}-${index}`} aria-label={`${index + 1} of ${images.length}`}>
@@ -94,9 +96,10 @@ export const ResponsiveSlideShowSwipe = () => {
                         nextButtonProps: { label: 'Next' },
                         previousButtonProps: { label: 'Previous' },
                     }}
+                    slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
                 >
-                    {slides.map((slide, key) => (
-                        <SlideshowItem key={`${slide}`} aria-label={`${key + 1} of ${slides.length}`}>
+                    {slides.map((slide) => (
+                        <SlideshowItem key={`${slide}`}>
                             <FlexBox
                                 style={{ border: '1px solid grey', maxWidth: 300, height: 300 }}
                                 hAlign="center"
@@ -120,6 +123,7 @@ export const ResponsiveSlideShowSwipe = () => {
 
 const slides = [
     {
+        id: 0,
         src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/foyleswarslide__800x600.jpg',
         alt: 'A man in a suit and fedora and a woman with coiffed hair look sternly into the camera.',
         title: 'Foyle’s War Revisited',
@@ -127,12 +131,37 @@ const slides = [
         link: '#',
     },
     {
+        id: 1,
         src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/britcomdavidslide__800x600.jpg',
         alt: 'British flag with WILL-TV host David Thiel.',
         title: 'Great Britain Vote: 7 pm Sat.',
         link: '#',
     },
     {
+        id: 2,
+        src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/mag800-2__800x600.jpg',
+        alt: 'Mid-American Gardener panelists on the set.',
+        title: 'Mid-American Gardener: Thursdays at 7 pm',
+        subtitle: 'Watch the latest episode',
+        link: '#',
+    },
+    {
+        id: 3,
+        src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/foyleswarslide__800x600.jpg',
+        alt: 'A man in a suit and fedora and a woman with coiffed hair look sternly into the camera.',
+        title: 'Foyle’s War Revisited',
+        subtitle: '8 pm Sunday, March 8, on TV: Sneak peek at the final season',
+        link: '#',
+    },
+    {
+        id: 4,
+        src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/britcomdavidslide__800x600.jpg',
+        alt: 'British flag with WILL-TV host David Thiel.',
+        title: 'Great Britain Vote: 7 pm Sat.',
+        link: '#',
+    },
+    {
+        id: 5,
         src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/mag800-2__800x600.jpg',
         alt: 'Mid-American Gardener panelists on the set.',
         title: 'Mid-American Gardener: Thursdays at 7 pm',
@@ -148,11 +177,14 @@ export const WithComplexContent = () => (
         slideshowControlsProps={{
             nextButtonProps: { label: 'Next' },
             previousButtonProps: { label: 'Previous' },
+            playButtonProps: { label: 'Play/Pause' },
+            paginationItemProps: (index) => ({ 'aria-label': `Slide ${index + 1}` }),
         }}
         autoPlay
+        slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
     >
-        {slides.map((slide, key) => (
-            <SlideshowItem aria-label={`${key + 1} of ${slides.length}`} key={slide.src}>
+        {slides.map((slide) => (
+            <SlideshowItem key={slide.id}>
                 <a href={slide.link}>
                     <img src={slide.src} alt={slide.alt} />
                 </a>

--- a/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import range from 'lodash/range';
-import { AspectRatio, Button, FlexBox, ImageBlock, Slideshow, SlideshowItem } from '@lumx/react';
+import { AspectRatio, Button, FlexBox, ImageBlock, Slideshow, SlideshowItem, Orientation } from '@lumx/react';
 import { boolean, number } from '@storybook/addon-knobs';
 import { thumbnailsKnob } from '@lumx/react/stories/knobs/thumbnailsKnob';
 
@@ -15,6 +15,7 @@ export const Simple = ({ theme }: any) => {
 
     return (
         <Slideshow
+            aria-label="Simple carousel example"
             activeIndex={activeIndex}
             autoPlay={autoPlay}
             interval={interval}
@@ -27,7 +28,7 @@ export const Simple = ({ theme }: any) => {
             style={{ width: '50%' }}
         >
             {images.map(({ image, alt }, index) => (
-                <SlideshowItem key={`${image}-${index}`}>
+                <SlideshowItem key={`${image}-${index}`} aria-label={`${index + 1} of ${images.length}`}>
                     <ImageBlock
                         thumbnailProps={{ aspectRatio: AspectRatio.horizontal, loading: 'eager' }}
                         image={image}
@@ -48,6 +49,7 @@ export const SimpleWithAutoPlay = ({ theme }: any) => {
 
     return (
         <Slideshow
+            aria-label="Simple with autoplay example"
             activeIndex={activeIndex}
             autoPlay
             interval={interval}
@@ -61,7 +63,7 @@ export const SimpleWithAutoPlay = ({ theme }: any) => {
             style={{ width: '50%' }}
         >
             {images.map(({ image, alt }, index) => (
-                <SlideshowItem key={`${image}-${index}`}>
+                <SlideshowItem key={`${image}-${index}`} aria-label={`${index + 1} of ${images.length}`}>
                     <ImageBlock
                         thumbnailProps={{ aspectRatio: AspectRatio.horizontal, loading: 'eager' }}
                         image={image}
@@ -75,7 +77,7 @@ export const SimpleWithAutoPlay = ({ theme }: any) => {
 };
 
 export const ResponsiveSlideShowSwipe = () => {
-    const slides = range(3);
+    const slides = range(5);
     return (
         <>
             In responsive mode
@@ -86,14 +88,15 @@ export const ResponsiveSlideShowSwipe = () => {
             </ul>
             <FlexBox vAlign="center">
                 <Slideshow
+                    aria-label="Responsive SlideShow Swipe"
                     activeIndex={0}
                     slideshowControlsProps={{
                         nextButtonProps: { label: 'Next' },
                         previousButtonProps: { label: 'Previous' },
                     }}
                 >
-                    {slides.map((slide) => (
-                        <SlideshowItem key={`${slide}`}>
+                    {slides.map((slide, key) => (
+                        <SlideshowItem key={`${slide}`} aria-label={`${key + 1} of ${slides.length}`}>
                             <FlexBox
                                 style={{ border: '1px solid grey', maxWidth: 300, height: 300 }}
                                 hAlign="center"
@@ -114,3 +117,56 @@ export const ResponsiveSlideShowSwipe = () => {
         </>
     );
 };
+
+const slides = [
+    {
+        src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/foyleswarslide__800x600.jpg',
+        alt: 'A man in a suit and fedora and a woman with coiffed hair look sternly into the camera.',
+        title: 'Foyle’s War Revisited',
+        subtitle: '8 pm Sunday, March 8, on TV: Sneak peek at the final season',
+        link: '#',
+    },
+    {
+        src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/britcomdavidslide__800x600.jpg',
+        alt: 'British flag with WILL-TV host David Thiel.',
+        title: 'Great Britain Vote: 7 pm Sat.',
+        link: '#',
+    },
+    {
+        src: 'https://www.w3.org/WAI/ARIA/apg/example-index/carousel/images/mag800-2__800x600.jpg',
+        alt: 'Mid-American Gardener panelists on the set.',
+        title: 'Mid-American Gardener: Thursdays at 7 pm',
+        subtitle: 'Watch the latest episode',
+        link: '#',
+    },
+];
+export const WithComplexContent = () => (
+    <Slideshow
+        aria-label="Carousel with complex content"
+        activeIndex={0}
+        groupBy={2}
+        slideshowControlsProps={{
+            nextButtonProps: { label: 'Next' },
+            previousButtonProps: { label: 'Previous' },
+        }}
+        autoPlay
+    >
+        {slides.map((slide, key) => (
+            <SlideshowItem aria-label={`${key + 1} of ${slides.length}`} key={slide.src}>
+                <a href={slide.link}>
+                    <img src={slide.src} alt={slide.alt} />
+                </a>
+                <FlexBox orientation={Orientation.vertical}>
+                    <h3>
+                        <a href={slide.link}>{slide.title}</a>
+                        {/* Add a non focusable element to test that it stays that way after a page change. */}
+                        <button type="button" tabIndex={-1} aria-hidden="true">
+                            Not focusable
+                        </button>
+                    </h3>
+                    {slide.subtitle && <p>{slide.subtitle}</p>}
+                </FlexBox>
+            </SlideshowItem>
+        ))}
+    </Slideshow>
+);

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -122,7 +122,7 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
             hasControls={showControls}
             slideGroupLabel={slideGroupLabel}
             afterSlides={
-                showControls ? (
+                slideshowControlsProps && slidesCount > 1 ? (
                     <div className={`${Slides.className}__controls`}>
                         <SlideshowControls
                             {...slideshowControlsProps}
@@ -142,11 +142,15 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
                                 'aria-controls': slideshowSlidesId,
                                 ...slideshowControlsProps.previousButtonProps,
                             }}
-                            playButtonProps={{
-                                'aria-controls': slideshowSlidesId,
-                                onClick: autoPlay ? toggleForcePause : undefined,
-                                ...slideshowControlsProps.playButtonProps,
-                            }}
+                            playButtonProps={
+                                autoPlay
+                                    ? {
+                                          'aria-controls': slideshowSlidesId,
+                                          onClick: toggleForcePause,
+                                          ...slideshowControlsProps.playButtonProps,
+                                      }
+                                    : undefined
+                            }
                             paginationItemProps={(index) => ({
                                 'aria-controls': buildSlideShowGroupId(slideshowSlidesId, index),
                                 ...slideshowControlsProps.paginationItemProps?.(index),

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -5,19 +5,23 @@ import { DEFAULT_OPTIONS } from '@lumx/react/hooks/useSlideshowControls';
 import { Comp, GenericProps } from '@lumx/react/utils';
 import { useFocusWithin } from '@lumx/react/hooks/useFocusWithin';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+import { buildSlideShowGroupId } from './SlideshowItemGroup';
 
 /**
  * Defines the props of the component.
  */
 export interface SlideshowProps
     extends GenericProps,
-        Pick<SlidesProps, 'autoPlay' | 'slidesId' | 'id' | 'theme' | 'fillHeight' | 'groupBy'> {
+        Pick<SlidesProps, 'autoPlay' | 'slidesId' | 'id' | 'theme' | 'fillHeight' | 'groupBy' | 'slideGroupLabel'> {
     /** current slide active */
     activeIndex?: SlidesProps['activeIndex'];
     /** Interval between each slide when automatic rotation is enabled. */
     interval?: number;
     /** Props to pass to the slideshow controls (minus those already set by the Slideshow props). */
-    slideshowControlsProps?: Pick<SlideshowControlsProps, 'nextButtonProps' | 'previousButtonProps'> &
+    slideshowControlsProps?: Pick<
+        SlideshowControlsProps,
+        'nextButtonProps' | 'previousButtonProps' | 'paginationItemProps'
+    > &
         Omit<
             SlideshowControlsProps,
             | 'activeIndex'
@@ -61,6 +65,7 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
         theme,
         id,
         slidesId,
+        slideGroupLabel,
         ...forwardedProps
     } = props;
     // Number of slideshow items.
@@ -99,6 +104,8 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
         onFocusOut: startAutoPlay,
     });
 
+    const showControls = slideshowControlsProps && slidesCount > 1;
+
     return (
         <Slides
             activeIndex={currentIndex}
@@ -112,8 +119,10 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
             slidesId={slideshowSlidesId}
             toggleAutoPlay={toggleAutoPlay}
             ref={mergeRefs(ref, setSlideshow)}
+            hasControls={showControls}
+            slideGroupLabel={slideGroupLabel}
             afterSlides={
-                slideshowControlsProps && slidesCount > 1 ? (
+                showControls ? (
                     <div className={`${Slides.className}__controls`}>
                         <SlideshowControls
                             {...slideshowControlsProps}
@@ -133,15 +142,15 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
                                 'aria-controls': slideshowSlidesId,
                                 ...slideshowControlsProps.previousButtonProps,
                             }}
-                            playButtonProps={
-                                autoPlay
-                                    ? {
-                                          'aria-controls': slideshowSlidesId,
-                                          onClick: toggleForcePause,
-                                          ...slideshowControlsProps.playButtonProps,
-                                      }
-                                    : undefined
-                            }
+                            playButtonProps={{
+                                'aria-controls': slideshowSlidesId,
+                                onClick: autoPlay ? toggleForcePause : undefined,
+                                ...slideshowControlsProps.playButtonProps,
+                            }}
+                            paginationItemProps={(index) => ({
+                                'aria-controls': buildSlideShowGroupId(slideshowSlidesId, index),
+                                ...slideshowControlsProps.paginationItemProps?.(index),
+                            })}
                         />
                     </div>
                 ) : undefined

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -111,7 +111,6 @@ export const Slideshow: Comp<SlideshowProps, HTMLDivElement> = forwardRef((props
             autoPlay={autoPlay}
             slidesId={slideshowSlidesId}
             toggleAutoPlay={toggleAutoPlay}
-            interval={interval}
             ref={mergeRefs(ref, setSlideshow)}
             afterSlides={
                 slideshowControlsProps && slidesCount > 1 ? (

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
@@ -26,6 +26,7 @@ export const Simple = () => {
             onPaginationClick={onPaginationClick}
             nextButtonProps={{ label: 'Next' }}
             previousButtonProps={{ label: 'Previous' }}
+            paginationItemLabel={(index) => `Slide ${index}`}
         />
     );
 };

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.stories.tsx
@@ -63,7 +63,6 @@ export const ControllingSlideshow = ({ theme }: any) => {
         onFocusOut: startAutoPlay,
     });
 
-    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
     return (
         <Slides
             activeIndex={currentIndex}

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -48,7 +48,7 @@ export interface SlideshowControlsProps extends GenericProps, HasTheme {
     /**
      * function to be executed in order to retrieve the props for a pagination item.
      */
-    paginationItemProps?: (itemIndex: number) => React.HTMLAttributes<HTMLButtonElement>;
+    paginationItemProps?: (itemIndex: number) => React.HTMLAttributes<HTMLButtonElement> & { label?: string };
     /** Props to pass to the lay button (minus those already set by the SlideshowControls props). */
     playButtonProps?: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
@@ -164,9 +164,14 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
                                     (index === visibleRange.min || index === visibleRange.max);
                                 const isActive = activeIndex === index;
                                 const isOutRange = index < visibleRange.min || index > visibleRange.max;
-                                const { className: itemClassName = undefined, ...itemProps } = paginationItemProps
-                                    ? paginationItemProps(index)
-                                    : {};
+                                const {
+                                    className: itemClassName = undefined,
+                                    label = undefined,
+                                    ...itemProps
+                                } = paginationItemProps ? paginationItemProps(index) : {};
+
+                                const ariaLabel =
+                                    label || paginationItemLabel?.(index) || `${index + 1} / ${slidesCount}`;
 
                                 return (
                                     <button
@@ -185,11 +190,7 @@ const InternalSlideshowControls: Comp<SlideshowControlsProps, HTMLDivElement> = 
                                         role="tab"
                                         aria-selected={isActive}
                                         onClick={() => onPaginationClick?.(index)}
-                                        {...{
-                                            'aria-label': paginationItemLabel
-                                                ? paginationItemLabel(index)
-                                                : `${index + 1} / ${slidesCount}`,
-                                        }}
+                                        aria-label={ariaLabel}
                                         {...itemProps}
                                     />
                                 );

--- a/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
@@ -20,7 +20,7 @@ const COMPONENT_NAME = 'SlideshowItem';
 /**
  * Component default class name and class prefix.
  */
-export const CLASSNAME = getRootClassName(COMPONENT_NAME);
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
 /**
  * SlideshowItem component.

--- a/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
@@ -8,8 +8,6 @@ import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/
  * Defines the props of the component.
  */
 export interface SlideshowItemProps extends GenericProps {
-    /** whether the slideshow item is currently visible */
-    isCurrentlyVisible?: boolean;
     /** interval in which slides are automatically shown */
     interval?: number;
 }
@@ -22,7 +20,7 @@ const COMPONENT_NAME = 'SlideshowItem';
 /**
  * Component default class name and class prefix.
  */
-const CLASSNAME = getRootClassName(COMPONENT_NAME);
+export const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
 /**
  * SlideshowItem component.
@@ -33,7 +31,6 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 export const SlideshowItem: Comp<SlideshowItemProps, HTMLDivElement> = forwardRef((props, ref) => {
     const { className, children, ...forwardedProps } = props;
-
     return (
         <div
             ref={ref}

--- a/packages/lumx-react/src/components/slideshow/SlideshowItemGroup.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItemGroup.tsx
@@ -1,8 +1,10 @@
 import React, { forwardRef } from 'react';
 
 import classNames from 'classnames';
+import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { useSlideFocusManagement } from './useSlideFocusManagement';
 
 /**
  * Defines the props of the component.
@@ -10,6 +12,7 @@ import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/
 export interface SlideshowItemGroupProps extends GenericProps {
     role?: 'tabpanel' | 'group';
     label?: string;
+    isDisplayed?: boolean;
 }
 
 /**
@@ -32,10 +35,14 @@ export const buildSlideShowGroupId = (slidesId: string, index: number) => `${sli
  * @return React element.
  */
 export const SlideshowItemGroup: Comp<SlideshowItemGroupProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const { className, children, role = 'group', label, ...forwardedProps } = props;
+    const { className, children, role = 'group', label, isDisplayed, ...forwardedProps } = props;
+    const groupRef = React.useRef<HTMLDivElement>(null);
+
+    useSlideFocusManagement({ isSlideDisplayed: isDisplayed, slideRef: groupRef });
+
     return (
         <div
-            ref={ref}
+            ref={mergeRefs(groupRef, ref)}
             role={role}
             className={classNames(
                 className,

--- a/packages/lumx-react/src/components/slideshow/SlideshowItemGroup.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItemGroup.tsx
@@ -7,39 +7,44 @@ import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/
 /**
  * Defines the props of the component.
  */
-export interface SlideshowItemProps extends GenericProps {
-    /** interval in which slides are automatically shown */
-    interval?: number;
+export interface SlideshowItemGroupProps extends GenericProps {
+    role?: 'tabpanel' | 'group';
+    label?: string;
 }
 
 /**
  * Component display name.
  */
-const COMPONENT_NAME = 'SlideshowItem';
+const COMPONENT_NAME = 'SlideshowItemGroup';
 
 /**
  * Component default class name and class prefix.
  */
 export const CLASSNAME = getRootClassName(COMPONENT_NAME);
 
+export const buildSlideShowGroupId = (slidesId: string, index: number) => `${slidesId}-slide-${index}`;
+
 /**
- * SlideshowItem component.
+ * SlideshowItemGroup component.
  *
  * @param  props Component props.
  * @param  ref   Component ref.
  * @return React element.
  */
-export const SlideshowItem: Comp<SlideshowItemProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const { className, children, ...forwardedProps } = props;
+export const SlideshowItemGroup: Comp<SlideshowItemGroupProps, HTMLDivElement> = forwardRef((props, ref) => {
+    const { className, children, role = 'group', label, ...forwardedProps } = props;
     return (
         <div
             ref={ref}
+            role={role}
             className={classNames(
                 className,
                 handleBasicClasses({
                     prefix: CLASSNAME,
                 }),
             )}
+            aria-roledescription="slide"
+            aria-label={label}
             {...forwardedProps}
         >
             {children}
@@ -47,5 +52,5 @@ export const SlideshowItem: Comp<SlideshowItemProps, HTMLDivElement> = forwardRe
     );
 });
 
-SlideshowItem.displayName = COMPONENT_NAME;
-SlideshowItem.className = CLASSNAME;
+SlideshowItemGroup.displayName = COMPONENT_NAME;
+SlideshowItemGroup.className = CLASSNAME;

--- a/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
+++ b/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
@@ -20,7 +20,14 @@ Array [
           onNextClick={[Function]}
           onPaginationClick={[Function]}
           onPreviousClick={[Function]}
+          paginationItemProps={[Function]}
           parentRef={null}
+          playButtonProps={
+            Object {
+              "aria-controls": "slideshow-slides2",
+              "onClick": undefined,
+            }
+          }
           previousButtonProps={
             Object {
               "aria-controls": "slideshow-slides2",
@@ -32,11 +39,13 @@ Array [
         />
       </div>
     }
+    aria-label="Simple carousel example"
     autoPlay={false}
     groupBy={1}
+    hasControls={true}
     id="slideshow1"
-    interval={1000}
     isAutoPlaying={false}
+    slideGroupLabel={[Function]}
     slidesId="slideshow-slides2"
     style={
       Object {

--- a/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
+++ b/packages/lumx-react/src/components/slideshow/__snapshots__/Slideshow.test.tsx.snap
@@ -22,12 +22,6 @@ Array [
           onPreviousClick={[Function]}
           paginationItemProps={[Function]}
           parentRef={null}
-          playButtonProps={
-            Object {
-              "aria-controls": "slideshow-slides2",
-              "onClick": undefined,
-            }
-          }
           previousButtonProps={
             Object {
               "aria-controls": "slideshow-slides2",

--- a/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
+++ b/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { INTERACTIVE_ELEMENTS_STRING } from '@lumx/core/js/constants';
+import { getFocusableElements } from '@lumx/react/utils/focus/getFocusableElements';
 
 import { CLASSNAME as ITEM_CLASSNAME } from './SlideshowItem';
 
@@ -20,7 +20,7 @@ export const useSlideFocusManagement = ({ activeIndex, groupBy = 1, wrapperRef }
         const startIndexVisible = activeIndex * groupBy;
         const endIndexVisible = startIndexVisible + groupBy;
 
-        const slideshowChildren = element?.getElementsByClassName(ITEM_CLASSNAME);
+        const slideshowChildren = element?.querySelectorAll<HTMLElement>(`.${ITEM_CLASSNAME}`);
 
         /**
          * Classname set on elements whose focus was blocked.
@@ -32,7 +32,7 @@ export const useSlideFocusManagement = ({ activeIndex, groupBy = 1, wrapperRef }
         /**
          * Display given slide to screen readers and, if focus was blocked, restore focus on elements..
          */
-        const enableSlide = (slide: Element) => {
+        const enableSlide = (slide: HTMLElement) => {
             // Hide from screen readers
             slide.setAttribute('aria-hidden', 'false');
             // Find elements we have blocked focus on
@@ -45,14 +45,11 @@ export const useSlideFocusManagement = ({ activeIndex, groupBy = 1, wrapperRef }
         /**
          * Hide given slide from screen readers and block focus on all focusable elements within.
          */
-        const blockSlide = (slide: Element) => {
+        const blockSlide = (slide: HTMLElement) => {
             slide.setAttribute('aria-hidden', 'true');
-            slide.querySelectorAll(INTERACTIVE_ELEMENTS_STRING).forEach((focusableElement) => {
-                // If the element already has blocked focus, we leave it as is as we would remove it when slide becomes visible.
-                if (!focusableElement.hasAttribute('tabindex') || focusableElement.getAttribute('tabindex') !== '-1') {
-                    focusableElement.setAttribute('tabindex', '-1');
-                    focusableElement.classList.add(elementWithBlockedFocusClass);
-                }
+            getFocusableElements(slide).forEach((focusableElement) => {
+                focusableElement.setAttribute('tabindex', '-1');
+                focusableElement.classList.add(elementWithBlockedFocusClass);
             });
         };
 

--- a/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
+++ b/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
@@ -1,67 +1,92 @@
 import React, { useEffect } from 'react';
 import { getFocusableElements } from '@lumx/react/utils/focus/getFocusableElements';
 
-import { CLASSNAME as ITEM_GROUP_CLASSNAME } from './SlideshowItemGroup';
-
 export interface UseSlideFocusManagementProps {
-    activeIndex: number;
-    groupBy?: number;
-    wrapperRef: React.RefObject<HTMLDivElement>;
+    isSlideDisplayed?: boolean;
+    slideRef: React.RefObject<HTMLDivElement>;
 }
+
+/**
+ * Classname set on elements whose focus was blocked.
+ * This is to easily find elements that have been tempered with,
+ * and not elements whose focus was already initially blocked.
+ * */
+const BLOCKED_FOCUS_CLASSNAME = `focus-blocked`;
 
 /**
  * Manage how slides must behave when visible or not.
  * When not visible, they should be hidden from screen readers and not focusable.
  */
-export const useSlideFocusManagement = ({ activeIndex, groupBy = 1, wrapperRef }: UseSlideFocusManagementProps) => {
+export const useSlideFocusManagement = ({ isSlideDisplayed, slideRef }: UseSlideFocusManagementProps) => {
     useEffect(() => {
-        const element = wrapperRef?.current;
-        const startIndexVisible = activeIndex;
-        const endIndexVisible = startIndexVisible + 1;
+        const element = slideRef?.current;
 
-        const slideshowChildren = element?.querySelectorAll<HTMLElement>(`.${ITEM_GROUP_CLASSNAME}`);
-
-        /**
-         * Classname set on elements whose focus was blocked.
-         * This is to easily find elements that have been tempered with,
-         * and not elements whose focus was already initially blocked.
-         * */
-        const elementWithBlockedFocusClass = `${ITEM_GROUP_CLASSNAME}__no-focus`;
+        if (!element) {
+            return undefined;
+        }
 
         /**
-         * Display given slide to screen readers and, if focus was blocked, restore focus on elements..
+         * Display given slide to screen readers and, if focus was blocked, restore focus on elements.
          */
-        const enableSlide = (slide: HTMLElement) => {
+        const enableSlide = () => {
             // Hide from screen readers
-            slide.setAttribute('aria-hidden', 'false');
+            element.setAttribute('aria-hidden', 'false');
             // Find elements we have blocked focus on
-            slide.querySelectorAll(`.${elementWithBlockedFocusClass}`).forEach((focusableElement) => {
+            element.querySelectorAll(`.${BLOCKED_FOCUS_CLASSNAME}`).forEach((focusableElement) => {
                 focusableElement.removeAttribute('tabindex');
-                focusableElement.classList.remove(elementWithBlockedFocusClass);
+                focusableElement.classList.remove(BLOCKED_FOCUS_CLASSNAME);
             });
         };
 
         /**
          * Hide given slide from screen readers and block focus on all focusable elements within.
          */
-        const blockSlide = (slide: HTMLElement) => {
-            slide.setAttribute('aria-hidden', 'true');
-            getFocusableElements(slide).forEach((focusableElement) => {
+        const blockSlide = () => {
+            element.setAttribute('aria-hidden', 'true');
+            getFocusableElements(element).forEach((focusableElement) => {
                 focusableElement.setAttribute('tabindex', '-1');
-                focusableElement.classList.add(elementWithBlockedFocusClass);
+                focusableElement.classList.add(BLOCKED_FOCUS_CLASSNAME);
             });
         };
 
-        if (slideshowChildren && slideshowChildren?.length > 0) {
-            Array.from(slideshowChildren).forEach((slide, slideIndex) => {
-                const slideIsVisible = slideIndex >= startIndexVisible && slideIndex < endIndexVisible;
+        const handleDisplay = () => {
+            if (!element) {
+                return;
+            }
+            if (isSlideDisplayed) {
+                enableSlide();
+            } else {
+                blockSlide();
+            }
+        };
 
-                if (slideIsVisible) {
-                    enableSlide(slide);
-                } else {
-                    blockSlide(slide);
+        // Callback function to execute when mutations are observed
+        const callback: MutationCallback = (mutationsList) => {
+            if (element) {
+                for (const mutation of mutationsList) {
+                    if (mutation.type === 'childList') {
+                        handleDisplay();
+                    }
                 }
-            });
+            }
+        };
+
+        // Create an observer instance linked to the callback function
+        const observer = new MutationObserver(callback);
+
+        if (element) {
+            handleDisplay();
+
+            /** If slide is hidden, start observing for elements to block focus  */
+            if (!isSlideDisplayed) {
+                observer.observe(element, { attributes: true, childList: true, subtree: true });
+            }
         }
-    }, [activeIndex, groupBy, wrapperRef]);
+
+        return () => {
+            if (!isSlideDisplayed) {
+                observer.disconnect();
+            }
+        };
+    }, [isSlideDisplayed, slideRef]);
 };

--- a/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
+++ b/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { getFocusableElements } from '@lumx/react/utils/focus/getFocusableElements';
 
-import { CLASSNAME as ITEM_CLASSNAME } from './SlideshowItem';
+import { CLASSNAME as ITEM_GROUP_CLASSNAME } from './SlideshowItemGroup';
 
 export interface UseSlideFocusManagementProps {
     activeIndex: number;
@@ -16,18 +16,17 @@ export interface UseSlideFocusManagementProps {
 export const useSlideFocusManagement = ({ activeIndex, groupBy = 1, wrapperRef }: UseSlideFocusManagementProps) => {
     useEffect(() => {
         const element = wrapperRef?.current;
+        const startIndexVisible = activeIndex;
+        const endIndexVisible = startIndexVisible + 1;
 
-        const startIndexVisible = activeIndex * groupBy;
-        const endIndexVisible = startIndexVisible + groupBy;
-
-        const slideshowChildren = element?.querySelectorAll<HTMLElement>(`.${ITEM_CLASSNAME}`);
+        const slideshowChildren = element?.querySelectorAll<HTMLElement>(`.${ITEM_GROUP_CLASSNAME}`);
 
         /**
          * Classname set on elements whose focus was blocked.
          * This is to easily find elements that have been tempered with,
          * and not elements whose focus was already initially blocked.
          * */
-        const elementWithBlockedFocusClass = `${ITEM_CLASSNAME}__no-focus`;
+        const elementWithBlockedFocusClass = `${ITEM_GROUP_CLASSNAME}__no-focus`;
 
         /**
          * Display given slide to screen readers and, if focus was blocked, restore focus on elements..

--- a/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
+++ b/packages/lumx-react/src/components/slideshow/useSlideFocusManagement.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import { INTERACTIVE_ELEMENTS_STRING } from '@lumx/core/js/constants';
+
+import { CLASSNAME as ITEM_CLASSNAME } from './SlideshowItem';
+
+export interface UseSlideFocusManagementProps {
+    activeIndex: number;
+    groupBy?: number;
+    wrapperRef: React.RefObject<HTMLDivElement>;
+}
+
+/**
+ * Manage how slides must behave when visible or not.
+ * When not visible, they should be hidden from screen readers and not focusable.
+ */
+export const useSlideFocusManagement = ({ activeIndex, groupBy = 1, wrapperRef }: UseSlideFocusManagementProps) => {
+    useEffect(() => {
+        const element = wrapperRef?.current;
+
+        const startIndexVisible = activeIndex * groupBy;
+        const endIndexVisible = startIndexVisible + groupBy;
+
+        const slideshowChildren = element?.getElementsByClassName(ITEM_CLASSNAME);
+
+        /**
+         * Classname set on elements whose focus was blocked.
+         * This is to easily find elements that have been tempered with,
+         * and not elements whose focus was already initially blocked.
+         * */
+        const elementWithBlockedFocusClass = `${ITEM_CLASSNAME}__no-focus`;
+
+        /**
+         * Display given slide to screen readers and, if focus was blocked, restore focus on elements..
+         */
+        const enableSlide = (slide: Element) => {
+            // Hide from screen readers
+            slide.setAttribute('aria-hidden', 'false');
+            // Find elements we have blocked focus on
+            slide.querySelectorAll(`.${elementWithBlockedFocusClass}`).forEach((focusableElement) => {
+                focusableElement.removeAttribute('tabindex');
+                focusableElement.classList.remove(elementWithBlockedFocusClass);
+            });
+        };
+
+        /**
+         * Hide given slide from screen readers and block focus on all focusable elements within.
+         */
+        const blockSlide = (slide: Element) => {
+            slide.setAttribute('aria-hidden', 'true');
+            slide.querySelectorAll(INTERACTIVE_ELEMENTS_STRING).forEach((focusableElement) => {
+                // If the element already has blocked focus, we leave it as is as we would remove it when slide becomes visible.
+                if (!focusableElement.hasAttribute('tabindex') || focusableElement.getAttribute('tabindex') !== '-1') {
+                    focusableElement.setAttribute('tabindex', '-1');
+                    focusableElement.classList.add(elementWithBlockedFocusClass);
+                }
+            });
+        };
+
+        if (slideshowChildren && slideshowChildren?.length > 0) {
+            Array.from(slideshowChildren).forEach((slide, slideIndex) => {
+                const slideIsVisible = slideIndex >= startIndexVisible && slideIndex < endIndexVisible;
+
+                if (slideIsVisible) {
+                    enableSlide(slide);
+                } else {
+                    blockSlide(slide);
+                }
+            });
+        }
+    }, [activeIndex, groupBy, wrapperRef]);
+};

--- a/packages/lumx-react/src/hooks/useRovingTabIndex.tsx
+++ b/packages/lumx-react/src/hooks/useRovingTabIndex.tsx
@@ -4,6 +4,8 @@ interface UseRovingTabIndexOptions {
     parentRef: RefObject<HTMLElement>;
     elementSelector: string;
     keepTabIndex?: boolean;
+    /** Action to trigger when an element is focused using roving tab index */
+    onElementFocus?: (element: HTMLElement) => void;
     /** List of values to be used as extra dependencies of the useEffect */
     extraDependencies?: any[];
 }
@@ -12,6 +14,7 @@ export const useRovingTabIndex = ({
     parentRef,
     elementSelector,
     keepTabIndex,
+    onElementFocus,
     extraDependencies = [],
 }: UseRovingTabIndexOptions): void => {
     useEffect(
@@ -47,6 +50,12 @@ export const useRovingTabIndex = ({
                 }
                 const newElement = elements[newTabFocus];
                 newElement?.focus();
+
+                // When an element is focused using roving tab index, trigger the onElementFocus callback
+                if (newElement && onElementFocus) {
+                    onElementFocus(newElement);
+                }
+
                 if (keepTabIndex) {
                     (evt.currentTarget as HTMLElement).setAttribute('tabindex', '-1');
                     newElement?.setAttribute('tabindex', '0');

--- a/packages/lumx-react/src/utils/focus/constants.ts
+++ b/packages/lumx-react/src/utils/focus/constants.ts
@@ -1,0 +1,5 @@
+/** CSS selector listing all tabbable elements. */
+export const TABBABLE_ELEMENTS_SELECTOR = `a[href], button, textarea, input:not([type="hidden"]):not([hidden]), [tabindex]`;
+
+/** CSS selector matching element that are disabled (should not receive focus). */
+export const DISABLED_SELECTOR = `[hidden], [tabindex="-1"], [disabled]:not([disabled="false"]), [aria-disabled]:not([aria-disabled="false"])`;

--- a/packages/lumx-react/src/utils/focus/getFirstAndLastFocusable.ts
+++ b/packages/lumx-react/src/utils/focus/getFirstAndLastFocusable.ts
@@ -1,10 +1,4 @@
-/** CSS selector listing all tabbable elements. */
-const TABBABLE_ELEMENTS_SELECTOR = `a[href], button, textarea, input:not([type="hidden"]):not([hidden]), [tabindex]`;
-
-/** CSS selector matching element that are disabled (should not receive focus). */
-const DISABLED_SELECTOR = `[hidden], [tabindex="-1"], [disabled]:not([disabled="false"]), [aria-disabled]:not([aria-disabled="false"])`;
-
-const isNotDisabled = (element: HTMLElement) => !element.matches(DISABLED_SELECTOR);
+import { getFocusableElements } from './getFocusableElements';
 
 /**
  * Get first and last elements focusable in an element.
@@ -13,12 +7,12 @@ const isNotDisabled = (element: HTMLElement) => !element.matches(DISABLED_SELECT
  * @return first and last focusable elements
  */
 export function getFirstAndLastFocusable(parentElement: HTMLElement) {
-    const focusableElements = Array.from(parentElement.querySelectorAll<HTMLElement>(TABBABLE_ELEMENTS_SELECTOR));
+    const focusableElements = getFocusableElements(parentElement);
 
     // First non disabled element.
-    const first = focusableElements.find(isNotDisabled);
+    const first = focusableElements[0];
     // Last non disabled element.
-    const last = focusableElements.reverse().find(isNotDisabled);
+    const last = focusableElements[focusableElements.length - 1];
 
     if (last && first) {
         return { first, last };

--- a/packages/lumx-react/src/utils/focus/getFocusableElements.test.ts
+++ b/packages/lumx-react/src/utils/focus/getFocusableElements.test.ts
@@ -23,29 +23,6 @@ describe(getFocusableElements.name, () => {
         `);
     });
 
-    // it('should get first and last', () => {
-    //     const element = htmlToElement(`
-    //         <div>
-    //             <div>Non focusable div</div>
-    //             <button>Simple button</button>
-    //             <div>Non focusable div</div>
-    //             <input />
-    //             <div>Non focusable div</div>
-    //         </div>
-    //     `);
-    //     const focusable = getFocusableElements(element);
-    //     expect(focusable.first).toMatchInlineSnapshot(`
-    //         <button>
-    //           Simple button
-    //         </button>
-    //     `);
-    //     expect(focusable.first).toMatchInlineSnapshot(`
-    //         <button>
-    //           Simple button
-    //         </button>
-    //     `);
-    // });
-
     describe('match focusable elements', () => {
         it('should match input element', () => {
             const element = htmlToElement(`<div><input /></div>`);

--- a/packages/lumx-react/src/utils/focus/getFocusableElements.test.ts
+++ b/packages/lumx-react/src/utils/focus/getFocusableElements.test.ts
@@ -1,0 +1,174 @@
+import { getFocusableElements } from '@lumx/react/utils/focus/getFocusableElements';
+
+function htmlToElement(html: string): any {
+    const template = document.createElement('template');
+    template.innerHTML = html.trim();
+    return template.content.firstChild;
+}
+
+describe(getFocusableElements.name, () => {
+    it('should get empty', () => {
+        const element = htmlToElement(`<div></div>`);
+        const focusable = getFocusableElements(element);
+        expect(focusable).toEqual([]);
+    });
+
+    it('should get single item', () => {
+        const element = htmlToElement(`<div><button /></div>`);
+        const focusable = getFocusableElements(element);
+        expect(focusable).toMatchInlineSnapshot(`
+            Array [
+              <button />,
+            ]
+        `);
+    });
+
+    // it('should get first and last', () => {
+    //     const element = htmlToElement(`
+    //         <div>
+    //             <div>Non focusable div</div>
+    //             <button>Simple button</button>
+    //             <div>Non focusable div</div>
+    //             <input />
+    //             <div>Non focusable div</div>
+    //         </div>
+    //     `);
+    //     const focusable = getFocusableElements(element);
+    //     expect(focusable.first).toMatchInlineSnapshot(`
+    //         <button>
+    //           Simple button
+    //         </button>
+    //     `);
+    //     expect(focusable.first).toMatchInlineSnapshot(`
+    //         <button>
+    //           Simple button
+    //         </button>
+    //     `);
+    // });
+
+    describe('match focusable elements', () => {
+        it('should match input element', () => {
+            const element = htmlToElement(`<div><input /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <input />,
+                ]
+            `);
+        });
+
+        it('should match link element', () => {
+            const element = htmlToElement(`<div><a href="#" /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <a
+                    href="#"
+                  />,
+                ]
+            `);
+        });
+
+        it('should match textarea element', () => {
+            const element = htmlToElement(`<div><textarea /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <textarea>
+                    &lt;/div&gt;
+                  </textarea>,
+                ]
+            `);
+        });
+
+        it('should match element with tabindex', () => {
+            const element = htmlToElement(`<div><span tabindex="0" /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <span
+                    tabindex="0"
+                  />,
+                ]
+            `);
+        });
+
+        it('should keep disabled=false', () => {
+            const element = htmlToElement(`<div><button disabled="false" /><button /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <button
+                    disabled="false"
+                  />,
+                  <button />,
+                ]
+            `);
+        });
+
+        it('should keep aria-disabled=false', () => {
+            const element = htmlToElement(`<div><button aria-disabled="false" /><button /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <button
+                    aria-disabled="false"
+                  />,
+                  <button />,
+                ]
+            `);
+        });
+    });
+
+    describe('skip disabled elements', () => {
+        it('should skip disabled', () => {
+            const element = htmlToElement(`<div><button disabled /><button /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <button />,
+                ]
+            `);
+        });
+
+        it('should skip aria-disabled', () => {
+            const element = htmlToElement(`<div><button aria-disabled /><button /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <button />,
+                ]
+            `);
+        });
+
+        it('should skip tabindex=-1', () => {
+            const element = htmlToElement(`<div><button tabindex="-1" /><button /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <button />,
+                ]
+            `);
+        });
+
+        it('should skip input type hidden', () => {
+            const element = htmlToElement(`<div><input type="hidden" /><button /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <button />,
+                ]
+            `);
+        });
+
+        it('should skip hidden input', () => {
+            const element = htmlToElement(`<div><input hidden /><button /></div>`);
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                Array [
+                  <button />,
+                ]
+            `);
+        });
+    });
+});

--- a/packages/lumx-react/src/utils/focus/getFocusableElements.ts
+++ b/packages/lumx-react/src/utils/focus/getFocusableElements.ts
@@ -1,0 +1,7 @@
+import { DISABLED_SELECTOR, TABBABLE_ELEMENTS_SELECTOR } from './constants';
+
+const isNotDisabled = (element: HTMLElement) => !element.matches(DISABLED_SELECTOR);
+
+export function getFocusableElements(element: HTMLElement): HTMLElement[] {
+    return Array.from(element.querySelectorAll<HTMLElement>(TABBABLE_ELEMENTS_SELECTOR)).filter(isNotDisabled);
+}


### PR DESCRIPTION
# General summary

* Fixed keyboard navigation and screen reader compatibility for slideshows
  * Non visible slides now can't be navigated to using the keyboard.
  * Non visible slides are hidden from screen readers.
  * When slides become visible, the focus is restored and so is their screen reader visibility.

* Added roving tab index to controls
* Slides grouped together are now wrapped inside individual divs.
* Added roles and attributes to improve a11y complience.

<!-- Please describe the PR content -->

# Screenshots
![slideshow-focus-management](https://user-images.githubusercontent.com/7147342/189935835-0e12fb5d-f2bb-4d69-b5a2-b49907c135db.gif)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

# Test scenarios: 

## Keyboard navigation
1) Go to a slideshow with complex contents (with focusable element)
2) With your keyboard, navigate inside the slideshow
3) Only the visible slides should be focusable
4) Change pages
5) Now only the new slides should be focusable
6) Any element within a slide that previously had `tabindex=-1` should remain non focusable, even if the slide is visible.

## Screen reader
1) Using a screen reader such as NVDA (you can use assistive lab if you don't have a screen reader available), go to any slideshow.
2) When changing pages, the new slide content should be read (either the images alternative texts or actual texts).
3) The hidden slide should not be read.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
