### PR TITLE
fix(textfield): focus the input on clear button click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   IconButton: remove the `aria-describedby` attribute when the `aria-label` and the `aria-describedby` have the same value.
+-   TextField: focus the text field input when clicking on the clear button
 
 ## [3.3.0][] - 2023-05-03
 

--- a/packages/lumx-react/src/components/text-field/TextField.stories.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.stories.tsx
@@ -50,11 +50,19 @@ export const LabelAndHelper = {
 /**
  * With clear button
  */
-export const Clearable = {
-    args: {
-        value: 'Some value',
-        clearButtonProps: { label: 'Clear' },
-    },
+export const Clearable = () => {
+    const inputRef = React.useRef(null);
+    const [value, setValue] = React.useState('Some value');
+
+    return (
+        <TextField
+            value={value}
+            clearButtonProps={{ label: 'Clear' }}
+            onChange={setValue}
+            inputRef={inputRef}
+            {...TextField.defaultProps}
+        />
+    );
 };
 
 /**

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -1,4 +1,14 @@
-import React, { forwardRef, ReactNode, Ref, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+    forwardRef,
+    ReactNode,
+    Ref,
+    RefObject,
+    SyntheticEvent,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 
 import classNames from 'classnames';
 import get from 'lodash/get';
@@ -304,6 +314,12 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
 
         if (onClear) {
             onClear(evt);
+        }
+
+        const inputElement = inputRef as RefObject<HTMLInputElement | HTMLTextAreaElement>;
+
+        if (inputElement && inputElement.current) {
+            inputElement.current.focus();
         }
     };
 


### PR DESCRIPTION
# General summary
Clicking on the clear button of the textfield focus the previous element instead of the input
<!-- Please describe the PR content -->

Tests steps:

- Go to the textfield component, on the Clearable story, focus the input with the keyboard, and focus the clear button with the keyboard, press enter and check that the focus is now on the input


<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
