### PR TITLE
chore(lumx-react): export utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   FlexBox: add `as` prop to customize the root element component render.
 -   GenericBlock: add `as` prop to customize the root, the figure, the content and actions elements component render.
+-   New `ClickAwayProvider` utility component (exported in the new `@lumx/react/utils` module).
 
 ## [3.0.2][] - 2022-09-23
 

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -66,6 +66,7 @@
         "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-cleaner": "^1.0.0",
         "rollup-plugin-copy": "^3.3.0",
+        "rollup-plugin-dts": "^4.2.2",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-ts-paths-resolve": "^1.3.0",
         "rollup-plugin-typescript-paths": "^1.2.2",
@@ -97,8 +98,8 @@
         "React"
     ],
     "license": "MIT",
-    "module": "esm/index.js",
-    "main": "esm/index.js",
+    "module": "index.js",
+    "main": "index.js",
     "types": "types.d.ts",
     "name": "@lumx/react",
     "publishConfig": {

--- a/packages/lumx-react/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/lumx-react/src/components/alert-dialog/AlertDialog.tsx
@@ -17,7 +17,8 @@ import {
 
 import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons/';
 import { uid } from 'uid';
-import { Comp, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 export interface AlertDialogProps extends Omit<DialogProps, 'header' | 'footer'> {
     /** Message variant. */

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 
 import { Dropdown, IconButtonProps, Offset, Placement, TextField, TextFieldProps } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
-
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 

--- a/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
+++ b/packages/lumx-react/src/components/autocomplete/AutocompleteMultiple.tsx
@@ -1,7 +1,8 @@
 import { mdiClose } from '@lumx/icons';
 import { Autocomplete, AutocompleteProps, Chip, HorizontalAlignment, Icon, Size } from '@lumx/react';
 
-import { Comp, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import classNames from 'classnames';
 import React, { forwardRef, ReactNode } from 'react';

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 import { AspectRatio, Size, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Avatar sizes.

--- a/packages/lumx-react/src/components/badge/Badge.test.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Theme } from '@lumx/react';
 import { Badge, BadgeProps } from './Badge';

--- a/packages/lumx-react/src/components/badge/Badge.tsx
+++ b/packages/lumx-react/src/components/badge/Badge.tsx
@@ -1,5 +1,6 @@
 import { Color, ColorPalette } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 import React, { forwardRef, ReactNode } from 'react';
 

--- a/packages/lumx-react/src/components/button/Button.test.tsx
+++ b/packages/lumx-react/src/components/button/Button.test.tsx
@@ -5,7 +5,7 @@ import 'jest-enzyme';
 
 import { mdiCheck, mdiChevronDown, mdiPlus } from '@lumx/icons';
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 import { Button, ButtonProps } from './Button';
 
 const DEFAULT_PROPS = Button.defaultProps as any;

--- a/packages/lumx-react/src/components/button/Button.tsx
+++ b/packages/lumx-react/src/components/button/Button.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
 import { Emphasis, Icon, Size, Theme } from '@lumx/react';
-import { Comp, getBasicClass, getRootClassName } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
+import { getBasicClass, getRootClassName } from '@lumx/react/utils/className';
 import { BaseButtonProps, ButtonRoot } from './ButtonRoot';
 
 /**

--- a/packages/lumx-react/src/components/button/ButtonGroup.tsx
+++ b/packages/lumx-react/src/components/button/ButtonGroup.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component

--- a/packages/lumx-react/src/components/button/ButtonRoot.test.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.test.tsx
@@ -12,7 +12,7 @@ import {
     ButtonRoot,
     ButtonRootProps,
 } from '@lumx/react/components/button/ButtonRoot';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 type SetupProps = Partial<ButtonRootProps>;
 

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 
 import { Color, ColorPalette, Emphasis, Size, Theme } from '@lumx/react';
 import { CSS_PREFIX } from '@lumx/react/constants';
-import { Comp, GenericProps, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { handleBasicClasses } from '@lumx/react/utils/className';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 type HTMLButtonProps = DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 
 import { Emphasis, Icon, Size, Theme, Tooltip, TooltipProps } from '@lumx/react';
 import { BaseButtonProps, ButtonRoot } from '@lumx/react/components/button/ButtonRoot';
-import { Comp, getRootClassName } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
+import { getRootClassName } from '@lumx/react/utils/className';
 
 export interface IconButtonProps extends BaseButtonProps {
     /**

--- a/packages/lumx-react/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Checkbox, CheckboxProps } from './Checkbox';
 

--- a/packages/lumx-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.tsx
@@ -6,7 +6,8 @@ import { uid } from 'uid';
 import { mdiCheck } from '@lumx/icons';
 
 import { Icon, InputHelper, InputLabel, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/chip/Chip.test.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.test.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement } from 'react';
 
 import { ColorPalette, Theme } from '@lumx/react';
 import { Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 import { Chip, ChipProps } from './Chip';
 
 const CLASSNAME = Chip.className as string;

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -1,7 +1,9 @@
 import { Color, ColorPalette, Size, Theme } from '@lumx/react';
 import { useStopPropagation } from '@lumx/react/hooks/useStopPropagation';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, onEnterPressed } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { onEnterPressed } from '@lumx/react/utils/event';
 
 import classNames from 'classnames';
 

--- a/packages/lumx-react/src/components/chip/ChipGroup.tsx
+++ b/packages/lumx-react/src/components/chip/ChipGroup.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { useChipGroupNavigation } from '@lumx/react/hooks/useChipGroupNavigation';
 

--- a/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
+++ b/packages/lumx-react/src/components/comment-block/CommentBlock.tsx
@@ -3,7 +3,8 @@ import React, { Children, forwardRef, KeyboardEvent, KeyboardEventHandler, React
 import classNames from 'classnames';
 
 import { Avatar, Size, Theme, Tooltip } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import isFunction from 'lodash/isFunction';
 import { AvatarProps } from '../avatar/Avatar';

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import React, { forwardRef, useState } from 'react';
-import { Comp } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
 import { CLASSNAME, COMPONENT_NAME } from './constants';
 import { DatePickerControlled } from './DatePickerControlled';
 import { DatePickerProps } from './types';

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { DatePickerProps, Emphasis, IconButton, Toolbar } from '@lumx/react';
 import { mdiChevronLeft, mdiChevronRight } from '@lumx/icons';
 import { getAnnotatedMonthCalendar, getWeekDays } from '@lumx/core/js/date-picker';
-import { Comp } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
 import { CLASSNAME } from './constants';
 
 /**

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import React, { forwardRef, SyntheticEvent, useCallback, useRef, useState } from 'react';
 
 import { useFocus } from '@lumx/react/hooks/useFocus';
-import { Comp, GenericProps } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/date-picker/constants.ts
+++ b/packages/lumx-react/src/components/date-picker/constants.ts
@@ -1,4 +1,4 @@
-import { getRootClassName } from '@lumx/react/utils';
+import { getRootClassName } from '@lumx/react/utils/className';
 
 /**
  * Component display name.

--- a/packages/lumx-react/src/components/date-picker/types.ts
+++ b/packages/lumx-react/src/components/date-picker/types.ts
@@ -1,5 +1,5 @@
 import { IconButtonProps } from '@lumx/react';
-import { GenericProps } from '@lumx/react/utils';
+import { GenericProps } from '@lumx/react/utils/type';
 import { Ref } from 'react';
 
 /**

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -9,14 +9,10 @@ import { DIALOG_TRANSITION_DURATION, DOCUMENT } from '@lumx/react/constants';
 import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useIntersectionObserver } from '@lumx/react/hooks/useIntersectionObserver';
-import {
-    Comp,
-    GenericProps,
-    getRootClassName,
-    handleBasicClasses,
-    isComponent,
-    partitionMulti,
-} from '@lumx/react/utils';
+
+import { Comp, GenericProps, isComponent } from '@lumx/react/utils/type';
+import { partitionMulti } from '@lumx/react/utils/partitionMulti';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 

--- a/packages/lumx-react/src/components/divider/Divider.test.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Theme } from '@lumx/react';
 import { Divider, DividerProps } from './Divider';

--- a/packages/lumx-react/src/components/divider/Divider.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.tsx
@@ -24,7 +24,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
 /**
  * Component default props.
  */
-export const DEFAULT_PROPS: Partial<DividerProps> = {
+const DEFAULT_PROPS: Partial<DividerProps> = {
     theme: Theme.light,
 };
 

--- a/packages/lumx-react/src/components/divider/Divider.tsx
+++ b/packages/lumx-react/src/components/divider/Divider.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
+++ b/packages/lumx-react/src/components/drag-handle/DragHandle.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 import { mdiDragVertical } from '@lumx/icons';
 import { ColorPalette, Icon, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -5,7 +5,8 @@ import classNames from 'classnames';
 import { List, ListProps } from '@lumx/react/components/list/List';
 import { Offset, Placement, Popover, PopoverProps } from '@lumx/react/components/popover/Popover';
 import { useInfiniteScroll } from '@lumx/react/hooks/useInfiniteScroll';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, isComponent } from '@lumx/react/utils';
+import { Comp, GenericProps, isComponent } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Theme } from '@lumx/react';
 import { ExpansionPanel, ExpansionPanelProps } from './ExpansionPanel';

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -9,16 +9,9 @@ import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
 
 import { ColorPalette, DragHandle, Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
-import {
-    Callback,
-    Comp,
-    GenericProps,
-    getRootClassName,
-    handleBasicClasses,
-    HasTheme,
-    isComponent,
-    partitionMulti,
-} from '@lumx/react/utils';
+import { Callback, Comp, GenericProps, HasTheme, isComponent } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { partitionMulti } from '@lumx/react/utils/partitionMulti';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/flag/Flag.test.tsx
+++ b/packages/lumx-react/src/components/flag/Flag.test.tsx
@@ -5,7 +5,7 @@ import React, { ReactElement } from 'react';
 import { ColorPalette, Theme } from '@lumx/react';
 import { mdiAbTesting } from '@lumx/icons';
 import { itShouldRenderStories, commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Flag, FlagProps } from './Flag';
 import * as stories from './Flag.stories';

--- a/packages/lumx-react/src/components/flag/Flag.tsx
+++ b/packages/lumx-react/src/components/flag/Flag.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { ColorPalette, Icon, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 export interface FlagProps extends GenericProps, HasTheme {
     /** Color of the component. */

--- a/packages/lumx-react/src/components/flex-box/FlexBox.tsx
+++ b/packages/lumx-react/src/components/flex-box/FlexBox.tsx
@@ -1,5 +1,6 @@
 import { Alignment, Orientation } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 import castArray from 'lodash/castArray';
 import React, { forwardRef, ReactNode } from 'react';

--- a/packages/lumx-react/src/components/generic-block/GenericBlock.tsx
+++ b/packages/lumx-react/src/components/generic-block/GenericBlock.tsx
@@ -2,7 +2,9 @@ import React, { Children, forwardRef, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 import noop from 'lodash/noop';
-import { Comp, getRootClassName, isComponentType, partitionMulti } from '@lumx/react/utils';
+import { Comp, isComponentType } from '@lumx/react/utils/type';
+import { getRootClassName } from '@lumx/react/utils/className';
+import { partitionMulti } from '@lumx/react/utils/partitionMulti';
 import { Orientation, Size, FlexBox, FlexBoxProps } from '@lumx/react';
 
 export interface GenericBlockProps extends FlexBoxProps {

--- a/packages/lumx-react/src/components/grid/Grid.tsx
+++ b/packages/lumx-react/src/components/grid/Grid.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { Alignment, Orientation, Size } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 type GridGutterSize = Extract<Size, 'regular' | 'big' | 'huge'>;
 

--- a/packages/lumx-react/src/components/grid/GridItem.tsx
+++ b/packages/lumx-react/src/components/grid/GridItem.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { Alignment } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 type Columns = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12';
 

--- a/packages/lumx-react/src/components/heading/Heading.tsx
+++ b/packages/lumx-react/src/components/heading/Heading.tsx
@@ -1,4 +1,5 @@
-import { Comp, getRootClassName, handleBasicClasses, HeadingElement } from '@lumx/react/utils';
+import { Comp, HeadingElement } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 import React, { forwardRef } from 'react';
 import { Text, TextProps } from '../text';

--- a/packages/lumx-react/src/components/heading/HeadingLevelProvider.tsx
+++ b/packages/lumx-react/src/components/heading/HeadingLevelProvider.tsx
@@ -1,4 +1,4 @@
-import { HeadingElement } from '@lumx/react/utils';
+import { HeadingElement } from '@lumx/react/utils/type';
 import React, { ReactNode } from 'react';
 import { MAX_HEADING_LEVEL } from './constants';
 import { HeadingLevelContext } from './context';

--- a/packages/lumx-react/src/components/heading/context.tsx
+++ b/packages/lumx-react/src/components/heading/context.tsx
@@ -1,4 +1,4 @@
-import { HeadingElement } from '@lumx/react/utils';
+import { HeadingElement } from '@lumx/react/utils/type';
 import { createContext } from 'react';
 
 interface HeadingLevelContext {

--- a/packages/lumx-react/src/components/icon/Icon.test.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.test.tsx
@@ -7,7 +7,7 @@ import { build, fake, oneOf } from 'test-data-bot';
 import { mdiCheck, mdiPlus } from '@lumx/icons';
 import { ColorPalette, ColorVariant, Size } from '@lumx/react';
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Icon, IconProps } from './Icon';
 

--- a/packages/lumx-react/src/components/icon/Icon.tsx
+++ b/packages/lumx-react/src/components/icon/Icon.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 import { Color, ColorPalette, ColorVariant, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mdiAlertCircle } from '@lumx/icons';
 
 export type IconSizes = Extract<Size, 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl'>;

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -6,7 +6,8 @@ import isObject from 'lodash/isObject';
 
 import { Alignment, HorizontalAlignment, Size, Theme, Thumbnail } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { ThumbnailProps } from '../thumbnail/Thumbnail';
 
 /**

--- a/packages/lumx-react/src/components/index.ts
+++ b/packages/lumx-react/src/components/index.ts
@@ -1,4 +1,4 @@
-import { ValueOf } from '@lumx/react/utils';
+import { ValueOf } from '@lumx/react/utils/type';
 
 /**
  * Alignments.

--- a/packages/lumx-react/src/components/input-helper/InputHelper.tsx
+++ b/packages/lumx-react/src/components/input-helper/InputHelper.tsx
@@ -1,5 +1,6 @@
 import { Kind, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 import React, { forwardRef, ReactNode } from 'react';
 

--- a/packages/lumx-react/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-react/src/components/input-label/InputLabel.tsx
@@ -1,5 +1,6 @@
 import { Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 import React, { forwardRef, ReactNode } from 'react';
 

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -6,7 +6,8 @@ import { createPortal } from 'react-dom';
 import { mdiClose } from '@lumx/icons';
 import { ColorPalette, Emphasis, IconButton, IconButtonProps } from '@lumx/react';
 import { DOCUMENT } from '@lumx/react/constants';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.test.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 import { Link, Thumbnail } from '@lumx/react';
 
 import { Size, Theme } from '..';

--- a/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
+++ b/packages/lumx-react/src/components/link-preview/LinkPreview.tsx
@@ -14,7 +14,8 @@ import {
     ThumbnailProps,
 } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HeadingElement, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HeadingElement, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -5,7 +5,8 @@ import isEmpty from 'lodash/isEmpty';
 import classNames from 'classnames';
 
 import { Color, ColorVariant, Icon, Size, Typography } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 type HTMLAnchorProps = React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;

--- a/packages/lumx-react/src/components/list/List.tsx
+++ b/packages/lumx-react/src/components/list/List.tsx
@@ -1,7 +1,8 @@
 import { Size } from '@lumx/react';
 
 import { useKeyboardListNavigation } from '@lumx/react/hooks/useKeyboardListNavigation';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import classNames from 'classnames';

--- a/packages/lumx-react/src/components/list/ListDivider.tsx
+++ b/packages/lumx-react/src/components/list/ListDivider.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/list/ListItem.tsx
+++ b/packages/lumx-react/src/components/list/ListItem.tsx
@@ -4,14 +4,9 @@ import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
 import { ListProps, Size } from '@lumx/react';
-import {
-    Comp,
-    GenericProps,
-    getRootClassName,
-    handleBasicClasses,
-    onEnterPressed,
-    onButtonPressed,
-} from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { onEnterPressed, onButtonPressed } from '@lumx/react/utils/event';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 export type ListItemSize = Extract<Size, 'tiny' | 'regular' | 'big' | 'huge'>;

--- a/packages/lumx-react/src/components/list/ListSubheader.tsx
+++ b/packages/lumx-react/src/components/list/ListSubheader.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/list/useInteractiveList.tsx
+++ b/packages/lumx-react/src/components/list/useInteractiveList.tsx
@@ -1,7 +1,7 @@
 import { ListItemProps } from '@lumx/react';
 import { isClickable } from '@lumx/react/components/list/ListItem';
 
-import { isComponent } from '@lumx/react/utils';
+import { isComponent } from '@lumx/react/utils/type';
 import { flattenChildren } from '@lumx/react/utils/flattenChildren';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import get from 'lodash/get';

--- a/packages/lumx-react/src/components/message/Message.test.tsx
+++ b/packages/lumx-react/src/components/message/Message.test.tsx
@@ -1,6 +1,6 @@
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
 import { Kind } from '@lumx/react';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 import React, { ReactElement } from 'react';

--- a/packages/lumx-react/src/components/message/Message.tsx
+++ b/packages/lumx-react/src/components/message/Message.tsx
@@ -1,6 +1,7 @@
 import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons';
 import { ColorPalette, Icon, Kind, Size } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 import React, { forwardRef, ReactNode } from 'react';
 

--- a/packages/lumx-react/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-react/src/components/mosaic/Mosaic.tsx
@@ -1,7 +1,8 @@
 import React, { forwardRef, MouseEventHandler, useMemo } from 'react';
 
 import { Alignment, AspectRatio, Theme, Thumbnail, ThumbnailProps } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 import take from 'lodash/take';
 

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -9,7 +9,8 @@ import { Button, Emphasis, Icon, Kind, Size, Theme } from '@lumx/react';
 
 import { DOCUMENT, NOTIFICATION_TRANSITION_DURATION } from '@lumx/react/constants';
 import { NOTIFICATION_CONFIGURATION } from '@lumx/react/components/notification/constants';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { useDelayedVisibility } from '@lumx/react/hooks/useDelayedVisibility';
 

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -10,7 +10,8 @@ import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, ValueOf } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { useFocusWithin } from '@lumx/react/hooks/useFocusWithin';
 import { getFirstAndLastFocusable } from '@lumx/react/utils/focus/getFirstAndLastFocusable';

--- a/packages/lumx-react/src/components/post-block/PostBlock.tsx
+++ b/packages/lumx-react/src/components/post-block/PostBlock.tsx
@@ -6,7 +6,8 @@ import isObject from 'lodash/isObject';
 
 import { Orientation, Theme, Thumbnail, ThumbnailProps, ThumbnailVariant } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTracker.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { useRovingTabIndex } from '../../hooks/useRovingTabIndex';
 import { useTabProviderContextState } from '../tabs/state';

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.test.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.test.tsx
@@ -1,5 +1,5 @@
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStep.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 import { Icon, InputHelper, InputLabel, Kind, Size } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { mdiAlertCircle, mdiCheckCircle, mdiRadioboxBlank, mdiRadioboxMarked } from '@lumx/icons';
 import { useTabProviderContext } from '../tabs/state';

--- a/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStepPanel.tsx
+++ b/packages/lumx-react/src/components/progress-tracker/ProgressTrackerStepPanel.tsx
@@ -1,6 +1,7 @@
 import { useTabProviderContext } from '@lumx/react/components/tabs/state';
 import { CSS_PREFIX } from '@lumx/react/constants';
-import { Comp, GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { handleBasicClasses } from '@lumx/react/utils/className';
 
 import classNames from 'classnames';
 import React, { forwardRef } from 'react';

--- a/packages/lumx-react/src/components/progress/Progress.tsx
+++ b/packages/lumx-react/src/components/progress/Progress.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 import { Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Progress variants.

--- a/packages/lumx-react/src/components/radio-button/RadioButton.test.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Theme } from '@lumx/react';
 import { RadioButton, RadioButtonProps } from './RadioButton';

--- a/packages/lumx-react/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.tsx
@@ -5,7 +5,8 @@ import { uid } from 'uid';
 
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/radio-button/RadioGroup.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioGroup.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/select/Select.test.tsx
+++ b/packages/lumx-react/src/components/select/Select.test.tsx
@@ -8,7 +8,7 @@ import { Chip } from '@lumx/react/components/chip/Chip';
 import { Icon } from '@lumx/react/components/icon/Icon';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { mdiCloseCircle, mdiMenuDown } from '@lumx/icons';
 import { Dropdown } from '@lumx/react/components/dropdown/Dropdown';

--- a/packages/lumx-react/src/components/select/Select.tsx
+++ b/packages/lumx-react/src/components/select/Select.tsx
@@ -11,7 +11,8 @@ import { Chip } from '@lumx/react/components/chip/Chip';
 import { Icon } from '@lumx/react/components/icon/Icon';
 import { InputLabel } from '@lumx/react/components/input-label/InputLabel';
 
-import { Comp, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { WithSelectContext } from './WithSelectContext';
 import { CoreSelectProps, SelectVariant } from './constants';

--- a/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
@@ -10,7 +10,7 @@ import { Dropdown } from '@lumx/react/components/dropdown/Dropdown';
 import { Icon } from '@lumx/react/components/icon/Icon';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 import { SelectMultiple, SelectMultipleProps } from './SelectMultiple';
 import { DEFAULT_PROPS } from './WithSelectContext';
 import { SelectVariant } from './constants';

--- a/packages/lumx-react/src/components/select/SelectMultiple.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.tsx
@@ -9,7 +9,8 @@ import { Chip } from '@lumx/react/components/chip/Chip';
 import { Icon } from '@lumx/react/components/icon/Icon';
 import { InputLabel } from '@lumx/react/components/input-label/InputLabel';
 
-import { Comp, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { WithSelectContext } from './WithSelectContext';
 import { CoreSelectProps, SelectVariant } from './constants';

--- a/packages/lumx-react/src/components/select/WithSelectContext.tsx
+++ b/packages/lumx-react/src/components/select/WithSelectContext.tsx
@@ -8,7 +8,7 @@ import { Dropdown } from '@lumx/react/components/dropdown/Dropdown';
 import { InputHelper } from '@lumx/react/components/input-helper/InputHelper';
 import { Placement } from '@lumx/react/components/popover/Popover';
 
-import { getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { useListenFocus } from '@lumx/react/hooks/useListenFocus';
 import { CoreSelectProps, SelectVariant } from './constants';

--- a/packages/lumx-react/src/components/select/constants.ts
+++ b/packages/lumx-react/src/components/select/constants.ts
@@ -1,5 +1,5 @@
 import { IconButtonProps } from '@lumx/react';
-import { GenericProps, HasTheme, ValueOf } from '@lumx/react/utils';
+import { GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
 import { ReactNode, SyntheticEvent } from 'react';
 
 /**

--- a/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigation.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 import { SideNavigationItem, Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, isComponent } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme, isComponent } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
@@ -5,7 +5,7 @@ import 'jest-enzyme';
 import without from 'lodash/without';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { mdiAccount } from '@lumx/icons';
 

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -7,15 +7,9 @@ import { mdiChevronDown, mdiChevronUp } from '@lumx/icons';
 
 import { Emphasis, Icon, Size, IconButton, IconButtonProps } from '@lumx/react';
 
-import {
-    Callback,
-    Comp,
-    GenericProps,
-    getRootClassName,
-    handleBasicClasses,
-    isComponent,
-    onEnterPressed,
-} from '@lumx/react/utils';
+import { Callback, Comp, GenericProps, isComponent } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { onEnterPressed } from '@lumx/react/utils/event';
 import { renderLink } from '@lumx/react/utils/renderLink';
 
 /**

--- a/packages/lumx-react/src/components/skeleton/SkeletonCircle.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonCircle.tsx
@@ -2,7 +2,8 @@ import classNames from 'classnames';
 import React, { forwardRef } from 'react';
 
 import { GlobalSize, Theme, ColorPalette } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonRectangle.tsx
@@ -2,7 +2,8 @@ import classNames from 'classnames';
 import React, { forwardRef } from 'react';
 
 import { AspectRatio, GlobalSize, Theme, ColorPalette } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Skeleton variants.

--- a/packages/lumx-react/src/components/skeleton/SkeletonTypography.tsx
+++ b/packages/lumx-react/src/components/skeleton/SkeletonTypography.tsx
@@ -2,7 +2,8 @@ import classNames from 'classnames';
 import React, { CSSProperties, forwardRef } from 'react';
 
 import { Theme, TypographyInterface, ColorPalette } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/slider/Slider.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.tsx
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import useEventCallback from '@lumx/react/hooks/useEventCallback';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { uid } from 'uid';
 import { clamp } from '@lumx/react/utils/clamp';

--- a/packages/lumx-react/src/components/slideshow/Slides.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slides.tsx
@@ -4,7 +4,8 @@ import chunk from 'lodash/chunk';
 import classNames from 'classnames';
 
 import { FULL_WIDTH_PERCENT } from '@lumx/react/components/slideshow/constants';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { buildSlideShowGroupId, SlideshowItemGroup } from './SlideshowItemGroup';
 
 export interface SlidesProps extends GenericProps, HasTheme {

--- a/packages/lumx-react/src/components/slideshow/Slideshow.tsx
+++ b/packages/lumx-react/src/components/slideshow/Slideshow.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 
 import { SlideshowControls, SlideshowControlsProps, Theme, Slides, SlidesProps } from '@lumx/react';
 import { DEFAULT_OPTIONS } from '@lumx/react/hooks/useSlideshowControls';
-import { Comp, GenericProps } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
 import { useFocusWithin } from '@lumx/react/hooks/useFocusWithin';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { buildSlideShowGroupId } from './SlideshowItemGroup';

--- a/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowControls.tsx
@@ -5,7 +5,8 @@ import range from 'lodash/range';
 
 import { mdiChevronLeft, mdiChevronRight, mdiPlayCircleOutline, mdiPauseCircleOutline } from '@lumx/icons';
 import { Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { WINDOW } from '@lumx/react/constants';
 import { useSlideshowControls, DEFAULT_OPTIONS } from '@lumx/react/hooks/useSlideshowControls';
 import { useRovingTabIndex } from '@lumx/react/hooks/useRovingTabIndex';

--- a/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItem.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/slideshow/SlideshowItemGroup.tsx
+++ b/packages/lumx-react/src/components/slideshow/SlideshowItemGroup.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { useSlideFocusManagement } from './useSlideFocusManagement';
 
 /**

--- a/packages/lumx-react/src/components/switch/Switch.test.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.test.tsx
@@ -7,7 +7,7 @@ import { build, oneOf } from 'test-data-bot';
 import without from 'lodash/without';
 
 import { Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Theme, Alignment } from '@lumx/react';
 import { Switch, SwitchProps } from './Switch';

--- a/packages/lumx-react/src/components/switch/Switch.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.tsx
@@ -7,7 +7,8 @@ import isEmpty from 'lodash/isEmpty';
 
 import { Alignment, InputHelper, InputLabel, Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/table/Table.tsx
+++ b/packages/lumx-react/src/components/table/Table.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 
 import { Theme } from '@lumx/react';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/table/TableBody.tsx
+++ b/packages/lumx-react/src/components/table/TableBody.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/table/TableCell.tsx
+++ b/packages/lumx-react/src/components/table/TableCell.tsx
@@ -3,7 +3,9 @@ import React, { forwardRef, useCallback } from 'react';
 import classNames from 'classnames';
 
 import { Icon, Size } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, onEnterPressed, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, ValueOf } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { onEnterPressed } from '@lumx/react/utils/event';
 
 import { mdiArrowDown, mdiArrowUp } from '@lumx/icons';
 

--- a/packages/lumx-react/src/components/table/TableHeader.tsx
+++ b/packages/lumx-react/src/components/table/TableHeader.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/table/TableRow.tsx
+++ b/packages/lumx-react/src/components/table/TableRow.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/tabs/Tab.test.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.test.tsx
@@ -1,6 +1,6 @@
 import { mdiCheck } from '@lumx/icons';
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';

--- a/packages/lumx-react/src/components/tabs/Tab.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.tsx
@@ -1,6 +1,7 @@
 import { Icon, IconProps, Size } from '@lumx/react';
 import { CSS_PREFIX } from '@lumx/react/constants';
-import { Comp, GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { handleBasicClasses } from '@lumx/react/utils/className';
 
 import classNames from 'classnames';
 import React, { FocusEventHandler, forwardRef, KeyboardEventHandler, ReactNode, useCallback } from 'react';

--- a/packages/lumx-react/src/components/tabs/TabList.test.tsx
+++ b/packages/lumx-react/src/components/tabs/TabList.test.tsx
@@ -1,7 +1,7 @@
 import { Tab, Alignment } from '@lumx/react';
 
 import { Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';

--- a/packages/lumx-react/src/components/tabs/TabList.tsx
+++ b/packages/lumx-react/src/components/tabs/TabList.tsx
@@ -1,6 +1,7 @@
 import { Alignment, Theme } from '@lumx/react';
 import { CSS_PREFIX } from '@lumx/react/constants';
-import { Comp, GenericProps, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import classNames from 'classnames';

--- a/packages/lumx-react/src/components/tabs/TabPanel.tsx
+++ b/packages/lumx-react/src/components/tabs/TabPanel.tsx
@@ -1,6 +1,7 @@
 import { useTabProviderContext } from '@lumx/react/components/tabs/state';
 import { CSS_PREFIX } from '@lumx/react/constants';
-import { Comp, GenericProps, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { handleBasicClasses } from '@lumx/react/utils/className';
 
 import classNames from 'classnames';
 import React, { forwardRef } from 'react';

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -5,7 +5,7 @@ import 'jest-enzyme';
 import { build } from 'test-data-bot';
 
 import { Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Kind } from '@lumx/react';
 import { TextField, TextFieldProps } from './TextField';

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -6,7 +6,8 @@ import { uid } from 'uid';
 
 import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from '@lumx/icons';
 import { Emphasis, Icon, IconButton, IconButtonProps, InputHelper, InputLabel, Kind, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 /**

--- a/packages/lumx-react/src/components/text/Text.tsx
+++ b/packages/lumx-react/src/components/text/Text.tsx
@@ -1,7 +1,8 @@
 import React, { forwardRef } from 'react';
 
 import { Color, ColorVariant, Typography } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HeadingElement } from '@lumx/react/utils';
+import { Comp, GenericProps, HeadingElement } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 
 type TextComponents = 'span' | 'p' | HeadingElement;

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -13,7 +13,8 @@ import classNames from 'classnames';
 
 import { AspectRatio, HorizontalAlignment, Icon, Size, Theme } from '@lumx/react';
 
-import { Comp, Falsy, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, Falsy, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { mdiImageBroken } from '@lumx/icons';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';

--- a/packages/lumx-react/src/components/thumbnail/types.ts
+++ b/packages/lumx-react/src/components/thumbnail/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AspectRatio, Size } from '@lumx/react';
-import { ValueOf } from '@lumx/react/utils';
+import { ValueOf } from '@lumx/react/utils/type';
 
 /**
  *  Focal point using vertical alignment, horizontal alignment or coordinates (from -1 to 1).

--- a/packages/lumx-react/src/components/toolbar/Toolbar.tsx
+++ b/packages/lumx-react/src/components/toolbar/Toolbar.tsx
@@ -2,7 +2,8 @@ import React, { forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -10,7 +10,8 @@ import { Placement } from '@lumx/react/components/popover/Popover';
 
 import { DOCUMENT } from '@lumx/react/constants';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 import { useInjectTooltipRef } from './useInjectTooltipRef';

--- a/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
+++ b/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
@@ -1,4 +1,4 @@
-import { onEscapePressed } from '@lumx/react/utils';
+import { onEscapePressed } from '@lumx/react/utils/event';
 import { useEffect, useState } from 'react';
 import { browserDoesNotSupportHover } from '@lumx/react/utils/browserDoesNotSupportHover';
 import { TOOLTIP_HOVER_DELAY, TOOLTIP_LONG_PRESS_DELAY } from '@lumx/react/constants';

--- a/packages/lumx-react/src/components/uploader/Uploader.test.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.test.tsx
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite, Wrapper } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { Uploader, UploaderProps } from './Uploader';
 

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -3,7 +3,8 @@ import React, { forwardRef, MouseEventHandler } from 'react';
 import classNames from 'classnames';
 
 import { AspectRatio, Icon, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme, ValueOf } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Uploader variants.

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 import set from 'lodash/set';
 
 import { Avatar, ColorPalette, Link, Orientation, Size, Theme } from '@lumx/react';
-import { Comp, GenericProps, getRootClassName, handleBasicClasses, HasTheme } from '@lumx/react/utils';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 import { AvatarProps } from '../avatar/Avatar';
 

--- a/packages/lumx-react/src/hooks/useCallbackOnEscape.ts
+++ b/packages/lumx-react/src/hooks/useCallbackOnEscape.ts
@@ -1,5 +1,6 @@
 import { DOCUMENT } from '@lumx/react/constants';
-import { Callback, onEscapePressed } from '@lumx/react/utils';
+import { Callback } from '@lumx/react/utils/type';
+import { onEscapePressed } from '@lumx/react/utils/event';
 import { useEffect } from 'react';
 import { Listener, makeListenerTowerContext } from '@lumx/react/utils/makeListenerTowerContext';
 

--- a/packages/lumx-react/src/hooks/useClickAway.tsx
+++ b/packages/lumx-react/src/hooks/useClickAway.tsx
@@ -1,6 +1,6 @@
 import { RefObject, useEffect } from 'react';
 
-import { Falsy } from '@lumx/react/utils';
+import { Falsy } from '@lumx/react/utils/type';
 
 import isEmpty from 'lodash/isEmpty';
 

--- a/packages/lumx-react/src/hooks/useDisableBodyScroll.ts
+++ b/packages/lumx-react/src/hooks/useDisableBodyScroll.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
-import { Falsy } from '@lumx/react/utils';
+import { Falsy } from '@lumx/react/utils/type';
 
 /**
  * Disables the scroll on the body to make it only usable in the current modal element.

--- a/packages/lumx-react/src/hooks/useFocusTrap.ts
+++ b/packages/lumx-react/src/hooks/useFocusTrap.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { DOCUMENT } from '@lumx/react/constants';
 import { getFirstAndLastFocusable } from '@lumx/react/utils/focus/getFirstAndLastFocusable';
-import { Falsy } from '@lumx/react/utils';
+import { Falsy } from '@lumx/react/utils/type';
 import { Listener, makeListenerTowerContext } from '@lumx/react/utils/makeListenerTowerContext';
 
 const FOCUS_TRAPS = makeListenerTowerContext();

--- a/packages/lumx-react/src/hooks/useInterval.tsx
+++ b/packages/lumx-react/src/hooks/useInterval.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import isFunction from 'lodash/isFunction';
-import { Callback } from '../utils';
+import { Callback } from '@lumx/react/utils/type';
 
 /**
  * Making setInterval Declarative with React Hooks.

--- a/packages/lumx-react/src/hooks/useOnResize.ts
+++ b/packages/lumx-react/src/hooks/useOnResize.ts
@@ -1,4 +1,4 @@
-import { Callback, Falsy } from '@lumx/react/utils';
+import { Callback, Falsy } from '@lumx/react/utils/type';
 import { MutableRefObject, RefObject, useEffect, useRef } from 'react';
 import { WINDOW } from '@lumx/react/constants';
 import { ResizeObserver as Polyfill } from '@juggle/resize-observer';

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Components listed here will be exposed to NPM in '@lumx/react'.
+ */
+
 export * from './components';
 export * from './components/alert-dialog';
 export * from './components/autocomplete';

--- a/packages/lumx-react/src/testing/utils/commonTestsSuite.ts
+++ b/packages/lumx-react/src/testing/utils/commonTestsSuite.ts
@@ -4,7 +4,7 @@ import 'jest-enzyme';
 import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
 
-import { GenericProps } from '@lumx/react/utils';
+import { GenericProps } from '@lumx/react/utils/type';
 
 export type Wrapper = ShallowWrapper | ReactWrapper;
 

--- a/packages/lumx-react/src/utils/className.ts
+++ b/packages/lumx-react/src/utils/className.ts
@@ -5,6 +5,8 @@ import kebabCase from 'lodash/kebabCase';
 // See https://regex101.com/r/YjS1uI/3
 const LAST_PART_CLASSNAME = /^(.*)-(.+)$/gi;
 
+export { getBasicClass, handleBasicClasses } from '@lumx/core/js/utils';
+
 /**
  * Get the name of the root CSS class of a component based on its name.
  *

--- a/packages/lumx-react/src/utils/event.ts
+++ b/packages/lumx-react/src/utils/event.ts
@@ -1,0 +1,1 @@
+export { onEnterPressed, onButtonPressed, onEscapePressed } from '@lumx/core/js/utils';

--- a/packages/lumx-react/src/utils/index.ts
+++ b/packages/lumx-react/src/utils/index.ts
@@ -1,0 +1,5 @@
+/**
+ * WARNING: All modules exported here are exposed to NPM in '@lumx/react/utils'.
+ */
+
+export * from './ClickAwayProvider';

--- a/packages/lumx-react/src/utils/index.tsx
+++ b/packages/lumx-react/src/utils/index.tsx
@@ -1,7 +1,5 @@
-export * from '@lumx/core/js/utils';
+/**
+ * WARNING: All modules exported here are exposed to NPM in @lumx/react/utils.
+ */
 
-export * from './getRootClassName';
-
-export * from './partitionMulti';
-
-export * from './type';
+export * from './ClickAwayProvider';

--- a/packages/lumx-react/src/utils/index.tsx
+++ b/packages/lumx-react/src/utils/index.tsx
@@ -1,5 +1,0 @@
-/**
- * WARNING: All modules exported here are exposed to NPM in @lumx/react/utils.
- */
-
-export * from './ClickAwayProvider';

--- a/packages/lumx-react/src/utils/utils.test.ts
+++ b/packages/lumx-react/src/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import partition from 'lodash/partition';
-import { partitionMulti } from '.';
+import { partitionMulti } from './partitionMulti';
 import { isInternetExplorer } from './isInternetExplorer';
 
 describe(`partitionMulti`, () => {

--- a/packages/site-demo/content/product/utilities/miscellaneous/index.mdx
+++ b/packages/site-demo/content/product/utilities/miscellaneous/index.mdx
@@ -1,0 +1,24 @@
+import { Message } from '@lumx/react';
+
+# Miscellaneous utilities
+
+The `@lumx/react/utils` module contains utilities like React hooks, functions and component that provide re-usable logic.
+
+## ClickAwayProvider
+
+A React context provider that build a tree (both DOM and React) of elements that are considered "within" the context even if children are rendered as in a React portal. User clicks outside this context will trigger to provided `callback`.
+
+```tsx
+<ClickAwayProvider callback={close} childrenRefs={useRef([cardRef])}>
+    <article ref={cardRef}>
+        <p>Click outside this card to close it.</p>
+        <Dropdown>...</Dropdown>
+    </article>
+</ClickAwayProvider>
+```
+
+<Message kind="info">
+    In this example, clicking outside the card (referenced by <code>cardRef</code>) will trigger the <code>close</code> callback. Clicks in children DOM nodes of the card or children of nested "click away" contexts (here the dropdown) are all considered as "in" the the context and won't trigger the callback.
+</Message>
+
+This is used to provide correct "click away" behavior on nested `Dialog` or `Dropdown` even though they are not nested in the DOM tree.

--- a/packages/site-demo/src/components/content/CodeBlock/CodeBlock.scss
+++ b/packages/site-demo/src/components/content/CodeBlock/CodeBlock.scss
@@ -1,5 +1,5 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "~@lumx/core/src/scss/design-tokens";
+@import "~@lumx/core/src/scss/core";
 
 /* ==========================================================================
    Code block
@@ -8,8 +8,10 @@
 .code-block {
     display: block;
     padding: $lumx-spacing-unit * 2;
-    background-color: transparent;
-    color: #333;
-    font-size: 14px;
     overflow-x: auto;
+    font-size: 14px;
+    color: #333;
+    background-color: transparent;
+    border: 1px solid $lumx-color-dark-L4;
+    border-radius: var(--lumx-border-radius);
 }

--- a/packages/site-demo/src/components/content/DemoBlock/DemoBlock.scss
+++ b/packages/site-demo/src/components/content/DemoBlock/DemoBlock.scss
@@ -1,5 +1,5 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "~@lumx/core/src/scss/design-tokens";
+@import "~@lumx/core/src/scss/core";
 
 /* ==========================================================================
    Demo block
@@ -7,12 +7,13 @@
 
 .demo-block {
     $self: &;
+
     border: 1px solid $lumx-color-dark-L4;
     border-radius: var(--lumx-border-radius);
 
     &__content {
-        overflow: auto;
         padding: $lumx-spacing-unit * 3;
+        overflow: auto;
 
         #{$self}--has-play-button & {
             display: flex;
@@ -37,7 +38,9 @@
     }
 
     &__code {
+        border: none;
         border-top: 1px solid $lumx-color-dark-L4;
+        border-radius: 0;
     }
 
     &__filename {

--- a/packages/site-demo/src/components/layout/MainContent/MainContent.scss
+++ b/packages/site-demo/src/components/layout/MainContent/MainContent.scss
@@ -1,6 +1,6 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
-@import '~@lumx/core/src/scss/components/link/mixins';
+@import "~@lumx/core/src/scss/design-tokens";
+@import "~@lumx/core/src/scss/core";
+@import "~@lumx/core/src/scss/components/link/mixins";
 
 /* Main content
    ========================================================================== */
@@ -8,9 +8,9 @@
 .main-content {
     &__loading {
         display: flex;
-        width: 100%;
         flex-direction: column;
         align-items: center;
+        width: 100%;
     }
 
     &__wrapper {
@@ -40,17 +40,17 @@
         }
 
         & p a {
-            @include lumx-link('primary');
+            @include lumx-link("primary");
         }
 
         /* stylelint-disable-next-line selector-type-no-unknown */
         code {
             padding: 0 $lumx-spacing-unit-tiny;
-            background-color: $lumx-color-dark-L5;
-            color: $lumx-color-dark-N;
             font-family: monospace;
             font-size: 14px;
             font-weight: 700;
+            color: $lumx-color-dark-N;
+            background-color: $lumx-color-dark-L5;
         }
 
         & > ul {
@@ -70,16 +70,18 @@
         & > p,
         & > ul,
         & > div,
+        & > pre,
         & > img,
         & > table {
             margin-bottom: $lumx-spacing-unit * 2;
+
             &:last-child {
                 margin-bottom: 0;
             }
         }
 
         & > table tr,
-        & > div > table tr{
+        & > div > table tr {
             border: solid 1px $lumx-color-dark-L5;
 
             & th,

--- a/packages/site-demo/src/wrapRootElement.tsx
+++ b/packages/site-demo/src/wrapRootElement.tsx
@@ -16,7 +16,7 @@ const mdxComponents = {
         const { children } = props;
         const codeProps = children?.props?.mdxType === 'code' && children?.props;
         if (codeProps) {
-            return <CodeBlock {...codeProps} />;
+            return <CodeBlock {...codeProps}>{codeProps.children?.trim()}</CodeBlock>;
         }
         return <pre {...props} />;
     },

--- a/packages/yo-generators/generators/component/templates/FunctionalComponent.tsx.ejs
+++ b/packages/yo-generators/generators/component/templates/FunctionalComponent.tsx.ejs
@@ -2,7 +2,8 @@ import React, { ReactElement } from 'react';
 
 import classNames from 'classnames';
 
-import { Comp, GenericProps, getRootClassName, handleBasicClasses } from '@lumx/react/utils';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
 /**
  * Defines the props of the component.

--- a/packages/yo-generators/generators/tests/templates/Component.test.tsx.ejs
+++ b/packages/yo-generators/generators/tests/templates/Component.test.tsx.ejs
@@ -4,7 +4,7 @@ import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { Wrapper, commonTestsSuite } from '@lumx/react/testing/utils';
-import { getBasicClass } from '@lumx/react/utils';
+import { getBasicClass } from '@lumx/react/utils/className';
 
 import { <%= componentName %>, <%= componentName %>Props } from './<%= componentName %>';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,6 +79,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.16.7":
+  version: 7.18.6
+  resolution: "@babel/code-frame@npm:7.18.6"
+  dependencies:
+    "@babel/highlight": ^7.18.6
+  checksum: 195e2be3172d7684bf95cff69ae3b7a15a9841ea9d27d3c843662d50cdd7d6470fd9c8e64be84d031117e4a4083486effba39f9aef6bbb2c89f7f21bcfba33ba
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/code-frame@npm:7.8.3"
@@ -1008,6 +1017,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.18.6":
+  version: 7.19.1
+  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
+  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.12.1":
   version: 7.12.1
   resolution: "@babel/helper-validator-option@npm:7.12.1"
@@ -1113,6 +1129,17 @@ __metadata:
     chalk: ^2.0.0
     js-tokens: ^4.0.0
   checksum: abf244c48fcff20ec87830e8b99c776f4dcdd9138e63decc195719a94148da35339639e0d8045eb9d1f3e67a39ab90a9c3f5ce2d579fb1a0368d911ddf29b4e5
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/highlight@npm:7.18.6"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.18.6
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
   languageName: node
   linkType: hard
 
@@ -4946,6 +4973,7 @@ __metadata:
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-cleaner: ^1.0.0
     rollup-plugin-copy: ^3.3.0
+    rollup-plugin-dts: ^4.2.2
     rollup-plugin-peer-deps-external: ^2.2.4
     rollup-plugin-ts-paths-resolve: ^1.3.0
     rollup-plugin-typescript-paths: ^1.2.2
@@ -20559,6 +20587,15 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.26.1":
+  version: 0.26.6
+  resolution: "magic-string@npm:0.26.6"
+  dependencies:
+    sourcemap-codec: ^1.4.8
+  checksum: 0147380c7a21af9dc661fb5282f0bb06854da6ababdc58a669ec0054093cd1afcfb454a0603495587b5f308bad9efcaceeb17b60887df87c51d692ec01ce4a8a
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^1.0.0":
   version: 1.3.0
   resolution: "make-dir@npm:1.3.0"
@@ -26572,6 +26609,22 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"rollup-plugin-dts@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "rollup-plugin-dts@npm:4.2.2"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    magic-string: ^0.26.1
+  peerDependencies:
+    rollup: ^2.55
+    typescript: ^4.1
+  dependenciesMeta:
+    "@babel/code-frame":
+      optional: true
+  checksum: cf4b45f6cca442a5f44af0f0fb567c8fc540ecb792c763571d1bcda9bf495803bcc8d4eaef451a2dd32f7f391eb822e2b96cc6b86b096db54a4d3935236fd8da
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-peer-deps-external@npm:^2.2.4":
   version: 2.2.4
   resolution: "rollup-plugin-peer-deps-external@npm:2.2.4"
@@ -27734,7 +27787,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"sourcemap-codec@npm:^1.4.4":
+"sourcemap-codec@npm:^1.4.4, sourcemap-codec@npm:^1.4.8":
   version: 1.4.8
   resolution: "sourcemap-codec@npm:1.4.8"
   checksum: b57981c05611afef31605732b598ccf65124a9fcb03b833532659ac4d29ac0f7bfacbc0d6c5a28a03e84c7510e7e556d758d0bb57786e214660016fb94279316


### PR DESCRIPTION
# General summary

- refactor(utils): split utils
  => reserve `@lumx/react/utils` for elements we want to expose to NPM
  => internal utils are moved in separate modules (ex: `@lumx/utils/className`, `@lumx/utils/event`, etc.)
- chore(lumx-react): rework exported modules
  => simplify rollup build
  => export `@lumx/react/utils` to NPM (contains only the ClickAwayProvider for now)
- docs(utils): document miscellaneous utils

<details><summary>Utils doc page screenshot:</summary> 

![doc](https://user-images.githubusercontent.com/939567/195198492-633aec61-e76a-4e97-bc5e-4983cd22aae6.png)

</details>
