### PR TITLE
chore(storybook): improve stories `today` param handling

### DIFF
--- a/packages/lumx-react/src/stories/generated/Heading/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/Heading/Demos.stories.tsx
@@ -1,0 +1,6 @@
+/**
+ * File generated when storybook is started. Do not edit directly!
+ */
+export default { title: 'LumX components/heading/Heading Demos' };
+
+export { App as AutomaticHeadingLevel } from './automatic-heading-level';

--- a/packages/lumx-react/src/stories/generated/Heading/automatic-heading-level.tsx
+++ b/packages/lumx-react/src/stories/generated/Heading/automatic-heading-level.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/heading/react/automatic-heading-level.tsx

--- a/packages/lumx-react/storybook/story-block/StoryBlock.tsx
+++ b/packages/lumx-react/storybook/story-block/StoryBlock.tsx
@@ -23,8 +23,8 @@ export const StoryBlock: React.FC<StoryBlockProps> = (props) => {
     context.args.theme = theme;
     const toggleTheme = () => setTheme(theme === Theme.light ? Theme.dark : Theme.light);
 
-    // Hard code today date for chromatic.
-    context.args.today = isChromatic() ? new Date('May 25 2021 01:00') : new Date();
+    // Hard code today date for stable chromatic stories snapshots.
+    context.parameters.today = isChromatic() ? new Date('May 25 2021 01:00') : new Date();
 
     if (isChromatic()) return <Story />;
 

--- a/packages/site-demo/content/product/components/date-picker/react/default.tsx
+++ b/packages/site-demo/content/product/components/date-picker/react/default.tsx
@@ -1,7 +1,8 @@
 import { DatePicker } from '@lumx/react';
 import React, { useState } from 'react';
 
-export const App = ({ today = new Date() }: any) => {
+export const App = (_: any, context: any) => {
+    const today = context?.parameters?.today || new Date();
     const [datePicked, setDatePicked] = useState<Date | undefined>(new Date(today));
 
     return (

--- a/packages/site-demo/content/product/components/date-picker/react/input.tsx
+++ b/packages/site-demo/content/product/components/date-picker/react/input.tsx
@@ -2,8 +2,9 @@ import { mdiCalendar } from '@lumx/icons';
 import { DatePickerField } from '@lumx/react';
 import React, { useState } from 'react';
 
-export const App = ({ today = new Date() }: any) => {
-    const [datePicked, setDatePicked] = useState<Date | undefined>(new Date(today));
+export const App = (_: any, context: any) => {
+    const today = context?.parameters?.today || new Date();
+    const [datePicked, setDatePicked] = useState<Date | undefined>(today);
 
     return (
         <DatePickerField

--- a/packages/site-demo/content/product/components/date-picker/react/restricted.tsx
+++ b/packages/site-demo/content/product/components/date-picker/react/restricted.tsx
@@ -1,7 +1,8 @@
 import { DatePicker } from '@lumx/react';
 import React, { useState } from 'react';
 
-export const App = ({ today = new Date() }: any) => {
+export const App = (_: any, context: any) => {
+    const today = context?.parameters?.today || new Date();
     const maxDate = new Date(today);
     const minDate = new Date(today);
     minDate.setDate(minDate.getDate() - 1);


### PR DESCRIPTION
# General summary

When snapshoting stories in chromatic we need to inject the `today` Date so that it's always the same.

Previously this was injected in stories args but it can cause problems for stories that just sread the `args` as props. 

To improve the situation, the `today` value will be injected in the storybook `context.parameters`.

**Non regression tests**
- Check date picker [SB stories show the same default date as before](https://5fbfb1d508c0520021560f10-apdillnpmd.chromatic.com/?path=/story/lumx-components-date-picker-datepickerfield--simple)
- Check date picker demos (on the demo site) show the same default date as before
- Check chromatic snapshots still show the same date

