### PR TITLE
feat(heading): create heading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   New `Text` component.
+-   New `Heading` component. The component comes with a `HeadingProvider` that allows the `Heading` component to automatically use the correct heading level depending on the nested providers.
+-   New `useHeadingLevel` hook to get the current heading level.
 
 ## [3.0.1][] - 2022-09-21
 

--- a/packages/lumx-react/src/components/heading/Heading.stories.tsx
+++ b/packages/lumx-react/src/components/heading/Heading.stories.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { imageKnob } from '@lumx/react/stories/knobs/image';
+import { Orientation, Size, Typography } from '..';
+import { Heading, HeadingLevelProvider } from '.';
+import { FlexBox } from '../flex-box';
+import { GenericBlock } from '../generic-block';
+import { Thumbnail } from '../thumbnail';
+
+export default { title: 'LumX components/heading/Heading' };
+
+export const Default = () => {
+    return (
+        <div>
+            {/* This will render a h1 */}
+            <Heading>First level</Heading>
+            <HeadingLevelProvider>
+                {/* This will render a h2 */}
+                <Heading>Second Level</Heading>
+                <HeadingLevelProvider>
+                    {/* This will render a h3 */}
+                    <Heading>Third Level</Heading>
+                    {/* This will also render a h3 */}
+                    <Heading>Other Third Level</Heading>
+                    <HeadingLevelProvider>
+                        {/* This will render a h4 */}
+                        <Heading>Fourth Level</Heading>
+                        <HeadingLevelProvider>
+                            {/* This will render a h5 */}
+                            <Heading>Fifth Level</Heading>
+                        </HeadingLevelProvider>
+                    </HeadingLevelProvider>
+                </HeadingLevelProvider>
+            </HeadingLevelProvider>
+        </div>
+    );
+};
+
+export const LevelOverride = () => {
+    return (
+        <div>
+            {/* This will render a h1 */}
+            <Heading>First level</Heading>
+            <HeadingLevelProvider>
+                {/* This will render a h2 */}
+                <Heading>Second Level</Heading>
+                <HeadingLevelProvider level={2}>
+                    {/* This will also render a h2 */}
+                    <Heading>Lorem ipsum</Heading>
+                    <Heading>Dolor sit amet</Heading>
+                    <Heading>Reprehenderit et aute</Heading>
+                </HeadingLevelProvider>
+            </HeadingLevelProvider>
+        </div>
+    );
+};
+
+export const HeadingManualOverride = () => {
+    return (
+        <div>
+            {/* This will render a h1 */}
+            <Heading>First level</Heading>
+            <HeadingLevelProvider>
+                {/* This will render a h2 */}
+                <Heading as="h2">Forced second Level</Heading>
+                <Heading as="h3">Forced third Level</Heading>
+                <Heading as="h4">Forced fourth Level</Heading>
+            </HeadingLevelProvider>
+        </div>
+    );
+};
+
+const ListWithSubElements = () => {
+    return (
+        <HeadingLevelProvider>
+            <FlexBox orientation={Orientation.vertical} gap={Size.big}>
+                <GenericBlock figure={<Thumbnail image={imageKnob()} alt="First Item" size={Size.l} />}>
+                    <Heading typography={Typography.subtitle2}>First item</Heading>
+                </GenericBlock>
+                <GenericBlock figure={<Thumbnail image={imageKnob()} alt="First Item" size={Size.l} />}>
+                    <Heading typography={Typography.subtitle2}>Second item</Heading>
+                </GenericBlock>
+                <GenericBlock figure={<Thumbnail image={imageKnob()} alt="First Item" size={Size.l} />}>
+                    <Heading typography={Typography.subtitle2}>Third item</Heading>
+                </GenericBlock>
+            </FlexBox>
+        </HeadingLevelProvider>
+    );
+};
+
+export const TypographyOverride = () => {
+    return (
+        <FlexBox orientation={Orientation.vertical} gap={Size.big}>
+            <Heading>My lists</Heading>
+
+            <FlexBox orientation={Orientation.horizontal} gap={Size.huge}>
+                <ListWithSubElements />
+
+                <FlexBox orientation={Orientation.vertical} gap={Size.big}>
+                    <HeadingLevelProvider>
+                        <Heading>Sub list</Heading>
+
+                        <ListWithSubElements />
+                    </HeadingLevelProvider>
+                </FlexBox>
+            </FlexBox>
+        </FlexBox>
+    );
+};

--- a/packages/lumx-react/src/components/heading/Heading.test.tsx
+++ b/packages/lumx-react/src/components/heading/Heading.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { mount, shallow } from 'enzyme';
+import 'jest-enzyme';
+
+import { commonTestsSuite } from '@lumx/react/testing/utils';
+import { Heading, HeadingProps } from './Heading';
+import { HeadingLevelProvider } from './HeadingLevelProvider';
+
+const setup = (props: Partial<HeadingProps> = {}) => {
+    const wrapper = shallow(<Heading {...props} />);
+    return { props, wrapper };
+};
+
+describe(`<${Heading.displayName}>`, () => {
+    describe('Snapshots and structure', () => {
+        it('should render a Text component with h1 by default', () => {
+            const { wrapper } = setup({ children: 'Some text' });
+            expect(wrapper).toHaveDisplayName('Text');
+            expect(wrapper).toHaveProp('as', 'h1');
+            expect(wrapper.prop('className')).toBe(Heading.className);
+        });
+
+        it('should render with as', () => {
+            const { wrapper } = setup({ children: 'Some text', as: 'h2' });
+            expect(wrapper).toHaveDisplayName('Text');
+            expect(wrapper).toHaveProp('as', 'h2');
+            expect(wrapper.prop('className')).toBe(Heading.className);
+        });
+
+        it('should correctly render levels nested in HeadingLevel', () => {
+            const wrapper = mount(
+                <>
+                    <Heading>Level 1</Heading>
+                    <HeadingLevelProvider>
+                        <Heading>Level 2</Heading>
+                        <HeadingLevelProvider>
+                            <Heading>Level 3</Heading>
+                            <HeadingLevelProvider>
+                                <Heading>Level 4</Heading>
+                                <HeadingLevelProvider>
+                                    <Heading>Level 5 - 1</Heading>
+                                    <Heading>Level 5 - 2</Heading>
+                                    <HeadingLevelProvider>
+                                        <Heading>Level 6</Heading>
+                                        <HeadingLevelProvider>
+                                            <Heading>Level 7</Heading>
+                                        </HeadingLevelProvider>
+                                    </HeadingLevelProvider>
+                                </HeadingLevelProvider>
+                            </HeadingLevelProvider>
+                        </HeadingLevelProvider>
+                    </HeadingLevelProvider>
+                    ,
+                </>,
+            );
+
+            expect(wrapper.find('h1')).toHaveText('Level 1');
+            expect(wrapper.find('h2')).toHaveText('Level 2');
+            expect(wrapper.find('h3')).toHaveText('Level 3');
+            expect(wrapper.find('h4')).toHaveText('Level 4');
+
+            const h5 = wrapper.find('h5');
+            expect(h5).toHaveLength(2);
+            expect(h5.at(0)).toHaveText('Level 5 - 1');
+            expect(h5.at(1)).toHaveText('Level 5 - 2');
+            // There should be 2 h6 because it is the maximum value;
+            const h6 = wrapper.find('h6');
+            expect(h6).toHaveLength(2);
+            expect(h6.at(0)).toHaveText('Level 6');
+            expect(h6.at(1)).toHaveText('Level 7');
+        });
+    });
+
+    // Common tests suite.
+    commonTestsSuite(setup, { className: 'wrapper', prop: 'wrapper' }, { className: Heading.className });
+});

--- a/packages/lumx-react/src/components/heading/Heading.tsx
+++ b/packages/lumx-react/src/components/heading/Heading.tsx
@@ -1,0 +1,62 @@
+import { Comp, getRootClassName, handleBasicClasses, HeadingElement } from '@lumx/react/utils';
+import classNames from 'classnames';
+import React, { forwardRef } from 'react';
+import { Text, TextProps } from '../text';
+import { DEFAULT_TYPOGRAPHY_BY_LEVEL } from './constants';
+import { useHeadingLevel } from './useHeadingLevel';
+
+/**
+ * Defines the props of the component.
+ */
+export interface HeadingProps extends Partial<TextProps> {
+    /**
+     * Display a specific heading level instead of the one provided by parent context provider.
+     */
+    as?: HeadingElement;
+}
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'Heading';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
+
+/**
+ * Component default props.
+ */
+const DEFAULT_PROPS = {} as const;
+
+/**
+ * Renders a heading component.
+ * Extends the `Text` Component with the heading level automatically computed based on
+ * the current level provided by the context.
+ */
+export const Heading: Comp<HeadingProps> = forwardRef((props, ref) => {
+    const { children, as, className, ...forwardedProps } = props;
+    const { headingElement } = useHeadingLevel();
+
+    return (
+        <Text
+            ref={ref}
+            className={classNames(
+                className,
+                handleBasicClasses({
+                    prefix: CLASSNAME,
+                }),
+            )}
+            as={as || headingElement}
+            typography={DEFAULT_TYPOGRAPHY_BY_LEVEL[headingElement]}
+            {...forwardedProps}
+        >
+            {children}
+        </Text>
+    );
+});
+
+Heading.displayName = COMPONENT_NAME;
+Heading.className = CLASSNAME;
+Heading.defaultProps = DEFAULT_PROPS;

--- a/packages/lumx-react/src/components/heading/HeadingLevelProvider.tsx
+++ b/packages/lumx-react/src/components/heading/HeadingLevelProvider.tsx
@@ -1,0 +1,30 @@
+import { HeadingElement } from '@lumx/react/utils';
+import React, { ReactNode } from 'react';
+import { MAX_HEADING_LEVEL } from './constants';
+import { HeadingLevelContext } from './context';
+import { useHeadingLevel } from './useHeadingLevel';
+
+export interface HeadingLevelProviderProps {
+    /** The heading level to start at. If left undefined, the parent context will be used, if any. */
+    level?: number;
+    /** The children to display */
+    children: ReactNode;
+}
+
+/**
+ * Provide a new heading level context.
+ */
+export const HeadingLevelProvider: React.FC<HeadingLevelProviderProps> = ({ children, level }) => {
+    const { level: contextLevel } = useHeadingLevel();
+
+    const incrementedLevel = level || contextLevel + 1;
+    /** Don't allow a level beyond the maximum level. */
+    const nextLevel = incrementedLevel > MAX_HEADING_LEVEL ? MAX_HEADING_LEVEL : incrementedLevel;
+    const headingElement = `h${nextLevel}` as HeadingElement;
+
+    return (
+        <HeadingLevelContext.Provider value={{ level: nextLevel, headingElement }}>
+            {children}
+        </HeadingLevelContext.Provider>
+    );
+};

--- a/packages/lumx-react/src/components/heading/constants.ts
+++ b/packages/lumx-react/src/components/heading/constants.ts
@@ -1,0 +1,16 @@
+import { Typography } from '..';
+
+/** The maximum authorized heading level. */
+export const MAX_HEADING_LEVEL = 6;
+
+/**
+ * Typography to use by default depending on the heading level.
+ */
+export const DEFAULT_TYPOGRAPHY_BY_LEVEL = {
+    h1: Typography.display1,
+    h2: Typography.headline,
+    h3: Typography.title,
+    h4: Typography.subtitle2,
+    h5: Typography.subtitle1,
+    h6: Typography.body2,
+};

--- a/packages/lumx-react/src/components/heading/context.tsx
+++ b/packages/lumx-react/src/components/heading/context.tsx
@@ -1,0 +1,13 @@
+import { HeadingElement } from '@lumx/react/utils';
+import { createContext } from 'react';
+
+interface HeadingLevelContext {
+    /** The current level */
+    level: number;
+    /** The heading element matching the current level */
+    headingElement: HeadingElement;
+}
+
+const defaultContext: HeadingLevelContext = { level: 1, headingElement: 'h1' };
+
+export const HeadingLevelContext = createContext<HeadingLevelContext>(defaultContext);

--- a/packages/lumx-react/src/components/heading/index.ts
+++ b/packages/lumx-react/src/components/heading/index.ts
@@ -1,0 +1,3 @@
+export * from './Heading';
+export * from './HeadingLevelProvider';
+export * from './useHeadingLevel';

--- a/packages/lumx-react/src/components/heading/useHeadingLevel.tsx
+++ b/packages/lumx-react/src/components/heading/useHeadingLevel.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { HeadingLevelContext } from './context';
+
+export const useHeadingLevel = () => {
+    const { level = 1, headingElement = 'h1' } = React.useContext(HeadingLevelContext);
+
+    return { level, headingElement };
+};

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -16,6 +16,7 @@ export * from './components/expansion-panel';
 export * from './components/flag';
 export * from './components/flex-box';
 export * from './components/generic-block';
+export * from './components/heading';
 export * from './components/grid';
 export * from './components/icon';
 export * from './components/image-block';


### PR DESCRIPTION
CF-365

# General summary

Create a `Heading` component to manage html headings (h1 / h2 / h3 / h4 / h5 / h6).
The component extends the `Text` component for styling but only accepts `HeadingElement` as `as` prop.

It also comes with a `HeadingLevelProvider` to allow the `HeadingComponent` to automatically know what level to use by default. The correct typography based on this level will also be applied.

Both the level and the typography can be overridden if needed.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
