### PR TITLE
fix(iconbutton): remove ariadescribedby attribute when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   IconButton: remove the `aria-describedby` attribute when the `aria-label` and the `aria-describedby` have the same value.
+
 ## [3.3.0][] - 2023-05-03
 
 ### Added

--- a/packages/lumx-react/src/components/button/IconButton.stories.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.stories.tsx
@@ -37,6 +37,13 @@ export const WithImage = {
 };
 
 /**
+ * IconButton using a tooltip
+ */
+export const WithTooltip = {
+    args: { icon: mdiSend, label: 'Send a message' },
+};
+
+/**
  * Check icon button style variations (color, states, emphasis, etc.)
  */
 export const IconButtonVariations = {

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -61,7 +61,13 @@ export const IconButton: Comp<IconButtonProps, HTMLButtonElement> = forwardRef((
 
     return (
         <Tooltip label={hideTooltip ? '' : label} {...tooltipProps}>
-            <ButtonRoot ref={ref} {...{ emphasis, size, theme, ...forwardedProps }} aria-label={label} variant="icon">
+            <ButtonRoot
+                ref={ref}
+                {...{ emphasis, size, theme, ...forwardedProps }}
+                aria-label={label}
+                variant="icon"
+                aria-describedby={tooltipProps?.label && tooltipProps?.label !== label ? null : undefined}
+            >
                 {image ? (
                     <img
                         // no need to set alt as an aria-label is already set on the button

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -66,7 +66,8 @@ export const IconButton: Comp<IconButtonProps, HTMLButtonElement> = forwardRef((
                 {...{ emphasis, size, theme, ...forwardedProps }}
                 aria-label={label}
                 variant="icon"
-                aria-describedby={tooltipProps?.label && tooltipProps?.label !== label ? null : undefined}
+                // Remove the aria-describedby added by the tooltip when it is the same text as the aria-label
+                aria-describedby={tooltipProps?.label && tooltipProps?.label === label && undefined}
             >
                 {image ? (
                     <img

--- a/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
+++ b/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
@@ -1,6 +1,8 @@
-import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import get from 'lodash/get';
+import isUndefined from 'lodash/isUndefined';
 import React, { cloneElement, ReactNode, useMemo } from 'react';
+
+import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
 /**
  * Add ref and ARIA attribute(s) in tooltip children or wrapped children.
@@ -20,7 +22,12 @@ export const useInjectTooltipRef = (
     id: string,
 ): ReactNode => {
     return useMemo(() => {
-        const ariaProps = { 'aria-describedby': isOpen ? id : undefined };
+        // Let the children remove the aria-describedby attribute by setting it to undefined
+        const childrenHasAriaProp = get(children, 'props')
+            ? 'aria-describedby' in get(children, 'props') && isUndefined(get(children, 'props.aria-describedby'))
+            : false;
+        const ariaProps = { 'aria-describedby': isOpen && !childrenHasAriaProp ? id : undefined };
+
         if (
             children &&
             get(children, '$$typeof') &&


### PR DESCRIPTION
# General summary
Screen reader was reading two time the icon button label on focus because of the label being present in aria-label and on aria-describedby (which read the tooltip label). 

This PR aim to remove the aria-describedby attribute on icon button when the aria-label and the tooltip label are the same
<!-- Please describe the PR content -->
Tests steps:
- Go to the tooltip component and check that when you focus the button you have an aria-describedby attribute
- Go to the iconButton Tooltip component and check that when you focus the button you don't see the aria-describedby attribute

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
