### PR TITLE
chore(dialog): new props for disabling scroll and events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dialog: added new props `disableBodyScroll`, `preventCloseOnClick` and `preventCloseOnEscape`
+
 ## [3.1.4][] - 2023-01-26
 
 ### Changed

--- a/packages/lumx-react/src/components/alert-dialog/__snapshots__/AlertDialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/alert-dialog/__snapshots__/AlertDialog.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`<AlertDialog> Snapshots and structure should render story 'Default' 1`]
       "role": "alertdialog",
     }
   }
+  disableBodyScroll={true}
   focusElement={
     {
       "current": null,
@@ -84,6 +85,7 @@ exports[`<AlertDialog> Snapshots and structure should render story 'Error' 1`] =
       "role": "alertdialog",
     }
   }
+  disableBodyScroll={true}
   focusElement={
     {
       "current": null,
@@ -157,6 +159,7 @@ exports[`<AlertDialog> Snapshots and structure should render story 'RichDescript
       "role": "alertdialog",
     }
   }
+  disableBodyScroll={true}
   focusElement={
     {
       "current": null,
@@ -243,6 +246,7 @@ exports[`<AlertDialog> Snapshots and structure should render story 'Success' 1`]
       "role": "alertdialog",
     }
   }
+  disableBodyScroll={true}
   focusElement={
     {
       "current": null,
@@ -316,6 +320,7 @@ exports[`<AlertDialog> Snapshots and structure should render story 'Warning' 1`]
       "role": "alertdialog",
     }
   }
+  disableBodyScroll={true}
   focusElement={
     {
       "current": null,
@@ -389,6 +394,7 @@ exports[`<AlertDialog> Snapshots and structure should render story 'WithCancel' 
       "role": "alertdialog",
     }
   }
+  disableBodyScroll={true}
   focusElement={
     {
       "current": null,
@@ -470,6 +476,7 @@ exports[`<AlertDialog> Snapshots and structure should render story 'WithForwarde
       "role": "alertdialog",
     }
   }
+  disableBodyScroll={true}
   focusElement={
     {
       "current": null,

--- a/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.stories.tsx
@@ -72,12 +72,66 @@ export const SimpleDialog = ({ theme }: any) => {
     );
 };
 
+export const WithBodyScroll = ({ theme }: any) => {
+    const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
+    return (
+        <>
+            {button}
+            <Dialog isOpen={isOpen} onClose={closeDialog} parentElement={buttonRef} disableBodyScroll={false}>
+                {content}
+            </Dialog>
+        </>
+    );
+};
+
 export const PreventDialogAutoClose = ({ theme }: any) => {
     const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
     return (
         <>
             {button}
             <Dialog preventAutoClose isOpen={isOpen} onClose={closeDialog} parentElement={buttonRef}>
+                {content}
+                <footer>
+                    <Toolbar
+                        after={
+                            <Button onClick={closeDialog} emphasis={Emphasis.low}>
+                                Close
+                            </Button>
+                        }
+                    />
+                </footer>
+            </Dialog>
+        </>
+    );
+};
+
+export const PreventDialogCloseOnEscape = ({ theme }: any) => {
+    const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
+    return (
+        <>
+            {button}
+            <Dialog preventCloseOnEscape isOpen={isOpen} onClose={closeDialog} parentElement={buttonRef}>
+                {content}
+                <footer>
+                    <Toolbar
+                        after={
+                            <Button onClick={closeDialog} emphasis={Emphasis.low}>
+                                Close
+                            </Button>
+                        }
+                    />
+                </footer>
+            </Dialog>
+        </>
+    );
+};
+
+export const PreventDialogCloseOnClick = ({ theme }: any) => {
+    const { button, buttonRef, closeDialog, isOpen } = useOpenButton(theme);
+    return (
+        <>
+            {button}
+            <Dialog preventCloseOnClick isOpen={isOpen} onClose={closeDialog} parentElement={buttonRef}>
                 {content}
                 <footer>
                     <Toolbar

--- a/packages/lumx-react/src/components/dialog/Dialog.test.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.test.tsx
@@ -76,6 +76,14 @@ describe(`<${Dialog.displayName}>`, () => {
             document.body.dispatchEvent(keyDown('Escape'));
             expect(onClose).not.toHaveBeenCalled();
         });
+
+        it('should not trigger `onClose` when pressing `escape` key with `preventCloseOnEscape` set to `true`', () => {
+            const onClose = jest.fn();
+            setup({ isOpen: true, onClose, preventCloseOnEscape: true }, false);
+
+            document.body.dispatchEvent(keyDown('Escape'));
+            expect(onClose).not.toHaveBeenCalled();
+        });
     });
 
     // 4. Test conditions (i.e. things that display or not in the UI based on props).

--- a/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/lumx-react/src/components/dialog/__snapshots__/Dialog.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogFocusTrap 1`
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     focusElement={
       {
         "current": null,
@@ -96,6 +97,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogFocusTrap 1`
           Open date picker
         </Button>
         <Dialog
+          disableBodyScroll={true}
           isOpen={false}
           onClose={[Function]}
           parentElement={
@@ -242,6 +244,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithAlertDia
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     parentElement={
@@ -318,6 +321,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithHeaderFo
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     forceFooterDivider={true}
     forceHeaderDivider={true}
     isOpen={true}
@@ -372,6 +376,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithHeaderFo
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     parentElement={
@@ -424,6 +429,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithHeaderFo
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     footer="Footer prop"
     header="Header prop"
     isOpen={true}
@@ -468,6 +474,7 @@ exports[`<Dialog> Snapshots and structure should render story DialogWithHeaderFo
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     footer=" Footer prop"
     header=" Header prop"
     isOpen={true}
@@ -522,6 +529,7 @@ exports[`<Dialog> Snapshots and structure should render story LoadingDialog 1`] 
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isLoading={true}
     isOpen={true}
     onClose={[Function]}
@@ -565,6 +573,7 @@ exports[`<Dialog> Snapshots and structure should render story PreventDialogAutoC
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     parentElement={
@@ -573,6 +582,122 @@ exports[`<Dialog> Snapshots and structure should render story PreventDialogAutoC
       }
     }
     preventAutoClose={true}
+    size="big"
+  >
+    <div
+      className="lumx-spacing-padding"
+    >
+      
+Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros
+Afros. Magna pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum
+dapibus. Praeterea iter est quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea
+commodi consequat. Inmensae subtilitatis, obscuris et malesuada fames. Me non paenitet nullum
+festiviorem excogitasse ad hoc. Cum ceteris in veneratione tui montes, nascetur mus. Etiam
+habebis sem dicantur magna mollis euismod. Quis aute iure reprehenderit in voluptate velit esse.
+Phasellus laoreet lorem vel dolor tempus vehicula. Ambitioni dedisse scripsisse iudicaretur.
+Paullum deliquit, ponderibus modulisque suis ratio utitur. Ab illo tempore, ab est sed
+immemorabili. Nec dubitamus multa iter quae et nos invenerat. Tu quoque, Brute, fili mi, nihil
+timor populi, nihil! Morbi fringilla convallis sapien, id pulvinar odio volutpat. Cras mattis
+iudicium purus sit amet fermentum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus.
+Quisque ut dolor gravida, placerat libero vel, euismod. Unam incolunt Belgae, aliam Aquitani,
+tertiam. Cras mattis iudicium purus sit amet fermentum
+    </div>
+    <footer>
+      <Toolbar
+        after={
+          <Button
+            emphasis="low"
+            onClick={[Function]}
+            size="m"
+            theme="light"
+          >
+            Close
+          </Button>
+        }
+      />
+    </footer>
+  </Dialog>
+</Fragment>
+`;
+
+exports[`<Dialog> Snapshots and structure should render story PreventDialogCloseOnClick 1`] = `
+<Fragment>
+  <Button
+    emphasis="high"
+    onClick={[Function]}
+    size="m"
+    theme="light"
+  >
+    Open dialog
+  </Button>
+  <Dialog
+    disableBodyScroll={true}
+    isOpen={true}
+    onClose={[Function]}
+    parentElement={
+      {
+        "current": undefined,
+      }
+    }
+    preventCloseOnClick={true}
+    size="big"
+  >
+    <div
+      className="lumx-spacing-padding"
+    >
+      
+Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros
+Afros. Magna pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum
+dapibus. Praeterea iter est quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea
+commodi consequat. Inmensae subtilitatis, obscuris et malesuada fames. Me non paenitet nullum
+festiviorem excogitasse ad hoc. Cum ceteris in veneratione tui montes, nascetur mus. Etiam
+habebis sem dicantur magna mollis euismod. Quis aute iure reprehenderit in voluptate velit esse.
+Phasellus laoreet lorem vel dolor tempus vehicula. Ambitioni dedisse scripsisse iudicaretur.
+Paullum deliquit, ponderibus modulisque suis ratio utitur. Ab illo tempore, ab est sed
+immemorabili. Nec dubitamus multa iter quae et nos invenerat. Tu quoque, Brute, fili mi, nihil
+timor populi, nihil! Morbi fringilla convallis sapien, id pulvinar odio volutpat. Cras mattis
+iudicium purus sit amet fermentum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus.
+Quisque ut dolor gravida, placerat libero vel, euismod. Unam incolunt Belgae, aliam Aquitani,
+tertiam. Cras mattis iudicium purus sit amet fermentum
+    </div>
+    <footer>
+      <Toolbar
+        after={
+          <Button
+            emphasis="low"
+            onClick={[Function]}
+            size="m"
+            theme="light"
+          >
+            Close
+          </Button>
+        }
+      />
+    </footer>
+  </Dialog>
+</Fragment>
+`;
+
+exports[`<Dialog> Snapshots and structure should render story PreventDialogCloseOnEscape 1`] = `
+<Fragment>
+  <Button
+    emphasis="high"
+    onClick={[Function]}
+    size="m"
+    theme="light"
+  >
+    Open dialog
+  </Button>
+  <Dialog
+    disableBodyScroll={true}
+    isOpen={true}
+    onClose={[Function]}
+    parentElement={
+      {
+        "current": undefined,
+      }
+    }
+    preventCloseOnEscape={true}
     size="big"
   >
     <div
@@ -622,6 +747,7 @@ exports[`<Dialog> Snapshots and structure should render story ScrollableDialog 1
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     parentElement={
@@ -706,6 +832,7 @@ exports[`<Dialog> Snapshots and structure should render story ScrollableDialogWi
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     parentElement={
@@ -800,6 +927,7 @@ exports[`<Dialog> Snapshots and structure should render story SimpleDialog 1`] =
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     parentElement={
@@ -843,6 +971,7 @@ exports[`<Dialog> Snapshots and structure should render story Sizes 1`] = `
   </Button>
   Use the knobs to change the dialog size!
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     parentElement={
@@ -927,6 +1056,7 @@ exports[`<Dialog> Snapshots and structure should render story WithAnimationCallb
     Open dialog
   </Button>
   <Dialog
+    disableBodyScroll={true}
     isOpen={true}
     onClose={[Function]}
     onVisibilityChange={[Function]}
@@ -936,6 +1066,49 @@ exports[`<Dialog> Snapshots and structure should render story WithAnimationCallb
       }
     }
     size="regular"
+  >
+    <div
+      className="lumx-spacing-padding"
+    >
+      
+Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros
+Afros. Magna pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum
+dapibus. Praeterea iter est quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea
+commodi consequat. Inmensae subtilitatis, obscuris et malesuada fames. Me non paenitet nullum
+festiviorem excogitasse ad hoc. Cum ceteris in veneratione tui montes, nascetur mus. Etiam
+habebis sem dicantur magna mollis euismod. Quis aute iure reprehenderit in voluptate velit esse.
+Phasellus laoreet lorem vel dolor tempus vehicula. Ambitioni dedisse scripsisse iudicaretur.
+Paullum deliquit, ponderibus modulisque suis ratio utitur. Ab illo tempore, ab est sed
+immemorabili. Nec dubitamus multa iter quae et nos invenerat. Tu quoque, Brute, fili mi, nihil
+timor populi, nihil! Morbi fringilla convallis sapien, id pulvinar odio volutpat. Cras mattis
+iudicium purus sit amet fermentum. Vivamus sagittis lacus vel augue laoreet rutrum faucibus.
+Quisque ut dolor gravida, placerat libero vel, euismod. Unam incolunt Belgae, aliam Aquitani,
+tertiam. Cras mattis iudicium purus sit amet fermentum
+    </div>
+  </Dialog>
+</Fragment>
+`;
+
+exports[`<Dialog> Snapshots and structure should render story WithBodyScroll 1`] = `
+<Fragment>
+  <Button
+    emphasis="high"
+    onClick={[Function]}
+    size="m"
+    theme="light"
+  >
+    Open dialog
+  </Button>
+  <Dialog
+    disableBodyScroll={false}
+    isOpen={true}
+    onClose={[Function]}
+    parentElement={
+      {
+        "current": undefined,
+      }
+    }
+    size="big"
   >
     <div
       className="lumx-spacing-padding"


### PR DESCRIPTION
# General summary
Added 3 new props to the `Dialog` component to make it more customizable
- `disableBodyScroll`: defaults to true, allows to enable/disable the scroll on the body
- `preventCloseOnClick`: only prevents the close on click. Useful when we want to keep the close on `Escape`
- `preventCloseOnEscape`: only prevents the close on escape. Useful when we want to keep the close on `Click`

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
