### PR TITLE
chore(workflow): create automatic release workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,18 +13,14 @@ runs:
             uses: actions/setup-node@v3
             with:
                 node-version: ${{ inputs.node_version }}
-
-        -   name: "Get cache key"
-            id: cache-prep
-            run: echo "cacheKey=${{ runner.os }}-dependency-hash-${{ hashFiles('yarn.lock') }}" >> $GITHUB_OUTPUT
-            shell: bash
+                registry-url: 'https://registry.npmjs.org'
 
         -   name: "Cache dependencies"
             id: cache
             uses: actions/cache@v3
             with:
                 path: "**/node_modules"
-                key: ${{ steps.cache-prep.outputs.cacheKey }}
+                key: ${{ runner.os }}-dependency-hash-${{ hashFiles('yarn.lock') }}
                 restore-keys: |
                     ${{ runner.os }}-dependency-hash-
 

--- a/.github/workflows/deploy-chromatic.yaml
+++ b/.github/workflows/deploy-chromatic.yaml
@@ -1,27 +1,24 @@
-name: Chromatic
+name: "Deploy chromatic"
 
 on:
     pull_request:
-        types: [ opened, synchronize, reopened, labeled ]
-    push:
-        tags:
-            - v*
-            - '!v*-alpha.*' # ignore alpha versions
+        types: [ labeled ]
 
 concurrency:
-    group: chromatic-${{ github.head_ref || github.run_id }}
+    group: chromatic-${{ github.head_ref }}
     cancel-in-progress: true
 
 jobs:
-    deploy:
-        # Run on push version tag OR on PR with the "need: deploy-chromatic" label
-        if: "github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'need: deploy-chromatic')"
+    deploy_chromatic:
+        if: "github.event.label.name == 'need: deploy-chromatic'"
+        name: "Deploy chromatic"
         runs-on: ubuntu-latest
         steps:
             -   name: "Checkout repository"
                 uses: actions/checkout@v3
                 with:
                     fetch-depth: 0 # retrieve all the repo history (required by chromatic)
+                    ref: ${{ inputs.ref }}
 
             -   name: "Setup"
                 uses: ./.github/actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,75 +1,238 @@
 name: "Release Workflow"
 
 on:
-    push:
-        tags:
-            - 'v[0-9].[0-9]+.[0-9]+*'
+    workflow_dispatch:
+        inputs:
+            releaseType:
+                description: 'Release type'
+                required: true
+                default: 'prerelease'
+                type: choice
+                options:
+                    - prerelease
+                    - patch
+                    - minor
+                    - major
+            prereleaseName:
+                description: 'Prerelease name (ignore if release type is not `prerelease`)'
+                default: 'alpha'
+                type: string
 
 concurrency:
     group: "${{ github.workflow }}-${{ github.ref_name }}"
     cancel-in-progress: true
 
 jobs:
-
-    gh_release:
-        name: "Create release on github"
+    publish_version:
+        name: "Publish version"
         runs-on: ubuntu-latest
         steps:
-            -   name: "Checkout code"
+            -   name: "Checkout repository"
                 uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
 
-            -   name: "Create release"
+            -   name: "Setup"
+                uses: ./.github/actions/setup
+
+            -   name: "Create version"
+                id: version
+                uses: actions/github-script@v6
+                with:
+                    script: |
+                        const refType = '${{ github.ref_type }}';
+                        const refName = '${{ github.ref_name }}';
+
+                        if (refType !== 'branch') {
+                            console.log(`Release workflow can only be run from a branch.\n`);
+                            process.exit(1);
+                        }
+
+                        const run = require('util').promisify(require('child_process').exec);
+                        const lodash = require('lodash');
+                        const releaseType = '${{ inputs.releaseType }}' || 'prerelease';
+                        console.log(`Release type: ${releaseType}`);
+                        const prereleaseName = lodash.kebabCase('${{ inputs.prereleaseName }}' || 'alpha');
+
+                        if (releaseType !== 'prerelease') {
+                            // Exit if not on master
+                            if (refName !== 'master') {
+                                console.log(`New ${releaseType} release can only be created from master.\n`);
+                                process.exit(1);
+                            }
+
+                            // Check that the changelog has unreleased changes.
+                            try {
+                                await run('yarn changelog-verify --unreleased');
+                            } catch(err) {
+                                console.log(err);
+                                process.exit(1);
+                            }
+                        } else {
+                            console.log(`Prerelease name: ${prereleaseName}`);
+                        }
+
+                        // Get NPM dist tag
+                        const distTag = releaseType === 'prerelease' ? prereleaseName : 'latest';
+                        console.log(`NPM dist tag: ${distTag}`);
+
+                        const getVersion = (tag) => run(`npm view @lumx/core@${tag} version`).then(({ stdout }) => stdout.trim());
+
+                        // Get latest version
+                        const latestVersion = await getVersion(distTag)
+                            // Fallback on 'latest' dist tag as it always exists
+                            || await getVersion('latest');
+                        console.log(`Latest ${releaseType} version: ${latestVersion}`);
+
+                        // Increment version
+                        const nextVersion = require('semver').inc(latestVersion, releaseType, prereleaseName);
+                        console.log(`New ${releaseType} version: ${nextVersion}`);
+
+                        // Checkout new branch (lerna version requires this)
+                        const branch = `release/${nextVersion}`;
+                        await run(`git checkout -b ${branch}`);
+
+                        // Update version in all packages
+                        await run(`yarn lerna version --no-git-tag-version --yes ${nextVersion}`);
+
+                        // Update yarn.lock with new package versions
+                        await run(`YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install`);
+
+                        // Update version in changelog (need to run in a package which has a version, so not the root package)
+                        await run(`yarn workspace @lumx/core update-version-changelog`);
+
+                        return { nextVersion, distTag, branch, releaseType, refName };
+
+            -   name: "Build libs"
+                run: yarn build:libs
+
+            -   name: "Publish version to NPM"
+                env:
+                    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                    DIST_TAG: ${{ fromJSON(steps.version.outputs.result).distTag }}
+                run: |
+                    for package in $(echo packages/lumx-*);
+                    do
+                        (echo "Publishing $package"; cd $package; npm publish --tag $DIST_TAG)
+                    done
+
+            -   name: "Git commit, tag & push"
+                if: ${{ fromJSON(steps.version.outputs.result).releaseType != 'prerelease' }}
+                id: git
+                run: |
+                    git config --global user.name "github-actions"
+                    git config --global user.email "github-actions@users.noreply.github.com"
+
+                    branch="${{ fromJSON(steps.version.outputs.result).branch }}"
+                    echo "branch=$branch" >> $GITHUB_OUTPUT
+
+                    tag="v${{ fromJSON(steps.version.outputs.result).nextVersion }}"
+                    echo "tag=$tag" >> $GITHUB_OUTPUT
+
+                    # Commit and push branch
+                    commit="chore(release): release $tag"
+                    echo "commit=$commit" >> $GITHUB_OUTPUT
+                    git commit -am "$commit"
+                    git push origin "$branch"
+
+                    # Tag and push tag
+                    git tag "$tag"
+                    git push origin "$tag"
+
+        outputs:
+            releaseType: ${{ fromJSON(steps.version.outputs.result).releaseType }}
+            baseRef: ${{ fromJSON(steps.version.outputs.result).refName }}
+            commit: ${{ steps.git.outputs.commit }}
+            branch: ${{ steps.git.outputs.branch }}
+            versionTag: ${{ steps.git.outputs.tag }}
+
+    create_gh_pull_request:
+        if: ${{ needs.publish_version.outputs.releaseType != 'prerelease' }}
+        name: "Create pull request"
+        runs-on: ubuntu-latest
+        needs: [ publish_version ]
+        steps:
+            -   name: "Create pull request"
+                uses: actions/github-script@v6
+                with:
+                    script: |
+                        github.rest.pulls.create({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            title: '${{ needs.publish_version.outputs.commit }}',
+                            head: '${{ needs.publish_version.outputs.branch }}',
+                            base: '${{ needs.publish_version.outputs.baseRef }}',
+                            body: 'https://github.com/lumapps/design-system/releases/tag/${{ needs.publish_version.outputs.versionTag }}',
+                            draft: false,
+                        });
+
+    create_gh_release:
+        if: ${{ needs.publish_version.outputs.releaseType != 'prerelease' }}
+        name: "Create release note"
+        runs-on: ubuntu-latest
+        needs: [ publish_version ]
+        steps:
+            -   name: "Checkout repository"
+                uses: actions/checkout@v3
+                with:
+                    ref: ${{ needs.publish_version.outputs.versionTag }}
+
+            -   name: "Create release note"
                 uses: ./.github/actions/release-note
                 with:
-                    versionTag: ${{ github.ref }}
+                    versionTag: ${{ needs.publish_version.outputs.versionTag }}
 
-    push_image:
+    build_demo_site:
+        if: ${{ needs.publish_version.outputs.releaseType != 'prerelease' }}
+        name: "Build & push demo site"
         timeout-minutes: 30
-        name: Push the image on release
         runs-on: ubuntu-latest
+        needs: [ publish_version ]
         env:
             GCP_PROD_REGISTRY: gcr.io/lumapps-registry
         steps:
-            -   name: Checkout code
+            -   name: "Checkout repository"
                 uses: actions/checkout@v3
+                with:
+                    ref: ${{ needs.publish_version.outputs.versionTag }}
 
-            -   name: Login to GCR
+            -   name: "Login to GCR"
                 uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
                 with:
                     registry: gcr.io
                     username: _json_key
                     password: ${{ secrets.GCR_PROD_RW_CREDS }}
 
-            -   name: Setup buildx
+            -   name: "Setup buildx"
                 id: buildx_setup
                 uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
                 with:
                     install: true
 
             -   run: |
-                    echo "git_commit=$(rev-parse  HEAD)" >> $GITHUB_ENV
+                    echo "git_commit=$(git rev-parse HEAD)" >> $GITHUB_ENV
                     echo "build_date=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
 
-            -   name: Docker metadata
+            -   name: "Docker metadata"
                 id: meta
                 uses: docker/metadata-action@f206c36955d3cc6213c38fb3747d9ba4113e686a
                 with:
                     tags: |
                         type=match,pattern=/^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-                        type=raw,enable=true,priority=200,value=${{ github.sha }},event=tag
+                        type=raw,enable=true,priority=200,value=${{ env.git_commit }},event=tag
                     images: |
                         ${{ env.GCP_PROD_REGISTRY }}/design-system
                     labels: |
                         com.lumapps.image.created=${{ env.build_date }}
-                        com.lumapps.image.sha1=${{ env.GITHUB_SHA }}
+                        com.lumapps.image.sha1=${{ env.git_commit }}
                         com.lumapps.image.authors=frontend@lumapps.com
                         com.lumapps.image.version={{tag}}
 
-            -   name: Build image
+            -   name: "Build image"
                 uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
                 with:
                     context: ./
-                    file: ${{ matrix.dockerfile}}
+                    file: ${{ matrix.dockerfile }}
                     builder: ${{ steps.buildx_setup.outputs.name }}
                     build-args: version=${{ env.version }}
                     push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,28 @@ jobs:
                 with:
                     versionTag: ${{ needs.publish_version.outputs.versionTag }}
 
+    deploy_chromatic:
+        if: ${{ needs.push_version.outputs.releaseType != 'prerelease' }}
+        name: "Deploy chromatic"
+        runs-on: ubuntu-latest
+        needs: [push_version]
+        steps:
+            -   name: "Checkout repository"
+                uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0 # retrieve all the repo history (required by chromatic)
+                    ref: ${{ needs.push_version.outputs.versionTag }}
+
+            -   name: "Setup"
+                uses: ./.github/actions/setup
+
+            -   name: "Deploy chromatic"
+                uses: chromaui/action@3f82bf5d065290658af8add6dce946809ee0f923 #v6.1.0
+                with:
+                    token: ${{ secrets.GITHUB_TOKEN }}
+                    projectToken: ${{ secrets.CHROMATIC_TOKEN }}
+                    buildScriptName: build:storybook
+
     build_demo_site:
         if: ${{ needs.publish_version.outputs.releaseType != 'prerelease' }}
         name: "Build & push demo site"

--- a/README.md
+++ b/README.md
@@ -80,18 +80,24 @@ This will produce the target build for `@lumx/core`, `@lumx/angularjs`, `@lumx/r
 
 ## How to publish packages
 
-1. Create a release branch (ex: `release/vX.Y.Z`) based on `master`
-2. Push it to remote (`git push origin release/vX.Y.Z`)
-3. Login to NPM with an authorized account: `npm login`
-4. Make sure your packages are up to date: `yarn`
-5. (Optional) Make sure the build doesn't crash: `yarn build`
-6. Publish the packages to NPM
-   * to release an alpha version:
-     `yarn release --dist-tag <npm-tag> vX.Y.Z-alpha.N`
-     * the `--dist-tag <npm-tag>` option is used to avoid replacing the `latest` tag on NPM
-   * to release a version: `yarn release`
-     (you will be asked what version bump to apply)
-7. Create a PR for the release branch to merge into master
+**The full release process is automated in a GitHub workflow** which can be triggered on the [release.yml](https://github.com/lumapps/design-system/actions/workflows/release.yml) page with the "Run workflow" button.
+
+Three parameters are available:
+
+1. The base branch used for the release. Tags cannot be used and only the `master` branch is authorised when releasing a "patch", "minor" or "major" version.
+2. The release type
+    - "patch", "minor" & "major" will release a version increment `vX.Y.Z`
+    - "prerelease" will release increment the last prerelease version if it exists (ex: `3.0.1-alpha.0` => `3.0.1-alpha.1`) or will increment the last patch version and append the release name (ex: `3.0.2` => `3.0.3-alpha.0`)
+3. (Optional) The prerelease name (if applicable).
+
+Releasing a new version of the lumx packages consists in:
+
+1. Incrementing the version number (patch, minor, major or prerelease)
+2. Building all lumx packages (`yarn build` for all packages)
+3. Pushing on NPM (`npm publish` for all packages)
+4. (if not a prerelease) Pushing updated version on GitHub (new tag & new pull request)
+
+**Prereleases** are used to test the lumx libs before committing to a release. They are never merged in master and never mentioned in the CHANGELOG.md file. By default, prereleases use the tag `alpha` (ex: `3.0.1-alpha.0` aliased to `alpha` on NPM) but this can be changed to test multiple and unrelated versions (ex: `alpha-fix-thumbnail`, `alpha-refactor-types`, etc.).
 
 ## Copyright and license
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.13.0",
         "@typescript-eslint/parser": "^5.13.0",
+        "changelog-verify": "^1.1.2",
         "es-abstract": "1.17.6",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
@@ -23,6 +24,7 @@
         "postcss-hover-media-feature": "^0.3.1",
         "prettier": "^2.2.1",
         "prettier-eslint": "^12.0.0",
+        "semver": "^7.3.5",
         "stylelint": "^14.9.1",
         "stylelint-config-recess-order": "^3.0.0",
         "stylelint-config-standard-scss": "^5.0.0",
@@ -61,6 +63,7 @@
     },
     "scripts": {
         "build": "lerna run --stream build",
+        "build:libs": "lerna run --no-private --stream build",
         "build:site": "yarn workspace lumx-site-demo clean && yarn workspace lumx-site-demo build",
         "build:react": "yarn workspace @lumx/react build",
         "build:core": "yarn workspace @lumx/core build",
@@ -83,8 +86,6 @@
         "test": "yarn workspace @lumx/react test",
         "storybook:react": "yarn workspace @lumx/react storybook",
         "storybook": "yarn storybook:react",
-        "check:not-master": "git symbolic-ref --short -q HEAD | egrep -q '^master$' && echo 'ERROR: You can not release from the master branch.' && exit 1 || true",
-        "version": "yarn check:not-master && yarn && git add yarn.lock",
         "generate:design-tokens": "yarn workspace @lumx/core generate:design-tokens"
     },
     "workspaces": [

--- a/packages/lumx-angularjs/package.json
+++ b/packages/lumx-angularjs/package.json
@@ -37,8 +37,7 @@
     },
     "scripts": {
         "build": "webpack",
-        "prepare": "install-peers || exit 0",
-        "prepublishOnly": "yarn build"
+        "prepare": "install-peers || exit 0"
     },
     "version": "3.0.7",
     "devDependencies": {

--- a/packages/lumx-core/package.json
+++ b/packages/lumx-core/package.json
@@ -26,8 +26,7 @@
     "license": "MIT",
     "name": "@lumx/core",
     "publishConfig": {
-        "directory": "dist",
-        "prepublishOnly": "yarn build"
+        "directory": "dist"
     },
     "repository": {
         "type": "git",
@@ -38,8 +37,7 @@
         "build": "webpack && yarn clean:unwanted-dist",
         "clean:unwanted-dist": "rm -rf ./dist/*.js ./dist/*.js.map",
         "prepare": "install-peers || exit 0",
-        "prepublishOnly": "yarn build",
-        "version": "yarn version-changelog ../../CHANGELOG.md && yarn changelog-verify ../../CHANGELOG.md && git add ../../CHANGELOG.md"
+        "update-version-changelog": "yarn version-changelog ../../CHANGELOG.md"
     },
     "sideEffects": false,
     "version": "3.0.7",
@@ -54,7 +52,6 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
         "autoprefixer": "^9.7.4",
-        "changelog-verify": "^1.1.2",
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^5.1.1",
         "core-js": "^3.6.4",

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -32,8 +32,7 @@
         "directory": "dist"
     },
     "scripts": {
-        "build": "rollup -c",
-        "prepublishOnly": "yarn build"
+        "build": "rollup -c"
     },
     "sideEffects": false,
     "version": "3.0.7"

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -107,7 +107,6 @@
     "scripts": {
         "build": "rollup -c",
         "prepare": "install-peers || exit 0",
-        "prepublishOnly": "yarn build",
         "test": "jest --config jest/index.js --coverage --notify --passWithNoTests --detectOpenHandles --runInBand",
         "storybook": "yarn start:storybook",
         "start:storybook": "cd storybook && ./start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4660,7 +4660,6 @@ __metadata:
     "@babel/preset-env": ^7.20.2
     "@babel/preset-typescript": ^7.18.6
     autoprefixer: ^9.7.4
-    changelog-verify: ^1.1.2
     classnames: ^2.2.6
     clean-webpack-plugin: ^3.0.0
     copy-webpack-plugin: ^5.1.1
@@ -4712,6 +4711,7 @@ __metadata:
   dependencies:
     "@typescript-eslint/eslint-plugin": ^5.13.0
     "@typescript-eslint/parser": ^5.13.0
+    changelog-verify: ^1.1.2
     es-abstract: 1.17.6
     eslint: ^7.32.0
     eslint-config-airbnb: ^18.2.1
@@ -4728,6 +4728,7 @@ __metadata:
     postcss-hover-media-feature: ^0.3.1
     prettier: ^2.2.1
     prettier-eslint: ^12.0.0
+    semver: ^7.3.5
     stylelint: ^14.9.1
     stylelint-config-recess-order: ^3.0.0
     stylelint-config-standard-scss: ^5.0.0


### PR DESCRIPTION
1. Remove old npm script setup (using prepublishOnly and version)
3. Create a fully automatic GH workflow for prerelease and release 
    1. Assetions 
        - assert we are on a branch
        - (if release) assert we are on master
        - (if release) assert changelog has unreleased changes
    2. Prepare version (get latest version and increment)
    4. Update versions in all packages
    5. Update version in CHANGELOG
    6. Build all libs
    7. Publish on NPM
    8. (if release) Git commit, tag & push
    9. (if release) Create a pull request 
3. Move old post-release job to the new release workflow
    => Run the "release note", "build & push demo site" & "deploy chromatic" jobs after the release instead of running them after pushing a release tag to github

TODO:
  - Test prerelease use case: [OK](https://github.com/lumapps/design-system/actions/runs/3686337211/jobs/6238428063) :heavy_check_mark: 
  - Test prerelease use case + deploys like with releases [OK](https://github.com/lumapps/design-system/actions/runs/3689408798) :heavy_check_mark:  
  - Test chromatic PR deploy [OK](https://github.com/lumapps/design-system/actions/runs/3689302081/jobs/6245097605) :heavy_check_mark: 
  - Document new release process in README.md :heavy_check_mark: 