### PR TITLE
fix(grid-column): fix scss variable interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   ExpansionPanel: passed event to the `onOpen`, `onClose` and `onToggleOpen` callbacks.
 
+### Fixed
+
+-   GridColumn: fix SCSS variable interpolation.
+
 ## [3.1.2][] - 2023-01-05
 
 ### Added

--- a/packages/lumx-core/src/scss/components/grid-column/_index.scss
+++ b/packages/lumx-core/src/scss/components/grid-column/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:string";
+
 /* ==========================================================================
    Grid Column
    ========================================================================== */
@@ -10,9 +12,13 @@
     $min-width: var(--lumx-grid-column-item-min-width);
     $gap: var(--lumx-grid-column-gap);
     $columns: var(--lumx-grid-column-columns);
-    $column-max-width: max(min(#{$min-width}, 100%), calc((100% - (#{$columns} - 1) * #{$gap}) / #{$columns}));
+
+    // Using `unquote` to make sure the `calc()` function is not removed at compile time.
+    $column-max-width: string.unquote(
+        "max(min(" + $min-width + ", 100%), calc((100% - (" + $columns + " - 1) * " + $gap + ") / " + $columns + "))"
+    );
 
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(#{$column-max-width}, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax($column-max-width, 1fr));
     gap: var(--lumx-grid-column-gap);
 }


### PR DESCRIPTION
# General summary

GridColumn: fix error in SCSS variable interpolation (removing the `calc()` funciton)

