### PR TITLE
chore(autocomplete): forward textfield props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   GenericBlock: add `as` prop to customize the root, the figure, the content and actions elements component render.
 -   New `ClickAwayProvider` utility component (exported in the new `@lumx/react/utils` module).
 -   New `InlineList` component.
+-   Autocomplete: add `textFieldProps` props to the autocomplete component.
 
 ### Changed
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.tsx
@@ -155,6 +155,12 @@ export interface AutocompleteProps extends GenericProps, HasTheme {
      * @see {@link DropdownProps#onInfiniteScroll}
      */
     onInfiniteScroll?(): void;
+    /**
+     * Props forwarded to the underlying TextField component.
+     * Only the props not managed by the Autocomplete can be set.
+     * @see {@link TextFieldProps}
+     */
+    textFieldProps?: TextFieldProps;
 }
 
 /**
@@ -219,6 +225,7 @@ export const Autocomplete: Comp<AutocompleteProps, HTMLDivElement> = forwardRef(
         shouldFocusOnClose,
         theme,
         value,
+        textFieldProps = {},
         ...forwardedProps
     } = props;
     const inputAnchorRef = useRef<HTMLElement>(null);
@@ -237,6 +244,7 @@ export const Autocomplete: Comp<AutocompleteProps, HTMLDivElement> = forwardRef(
             )}
         >
             <TextField
+                {...textFieldProps}
                 chips={chips}
                 error={error}
                 hasError={hasError}


### PR DESCRIPTION
# General summary

Forward TextField props explicitly in the autocomplete component to allow easier customization.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
