### PR TITLE
feat(text): improve icon alignment and add noWrap prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   GenericBlock: add `as` prop to customize the root, the figure, the content and actions elements component render.
 -   New `ClickAwayProvider` utility component (exported in the new `@lumx/react/utils` module).
 
+### Changed
+
+-   Text: improve icon alignment inside text.
+-   Text: add `noWrap` prop to disable line wrap.
+
 ## [3.0.2][] - 2022-09-23
 
 ### Added

--- a/packages/lumx-core/src/scss/components/text/_index.scss
+++ b/packages/lumx-core/src/scss/components/text/_index.scss
@@ -11,10 +11,19 @@
     }
 
     &--is-truncated-multiline {
-        /*autoprefixer: off */
+        /* autoprefixer: off */
         display: -webkit-box;
         overflow: hidden;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: var(--lumx-text-truncate-lines);
+    }
+
+    &--no-wrap {
+        white-space: nowrap;
+    }
+
+    // Fix icon alignment
+    .#{$lumx-base-prefix}-icon, .#{$lumx-base-prefix}-icon > svg {
+        display: inline;
     }
 }

--- a/packages/lumx-react/src/components/text/Text.stories.jsx
+++ b/packages/lumx-react/src/components/text/Text.stories.jsx
@@ -1,38 +1,37 @@
 import React from 'react';
-import { ColorPalette, ColorVariant, TypographyCustom, TypographyInterface } from '@lumx/react';
+import { ColorPalette, ColorVariant, Icon, TypographyCustom, TypographyInterface } from '@lumx/react';
+import { mdiEarth, mdiHeart } from '@lumx/icons';
+import { withResizableBox } from '@lumx/react/stories/withResizableBox';
 import { Text } from './Text';
 
 export default { title: 'LumX components/text/Text' };
 
 export const Default = () => <Text as="p">Some text</Text>;
 
-const withResizableBox = (Story: any) => (
-    <div
-        style={{
-            width: 150,
-            height: 60,
-            border: '1px solid red',
-            resize: 'both',
-            overflow: 'hidden',
-        }}
-    >
-        <Story />
-    </div>
-);
-
-export const Truncate = () => (
-    <Text as="p" truncate>
-        Some very very very long text
+export const WithIcon = (args) => (
+    <Text as="p" {...args}>
+        Some text <Icon icon={mdiHeart} /> with icons <Icon icon={mdiEarth} />
     </Text>
 );
-Truncate.decorators = [withResizableBox];
 
-export const TruncateMultiline = () => (
-    <Text as="p" truncate={{ lines: 2 }}>
+export const LongText = (args) => (
+    <Text as="p" {...args}>
         Some very very very very very very very very very long text
     </Text>
 );
-TruncateMultiline.decorators = [withResizableBox];
+LongText.decorators = [withResizableBox()];
+
+export const NoWrap = LongText.bind({});
+NoWrap.args = { noWrap: true };
+NoWrap.decorators = [withResizableBox()];
+
+export const Truncate = LongText.bind({});
+Truncate.args = { truncate: true };
+Truncate.decorators = [withResizableBox()];
+
+export const TruncateMultiline = LongText.bind({});
+TruncateMultiline.args = { truncate: { lines: 2 } };
+TruncateMultiline.decorators = [withResizableBox()];
 
 export const AllTypography = () => {
     const typographies = [undefined, ...Object.values(TypographyInterface), ...Object.values(TypographyCustom)];
@@ -42,9 +41,7 @@ export const AllTypography = () => {
                 <tr key={typography}>
                     <td>{typography}</td>
                     <td>
-                        <Text as="p" typography={typography}>
-                            Some text
-                        </Text>
+                        <WithIcon typography={typography} />
                     </td>
                 </tr>
             ))}
@@ -68,9 +65,7 @@ export const AllColor = () => {
                     <td>{color}</td>
                     {colorVariants.map((colorVariant) => (
                         <td key={colorVariant}>
-                            <Text as="p" color={color} colorVariant={colorVariant}>
-                                Some text
-                            </Text>
+                            <WithIcon color={color} colorVariant={colorVariant} />
                         </td>
                     ))}
                 </tr>

--- a/packages/lumx-react/src/components/text/Text.test.tsx
+++ b/packages/lumx-react/src/components/text/Text.test.tsx
@@ -4,7 +4,9 @@ import { shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { commonTestsSuite } from '@lumx/react/testing/utils';
-import { Text, TextProps } from './Text';
+import { mdiEarth } from '@lumx/icons';
+import { Icon } from '@lumx/react';
+import { Text, TextProps } from '.';
 
 const setup = (props: Partial<TextProps> = {}) => {
     const wrapper = shallow(<Text as="span" {...props} />);
@@ -54,6 +56,18 @@ describe(`<${Text.displayName}>`, () => {
             expect(wrapper).toHaveDisplayName('span');
             expect(wrapper).toHaveClassName('lumx-text--is-truncated-multiline');
             expect(wrapper).toHaveStyle({ '--lumx-text-truncate-lines': 2 });
+        });
+
+        it('should render noWrap', () => {
+            const { wrapper } = setup({ noWrap: true });
+            expect(wrapper).toHaveDisplayName('span');
+            expect(wrapper).toHaveClassName('lumx-text--no-wrap');
+        });
+
+        it('should wrap icons with spaces', () => {
+            const { wrapper } = setup({ children: ['Some text', <Icon key="icon" icon={mdiEarth} />, 'with icon'] });
+            // Spaces have been inserted around the icon.
+            expect(wrapper).toHaveText('Some text  with icon');
         });
     });
 

--- a/packages/lumx-react/src/components/text/Text.tsx
+++ b/packages/lumx-react/src/components/text/Text.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef } from 'react';
+import React, { Children, Fragment, forwardRef } from 'react';
 
-import { Color, ColorVariant, Typography } from '@lumx/react';
-import { Comp, GenericProps, HeadingElement } from '@lumx/react/utils/type';
+import { Icon, Color, ColorVariant, Typography } from '@lumx/react';
+import { Comp, GenericProps, HeadingElement, isComponent } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
 
@@ -33,6 +33,11 @@ export interface TextProps extends GenericProps {
      * Setting as `{ lines: number }` will make the text truncate on a multiple lines.
      */
     truncate?: boolean | { lines: number };
+    /**
+     * Prevents text to wrap on multiple lines
+     * (automatically activated when single line text truncate is activated).
+     */
+    noWrap?: boolean;
 }
 
 /**
@@ -58,7 +63,18 @@ const DEFAULT_PROPS = {} as const;
  * @return React element.
  */
 export const Text: Comp<TextProps> = forwardRef((props, ref) => {
-    const { as, children, className, color, colorVariant, typography, truncate, style, ...forwardedProps } = props;
+    const {
+        as,
+        children,
+        className,
+        color,
+        colorVariant,
+        noWrap,
+        typography,
+        truncate,
+        style,
+        ...forwardedProps
+    } = props;
 
     const Component = as as TextComponents;
     const colorClass = color && `lumx-color-font-${color}-${colorVariant || ColorVariant.N}`;
@@ -82,11 +98,18 @@ export const Text: Comp<TextProps> = forwardRef((props, ref) => {
                 }),
                 typographyClass,
                 colorClass,
+                noWrap && `${CLASSNAME}--no-wrap`,
             )}
             style={{ ...truncateLinesStyle, ...style }}
             {...forwardedProps}
         >
-            {children}
+            {Children.toArray(children).map((child, index) => {
+                // Force wrap spaces around icons to make sure they are never stuck against text.
+                if (isComponent(Icon)(child)) {
+                    return <Fragment key={child.key || index}> {child} </Fragment>;
+                }
+                return child;
+            })}
         </Component>
     );
 });

--- a/packages/lumx-react/src/stories/withResizableBox.tsx
+++ b/packages/lumx-react/src/stories/withResizableBox.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+/** Storybook decorator wrapping story in a resizable box  */
+// eslint-disable-next-line react/display-name
+export const withResizableBox = ({ width = 150, height = 50 } = {}) => (Story: any) => (
+    <div
+        style={{
+            display: 'flex',
+            width,
+            height,
+            border: '1px solid red',
+            resize: 'both',
+            overflow: 'hidden',
+        }}
+    >
+        <Story />
+    </div>
+);

--- a/packages/site-demo/content/product/components/text/index.mdx
+++ b/packages/site-demo/content/product/components/text/index.mdx
@@ -1,4 +1,5 @@
-import { Text, Message } from '@lumx/react';
+import { Icon, Text, Message } from '@lumx/react';
+import { mdiHeart } from '@lumx/icons';
 
 # Text
 
@@ -11,42 +12,60 @@ By default, text elements have no defined color or typography.
 
 ## Color and typography
 
-Both color and typography can be adapted on text elements (see list of [typography](/product/foundations/typography/) and [color](/product/foundations/color/) styles).
+Both **color** and **typography** can be adapted on text elements (see list of [typography](/product/foundations/typography/) and [color](/product/foundations/color/) styles).
 
 <DemoBlock gap="tiny">
     <Text as="h2" typography="title2">
         Title
     </Text>
     <Text as="p" typography="body1" color="dark" colorVariant="L2">
-        Some <Text as="span" color="red">colored</Text> text
+        Some <Text as="span" color="red"><Icon icon={mdiHeart} />colored</Text> text
     </Text>
 </DemoBlock>
 
 <Message kind="info">
-    Here "Title" is using <code>Text</code> for demo purpose but heading elements should generally use the <a href="/product/components/heading">Heading</a> component.
+    Here "Title" is using <code>Text</code> for demo purpose but the <a href="/product/components/heading">heading</a> element should generally use instead.
 </Message>
 
-## Truncate text
+## Text wrap and overflow
 
-Use `truncate` to cut text overflow with ellipsis. It can also truncate after multiple lines.
+By default, long texts will wrap on multiple lines. Use `noWrap` to prevent that.
+Alternatively, `truncate` can be used to cut with ellipsis (it can also truncate after multiple lines).
 
-
-<DemoBlock orientation="horizontal" vAlign="space-evenly">
-    <Text as="p" typography="body2" truncate style={{ maxWidth: 200 }}>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </Text>
-    <Text as="p" typography="body2" truncate={{ lines: 3 }} style={{ maxWidth: 200 }}>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus tempor urna dui non pretium ex porttitor ac.
-    </Text>
+<DemoBlock orientation="horizontal" vAlign="space-evenly" style={{ gap: 60 }}>
+    <div style="width: 200px; overflow: hidden">
+        <code>default</code>
+        <Text as="p" typography="body2">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </Text>
+    </div>
+    <div style="width: 200px; overflow: hidden">
+        <code>no wrap</code>
+        <Text as="p" typography="body2" noWrap>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </Text>
+    </div>
+    <div style="width: 200px; overflow: hidden">
+        <code>truncate</code>
+        <Text as="p" typography="body2" truncate>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </Text>
+    </div>
+    <div style="width: 200px; overflow: hidden">
+        <code>truncate multiline</code>
+        <Text as="p" typography="body2" truncate={{ lines: 2 }}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </Text>
+    </div>
 </DemoBlock>
 
 ### Accessibility concerns
 
 Text elements **require** the `as` prop to be filled. Semantic HTML tags should be used as much as possible to ensure screen readers gets the context.
 
-Particularly, on titles, consider using HTML heading tags (`h1`, `h2`, `h3`, etc.). The [Heading](/product/components/heading) component can help you automatically adapt to the current heading level.
+Particularly, on titles, consider using HTML heading tags (`h1`, `h2`, `h3`, etc.). The [heading](/product/components/heading/) element can help you automatically adapt to the current heading level.
 
-When using `truncate`, screen readers will read everything in text elements anyway so **make sure the truncated content is not too long** or cut it beforehand.
+When cutting text overflow (with `noWrap` or `truncate`), screen readers will still read everything in text elements so **make sure content is not too long** or cut it beforehand.
 
 ### Properties
 

--- a/packages/site-demo/plugins/utils/rewriteJSXComponent.spec.js
+++ b/packages/site-demo/plugins/utils/rewriteJSXComponent.spec.js
@@ -14,7 +14,7 @@ describe('rewriteJSXComponents', () => {
 
     it('should rewrite components', async () => {
         const jsx = `
-            <Foo>
+            <Foo fizz={buzz} style="foo: 4px" tu={{ to: 42 }}>
             children
             </Foo>
 
@@ -25,7 +25,7 @@ describe('rewriteJSXComponents', () => {
         const transformFunction = jest.fn((e) => ({ bar: 'baz', ...e }));
         expect(await rewriteJSXComponents('Foo', jsx, transformFunction)).toMatchInlineSnapshot(`
             "
-                        <Foo bar={baz}>
+                        <Foo bar={baz} fizz={buzz} style={\\"foo: 4px\\"} tu={{ to: 42 }}>
                         children
                         </Foo>
 

--- a/packages/site-demo/plugins/utils/rewriteJSXComponents.js
+++ b/packages/site-demo/plugins/utils/rewriteJSXComponents.js
@@ -1,5 +1,5 @@
 const lodash = require('lodash');
-const PROPS_REGEXP = `(\\w+)(?:=(?:{([^}]+)}|("[^"]+")))?`;
+const PROPS_REGEXP = `(\\w+)(?:=(?:{({[^}]+})}|{([^}]+)}|("[^"]+")))?`;
 let buildJSXComponent = require('./buildJSXComponent');
 
 /**
@@ -14,8 +14,8 @@ module.exports = async (componentName, string, transformFunction) => {
         const [_, propsString, children] = match;
         const props = propsString.trim()
             ? lodash.fromPairs(propsString.match(new RegExp(PROPS_REGEXP, 'g')).map((prop) => {
-                const [_, key, value, stringValue] = prop.match(new RegExp(PROPS_REGEXP));
-                return !value && !stringValue ? [key, 'true'] : [key, value || stringValue];
+                const [_, key, objectValue, value, stringValue] = prop.match(new RegExp(PROPS_REGEXP));
+                return !objectValue && !value && !stringValue ? [key, 'true'] : [key, objectValue || value || stringValue];
             }))
             : {};
         if (children) {


### PR DESCRIPTION
# General summary

- Fix `Icon` vertical align inside `Text`
- Add `noWrap` prop to prevent line wrap
- Improve doc on text wrap and overflow

Tests
- [Check text stories with icons](https://5fbfb1d508c0520021560f10-szoquuajox.chromatic.com/?path=/story/lumx-components-text-text--all-typography)
- [Check text story with noWrap](https://5fbfb1d508c0520021560f10-szoquuajox.chromatic.com/?path=/story/lumx-components-text-text--no-wrap)

# Screenshots
![text-doc](https://user-images.githubusercontent.com/939567/195542707-7e78baed-73da-4ba2-8e02-f6bb15359051.png)


