### PR TITLE
docs(dropdown): added example of actions states

### DIFF
--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -60,6 +60,8 @@ export interface DropdownProps extends GenericProps {
     placement?: Placement;
     /** Whether the focus should be set on the list when the dropdown is open or not. */
     shouldFocusOnOpen?: boolean;
+    /** Whether the dropdown should be rendered into a DOM node that exists outside the DOM hierarchy of the parent component. */
+    usePortal?: boolean;
     /** Whether the focus should go back on the anchor when dropdown closes and focus is within. */
     focusAnchorOnClose?: boolean;
     /**

--- a/packages/site-demo/content/product/components/dropdown/index.mdx
+++ b/packages/site-demo/content/product/components/dropdown/index.mdx
@@ -11,6 +11,13 @@ Dropdowns can be controlled from external events.
 
 <DemoBlock vAlign="center" demo="target" />
 
+## Actions states
+
+Presented actions have various states, they behave like [`clickable list`](/product/components/list/)
+
+<DemoBlock demo="selects" />
+
+
 ### Properties
 
 <PropTable component="Dropdown" />

--- a/packages/site-demo/content/product/components/dropdown/index.mdx
+++ b/packages/site-demo/content/product/components/dropdown/index.mdx
@@ -15,7 +15,7 @@ Dropdowns can be controlled from external events.
 
 Presented actions have various states, they behave like [`clickable list`](/product/components/list/)
 
-<DemoBlock demo="selects" />
+<DemoBlock demo="selects" backgroundColor={{ color: 'dark', variant: 'L6' }} vAlign="center" />
 
 
 ### Properties

--- a/packages/site-demo/content/product/components/dropdown/react/selects.tsx
+++ b/packages/site-demo/content/product/components/dropdown/react/selects.tsx
@@ -1,46 +1,48 @@
-import { Alignment, Divider, FlexBox, List, ListItem, ListSubheader, Size } from '@lumx/react';
+import { Dropdown, List, ListDivider, ListItem, ListSubheader, Size } from '@lumx/react';
 import React from 'react';
 
-export const App = () => {
-    return (
-        <>
-        <FlexBox vAlign={Alignment.center} fillSpace className="lumx-color-background-dark-L6 lumx-spacing-padding-huge">
-                <List className="lumx-color-background-light-N lumx-popover--elevation-3">
-                    <ListSubheader>Fruits</ListSubheader>
-
-                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
-                        Ananas
-                    </ListItem>
-
-                    <ListItem linkProps={{ href: '#' }} size={Size.tiny} isDisabled>
-                        Coconut (unavailable)
-                    </ListItem>
-
-                    <ListItem linkProps={{ href: '#' }} size={Size.tiny} >
-                        Kiwi
-                    </ListItem>
-
-                    <Divider className="lumx-spacing-margin-vertical-regular" />
-
-                    <ListSubheader>Vegetables</ListSubheader>
-
-                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
-                        Carrot
-                    </ListItem>
-
-                    <ListItem linkProps={{ href: '#' }} size={Size.tiny} isSelected>
-                        Onion (selected)
-                    </ListItem>
-
-                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
-                        Potato
-                    </ListItem>
-
-                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
-                        Rice
-                    </ListItem>
-                </List>
-            </FlexBox>
-        </>
-    );
+// Demo purpose only: force the dropdown position to have it show inline in the demo block
+const overridePositionStyle = (element: any) => {
+    // eslint-disable-next-line no-param-reassign
+    if (element?.style) element.style.position = 'initial';
 };
+
+export const App = () => (
+    <Dropdown isOpen anchorRef={{ current: null }} usePortal={false} ref={overridePositionStyle}>
+        <List>
+            <ListSubheader>Fruits</ListSubheader>
+
+            <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                Ananas
+            </ListItem>
+
+            <ListItem linkProps={{ href: '#' }} size={Size.tiny} isDisabled>
+                Coconut (unavailable)
+            </ListItem>
+
+            <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                Kiwi
+            </ListItem>
+
+            <ListDivider />
+
+            <ListSubheader>Vegetables</ListSubheader>
+
+            <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                Carrot
+            </ListItem>
+
+            <ListItem linkProps={{ href: '#' }} size={Size.tiny} isSelected>
+                Onion (selected)
+            </ListItem>
+
+            <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                Potato
+            </ListItem>
+
+            <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                Rice
+            </ListItem>
+        </List>
+    </Dropdown>
+);

--- a/packages/site-demo/content/product/components/dropdown/react/selects.tsx
+++ b/packages/site-demo/content/product/components/dropdown/react/selects.tsx
@@ -1,0 +1,46 @@
+import { Alignment, Divider, FlexBox, List, ListItem, ListSubheader, Size } from '@lumx/react';
+import React from 'react';
+
+export const App = () => {
+    return (
+        <>
+        <FlexBox vAlign={Alignment.center} fillSpace className="lumx-color-background-dark-L6 lumx-spacing-padding-huge">
+                <List className="lumx-color-background-light-N lumx-popover--elevation-3">
+                    <ListSubheader>Fruits</ListSubheader>
+
+                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                        Ananas
+                    </ListItem>
+
+                    <ListItem linkProps={{ href: '#' }} size={Size.tiny} isDisabled>
+                        Coconut (unavailable)
+                    </ListItem>
+
+                    <ListItem linkProps={{ href: '#' }} size={Size.tiny} >
+                        Kiwi
+                    </ListItem>
+
+                    <Divider className="lumx-spacing-margin-vertical-regular" />
+
+                    <ListSubheader>Vegetables</ListSubheader>
+
+                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                        Carrot
+                    </ListItem>
+
+                    <ListItem linkProps={{ href: '#' }} size={Size.tiny} isSelected>
+                        Onion (selected)
+                    </ListItem>
+
+                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                        Potato
+                    </ListItem>
+
+                    <ListItem linkProps={{ href: '#' }} size={Size.tiny}>
+                        Rice
+                    </ListItem>
+                </List>
+            </FlexBox>
+        </>
+    );
+};

--- a/packages/site-demo/src/components/content/DemoBlock/DemoBlock.tsx
+++ b/packages/site-demo/src/components/content/DemoBlock/DemoBlock.tsx
@@ -1,6 +1,18 @@
 import { CodeBlock } from '@lumx/demo/components/content/CodeBlock/CodeBlock';
 import { mdiCodeTags } from '@lumx/icons';
-import { Alignment, Button, Emphasis, FlexBox, FlexBoxProps, Orientation, Size, Switch, Theme } from '@lumx/react';
+import {
+    Alignment,
+    Button,
+    ColorPalette,
+    ColorVariant,
+    Emphasis,
+    FlexBox,
+    FlexBoxProps,
+    Orientation,
+    Size,
+    Switch,
+    Theme,
+} from '@lumx/react';
 
 import classNames from 'classnames';
 import isFunction from 'lodash/isFunction';
@@ -13,6 +25,7 @@ interface DemoBlockProps extends FlexBoxProps {
     codeString?: string;
     withThemeSwitcher?: boolean;
     hasPlayButton?: boolean;
+    backgroundColor?: { color: ColorPalette; variant: ColorVariant };
 }
 
 const DEFAULT_PROPS: Partial<DemoBlockProps> = {
@@ -26,6 +39,7 @@ export const DemoBlock: React.FC<DemoBlockProps> = ({
     codeString,
     withThemeSwitcher = false,
     hasPlayButton = false,
+    backgroundColor: propBackgroundColor,
     ...flexBoxProps
 }) => {
     const [theme, setTheme] = useState<Theme>(Theme.light);
@@ -42,10 +56,14 @@ export const DemoBlock: React.FC<DemoBlockProps> = ({
         // eslint-disable-next-line no-param-reassign
         flexBoxProps.vAlign = flexBoxProps.vAlign || Alignment.center;
     }
+    const backgroundColor = propBackgroundColor || (theme === Theme.dark ? { color: 'dark', variant: 'N' } : undefined);
     return (
         <div className={classNames('demo-block', { 'demo-block--has-play-button': hasPlayButton })}>
             <FlexBox
-                className={classNames('demo-block__content', theme === Theme.dark && 'lumx-color-background-dark-N')}
+                className={classNames(
+                    'demo-block__content',
+                    backgroundColor && `lumx-color-background-${backgroundColor.color}-${backgroundColor.variant}`,
+                )}
                 wrap
                 {...flexBoxProps}
             >


### PR DESCRIPTION
# General summary

Added an example section for showing that dropdown actions have states.

# Screenshots

<img width="837" alt="Capture d’écran 2022-10-24 à 17 38 42" src="https://user-images.githubusercontent.com/15898440/197567615-2c1ab55e-627f-4d3d-9d85-d7ed2ce39e38.png">

