### PR TITLE
chore(a11y): added a11y attributes to text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `TextField` component now shows `aria-describedby` and `aria-invalid` attributes.
+
 ## [3.2.1][] - 2023-04-26
 
 ### Fixed
@@ -29,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Dialog: added new props `disableBodyScroll`, `preventCloseOnClick` and `preventCloseOnEscape`
+-   Dialog: added new props `disableBodyScroll`, `preventCloseOnClick` and `preventCloseOnEscape`
 
 ## [3.1.4][] - 2023-01-26
 
@@ -1732,8 +1736,6 @@ _Failed released_
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.1.5...HEAD
 [3.1.5]: https://github.com/lumapps/design-system/compare/v3.1.4...v3.1.5
 [3.1.4]: https://github.com/lumapps/design-system/tree/v3.1.4
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.2.1...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.2.1...HEAD
 [3.2.1]: https://github.com/lumapps/design-system/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/lumapps/design-system/tree/v3.2.0

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -106,22 +106,27 @@ describe(`<${TextField.displayName}>`, () => {
         });
 
         it('should have helper text', () => {
-            const { helper } = setup({
+            const { helper, inputNative } = setup({
                 helper: 'helper',
                 label: 'test',
                 placeholder: 'test',
             });
+
             expect(helper).toHaveTextContent('helper');
+            expect(inputNative).toHaveAttribute('aria-describedby');
         });
 
         it('should have error text', () => {
-            const { error } = setup({
+            const { error, inputNative } = setup({
                 error: 'error',
                 hasError: true,
                 label: 'test',
                 placeholder: 'test',
             });
+
             expect(error).toHaveTextContent('error');
+            expect(inputNative).toHaveAttribute('aria-invalid', 'true');
+            expect(inputNative).toHaveAttribute('aria-describedby');
         });
 
         it('should not have error text', () => {

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -153,6 +153,8 @@ interface InputNativeProps {
     onChange(value: string, name?: string, event?: SyntheticEvent): void;
     onFocus?(value: React.FocusEvent): void;
     onBlur?(value: React.FocusEvent): void;
+    hasError?: boolean;
+    describedById?: string;
 }
 
 const renderInputNative: React.FC<InputNativeProps> = (props) => {
@@ -172,6 +174,8 @@ const renderInputNative: React.FC<InputNativeProps> = (props) => {
         recomputeNumberOfRows,
         type,
         name,
+        hasError,
+        describedById,
         ...forwardedProps
     } = props;
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -214,6 +218,8 @@ const renderInputNative: React.FC<InputNativeProps> = (props) => {
         onFocus: onTextFieldFocus,
         onBlur: onTextFieldBlur,
         onChange: handleChange,
+        'aria-invalid': hasError ? 'true' : undefined,
+        'aria-describedby': describedById,
         ref: mergeRefs(inputRef as any, ref) as any,
     };
     if (multiline) {
@@ -264,6 +270,17 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
         ...forwardedProps
     } = props;
     const textFieldId = useMemo(() => id || `text-field-${uid()}`, [id]);
+    /**
+     * Generate unique ids for both the helper and error texts, in order to
+     * later on add them to the input native as aria-describedby. If both the error and the helper are present,
+     * we want to first use the most important one, which is the errorId. That way, screen readers will read first
+     * the error and then the helper
+     */
+    const helperId = helper ? `text-field-helper-${uid()}` : undefined;
+    const errorId = error ? `text-field-error-${uid()}` : undefined;
+    const describedByIds = [errorId, helperId].filter(Boolean);
+    const describedById = describedByIds.length === 0 ? undefined : describedByIds.join(' ');
+
     const [isFocus, setFocus] = useState(false);
     const { rows, recomputeNumberOfRows } = useComputeNumberOfRows(multiline ? minimumRows || DEFAULT_MIN_ROWS : 0);
     const valueLength = (value || '').length;
@@ -359,6 +376,8 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
                             type,
                             value,
                             name,
+                            hasError,
+                            describedById,
                             ...forwardedProps,
                         })}
                     </div>
@@ -383,6 +402,8 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
                             type,
                             value,
                             name,
+                            hasError,
+                            describedById,
                             ...forwardedProps,
                         })}
                     </div>
@@ -414,13 +435,13 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
             </div>
 
             {hasError && error && (
-                <InputHelper className={`${CLASSNAME}__helper`} kind={Kind.error} theme={theme}>
+                <InputHelper className={`${CLASSNAME}__helper`} kind={Kind.error} theme={theme} id={errorId}>
                     {error}
                 </InputHelper>
             )}
 
             {helper && (
-                <InputHelper className={`${CLASSNAME}__helper`} theme={theme}>
+                <InputHelper className={`${CLASSNAME}__helper`} theme={theme} id={helperId}>
                     {helper}
                 </InputHelper>
             )}


### PR DESCRIPTION
# General summary
This PR adds 2 `aria` attributes to the `TextField` component:
- `aria-describedby` added to the `input` in order to associate the input to the helpers and errors
- `aria-invalid` when the component has `hasError = true`

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
