### PR TITLE
feat(inline-list): create InlineList component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   FlexBox: add `as` prop to customize the root element component render.
 -   GenericBlock: add `as` prop to customize the root, the figure, the content and actions elements component render.
 -   New `ClickAwayProvider` utility component (exported in the new `@lumx/react/utils` module).
+-   New `InlineList` component.
 
 ### Changed
 

--- a/packages/lumx-core/src/scss/components/inline-list/_index.scss
+++ b/packages/lumx-core/src/scss/components/inline-list/_index.scss
@@ -1,0 +1,15 @@
+@use "sass:list";
+
+/* ==========================================================================
+   Inline list
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-inline-list {
+    display: flex;
+    align-items: center;
+    list-style: none;
+
+    &__item {
+        display: contents;
+    }
+}

--- a/packages/lumx-core/src/scss/lumx.scss
+++ b/packages/lumx-core/src/scss/lumx.scss
@@ -35,6 +35,7 @@
 @import "./components/grid/index";
 @import "./components/icon/index";
 @import "./components/image-block/index";
+@import "./components/inline-list/index";
 @import "./components/input-helper/index";
 @import "./components/input-label/index";
 @import "./components/lightbox/index";

--- a/packages/lumx-react/src/components/inline-list/InlineList.stories.tsx
+++ b/packages/lumx-react/src/components/inline-list/InlineList.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { mdiEarth } from '@lumx/icons';
+import { ColorPalette, ColorVariant, Icon, Text, TypographyCustom, TypographyInterface } from '@lumx/react';
+import { withResizableBox } from '@lumx/react/stories/withResizableBox';
+import { InlineList } from '.';
+
+const ALL_TYPOGRAPHY = [undefined, ...Object.values(TypographyInterface), ...Object.values(TypographyCustom)];
+
+export default {
+    title: 'LumX components/inline-list/InlineList',
+    argTypes: {
+        typography: { control: 'select', options: ALL_TYPOGRAPHY },
+        color: { control: 'select', options: ColorPalette },
+        colorVariant: { control: 'select', options: ColorVariant },
+    },
+};
+
+export const Default = (args: any) => (
+    <InlineList as="p" {...args}>
+        <span>Some text</span>
+        <span>Some other text</span>
+        <span>Some other other text</span>
+    </InlineList>
+);
+
+export const MixedNoWrapAndTruncate = (args: any) => (
+    <InlineList typography="body1" color="dark" colorVariant="L2" {...args} style={{ width: '100%' }}>
+        <Text as="span" truncate>
+            Very very very very very long text
+        </Text>
+        <Text as="span" noWrap>
+            <Icon icon={mdiEarth} />
+            Some text
+        </Text>
+        <Text as="span" truncate>
+            Very very very very very long text
+        </Text>
+    </InlineList>
+);
+MixedNoWrapAndTruncate.decorators = [withResizableBox({ width: 400 })];

--- a/packages/lumx-react/src/components/inline-list/InlineList.test.tsx
+++ b/packages/lumx-react/src/components/inline-list/InlineList.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { shallow } from 'enzyme';
+import 'jest-enzyme';
+
+import { commonTestsSuite } from '@lumx/react/testing/utils';
+import { InlineList, InlineListProps } from '.';
+
+const setup = (props: Partial<InlineListProps> = {}) => {
+    const wrapper = shallow(<InlineList {...props} />);
+    return { props, wrapper };
+};
+
+describe(`<${InlineList.displayName}>`, () => {
+    describe('Snapshots and structure', () => {
+        it('should render default', () => {
+            const { wrapper } = setup({ children: ['Some text', 'Some other text'] });
+            expect(wrapper).toHaveDisplayName('ul');
+            expect(wrapper.prop('className')).toBe(InlineList.className);
+            expect(wrapper.find('li')).toHaveLength(2);
+        });
+
+        it('should render with typography', () => {
+            const { wrapper } = setup({ typography: 'body2', children: 'Some text' });
+            expect(wrapper).toHaveClassName('lumx-typography-body2');
+        });
+
+        it('should render with color', () => {
+            const { wrapper } = setup({ color: 'blue', children: 'Some text' });
+            expect(wrapper).toHaveClassName('lumx-color-font-blue-N');
+        });
+
+        it('should render with color and variant', () => {
+            const { wrapper } = setup({ color: 'blue', colorVariant: 'D2', children: 'Some text' });
+            expect(wrapper).toHaveClassName('lumx-color-font-blue-D2');
+        });
+    });
+
+    // Common tests suite.
+    commonTestsSuite(setup, { className: 'wrapper', prop: 'wrapper' }, { className: InlineList.className });
+});

--- a/packages/lumx-react/src/components/inline-list/InlineList.tsx
+++ b/packages/lumx-react/src/components/inline-list/InlineList.tsx
@@ -1,0 +1,80 @@
+import React, { Children, forwardRef, isValidElement } from 'react';
+
+import classNames from 'classnames';
+
+import { ColorPalette, ColorVariant, Typography } from '@lumx/react';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { getFontColorClassName, getRootClassName, getTypographyClassName } from '@lumx/react/utils/className';
+
+/**
+ * Defines the props of the component.
+ */
+export interface InlineListProps extends GenericProps {
+    /**
+     * Text color.
+     */
+    color?: ColorPalette;
+    /**
+     * Lightened or darkened variant of the selected color.
+     */
+    colorVariant?: ColorVariant;
+    /**
+     * Typography variant.
+     */
+    typography?: Typography;
+}
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'InlineList';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
+
+/**
+ * Component default props.
+ */
+const DEFAULT_PROPS = {} as const;
+
+/**
+ * InlineList component.
+ *
+ * @param  props Component props.
+ * @param  ref   Component ref.
+ * @return React element.
+ */
+export const InlineList: Comp<InlineListProps> = forwardRef((props, ref) => {
+    const { className, color, colorVariant, typography, children, ...forwardedProps } = props;
+    const fontColorClassName = color && getFontColorClassName(color, colorVariant);
+    const typographyClassName = typography && getTypographyClassName(typography);
+    return (
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles
+        <ul
+            {...forwardedProps}
+            ref={ref as any}
+            className={classNames(className, CLASSNAME, fontColorClassName, typographyClassName)}
+            // Lists with removed bullet style can lose their a11y list role on some browsers
+            role="list"
+        >
+            {Children.toArray(children).map((child, index) => {
+                const key = (isValidElement(child) && child.key) || index;
+                return (
+                    <li key={key} className={`${CLASSNAME}__item`}>
+                        {index !== 0 && (
+                            <span className={`${CLASSNAME}__item-separator`} aria-hidden="true">
+                                {'\u00A0•\u00A0'}
+                            </span>
+                        )}
+                        {child}
+                    </li>
+                );
+            })}
+        </ul>
+    );
+});
+InlineList.displayName = COMPONENT_NAME;
+InlineList.className = CLASSNAME;
+InlineList.defaultProps = DEFAULT_PROPS;

--- a/packages/lumx-react/src/components/inline-list/index.ts
+++ b/packages/lumx-react/src/components/inline-list/index.ts
@@ -1,0 +1,1 @@
+export { InlineList, InlineListProps } from './InlineList';

--- a/packages/lumx-react/src/components/text/Text.tsx
+++ b/packages/lumx-react/src/components/text/Text.tsx
@@ -1,11 +1,14 @@
 import React, { Children, Fragment, forwardRef } from 'react';
 
-import { Icon, Color, ColorVariant, Typography } from '@lumx/react';
-import { Comp, GenericProps, HeadingElement, isComponent } from '@lumx/react/utils/type';
-import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { Icon, ColorPalette, ColorVariant, Typography } from '@lumx/react';
+import { Comp, GenericProps, TextElement, isComponent } from '@lumx/react/utils/type';
+import {
+    getFontColorClassName,
+    getRootClassName,
+    handleBasicClasses,
+    getTypographyClassName,
+} from '@lumx/react/utils/className';
 import classNames from 'classnames';
-
-type TextComponents = 'span' | 'p' | HeadingElement;
 
 /**
  * Defines the props of the component.
@@ -14,7 +17,7 @@ export interface TextProps extends GenericProps {
     /**
      * Color variant.
      */
-    color?: Color;
+    color?: ColorPalette;
     /**
      * Lightened or darkened variant of the selected color.
      */
@@ -26,7 +29,7 @@ export interface TextProps extends GenericProps {
     /**
      * Custom component to render the text.
      */
-    as: TextComponents;
+    as: TextElement;
     /**
      * Control whether the text should truncate or not.
      * Setting as `true` will make the text truncate on a single line.
@@ -64,7 +67,7 @@ const DEFAULT_PROPS = {} as const;
  */
 export const Text: Comp<TextProps> = forwardRef((props, ref) => {
     const {
-        as,
+        as: Component,
         children,
         className,
         color,
@@ -76,9 +79,8 @@ export const Text: Comp<TextProps> = forwardRef((props, ref) => {
         ...forwardedProps
     } = props;
 
-    const Component = as as TextComponents;
-    const colorClass = color && `lumx-color-font-${color}-${colorVariant || ColorVariant.N}`;
-    const typographyClass = typography && `lumx-typography-${typography}`;
+    const colorClass = color && getFontColorClassName(color, colorVariant);
+    const typographyClass = typography && getTypographyClassName(typography);
 
     // Truncate mode
     const truncateLinesStyle = typeof truncate === 'object' &&

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -24,6 +24,7 @@ export * from './components/heading';
 export * from './components/grid';
 export * from './components/icon';
 export * from './components/image-block';
+export * from './components/inline-list';
 export * from './components/input-helper';
 export * from './components/input-label';
 export * from './components/lightbox';

--- a/packages/lumx-react/src/utils/className.ts
+++ b/packages/lumx-react/src/utils/className.ts
@@ -1,6 +1,7 @@
 import { CSS_PREFIX } from '@lumx/react/constants';
 
 import kebabCase from 'lodash/kebabCase';
+import { ColorPalette, ColorVariant, Typography } from '@lumx/react/components';
 
 // See https://regex101.com/r/YjS1uI/3
 const LAST_PART_CLASSNAME = /^(.*)-(.+)$/gi;
@@ -25,3 +26,19 @@ export function getRootClassName(componentName: string, subComponent?: boolean):
     }
     return formattedClassName;
 }
+
+/**
+ * Returns the classname associated to the given color and variant.
+ * For example, for 'dark' and 'L2' it returns `lumx-color-font-dark-l2`
+ */
+export const getFontColorClassName = (color: ColorPalette, colorVariant: ColorVariant = ColorVariant.N) => {
+    return `lumx-color-font-${color}-${colorVariant}`;
+};
+
+/**
+ * Returns the classname associated to the given typography.
+ * For example, for `Typography.title` it returns `lumx-typography-title`
+ */
+export const getTypographyClassName = (typography: Typography) => {
+    return `lumx-typography-${typography}`;
+};

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -35,6 +35,9 @@ export type Comp<P, T = HTMLElement> = {
 /** Union type of all heading elements */
 export type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
+/** Union type of all text elements */
+export type TextElement = 'span' | 'p' | HeadingElement;
+
 export interface HasTheme {
     /**
      * Theme adapting the component to light or dark background.

--- a/packages/site-demo/content/product/components/inline-list/index.mdx
+++ b/packages/site-demo/content/product/components/inline-list/index.mdx
@@ -1,0 +1,50 @@
+import { InlineList, Text, Link, Icon } from '@lumx/react';
+import { mdiEarth } from '@lumx/icons';
+
+# Inline list
+
+**Display inline list of elements.**
+
+<DemoBlock>
+    <InlineList>
+        <Text as="span">Some text</Text>
+        <Link href="#">Some link</Link>
+        <Icon icon={mdiEarth} />
+    </InlineList>
+</DemoBlock>
+
+## Color and typography
+
+Like [text](/product/components/text/) elements, inline lists can have customized **color** and **typography** (see list of [typography](/product/foundations/typography/) and [color](/product/foundations/color/) styles).
+
+<DemoBlock>
+    <InlineList typography="body1" color="dark" colorVariant="L2">
+        <Text as="span">Some text</Text>
+        <Link href="#">Some link</Link>
+        <Icon icon={mdiEarth} />
+    </InlineList>
+</DemoBlock>
+
+## Text wrap and overflow
+
+Inline lists pair well with [text](/product/components/text/) `noWrap` property to disable line wrap and `truncate` property to cut text with ellipsis.
+
+<DemoBlock orientation="horizontal" vAlign="space-around">
+    <InlineList typography="body1" color="dark" colorVariant="L2" style={{ maxWidth: 300 }}>
+        <Text as="span" noWrap>
+            <Icon icon={mdiEarth} />
+            Some text
+        </Text>
+        <Text as="span" truncate>
+            Very very very very very long text
+        </Text>
+    </InlineList>
+</DemoBlock>
+
+### Accessibility concerns
+
+Inline lists use standard `ul` list element and are read as such by screen readers.
+
+### Properties
+
+<PropTable component="InlineList" />


### PR DESCRIPTION
# General summary

A component to display inline list of elements separated by dots.

StoryBook: https://5fbfb1d508c0520021560f10-gtrtbxgvqy.chromatic.com/?path=/story/lumx-components-inline-list-inlinelist--mixed-no-wrap-and-truncate

# Screenshots

![inline-list-doc](https://user-images.githubusercontent.com/939567/195447906-e14208d3-64a3-48e1-ace9-fe2c7eea2b5c.png)


