### PR TITLE
chore(expansion-panel): pass event to the component callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   ExpansionPanel: passed event to the `onOpen`, `onClose` and `onToggleOpen` callbacks.
+
 ## [3.1.2][] - 2023-01-05
 
 ### Added

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.stories.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { Button, Dropdown, ExpansionPanel, List, ListItem, Placement, Size } from '@lumx/react';
+
+export default { title: 'LumX components/expansion-panel/ExpansionPanel' };
+
+export const ExpansionPanelInADropdown = () => {
+    const anchorDropdownButton = React.useRef(null);
+
+    const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+    const toggleDropdown = () => setIsDropdownOpen(!isDropdownOpen);
+    const closeDropdown = () => setIsDropdownOpen(false);
+
+    const [isExpansionPanelOpen, setIsExpansionPanelOpen] = React.useState(false);
+
+    const toggleExpansionPanel = (shouldOpen: boolean, evt: React.MouseEvent) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+        setIsExpansionPanelOpen(shouldOpen);
+    };
+
+    const onItemSelected = (item: string) => () => {
+        console.log('selected item', item);
+        closeDropdown();
+    };
+
+    return (
+        <>
+            <Button ref={anchorDropdownButton} onClick={toggleDropdown}>
+                Open dropdown
+            </Button>
+            <Dropdown
+                closeOnClickAway
+                closeOnEscape
+                isOpen={isDropdownOpen}
+                onClose={closeDropdown}
+                placement={Placement.BOTTOM_START}
+                anchorRef={anchorDropdownButton}
+            >
+                <List>
+                    <ListItem onItemSelected={onItemSelected('paris')} size={Size.tiny}>
+                        Paris
+                    </ListItem>
+                    <ExpansionPanel
+                        label="Lorem ipsum"
+                        isOpen={isExpansionPanelOpen}
+                        onToggleOpen={(shouldOpen, event) => toggleExpansionPanel(shouldOpen, event)}
+                        toggleButtonProps={{ label: 'Toggle' }}
+                    >
+                        <header>
+                            <ListItem size={Size.tiny}>United States</ListItem>
+                        </header>
+                        <ListItem onItemSelected={onItemSelected('georgetown')} size={Size.tiny}>
+                            Georgetown
+                        </ListItem>
+
+                        <ListItem onItemSelected={onItemSelected('newyork')} size={Size.tiny}>
+                            New York
+                        </ListItem>
+                    </ExpansionPanel>
+                </List>
+            </Dropdown>
+        </>
+    );
+};

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
@@ -94,7 +94,7 @@ describe(`<${ExpansionPanel.displayName}>`, () => {
             await userEvent.click(query.toggleButton() as any);
             expect(onOpen).toHaveBeenCalled();
             expect(onClose).not.toHaveBeenCalled();
-            expect(onToggleOpen).toHaveBeenCalledWith(true);
+            expect(onToggleOpen).toHaveBeenCalledWith(true, expect.anything());
         });
 
         it('should close on click', async () => {
@@ -107,7 +107,7 @@ describe(`<${ExpansionPanel.displayName}>`, () => {
             await userEvent.click(query.header() as any);
             expect(onOpen).not.toHaveBeenCalled();
             expect(onClose).toHaveBeenCalled();
-            expect(onToggleOpen).toHaveBeenCalledWith(false);
+            expect(onToggleOpen).toHaveBeenCalledWith(false, expect.anything());
         });
     });
 

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -9,7 +9,7 @@ import isEmpty from 'lodash/isEmpty';
 import isFunction from 'lodash/isFunction';
 
 import { ColorPalette, DragHandle, Emphasis, IconButton, IconButtonProps, Theme } from '@lumx/react';
-import { Callback, Comp, GenericProps, HasTheme, isComponent } from '@lumx/react/utils/type';
+import { Comp, GenericProps, HasTheme, isComponent } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { partitionMulti } from '@lumx/react/utils/partitionMulti';
 
@@ -26,14 +26,14 @@ export interface ExpansionPanelProps extends GenericProps, HasTheme {
     /** Label text (overwritten if a `<header>` is provided in the children). */
     label?: string;
     /** On open callback. */
-    onOpen?: Callback;
+    onOpen?: (event: React.MouseEvent) => void;
     /** On close callback. */
-    onClose?: Callback;
+    onClose?: (event: React.MouseEvent) => void;
     /** Props to pass to the toggle button (minus those already set by the ExpansionPanel props). */
     toggleButtonProps: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
     /** On toggle open or close callback. */
-    onToggleOpen?(shouldOpen: boolean): void;
+    onToggleOpen?(shouldOpen: boolean, event: React.MouseEvent): void;
 }
 
 /**
@@ -93,16 +93,16 @@ export const ExpansionPanel: Comp<ExpansionPanelProps, HTMLDivElement> = forward
         <span className={`${CLASSNAME}__label`}>{label}</span>
     );
 
-    const toggleOpen = () => {
+    const toggleOpen = (event: React.MouseEvent) => {
         const shouldOpen = !isOpen;
         if (isFunction(onOpen) && shouldOpen) {
-            onOpen();
+            onOpen(event);
         }
         if (isFunction(onClose) && !shouldOpen) {
-            onClose();
+            onClose(event);
         }
         if (isFunction(onToggleOpen)) {
-            onToggleOpen(shouldOpen);
+            onToggleOpen(shouldOpen, event);
         }
     };
 


### PR DESCRIPTION
[CF-494](https://lumapps.atlassian.net/browse/CF-494)

# General summary

<!-- Please describe the PR content -->
When the expansion panel is used inside a dropdown, the click on the expansion panel closed the dropdown, we need to have the MouseEvent to prevent this behavior.

This PR pass the onClick event to the onOpen, onClose and onToggleOpen callbacks of the ExpansionPanel component.

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [x] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


[CF-494]: https://lumapps.atlassian.net/browse/CF-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ