### PR TITLE
docs: document several components on a11y concerns

### DIFF
--- a/packages/site-demo/content/product/components/dropdown/index.mdx
+++ b/packages/site-demo/content/product/components/dropdown/index.mdx
@@ -17,6 +17,14 @@ Presented actions have various states, they behave like [`clickable list`](/prod
 
 <DemoBlock demo="selects" backgroundColor={{ color: 'dark', variant: 'L6' }} vAlign="center" />
 
+### Accessibility concerns
+
+Dropdowns are essentially a wrapper around Popover intended to be used either as a disclosure or a popup (containing a menu or a listbox).
+See the [Popover accessibility concerns](/product/components/popover#accessibility-concerns) documentation for more info on those two use case.
+
+We do not yet provide a simple way to create a full accessible menu or listbox to pair with dropdowns.
+
+On top of the popover, dropdowns provide an "infinite scroll" callback to load more data into the dropdown while the user scrolls. Consider adding [`aria-setsize`](https://w3c.github.io/aria/#aria-setsize) and [`aria-posinset`](https://w3c.github.io/aria/#aria-posinset) to your dropdown list items so that screen readers can know the size of the list and the position of items in the list.
 
 ### Properties
 

--- a/packages/site-demo/content/product/components/flex-box/index.mdx
+++ b/packages/site-demo/content/product/components/flex-box/index.mdx
@@ -4,6 +4,10 @@
 
 If you are new to or unfamiliar with flexbox, we encourage you to read this <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/" target="_blank">CSS-Tricks flexbox guide</a>, the component provide transpositions of flexbox CSS properties.
 
+### Accessibility concerns
+
+Flex boxes are simple layout blocks without any particular semantic or ARIA role. They use `<div>` by default, but it can be customized with the `as` property.
+
 ### Properties
 
 <PropTable component="FlexBox" />

--- a/packages/site-demo/content/product/components/link-preview/index.mdx
+++ b/packages/site-demo/content/product/components/link-preview/index.mdx
@@ -10,6 +10,11 @@ Use `big` size to give more emphasis to the displayed hyperlink, make sure to ha
 
 <DemoBlock orientation="horizontal" demo="big" withThemeSwitcher />
 
+### Accessibility concerns
+
+Link previews use a standard `article` HTML element making it a self-contained section in which the link preview title is the heading (use `titleHeading` to customize its level).
+The thumbnail, title and link are all clickable but on keyboard focus navigation, only one element is accessible, either the title (if present) or the full link.
+
 ### Properties
 
 <PropTable component="LinkPreview" />

--- a/packages/site-demo/content/product/components/popover/index.mdx
+++ b/packages/site-demo/content/product/components/popover/index.mdx
@@ -37,6 +37,38 @@ Popovers width can be forced to match anchors.
 
 <DemoBlock demo="matching-width" />
 
+### Accessibility concerns
+
+Popovers do not come with turnkey accessibility behavior as they can be used in multiple use cases.
+
+#### Disclosure
+
+Popovers can be used to disclose information by activating a button.
+
+To apply this pattern, the following concerns should be handled:
+
+- The activating element should have the `aria-expanded` ([see W3C documentation](https://w3c.github.io/aria/#aria-expanded) for detail usage)
+- The popover should not take focus on open (`focusElement` property should be left blank)
+- The popover should appear after the activating element in the tab order (`usePortal` property should be set to `false`)
+- The popover should be closable using the escape key (`closeOnEscape` property, activated by default)
+- The activating element should take focus on popover close (`focusAnchorOnClose` property, activated by default)
+
+Examples of this pattern can be found on the WAI-ARIA [disclosure pattern documentation](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
+
+#### Popup
+
+Popovers can be used as "popup" containing other accessibility pattern inside (menu, listbox, etc. See [W3C documentation](https://w3c.github.io/aria/#aria-haspopup) for the full list).
+
+In all of those cases, the following concerns should be handled:
+
+- The activating element should have the `aria-haspopup` ([see W3C documentation](https://w3c.github.io/aria/#aria-haspopup) for detail usage)
+- The popover should take focus on open (`focusElement` property should be filled)
+- The popover should be closable using the escape key (`closeOnEscape` property, activated by default)
+- The activating element should take focus on popover close (`focusAnchorOnClose` property, activated by default)
+
+Examples of this pattern can be found on the WAI-ARIA [combobox pattern documentation](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/), [menu pattern documentation](https://www.w3.org/WAI/ARIA/apg/patterns/menu/) or [dialog pattern documentation](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/).
+
+
 ### Properties
 
 <PropTable component="Popover" />

--- a/packages/site-demo/content/product/components/toolbar/index.mdx
+++ b/packages/site-demo/content/product/components/toolbar/index.mdx
@@ -28,6 +28,10 @@ A toolbar has three sections. An optional contextual icon button and a title on 
 
 <DemoBlock demo="file-widget" />
 
+### Accessibility concerns
+
+Toolbars are simple layout blocks without any particular semantic or ARIA role.
+
 ### Properties
 
 <PropTable component="Toolbar" />

--- a/packages/site-demo/content/product/components/tooltip/index.mdx
+++ b/packages/site-demo/content/product/components/tooltip/index.mdx
@@ -19,6 +19,14 @@ Tooltips display can be delayed.
 
 <DemoBlock orientation="horizontal" demo="delay" />
 
+### Accessibility concerns
+
+Tooltips implement the [WAI-ARIA tooltip role](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/) and are **only accessible via mouse hover or keyboard focus**. As such it should generally be used **only on focusable element**.
+
+Tooltip messages should be concise, directly describing the element that triggered it and should not contain essential information.
+
+Consider using the [Popover](/product/components/popover/#accessibility-concerns) as a disclosure element to show longer or richer messages.
+
 ### Properties
 
 <PropTable component="Tooltip" />

--- a/packages/site-demo/content/product/components/tooltip/react/placement.tsx
+++ b/packages/site-demo/content/product/components/tooltip/react/placement.tsx
@@ -1,9 +1,9 @@
 import { mdiPrinter } from '@lumx/icons';
-import { FlexBox, Icon, Orientation, Placement, Size, Tooltip } from '@lumx/react';
+import { Icon, Placement, Tooltip } from '@lumx/react';
 import React from 'react';
 
 export const App = () => (
-    <FlexBox orientation={Orientation.horizontal} gap={Size.regular}>
+    <>
         <Tooltip label="Print" placement={Placement.LEFT} forceOpen>
             <Icon hasShape icon={mdiPrinter} />
         </Tooltip>
@@ -19,5 +19,5 @@ export const App = () => (
         <Tooltip label="Print" placement={Placement.RIGHT} forceOpen>
             <Icon hasShape icon={mdiPrinter} />
         </Tooltip>
-    </FlexBox>
+    </>
 );

--- a/packages/site-demo/src/components/base/Link.tsx
+++ b/packages/site-demo/src/components/base/Link.tsx
@@ -7,17 +7,18 @@ interface Props {
     [key: string]: any;
 }
 
-const formatInternalURL = (url: string) => {
-    let formatted = url;
-    if (!formatted.endsWith('/')) {
-        // Force trailing slash on URL.
-        formatted += '/';
+// Format internal link to have the gatsby prefix and trailing slash
+const formatInternalLink = (path: string) => {
+    // origin is not important here as it's removed at the end.
+    const origin = 'http://localhost';
+    const url = new URL(path, origin);
+    if (!url.pathname.endsWith('/')) {
+        url.pathname += '/';
     }
-    if (formatted.startsWith('/')) {
-        // Absolute path should be prefixed with Gatsby path prefix.
-        formatted = withPrefix(formatted);
+    if (path.startsWith('/')) {
+        url.pathname = withPrefix(url.pathname);
     }
-    return formatted;
+    return url.toString().replace(origin, '');
 };
 
 /**
@@ -36,8 +37,8 @@ export const Link: React.FC<Props> = ({ href, ...forwardedProps }) => {
     } else {
         // User router link.
         props.linkAs = RouterLink;
-        // Format internal URL.
-        props.to = formatInternalURL(href);
+        // Format internal link.
+        props.to = formatInternalLink(href);
     }
 
     return <LumxLink {...props} />;


### PR DESCRIPTION
- docs(flex-box): add accessibility concerns section
- docs(toolbar): add accessibility concerns section
- docs(popover): add accessibility concerns section
- docs(tooltip): add accessibility concerns section
- docs(dropdown): add accessibility concerns section
- chore(demo-site): fix internal link format with anchor
- docs(link-preview): add accessibility concerns section

