### PR TITLE
fix(uploader): improve a11y & doc ARCH-59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   TableCell: fix clickable & sortable header cell accessibility
--   Uploader: use true button element for better accessibility
+-   Uploader: use button element by default
+-   Uploader: use label and input file elements when providing `fileInputProps`
 
 ## [3.3.1][] - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   TableCell: fix clickable & sortable header cell accessibility
+-   Uploader: use true button element for better accessibility
 
 ## [3.3.1][] - 2023-06-12
 

--- a/packages/lumx-core/src/scss/components/uploader/_index.scss
+++ b/packages/lumx-core/src/scss/components/uploader/_index.scss
@@ -11,6 +11,7 @@
     cursor: pointer;
     border: none;
     outline: none;
+    padding: 0;
 
     &--theme-light {
         @include lumx-state(lumx-base-const("state", "DEFAULT"), lumx-base-const("emphasis", "MEDIUM"), "dark");
@@ -75,13 +76,12 @@
         align-items: center;
         justify-content: center;
         height: 100%;
-        padding: 0 $lumx-spacing-unit * 2;
         user-select: none;
     }
 
     &--is-drag-hovering &__wrapper {
         outline: 2px dashed $lumx-color-dark-L2;
-        outline-offset: -2px;
+        outline-offset: -$lumx-spacing-unit;
     }
 
     &__icon {

--- a/packages/lumx-core/src/scss/components/uploader/_index.scss
+++ b/packages/lumx-core/src/scss/components/uploader/_index.scss
@@ -7,9 +7,9 @@
 
     @include lumx-state-transition;
 
-    border: none;
-    position: relative;
+    display: grid;
     cursor: pointer;
+    border: none;
     outline: none;
 
     &--theme-light {
@@ -23,7 +23,8 @@
             @include lumx-state(lumx-base-const("state", "ACTIVE"), lumx-base-const("emphasis", "MEDIUM"), "dark");
         }
 
-        &[data-focus-visible-added] {
+        &[data-focus-visible-added],
+        &:focus-within {
             @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "MEDIUM"), "dark");
         }
     }
@@ -39,35 +40,48 @@
             @include lumx-state(lumx-base-const("state", "ACTIVE"), lumx-base-const("emphasis", "MEDIUM"), "light");
         }
 
-        &[data-focus-visible-added] {
+        &[data-focus-visible-added],
+        &:focus-within {
             @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "MEDIUM"), "light");
         }
     }
 
-    &--variant-square {
-        border-radius: 0;
-    }
-
     &--variant-rounded {
-        border-radius: var(--lumx-border-radius);
+        &, #{$self}__wrapper {
+            border-radius: var(--lumx-border-radius);
+        }
     }
 
     &--variant-circle {
-        border-radius: 50%;
+        &, #{$self}__wrapper {
+            border-radius: 50%;
+        }
+    }
+
+    &__background,
+    &__wrapper,
+    &__input {
+        // Stack all onto the same cell
+        grid-area: 1 / 1 / 1 / 1;
+    }
+
+    &__input {
+        opacity: 0;
     }
 
     &__wrapper {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: center;
+        height: 100%;
         padding: 0 $lumx-spacing-unit * 2;
         user-select: none;
+    }
+
+    &--is-drag-hovering &__wrapper {
+        outline: 2px dashed $lumx-color-dark-L2;
+        outline-offset: -2px;
     }
 
     &__icon {

--- a/packages/lumx-core/src/scss/components/uploader/_index.scss
+++ b/packages/lumx-core/src/scss/components/uploader/_index.scss
@@ -7,6 +7,7 @@
 
     @include lumx-state-transition;
 
+    border: none;
     position: relative;
     cursor: pointer;
     outline: none;

--- a/packages/lumx-react/src/components/uploader/Uploader.stories.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.stories.tsx
@@ -1,8 +1,13 @@
-import { AspectRatio, Size, Uploader, UploaderVariant } from '@lumx/react';
-import { mdiTextBoxPlus } from '@lumx/icons';
+import React from 'react';
+import map from 'lodash/map';
+
 import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
 import { iconArgType } from '@lumx/react/stories/controls/icons';
 import { withNestedProps } from '@lumx/react/stories/decorators/withNestedProps';
+import { withWrapper } from '@lumx/react/stories/decorators/withWrapper';
+
+import { AspectRatio, GridColumn, Size, Uploader, UploaderVariant } from '@lumx/react';
+import { mdiTextBoxPlus } from '@lumx/icons';
 
 export default {
     title: 'LumX components/uploader/Uploader',
@@ -24,19 +29,39 @@ export const WithLabelAndIcon = {
     args: { label: 'Pick a file', icon: mdiTextBoxPlus },
 };
 
+// Decorator handling the file input change
+function withFileInputChange() {
+    // eslint-disable-next-line react/display-name
+    return (Story: any, ctx: any) => {
+        const [files, onChange] = React.useState<File[]>([]);
+        return (
+            <>
+                <Story args={{ ...ctx.args, fileInputProps: { ...ctx.args.fileInputProps, onChange } }} />
+                <p>Selection: {map(files, 'name').join(', ')}</p>
+            </>
+        );
+    };
+}
+
 /**
  * Use the embedded native input file which also make it possible to drop files onto it.
  */
-export const WithFileInput = {
-    args: {
-        ...WithLabelAndIcon.args,
-        'fileInputProps.accept': '*',
-        'fileInputProps.multiple': false,
-    },
-    argTypes: {
-        'fileInputProps.onChange': { action: true },
-    },
-    decorators: [withNestedProps()],
+export const FileInput = {
+    ...WithLabelAndIcon,
+    decorators: [
+        withNestedProps(),
+        withFileInputChange(),
+        withCombinations({
+            combinations: {
+                sections: {
+                    'Single file': { fileInputProps: {} },
+                    'Multiple files': { fileInputProps: { multiple: true } },
+                    'Images only': { fileInputProps: { multiple: true, accept: 'image/*' } },
+                },
+            },
+        }),
+        withWrapper({ maxColumns: 3, itemMinWidth: 200 }, GridColumn),
+    ],
 };
 
 /** All variants */
@@ -45,9 +70,14 @@ export const Variants = {
     decorators: [
         withCombinations({
             combinations: {
-                cols: { key: 'variant', options: UPLOADER_VARIANTS },
+                rows: { key: 'variant', options: UPLOADER_VARIANTS },
+                sections: {
+                    Button: {},
+                    'File input': { fileInputProps: {} },
+                },
             },
         }),
+        withWrapper({ maxColumns: 2, itemMinWidth: 300 }, GridColumn),
     ],
 };
 
@@ -59,7 +89,12 @@ export const RatioAndSize = {
             combinations: {
                 cols: { key: 'size', options: UPLOADER_SIZES },
                 rows: { key: 'aspectRatio', options: Object.values(AspectRatio) },
+                sections: {
+                    Button: {},
+                    'File input': { fileInputProps: {} },
+                },
             },
         }),
+        withWrapper({ maxColumns: 2, itemMinWidth: 200 }, GridColumn),
     ],
 };

--- a/packages/lumx-react/src/components/uploader/Uploader.stories.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.stories.tsx
@@ -2,6 +2,7 @@ import { AspectRatio, Size, Uploader, UploaderVariant } from '@lumx/react';
 import { mdiTextBoxPlus } from '@lumx/icons';
 import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
 import { iconArgType } from '@lumx/react/stories/controls/icons';
+import { withNestedProps } from '@lumx/react/stories/decorators/withNestedProps';
 
 export default {
     title: 'LumX components/uploader/Uploader',
@@ -15,14 +16,27 @@ export default {
 const UPLOADER_VARIANTS = [UploaderVariant.square, UploaderVariant.rounded, UploaderVariant.circle];
 const UPLOADER_SIZES = [Size.xl, Size.xxl];
 
-export const Empty = {};
-
 export const WithLabel = {
     args: { label: 'Pick a file' },
 };
 
 export const WithLabelAndIcon = {
     args: { label: 'Pick a file', icon: mdiTextBoxPlus },
+};
+
+/**
+ * Use the embedded native input file which also make it possible to drop files onto it.
+ */
+export const WithFileInput = {
+    args: {
+        ...WithLabelAndIcon.args,
+        'fileInputProps.accept': '*',
+        'fileInputProps.multiple': false,
+    },
+    argTypes: {
+        'fileInputProps.onChange': { action: true },
+    },
+    decorators: [withNestedProps()],
 };
 
 /** All variants */

--- a/packages/lumx-react/src/components/uploader/Uploader.stories.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.stories.tsx
@@ -1,0 +1,51 @@
+import { AspectRatio, Size, Uploader, UploaderVariant } from '@lumx/react';
+import { mdiTextBoxPlus } from '@lumx/icons';
+import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
+import { iconArgType } from '@lumx/react/stories/controls/icons';
+
+export default {
+    title: 'LumX components/uploader/Uploader',
+    component: Uploader,
+    argTypes: {
+        onClick: { action: true },
+        icon: iconArgType,
+    },
+};
+
+const UPLOADER_VARIANTS = [UploaderVariant.square, UploaderVariant.rounded, UploaderVariant.circle];
+const UPLOADER_SIZES = [Size.xl, Size.xxl];
+
+export const Empty = {};
+
+export const WithLabel = {
+    args: { label: 'Pick a file' },
+};
+
+export const WithLabelAndIcon = {
+    args: { label: 'Pick a file', icon: mdiTextBoxPlus },
+};
+
+/** All variants */
+export const Variants = {
+    args: WithLabelAndIcon.args,
+    decorators: [
+        withCombinations({
+            combinations: {
+                cols: { key: 'variant', options: UPLOADER_VARIANTS },
+            },
+        }),
+    ],
+};
+
+/** All sizes & ratio */
+export const RatioAndSize = {
+    args: WithLabelAndIcon.args,
+    decorators: [
+        withCombinations({
+            combinations: {
+                cols: { key: 'size', options: UPLOADER_SIZES },
+                rows: { key: 'aspectRatio', options: Object.values(AspectRatio) },
+            },
+        }),
+    ],
+};

--- a/packages/lumx-react/src/components/uploader/Uploader.test.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import userEvent from '@testing-library/user-event';
 import { mdiPlus } from '@lumx/icons';
@@ -29,9 +29,11 @@ const setup = (propsOverride: SetupProps = {}) => {
 describe(`<${Uploader.displayName}>`, () => {
     describe('Props', () => {
         it('should render default', () => {
-            const { uploader } = setup();
+            const label = 'Label';
+            const { uploader } = setup({ label });
 
             expect(uploader).toHaveClass(CLASSNAME);
+            expect(uploader).toBe(screen.queryByRole('button', { name: label }));
             expect(uploader).toHaveClass('lumx-uploader--aspect-ratio-horizontal');
             expect(uploader).toHaveClass('lumx-uploader--size-xl');
             expect(uploader).toHaveClass('lumx-uploader--theme-light');
@@ -41,12 +43,6 @@ describe(`<${Uploader.displayName}>`, () => {
         it('should render icon', () => {
             const { icon } = setup({ icon: mdiPlus });
             expect(icon).toBeInTheDocument();
-        });
-
-        it('should render label', () => {
-            const { label } = setup({ label: 'Label' });
-            expect(label).toBeInTheDocument();
-            expect(label).toHaveTextContent('Label');
         });
 
         it('should render variant circle', () => {
@@ -75,17 +71,29 @@ describe(`<${Uploader.displayName}>`, () => {
     });
 
     describe('Events', () => {
-        const onClick = jest.fn();
-
-        beforeEach(() => {
-            onClick.mockClear();
-        });
-
         it('should trigger `onClick` when clicked', async () => {
+            const onClick = jest.fn();
             const { uploader } = setup({ onClick });
 
             await userEvent.click(uploader);
+            expect(onClick).toHaveBeenCalled();
+        });
 
+        it('should trigger `onClick` when pressing Enter or Escape', async () => {
+            const onClick = jest.fn();
+            const { uploader } = setup({ onClick });
+
+            await userEvent.tab();
+            expect(uploader).toHaveFocus();
+
+            // Activate with Enter
+            await userEvent.keyboard('[Enter]');
+            expect(onClick).toHaveBeenCalled();
+
+            onClick.mockClear();
+
+            // Activate with Space
+            await userEvent.keyboard('[Space]');
             expect(onClick).toHaveBeenCalled();
         });
     });
@@ -95,5 +103,6 @@ describe(`<${Uploader.displayName}>`, () => {
         baseClassName: CLASSNAME,
         forwardClassName: 'uploader',
         forwardAttributes: 'uploader',
+        forwardRef: 'uploader',
     });
 });

--- a/packages/lumx-react/src/components/uploader/Uploader.test.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 
 import { render, screen } from '@testing-library/react';
-import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
+import { getByClassName, getByTagName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import userEvent from '@testing-library/user-event';
 import { mdiPlus } from '@lumx/icons';
 import { Uploader, UploaderProps } from './Uploader';
@@ -67,6 +67,19 @@ describe(`<${Uploader.displayName}>`, () => {
             expect(uploader).toHaveClass('lumx-uploader--size-xl');
             expect(uploader).toHaveClass('lumx-uploader--theme-light');
             expect(uploader).toHaveClass('lumx-uploader--variant-rounded');
+        });
+
+        it('should render file input', () => {
+            const label = 'Label';
+            const accept = '*';
+            const { uploader } = setup({ label, fileInputProps: { accept } });
+
+            expect(uploader.tagName).toBe('LABEL');
+            expect(uploader).toHaveTextContent(label);
+            const inputNative = getByTagName(uploader, 'input');
+            expect(inputNative).toHaveAttribute('type', 'file');
+            expect(inputNative).toHaveAttribute('accept', accept);
+            expect(uploader).toHaveAttribute('for', inputNative.id);
         });
     });
 

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -1,10 +1,11 @@
 import React, { forwardRef, MouseEventHandler } from 'react';
-
 import classNames from 'classnames';
+import uniqueId from 'lodash/uniqueId';
 
 import { AspectRatio, Icon, Size, Theme } from '@lumx/react';
 import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { useBooleanState } from '@lumx/react/hooks/useBooleanState';
 
 /**
  * Uploader variants.
@@ -36,7 +37,9 @@ export interface UploaderProps extends GenericProps, HasTheme {
     /** Variant. */
     variant?: UploaderVariant;
     /** On click callback. */
-    onClick?: MouseEventHandler<HTMLButtonElement>;
+    onClick?: MouseEventHandler;
+    /** Handle file selection with a native input file. */
+    fileInputProps?: React.ComponentProps<'input'>;
 }
 
 /**
@@ -66,15 +69,21 @@ const DEFAULT_PROPS: Partial<UploaderProps> = {
  * @param  ref   Component ref.
  * @return React element.
  */
-export const Uploader: Comp<UploaderProps, HTMLButtonElement> = forwardRef((props, ref) => {
-    const { aspectRatio, className, label, icon, size, theme, variant, ...forwardedProps } = props;
+export const Uploader: Comp<UploaderProps> = forwardRef((props, ref) => {
+    const { aspectRatio, className, label, icon, size, theme, variant, fileInputProps, ...forwardedProps } = props;
     // Adjust to square aspect ratio when using circle variants.
     const adjustedAspectRatio = variant === UploaderVariant.circle ? AspectRatio.square : aspectRatio;
 
+    const inputId = React.useMemo(() => fileInputProps?.id || uniqueId('uploader-input-'), [fileInputProps?.id]);
+    const [isDragHovering, unsetDragHovering, setDragHovering] = useBooleanState(false);
+    const wrapper = fileInputProps
+        ? { Component: 'label' as const, props: { htmlFor: inputId } as const }
+        : { Component: 'button' as const, props: { type: 'button' } as const };
+
     return (
-        <button
-            ref={ref}
-            type="button"
+        <wrapper.Component
+            ref={ref as any}
+            {...wrapper.props}
             {...forwardedProps}
             className={classNames(
                 className,
@@ -84,21 +93,30 @@ export const Uploader: Comp<UploaderProps, HTMLButtonElement> = forwardRef((prop
                     size,
                     theme,
                     variant,
+                    isDragHovering,
                 }),
             )}
         >
-            <div className={`${CLASSNAME}__background`} />
+            <span className={`${CLASSNAME}__background`} />
 
-            <div className={`${CLASSNAME}__wrapper`}>
-                {icon && (
-                    <div className={`${CLASSNAME}__icon`}>
-                        <Icon icon={icon} size={Size.s} />
-                    </div>
-                )}
+            <span className={`${CLASSNAME}__wrapper`}>
+                {icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.s} />}
 
                 {label && <span className={`${CLASSNAME}__label`}>{label}</span>}
-            </div>
-        </button>
+            </span>
+
+            {fileInputProps && (
+                <input
+                    type="file"
+                    id={inputId}
+                    className={`${CLASSNAME}__input`}
+                    {...fileInputProps}
+                    onDragEnter={setDragHovering}
+                    onDragLeave={unsetDragHovering}
+                    onDrop={unsetDragHovering}
+                />
+            )}
+        </wrapper.Component>
     );
 });
 Uploader.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -23,6 +23,13 @@ export type UploaderVariant = ValueOf<typeof UploaderVariant>;
 export type UploaderSize = Extract<Size, 'xl' | 'xxl'>;
 
 /**
+ * Extend native HTML input props with specialized `onChange` providing the a `File` array.
+ */
+interface FileInputProps extends Omit<React.ComponentProps<'input'>, 'onChange'> {
+    onChange(files: File[], evt: React.ChangeEvent<HTMLInputElement>): void;
+}
+
+/**
  * Defines the props of the component.
  */
 export interface UploaderProps extends GenericProps, HasTheme {
@@ -39,7 +46,7 @@ export interface UploaderProps extends GenericProps, HasTheme {
     /** On click callback. */
     onClick?: MouseEventHandler;
     /** Handle file selection with a native input file. */
-    fileInputProps?: React.ComponentProps<'input'>;
+    fileInputProps?: FileInputProps;
 }
 
 /**
@@ -80,6 +87,15 @@ export const Uploader: Comp<UploaderProps> = forwardRef((props, ref) => {
         ? { Component: 'label' as const, props: { htmlFor: inputId } as const }
         : { Component: 'button' as const, props: { type: 'button' } as const };
 
+    const onChange = React.useMemo(() => {
+        if (!fileInputProps?.onChange) return undefined;
+        return (evt: React.ChangeEvent<HTMLInputElement>) => {
+            const fileList = evt.target.files;
+            const files = fileList ? Array.from(fileList) : [];
+            fileInputProps.onChange(files, evt);
+        };
+    }, [fileInputProps]);
+
     return (
         <wrapper.Component
             ref={ref as any}
@@ -111,6 +127,7 @@ export const Uploader: Comp<UploaderProps> = forwardRef((props, ref) => {
                     id={inputId}
                     className={`${CLASSNAME}__input`}
                     {...fileInputProps}
+                    onChange={onChange}
                     onDragEnter={setDragHovering}
                     onDragLeave={unsetDragHovering}
                     onDrop={unsetDragHovering}

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -36,7 +36,7 @@ export interface UploaderProps extends GenericProps, HasTheme {
     /** Variant. */
     variant?: UploaderVariant;
     /** On click callback. */
-    onClick?: MouseEventHandler<HTMLDivElement>;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 /**
@@ -66,14 +66,15 @@ const DEFAULT_PROPS: Partial<UploaderProps> = {
  * @param  ref   Component ref.
  * @return React element.
  */
-export const Uploader: Comp<UploaderProps, HTMLDivElement> = forwardRef((props, ref) => {
+export const Uploader: Comp<UploaderProps, HTMLButtonElement> = forwardRef((props, ref) => {
     const { aspectRatio, className, label, icon, size, theme, variant, ...forwardedProps } = props;
     // Adjust to square aspect ratio when using circle variants.
     const adjustedAspectRatio = variant === UploaderVariant.circle ? AspectRatio.square : aspectRatio;
 
     return (
-        <div
+        <button
             ref={ref}
+            type="button"
             {...forwardedProps}
             className={classNames(
                 className,
@@ -97,7 +98,7 @@ export const Uploader: Comp<UploaderProps, HTMLDivElement> = forwardRef((props, 
 
                 {label && <span className={`${CLASSNAME}__label`}>{label}</span>}
             </div>
-        </div>
+        </button>
     );
 });
 Uploader.displayName = COMPONENT_NAME;

--- a/packages/site-demo/content/product/components/uploader/index.mdx
+++ b/packages/site-demo/content/product/components/uploader/index.mdx
@@ -16,6 +16,12 @@ There are three variants: `square`, `rounded` and `circle`.
 
 <DemoBlock orientation="horizontal" demo="avatar" withThemeSwitcher />
 
+### Accessibility concerns
+
+Uploaders have 2 accessibility use cases:
+1. **native file input**: using the `fileInputProps` prop transforms uploaders into a native HTML file input capable of handling file drop.
+2. **button** : using the `onClick` prop transforms uploaders into standard button for when you need to use a non-native file picker.
+
 ### Properties
 
 <PropTable component="Uploader" />


### PR DESCRIPTION
- fix(uploader): use true button to improve accessibility
- feat(uploader): add native file input handler
- docs(uploader): add accessibility concerns section

Use a true `<button>` button by default to improve accessibility. 
Use `<input type=file>` and `<label>` if `fileInputProps` is provided to handle a native file picker and to support dropping a file onto the uploader.

