### PR TITLE
chore(core): remove deprecated sass tilde imports

### DIFF
--- a/packages/lumx-core/src/scss/lumx.scss
+++ b/packages/lumx-core/src/scss/lumx.scss
@@ -1,6 +1,6 @@
 /** LUMX THEME */
 
-@import "~sass-mq";
+@import "sass-mq";
 @import "../css/design-tokens";
 
 // TODO: remove in next major version

--- a/packages/lumx-icons/font.scss
+++ b/packages/lumx-icons/font.scss
@@ -1,4 +1,4 @@
-$mdi-font-path: '~@mdi/font/fonts';
+$mdi-font-path: "~@mdi/font/fonts";
 
-@import '~@mdi/font/scss/materialdesignicons';
-@import './v4-to-v5-aliases';
+@import "@mdi/font/scss/materialdesignicons";
+@import "./v4-to-v5-aliases";

--- a/packages/lumx-react/storybook/story-block/index.scss
+++ b/packages/lumx-react/storybook/story-block/index.scss
@@ -1,5 +1,5 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 .story-block {
     position: absolute;
@@ -7,21 +7,21 @@
     right: 0;
     bottom: 0;
     left: 0;
-    overflow: auto;
     padding: 1rem;
+    overflow: auto;
 
     &--has-grey-background:not(&--theme-dark) {
         background: lightgray;
     }
 
     &--theme-dark {
-        background: lumx-color-variant('dark', 'N');
-        color: lumx-color-variant('light', 'N');
+        color: lumx-color-variant("light", "N");
+        background: lumx-color-variant("dark", "N");
     }
 
     &__toolbar {
         display: flex;
-        margin-bottom: $lumx-spacing-unit-big;
         gap: $lumx-spacing-unit-big;
+        margin-bottom: $lumx-spacing-unit-big;
     }
 }

--- a/packages/site-demo/src/components/content/AssetBlock/AssetBlock.scss
+++ b/packages/site-demo/src/components/content/AssetBlock/AssetBlock.scss
@@ -1,18 +1,18 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 /* ==========================================================================
    Asset block
    ========================================================================== */
 
 .asset-block {
-    border: 1px solid lumx-color-variant('dark', 'L4');
+    border: 1px solid lumx-color-variant("dark", "L4");
     border-radius: var(--lumx-border-radius);
 
     &__content {
         padding: $lumx-spacing-unit * 3;
-        background-color: lumx-color-variant('dark', 'L6');
         text-align: center;
+        background-color: lumx-color-variant("dark", "L6");
     }
 
     &__thumbnail {
@@ -24,7 +24,7 @@
         display: flex;
         align-items: center;
         padding: $lumx-spacing-unit $lumx-spacing-unit * 2 $lumx-spacing-unit $lumx-spacing-unit;
-        border-top: 1px solid lumx-color-variant('dark', 'L4');
+        border-top: 1px solid lumx-color-variant("dark", "L4");
     }
 
     &__filename {

--- a/packages/site-demo/src/components/content/CodeBlock/CodeBlock.scss
+++ b/packages/site-demo/src/components/content/CodeBlock/CodeBlock.scss
@@ -1,5 +1,5 @@
-@import "~@lumx/core/src/scss/design-tokens";
-@import "~@lumx/core/src/scss/core";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 /* ==========================================================================
    Code block

--- a/packages/site-demo/src/components/content/DemoBlock/DemoBlock.scss
+++ b/packages/site-demo/src/components/content/DemoBlock/DemoBlock.scss
@@ -1,5 +1,5 @@
-@import "~@lumx/core/src/scss/design-tokens";
-@import "~@lumx/core/src/scss/core";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 /* ==========================================================================
    Demo block

--- a/packages/site-demo/src/components/content/DemoColor/DemoColor.scss
+++ b/packages/site-demo/src/components/content/DemoColor/DemoColor.scss
@@ -1,5 +1,5 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 /* ==========================================================================
    Demo colors

--- a/packages/site-demo/src/components/content/PropTable/PropTable.scss
+++ b/packages/site-demo/src/components/content/PropTable/PropTable.scss
@@ -1,5 +1,5 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 /* ==========================================================================
    Prop table
@@ -7,7 +7,7 @@
 
 .prop-table {
     padding: $lumx-spacing-unit * 2 $lumx-spacing-unit * 3;
-    background-color: lumx-color-variant('dark', 'L6');
+    background-color: lumx-color-variant("dark", "L6");
     border-radius: var(--lumx-border-radius);
 
     &__type {

--- a/packages/site-demo/src/components/content/design-tokens/DesignToken.scss
+++ b/packages/site-demo/src/components/content/design-tokens/DesignToken.scss
@@ -1,7 +1,7 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
-@import '~@lumx/core/src/scss/components/divider/variables';
-@import '~@lumx/core/src/scss/components/divider/mixins';
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
+@import "@lumx/core/src/scss/components/divider/variables";
+@import "@lumx/core/src/scss/components/divider/mixins";
 
 /* ==========================================================================
    Design token
@@ -13,11 +13,11 @@
     background-color: transparent !important;
 
     &--theme-light {
-        @include lumx-has-divider(lumx-base-const('theme', 'LIGHT'));
+        @include lumx-has-divider(lumx-base-const("theme", "LIGHT"));
     }
 
     &--theme-dark {
-        @include lumx-has-divider(lumx-base-const('theme', 'DARK'));
+        @include lumx-has-divider(lumx-base-const("theme", "DARK"));
     }
 
     &:last-child {
@@ -37,12 +37,12 @@
 
     &__name,
     &__value {
-        @include lumx-typography('subtitle1');
+        @include lumx-typography("subtitle1");
     }
 
     &__name {
         #{$self}--theme-dark & {
-            color: lumx-color-variant('light', 'N');
+            color: lumx-color-variant("light", "N");
         }
     }
 
@@ -50,11 +50,11 @@
         margin-left: auto;
 
         #{$self}--theme-light & {
-            color: lumx-color-variant('dark', 'L3');
+            color: lumx-color-variant("dark", "L3");
         }
 
         #{$self}--theme-dark & {
-            color: lumx-color-variant('light', 'L3');
+            color: lumx-color-variant("light", "L3");
         }
     }
 
@@ -63,12 +63,12 @@
     }
 
     &__description {
-        @include lumx-typography('body1');
+        @include lumx-typography("body1");
 
         margin-bottom: $lumx-spacing-unit * 2;
 
         #{$self}--theme-dark & {
-            color: lumx-color-variant('light', 'N');
+            color: lumx-color-variant("light", "N");
         }
     }
 }

--- a/packages/site-demo/src/components/content/design-tokens/DesignTokenGroup.scss
+++ b/packages/site-demo/src/components/content/design-tokens/DesignTokenGroup.scss
@@ -1,6 +1,6 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
-@import '~@lumx/core/src/scss/components/divider/variables';
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
+@import "@lumx/core/src/scss/components/divider/variables";
 
 /* ==========================================================================
    Design token group
@@ -10,10 +10,10 @@
     border-radius: var(--lumx-border-radius);
 
     &--theme-light {
-        border: 1px solid lumx-color-variant('dark', $lumx-divider-color-variant);
+        border: 1px solid lumx-color-variant("dark", $lumx-divider-color-variant);
     }
 
     &--theme-dark {
-        background-color: lumx-color-variant('dark', 'N');
+        background-color: lumx-color-variant("dark", "N");
     }
 }

--- a/packages/site-demo/src/components/layout/Layout.scss
+++ b/packages/site-demo/src/components/layout/Layout.scss
@@ -1,7 +1,7 @@
-@import '~sass-mq';
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
-@import './variables';
+@import "sass-mq";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
+@import "./variables";
 
 /* ==========================================================================
    Main

--- a/packages/site-demo/src/components/layout/MainContent/MainContent.scss
+++ b/packages/site-demo/src/components/layout/MainContent/MainContent.scss
@@ -1,6 +1,6 @@
-@import "~@lumx/core/src/scss/design-tokens";
-@import "~@lumx/core/src/scss/core";
-@import "~@lumx/core/src/scss/components/link/mixins";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
+@import "@lumx/core/src/scss/components/link/mixins";
 
 /* Main content
    ========================================================================== */

--- a/packages/site-demo/src/components/layout/MainHeader/MainHeader.scss
+++ b/packages/site-demo/src/components/layout/MainHeader/MainHeader.scss
@@ -1,6 +1,6 @@
-@import 'sass-mq';
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "sass-mq";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 /* Main header
    ========================================================================== */
@@ -10,9 +10,9 @@
     &__extras {
         display: flex;
         flex-wrap: wrap;
+        gap: $lumx-spacing-unit-big;
         align-items: center;
         justify-content: flex-end;
-        gap: $lumx-spacing-unit-big;
     }
 
     &__home-logo-link {
@@ -36,8 +36,8 @@
 
         // Move material theme switcher and lumx version link to the end (wrapped on new line)
         &__extras {
-            width: 100%;
             order: 5;
+            width: 100%;
         }
     }
 }

--- a/packages/site-demo/src/components/layout/MainNav/HomeLogoLink/HomeLogoLink.scss
+++ b/packages/site-demo/src/components/layout/MainNav/HomeLogoLink/HomeLogoLink.scss
@@ -1,5 +1,5 @@
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 /* Home logo link
    ========================================================================== */
@@ -7,7 +7,7 @@
 .home-logo-link {
     .lumx-link__content {
         display: inline-flex;
-        align-items: center;
         gap: $lumx-spacing-unit-medium;
+        align-items: center;
     }
 }

--- a/packages/site-demo/src/components/layout/MainNav/MainNav.scss
+++ b/packages/site-demo/src/components/layout/MainNav/MainNav.scss
@@ -1,8 +1,8 @@
-@import '~sass-mq';
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
-@import '~@lumx/core/src/scss/components/link/mixins';
-@import '../variables';
+@import "sass-mq";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
+@import "@lumx/core/src/scss/components/link/mixins";
+@import "../variables";
 
 /* ==========================================================================
    Main nav
@@ -16,8 +16,8 @@ $transition-duration: 300ms;
     bottom: 0;
     left: 0;
     width: $main-nav-width;
-    background-color: white;
     overflow-y: auto;
+    background-color: white;
 
     // Non responsive: hide side nav close button
     @include mq($from: desktop) {
@@ -29,21 +29,24 @@ $transition-duration: 300ms;
     // Responsive: side nav overlay
     @include mq($until: desktop) {
         @include lumx-elevation(4);
+
         z-index: 1000;
-        opacity: 0;
-        transform: translateX(-24px);
-        transition: visibility $transition-duration, transform $transition-duration,
-            opacity $transition-duration linear 100ms;
         visibility: hidden;
+        opacity: 0;
+        transition:
+            visibility $transition-duration,
+            transform $transition-duration,
+            opacity $transition-duration linear 100ms;
+        transform: translateX(-24px);
 
         @media (prefers-reduced-motion: reduce) {
             transition: none;
         }
 
         &--is-open {
-            opacity: 1;
-            transform: translateX(0px);
             visibility: visible;
+            opacity: 1;
+            transform: translateX(0);
         }
 
         &__close-button {
@@ -57,20 +60,20 @@ $transition-duration: 300ms;
         position: relative;
         min-height: 100%;
         padding: $lumx-spacing-unit * 6 $lumx-spacing-unit * 4;
-        background-color: lumx-color-variant(dark, L6);
+        background-color: lumx-color-variant("dark", "L6");
     }
 
     &__overlay {
         position: fixed;
+        inset: 0;
         z-index: 999;
         width: 100vw;
+        visibility: hidden;
+        background-color: lumx-color-variant("dark", "L1");
         border: none;
-        appearance: none !important;
-        background-color: lumx-color-variant(dark, L1);
-        inset: 0;
         opacity: 0;
         transition: opacity $transition-duration, visibility $transition-duration;
-        visibility: hidden;
+        appearance: none !important;
 
         @media (prefers-reduced-motion: reduce) {
             transition: none;
@@ -79,8 +82,8 @@ $transition-duration: 300ms;
         // Backdrop when responsive nav is open
         @include mq($until: desktop) {
             &--is-open {
-                opacity: 1;
                 visibility: visible;
+                opacity: 1;
             }
         }
     }

--- a/packages/site-demo/src/components/search/SearchButton.scss
+++ b/packages/site-demo/src/components/search/SearchButton.scss
@@ -1,6 +1,6 @@
-@import 'sass-mq';
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "sass-mq";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 .search-button {
     // Collapse button on small screen
@@ -10,6 +10,7 @@
         .lumx-chip__label {
             display: none;
         }
+
         .lumx-chip__before {
             margin: 0;
         }
@@ -27,9 +28,9 @@
 
     kbd {
         padding: 0 $lumx-spacing-unit-tiny;
-        border: 1px solid lumx-color-variant('dark', 'L5');
         margin-left: $lumx-spacing-unit-tiny;
-        background-color: lumx-color-variant('light', 'L3');
+        background-color: lumx-color-variant("light", "L3");
+        border: 1px solid lumx-color-variant("dark", "L5");
         border-radius: 5px;
     }
 

--- a/packages/site-demo/src/components/search/dialog/SearchDialog.scss
+++ b/packages/site-demo/src/components/search/dialog/SearchDialog.scss
@@ -1,14 +1,14 @@
-@import 'sass-mq';
-@import '~@lumx/core/src/scss/design-tokens';
-@import '~@lumx/core/src/scss/core';
+@import "sass-mq";
+@import "@lumx/core/src/scss/design-tokens";
+@import "@lumx/core/src/scss/core";
 
 .search-dialog {
     header {
         display: flex;
+        gap: $lumx-spacing-unit;
         align-items: center;
         justify-content: space-between;
         padding: $lumx-spacing-unit;
-        gap: $lumx-spacing-unit;
 
         form {
             flex-grow: 1;
@@ -33,8 +33,8 @@
         --lumx-text-field-input-padding-horizontal: 16px;
         --lumx-text-field-input-min-height: 52px;
 
-        input[type='search']::-webkit-search-cancel-button {
-            -webkit-appearance: none;
+        input[type="search"]::-webkit-search-cancel-button {
+            appearance: none;
         }
     }
 
@@ -45,7 +45,7 @@
 
     /* Search result list item */
     .search-result {
-        border-top: 1px solid lumx-color-variant('dark', 'L5');
+        border-top: 1px solid lumx-color-variant("dark", "L5");
 
         .lumx-list-item__link {
             padding-top: $lumx-spacing-unit-big;
@@ -54,28 +54,31 @@
 
         .lumx-list-item__link,
         .lumx-list-item__content {
-            overflow: hidden;
             width: 100%;
+            overflow: hidden;
         }
 
         &__path {
             // Parent paths
             span:not(:last-child),
             span:not(:first-child)::before {
-                @include lumx-typography('caption');
-                color: lumx-color-variant('dark', 'L2');
-                content: ' > ';
+                @include lumx-typography("caption");
+
+                color: lumx-color-variant("dark", "L2");
+                content: " > ";
             }
+
             // Title
             span:last-child {
-                @include lumx-typography('subtitle2');
+                @include lumx-typography("subtitle2");
             }
         }
 
         &__content {
-            @include lumx-typography('caption');
+            @include lumx-typography("caption");
+
             overflow: hidden;
-            color: lumx-color-variant('dark', 'L2');
+            color: lumx-color-variant("dark", "L2");
             text-overflow: ellipsis;
             white-space: nowrap;
         }

--- a/packages/site-demo/src/style/index.scss
+++ b/packages/site-demo/src/style/index.scss
@@ -1,5 +1,5 @@
 /** DEMO THEME - LUMAPPS */
-@import '~@lumx/core/src/scss/lumx.scss';
+@import "@lumx/core/src/scss/lumx";
 
 /* ==========================================================================
    Base


### PR DESCRIPTION
# General summary

1. Remove `~` import in SCSS that are now deprecated (module import work fine without it)
2. Lint all SCSS files
