### PR TITLE
feat(textfield): add onClear callback to props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `TextField` component now shows `aria-describedby` and `aria-invalid` attributes.
+-   `TextField` component now has a new prop `onClear` to allow a callback to be passed.
 
 ## [3.2.1][] - 2023-04-26
 

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -12,6 +12,7 @@ export default {
         clearButtonProps: { control: false },
         chips: { control: false },
         afterElement: { control: false },
+        onClear: { action: true },
     },
     decorators: [withValueOnChange({})],
 };

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -5,8 +5,14 @@ import camelCase from 'lodash/camelCase';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import { getBasicClass } from '@lumx/react/utils/className';
 
-import { render } from '@testing-library/react';
-import { getByClassName, getByTagName, queryAllByClassName, queryByTagName } from '@lumx/react/testing/utils/queries';
+import { render, screen } from '@testing-library/react';
+import {
+    getByClassName,
+    getByTagName,
+    queryAllByClassName,
+    queryByClassName,
+    queryByTagName,
+} from '@lumx/react/testing/utils/queries';
 import partition from 'lodash/partition';
 import userEvent from '@testing-library/user-event';
 
@@ -27,9 +33,11 @@ const setup = (propsOverride: Partial<TextFieldProps> = {}) => {
         | HTMLInputElement;
     const helpers = queryAllByClassName(container, 'lumx-text-field__helper');
     const [[helper], [error]] = partition(helpers, (h) => !h.className.includes('lumx-input-helper--color-red'));
+    const clearButton = queryByClassName(container, 'lumx-text-field__input-clear');
 
     return {
         props,
+        clearButton,
         container,
         element,
         inputNative,
@@ -164,6 +172,41 @@ describe(`<${TextField.displayName}>`, () => {
             await userEvent.keyboard('a');
 
             expect(onChange).toHaveBeenCalledWith('a', 'name', expect.objectContaining({}));
+        });
+
+        it('should trigger `onChange` with empty value when text field is cleared', async () => {
+            const onChange = jest.fn();
+            const { clearButton } = setup({
+                value: 'initial value',
+                name: 'name',
+                clearButtonProps: { label: 'Clear' },
+                onChange,
+            });
+
+            expect(clearButton).toBeInTheDocument();
+
+            await userEvent.click(clearButton as HTMLElement);
+
+            expect(onChange).toHaveBeenCalledWith('');
+        });
+
+        it('should trigger `onChange` with empty value and `onClear` when text field is cleared', async () => {
+            const onChange = jest.fn();
+            const onClear = jest.fn();
+            const { clearButton } = setup({
+                value: 'initial value',
+                name: 'name',
+                clearButtonProps: { label: 'Clear' },
+                onChange,
+                onClear,
+            });
+
+            expect(clearButton).toBeInTheDocument();
+
+            await userEvent.click(clearButton as HTMLElement);
+
+            expect(onChange).toHaveBeenCalledWith('');
+            expect(onClear).toHaveBeenCalled();
         });
     });
 

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -61,6 +61,8 @@ export interface TextFieldProps extends GenericProps, HasTheme {
     onBlur?(event: React.FocusEvent): void;
     /** On change callback. */
     onChange(value: string, name?: string, event?: SyntheticEvent): void;
+    /** On clear callback. */
+    onClear?(event?: SyntheticEvent): void;
     /** On focus callback. */
     onFocus?(event: React.FocusEvent): void;
 }
@@ -260,6 +262,7 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
         name,
         onBlur,
         onChange,
+        onClear,
         onFocus,
         placeholder,
         textFieldRef,
@@ -292,12 +295,16 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
      * and remove focus from the clear button.
      * @param evt On clear event.
      */
-    const onClear = (evt: React.ChangeEvent) => {
+    const handleClear = (evt: React.ChangeEvent) => {
         evt.nativeEvent.preventDefault();
         evt.nativeEvent.stopPropagation();
         (evt.currentTarget as HTMLElement).blur();
 
         onChange('');
+
+        if (onClear) {
+            onClear(evt);
+        }
     };
 
     return (
@@ -426,7 +433,7 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
                         emphasis={Emphasis.low}
                         size={Size.s}
                         theme={theme}
-                        onClick={onClear}
+                        onClick={handleClear}
                         type="button"
                     />
                 )}


### PR DESCRIPTION
# General summary

Added a callback to be able to trigger some function when a user clicks on the clear button.

# Screenshots

**There are no visual updates in this PR**
![clearable-textfield](https://user-images.githubusercontent.com/13302420/235641896-dfb6df1e-1813-4004-90b2-4c3fa69c5850.png)



<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
