### PR TITLE
fix(text): fix dangerouslySetInnerHTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ### Fixed
 
 -   InlineList: Set `listitem` role to items since `display: contents` attribute removes the semantics.
-
+-   Text: ignore empty children to make `dangerouslySetInnerHTML` work as expected.
 
 ## [3.0.3][] - 2022-10-14
 

--- a/packages/lumx-react/src/components/text/Text.test.tsx
+++ b/packages/lumx-react/src/components/text/Text.test.tsx
@@ -92,6 +92,11 @@ describe(`<${Text.displayName}>`, () => {
                 </span>
             `);
         });
+
+        it('should render dangerouslySetInnerHTML', () => {
+            const { element } = setup({ dangerouslySetInnerHTML: { __html: '<strong>HTML text</strong>' } });
+            expect(element).toHaveTextContent('HTML text');
+        });
     });
 
     // Common tests suite.

--- a/packages/lumx-react/src/components/text/Text.tsx
+++ b/packages/lumx-react/src/components/text/Text.tsx
@@ -105,13 +105,14 @@ export const Text: Comp<TextProps> = forwardRef((props, ref) => {
             style={{ ...truncateLinesStyle, ...style }}
             {...forwardedProps}
         >
-            {Children.toArray(children).map((child, index) => {
-                // Force wrap spaces around icons to make sure they are never stuck against text.
-                if (isComponent(Icon)(child)) {
-                    return <Fragment key={child.key || index}> {child} </Fragment>;
-                }
-                return child;
-            })}
+            {children &&
+                Children.toArray(children).map((child, index) => {
+                    // Force wrap spaces around icons to make sure they are never stuck against text.
+                    if (isComponent(Icon)(child)) {
+                        return <Fragment key={child.key || index}> {child} </Fragment>;
+                    }
+                    return child;
+                })}
         </Component>
     );
 });


### PR DESCRIPTION
# General summary
 Text: ignore empty children to make `dangerouslySetInnerHTML` work as expected.

