### PR TITLE
fix(select): fix select dropdown focus not being trapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Select: fix the select dropdown focus not being trapped in it.
+
 ## [3.2.0][] - 2023-04-11
 
 ### Changed

--- a/packages/lumx-react/src/components/select/SelectMultiple.stories.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.stories.tsx
@@ -1,9 +1,20 @@
 /* istanbul ignore file */
 import { mdiTram } from '@lumx/icons/';
-import { Chip, List, ListItem, SelectMultiple, Size } from '@lumx/react';
+import {
+    Chip,
+    Dialog,
+    List,
+    ListDivider,
+    ListItem,
+    ListSubheader,
+    SelectMultiple,
+    Size,
+    TextField,
+    Toolbar,
+} from '@lumx/react';
 import { useBooleanState } from '@lumx/react/hooks/useBooleanState';
 import noop from 'lodash/noop';
-import React, { MouseEventHandler, SyntheticEvent, useState } from 'react';
+import React, { MouseEventHandler, SyntheticEvent, useRef, useState } from 'react';
 import { SelectVariant } from './constants';
 
 export default { title: 'LumX components/select/Select Multiple' };
@@ -223,5 +234,97 @@ export const ChipsCustomSelectMultiple = ({ theme }: any) => {
                       ]}
             </List>
         </SelectMultiple>
+    );
+};
+
+/**
+ * Test select focus trap (focus is contained inside the dialog then inside the select dropdown)
+ */
+export const SelectWithinADialog = ({ theme }: any) => {
+    const searchFieldRef = useRef(null);
+
+    const [searchText, setSearchText] = useState<string>();
+    const [values, setValues] = useState<string[]>([]);
+    const [isOpen, closeSelect, , toggleSelect] = useBooleanState(false);
+
+    const clearSelected = (event: SyntheticEvent, value: string) => {
+        event.stopPropagation();
+        setValues(value ? values.filter((val) => val !== value) : []);
+    };
+
+    const selectItem = (item: string) => () => {
+        if (values.includes(item)) {
+            return;
+        }
+
+        closeSelect();
+        setValues([...values, item]);
+    };
+
+    const filteredChoices =
+        searchText && searchText.length > 0 ? CHOICES.filter((choice) => choice.includes(searchText)) : CHOICES;
+
+    return (
+        <>
+            <Dialog isOpen>
+                <header>
+                    <Toolbar label={<span className="lumx-typography-title">Dialog header</span>} />
+                </header>
+                <div className="lumx-spacing-padding-horizontal-huge lumx-spacing-padding-bottom-huge">
+                    {/* Testing hidden input do not count in th focus trap*/}
+                    <input hidden type="file" />
+                    <input type="hidden" />
+
+                    <div className="lumx-spacing-margin-bottom-huge">The select should capture the focus on open.</div>
+
+                    <SelectMultiple
+                        isOpen={isOpen}
+                        value={values}
+                        onClear={clearSelected}
+                        clearButtonProps={{ label: 'Clear' }}
+                        label={LABEL}
+                        placeholder={PLACEHOLDER}
+                        theme={theme}
+                        onInputClick={toggleSelect}
+                        onDropdownClose={closeSelect}
+                        icon={mdiTram}
+                        focusElement={searchFieldRef}
+                    >
+                        <List isClickable>
+                            <>
+                                <ListSubheader>
+                                    <TextField
+                                        clearButtonProps={{ label: 'Clear' }}
+                                        placeholder="Search"
+                                        role="searchbox"
+                                        inputRef={searchFieldRef}
+                                        onChange={setSearchText}
+                                        value={searchText}
+                                    />
+                                </ListSubheader>
+                                <ListDivider role="presentation" />
+                            </>
+
+                            {filteredChoices.length > 0
+                                ? filteredChoices.map((choice) => (
+                                      <ListItem
+                                          isSelected={values.includes(choice)}
+                                          key={choice}
+                                          onItemSelected={selectItem(choice)}
+                                          size={Size.tiny}
+                                      >
+                                          {choice}
+                                      </ListItem>
+                                  ))
+                                : [
+                                      <ListItem key={0} size={Size.tiny}>
+                                          No data
+                                      </ListItem>,
+                                  ]}
+                        </List>
+                    </SelectMultiple>
+                </div>
+            </Dialog>
+        </>
     );
 };

--- a/packages/lumx-react/src/components/select/WithSelectContext.tsx
+++ b/packages/lumx-react/src/components/select/WithSelectContext.tsx
@@ -1,15 +1,15 @@
-import React, { Ref, useCallback, useMemo, useRef } from 'react';
-
 import classNames from 'classnames';
+import React, { Ref, useCallback, useMemo, useRef } from 'react';
 import { uid } from 'uid';
 
+import { Placement } from '@lumx/react';
 import { Kind, Theme } from '@lumx/react/components';
 import { Dropdown } from '@lumx/react/components/dropdown/Dropdown';
 import { InputHelper } from '@lumx/react/components/input-helper/InputHelper';
+import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
+import { useListenFocus } from '@lumx/react/hooks/useListenFocus';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
-import { useListenFocus } from '@lumx/react/hooks/useListenFocus';
-import { Placement } from '@lumx/react';
 
 import { CoreSelectProps, SelectVariant } from './constants';
 
@@ -30,6 +30,7 @@ export const WithSelectContext = (
     {
         children,
         className,
+        focusElement,
         isMultiple,
         closeOnClick = !isMultiple,
         disabled,
@@ -58,6 +59,7 @@ export const WithSelectContext = (
     const selectId = useMemo(() => id || `select-${uid()}`, [id]);
     const anchorRef = useRef<HTMLElement>(null);
     const selectRef = useRef<HTMLDivElement>(null);
+    const dropdownRef = useRef<HTMLDivElement>(null);
     const isFocus = useListenFocus(anchorRef);
 
     const handleKeyboardNav = useCallback(
@@ -76,6 +78,9 @@ export const WithSelectContext = (
         }
         anchorRef?.current?.blur();
     };
+
+    // Handle focus trap.
+    useFocusTrap(isOpen && dropdownRef.current, focusElement?.current);
 
     return (
         <div
@@ -125,6 +130,7 @@ export const WithSelectContext = (
                 placement={Placement.BOTTOM_START}
                 onClose={onClose}
                 onInfiniteScroll={onInfiniteScroll}
+                ref={dropdownRef}
             >
                 {children}
             </Dropdown>


### PR DESCRIPTION
# General summary
Fix select dropdown focus within a dialog not being trapped
<!-- Please describe the PR content -->

This PR trap the focus on the Select dropdown like it is the case with a Dialog, you can test it with the story SelectWithinADialog https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10
<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [x] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
