### PR TITLE
fix(inline-list): add listitem role to items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed
+
+-   InlineList: Set `listitem` role to items since `display: contents` attribute removes the semantics.
+
+
 ## [3.0.3][] - 2022-10-14
 
 ### Added

--- a/packages/lumx-react/src/components/inline-list/InlineList.tsx
+++ b/packages/lumx-react/src/components/inline-list/InlineList.tsx
@@ -62,7 +62,9 @@ export const InlineList: Comp<InlineListProps> = forwardRef((props, ref) => {
             {Children.toArray(children).map((child, index) => {
                 const key = (isValidElement(child) && child.key) || index;
                 return (
-                    <li key={key} className={`${CLASSNAME}__item`}>
+                    // We need to item is set as display: contents which removes the semantic.
+                    // eslint-disable-next-line jsx-a11y/no-redundant-roles
+                    <li key={key} role="listitem" className={`${CLASSNAME}__item`}>
                         {index !== 0 && (
                             <span className={`${CLASSNAME}__item-separator`} aria-hidden="true">
                                 {'\u00A0•\u00A0'}

--- a/packages/site-demo/content/product/components/inline-list/index.mdx
+++ b/packages/site-demo/content/product/components/inline-list/index.mdx
@@ -30,7 +30,7 @@ Like [text](/product/components/text/) elements, inline lists can have customize
 Inline lists pair well with [text](/product/components/text/) `noWrap` property to disable line wrap and `truncate` property to cut text with ellipsis.
 
 <DemoBlock orientation="horizontal" vAlign="space-around">
-    <InlineList typography="body1" color="dark" colorVariant="L2" style={{ maxWidth: 300 }}>
+    <InlineList typography="body1" color="dark" colorVariant="L2" style={{ maxWidth: 275 }}>
         <Text as="span" noWrap>
             <Icon icon={mdiEarth} />
             Some text

--- a/packages/site-demo/content/product/components/text/index.mdx
+++ b/packages/site-demo/content/product/components/text/index.mdx
@@ -32,26 +32,26 @@ Both **color** and **typography** can be adapted on text elements (see list of [
 By default, long texts will wrap on multiple lines. Use `noWrap` to prevent that.
 Alternatively, `truncate` can be used to cut with ellipsis (it can also truncate after multiple lines).
 
-<DemoBlock orientation="horizontal" vAlign="space-evenly" style={{ gap: 60 }}>
-    <div style="width: 200px; overflow: hidden">
+<DemoBlock orientation="horizontal" vAlign="space-evenly" style={{ gap: 90 }}>
+    <div style="max-width: 180px; overflow: hidden">
         <code>default</code>
         <Text as="p" typography="body2">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         </Text>
     </div>
-    <div style="width: 200px; overflow: hidden">
+    <div style="max-width: 180px; overflow: hidden">
         <code>no wrap</code>
         <Text as="p" typography="body2" noWrap>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         </Text>
     </div>
-    <div style="width: 200px; overflow: hidden">
+    <div style="max-width: 180px; overflow: hidden">
         <code>truncate</code>
         <Text as="p" typography="body2" truncate>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         </Text>
     </div>
-    <div style="width: 200px; overflow: hidden">
+    <div style="max-width: 180px; overflow: hidden">
         <code>truncate multiline</code>
         <Text as="p" typography="body2" truncate={{ lines: 2 }}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Since each element of the `InlineList` component has a `display: contents` css attribute, it removes the semantic value of these items.
Added back a `listitem` role on each items to reset the semantics.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
