### PR TITLE
fix(tab): fix css to make sure disabled tab is not displayed as active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Badge, Button, Chip, Icon, Link: only `ColorPalette` values are allowed on the `color` prop (instead of `string`). **This has no impact on functionality**, if you used unsupported color before, you can ignore TS errors with `as any`.
 
+### Fixed
+
+-   Tab: fix disabled state.
+
 ## [3.0.7][] - 2022-12-06
 
 ### Added

--- a/packages/lumx-core/src/scss/components/tabs/_index.scss
+++ b/packages/lumx-core/src/scss/components/tabs/_index.scss
@@ -16,7 +16,7 @@
     }
 
     &__link {
-        &:not(&--is-active) {
+        &:not(&--is-active):not(&--is-disabled) {
             @include lumx-tabs-link(lumx-base-const("emphasis", "LOW"));
 
             #{$self}--theme-light & {
@@ -83,11 +83,15 @@
 
 // Disabled state
 .#{$lumx-base-prefix}-tabs__link--is-disabled {
+    @include lumx-tabs-link(lumx-base-const("emphasis", "LOW"));
+
     .#{$lumx-base-prefix}-tabs--theme-light & {
+        @include lumx-tabs-link-color(lumx-base-const("emphasis", "LOW"), lumx-base-const("theme", "LIGHT"));
         @include lumx-state-disabled-text(lumx-base-const("theme", "LIGHT"));
     }
 
     .#{$lumx-base-prefix}-tabs--theme-dark & {
+        @include lumx-tabs-link-color(lumx-base-const("emphasis", "LOW"), lumx-base-const("theme", "DARK"));
         @include lumx-state-disabled-text(lumx-base-const("theme", "DARK"));
     }
 }


### PR DESCRIPTION
[DS-109](https://lumapps.atlassian.net/browse/DS-109)

# General summary
When a tab is disabled, the style was applied only if it's selected. It's now fixed, even if the tab is not active.
<!-- Please describe the PR content -->

# Screenshots
![image](https://user-images.githubusercontent.com/106673323/210260274-ca2f4a40-8ae7-4aff-9e4a-ec1d321bb165.png)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [X] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
