### PR TITLE
chore(ci): disable git tag and split release jobs

### DIFF
--- a/.github/workflows/release-build-site.yml
+++ b/.github/workflows/release-build-site.yml
@@ -1,0 +1,69 @@
+name: "Build & Push Demo Site"
+
+# Build and push the demo site on the docker registry when a new release tag is pushed on GitHub
+
+on:
+    push:
+        tags:
+            - v*
+            - '!v*-alpha.*' # ignore alpha versions
+
+concurrency:
+    group: "${{ github.workflow }}-${{ github.ref_name }}"
+    cancel-in-progress: true
+
+jobs:
+    build_demo_site:
+        name: "Build & push demo site"
+        timeout-minutes: 30
+        runs-on: ubuntu-latest
+        env:
+            GCP_PROD_REGISTRY: gcr.io/lumapps-registry
+        steps:
+            -   name: "Checkout repository"
+                uses: actions/checkout@v3
+
+            -   name: "Login to GCR"
+                uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+                with:
+                    registry: gcr.io
+                    username: _json_key
+                    password: ${{ secrets.GCR_PROD_RW_CREDS }}
+
+            -   name: "Setup buildx"
+                id: buildx_setup
+                uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+                with:
+                    install: true
+
+            -   run: |
+                    echo "git_commit=$(git rev-parse HEAD)" >> $GITHUB_ENV
+                    echo "build_date=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
+
+            -   name: "Docker metadata"
+                id: meta
+                uses: docker/metadata-action@f206c36955d3cc6213c38fb3747d9ba4113e686a
+                with:
+                    tags: |
+                        type=match,pattern=/^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+                        type=raw,enable=true,priority=200,value=${{ env.git_commit }},event=tag
+                    images: |
+                        ${{ env.GCP_PROD_REGISTRY }}/design-system
+                    labels: |
+                        com.lumapps.image.created=${{ env.build_date }}
+                        com.lumapps.image.sha1=${{ env.git_commit }}
+                        com.lumapps.image.authors=frontend@lumapps.com
+                        com.lumapps.image.version={{tag}}
+
+            -   name: "Build image"
+                uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
+                with:
+                    context: ./
+                    file: ${{ matrix.dockerfile }}
+                    builder: ${{ steps.buildx_setup.outputs.name }}
+                    build-args: version=${{ env.version }}
+                    push: true
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
+                    cache-from: type=gha, scope=${{ github.workflow }}
+                    cache-to: type=gha, scope=${{ github.workflow }}, mode=max

--- a/.github/workflows/release-deploy-chromatic.yaml
+++ b/.github/workflows/release-deploy-chromatic.yaml
@@ -1,7 +1,6 @@
-name: "Deploy chromatic release"
+name: "Deploy Chromatic Release"
 
-# Chromatic deploy on release cannot run in `release.yml` until this is merged: https://github.com/chromaui/chromatic-cli/pull/695
-# Triggering on tag push might not work since GitHub workflows cascade are disabled by default.
+# Deploy chromatic when a new release tag is pushed on GitHub
 
 on:
     push:

--- a/.github/workflows/release-github-release-note.yml
+++ b/.github/workflows/release-github-release-note.yml
@@ -1,0 +1,27 @@
+name: "Create GitHub Release Notes"
+
+# Generate a release note when a new release tag is pushed on GitHub
+
+on:
+    push:
+        tags:
+            - v*
+            - '!v*-alpha.*' # ignore alpha versions
+
+concurrency:
+    group: "${{ github.workflow }}-${{ github.ref_name }}"
+    cancel-in-progress: true
+
+jobs:
+    create_gh_release:
+        name: "Create release note"
+        runs-on: ubuntu-latest
+        steps:
+            -   name: "Checkout repository"
+                uses: actions/checkout@v3
+
+            -   name: "Create release note"
+                uses: ./.github/actions/release-note
+                with:
+                    versionTag: ${{ github.ref_name }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,11 @@ jobs:
                         console.log(`NPM dist tag: ${distTag}`);
 
                         // Get latest version
-                        const latestVersion = await getVersion(distTag)
+                        let latestVersion = await getVersion(distTag)
+                        if (!latestVersion || !latestVersion.startsWith(npmLatestVersion)) {
                             // Fallback on 'latest' dist tag as it always exists
-                            || npmLatestVersion;
+                            latestVersion = npmLatestVersion;
+                        }
                         console.log(`Latest ${releaseType} version: ${latestVersion}`);
 
                         // Increment version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: "Release Workflow"
 
+# Manual trigger workflow to automatically setup, build and push a new release (or prerelease) on NPM
+
 on:
     workflow_dispatch:
         inputs:
@@ -142,9 +144,10 @@ jobs:
                     git commit -am "$commit"
                     git push origin "$branch"
 
+                    # TODO: need to a new git user to push tags
                     # Tag and push tag
-                    git tag "$tag"
-                    git push origin "$tag"
+                    #git tag "$tag"
+                    #git push origin "$tag"
 
         outputs:
             releaseType: ${{ fromJSON(steps.version.outputs.result).releaseType }}
@@ -169,81 +172,6 @@ jobs:
                             title: '${{ needs.publish_version.outputs.commit }}',
                             head: '${{ needs.publish_version.outputs.branch }}',
                             base: '${{ needs.publish_version.outputs.baseRef }}',
-                            body: 'https://github.com/lumapps/design-system/releases/tag/${{ needs.publish_version.outputs.versionTag }}',
+                            body: 'https://github.com/lumapps/design-system/releases/tag/${{ needs.publish_version.outputs.versionTag }}\nTODO: `git tag ${{ needs.publish_version.outputs.versionTag }}` & `git push origin ${{ needs.publish_version.outputs.versionTag }}`',
                             draft: false,
                         });
-
-    create_gh_release:
-        if: ${{ needs.publish_version.outputs.releaseType != 'prerelease' }}
-        name: "Create release note"
-        runs-on: ubuntu-latest
-        needs: [ publish_version ]
-        steps:
-            -   name: "Checkout repository"
-                uses: actions/checkout@v3
-                with:
-                    ref: ${{ needs.publish_version.outputs.versionTag }}
-
-            -   name: "Create release note"
-                uses: ./.github/actions/release-note
-                with:
-                    versionTag: ${{ needs.publish_version.outputs.versionTag }}
-
-    build_demo_site:
-        if: ${{ needs.publish_version.outputs.releaseType != 'prerelease' }}
-        name: "Build & push demo site"
-        timeout-minutes: 30
-        runs-on: ubuntu-latest
-        needs: [ publish_version ]
-        env:
-            GCP_PROD_REGISTRY: gcr.io/lumapps-registry
-        steps:
-            -   name: "Checkout repository"
-                uses: actions/checkout@v3
-                with:
-                    ref: ${{ needs.publish_version.outputs.versionTag }}
-
-            -   name: "Login to GCR"
-                uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
-                with:
-                    registry: gcr.io
-                    username: _json_key
-                    password: ${{ secrets.GCR_PROD_RW_CREDS }}
-
-            -   name: "Setup buildx"
-                id: buildx_setup
-                uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
-                with:
-                    install: true
-
-            -   run: |
-                    echo "git_commit=$(git rev-parse HEAD)" >> $GITHUB_ENV
-                    echo "build_date=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
-
-            -   name: "Docker metadata"
-                id: meta
-                uses: docker/metadata-action@f206c36955d3cc6213c38fb3747d9ba4113e686a
-                with:
-                    tags: |
-                        type=match,pattern=/^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-                        type=raw,enable=true,priority=200,value=${{ env.git_commit }},event=tag
-                    images: |
-                        ${{ env.GCP_PROD_REGISTRY }}/design-system
-                    labels: |
-                        com.lumapps.image.created=${{ env.build_date }}
-                        com.lumapps.image.sha1=${{ env.git_commit }}
-                        com.lumapps.image.authors=frontend@lumapps.com
-                        com.lumapps.image.version={{tag}}
-
-            -   name: "Build image"
-                uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229
-                with:
-                    context: ./
-                    file: ${{ matrix.dockerfile }}
-                    builder: ${{ steps.buildx_setup.outputs.name }}
-                    build-args: version=${{ env.version }}
-                    push: true
-                    tags: ${{ steps.meta.outputs.tags }}
-                    labels: ${{ steps.meta.outputs.labels }}
-                    cache-from: type=gha, scope=${{ github.workflow }}
-                    cache-to: type=gha, scope=${{ github.workflow }}, mode=max


### PR DESCRIPTION
# General summary

- Removing git tag creation from the release workflow (github-actions user cannot push git tags anymore :() 
- Split deploy chromatic into a workflow triggered on tag pushed
- Split build site into workflow triggered on tag pushed

Git tags will have to be created manually until we find a way to create a dedicated bot user that can be configured to push git tags in the release workflow.

