### PR TITLE
fix(autocomplete): focus text field on clear button clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   TableCell: fix clickable & sortable header cell accessibility
 -   Uploader: use button element by default
 -   Uploader: use label and input file elements when providing `fileInputProps`
+-   Autocomplete: fix focus field when clear button is triggered
 
 ## [3.3.1][] - 2023-06-12
 

--- a/packages/lumx-react/src/components/autocomplete/Autocomplete.stories.tsx
+++ b/packages/lumx-react/src/components/autocomplete/Autocomplete.stories.tsx
@@ -8,7 +8,7 @@ export default { title: 'LumX components/autocomplete/Autocomplete' };
 
 const cityNames = CITIES.map((city) => city.text);
 
-export const Simple = ({ theme }: any) => {
+export const Simple = ({ theme, ...args }: any) => {
     const [showSuggestions, setShowSuggestions] = useState(false);
     const [value, setValue] = useState('');
     const inputRef = useRef(null);
@@ -50,6 +50,7 @@ export const Simple = ({ theme }: any) => {
             onChange={onChange}
             onFocus={onFocus}
             inputRef={inputRef}
+            {...args}
         >
             {hasSuggestions && (
                 <List isClickable>
@@ -67,4 +68,9 @@ export const Simple = ({ theme }: any) => {
             )}
         </Autocomplete>
     );
+};
+
+export const WithClearButton = Simple.bind({}) as any;
+WithClearButton.args = {
+    clearButtonProps: { label: 'Clear' },
 };

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -261,7 +261,7 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
         helper,
         icon,
         id,
-        inputRef,
+        inputRef: inputRefProps,
         isDisabled = disabled,
         isRequired,
         isValid,
@@ -283,6 +283,10 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
         ...forwardedProps
     } = props;
     const textFieldId = useMemo(() => id || `text-field-${uid()}`, [id]);
+    /** Keep a clean local input ref to manage focus */
+    const localInputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+    /** Merge prop input ref and local input ref */
+    const inputRef = mergeRefs(localInputRef, inputRefProps);
     /**
      * Generate unique ids for both the helper and error texts, in order to
      * later on add them to the input native as aria-describedby. If both the error and the helper are present,
@@ -316,7 +320,8 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
             onClear(evt);
         }
 
-        const inputElement = inputRef as RefObject<HTMLInputElement | HTMLTextAreaElement>;
+        /** Use local inputRef in case the prop input ref is a `mergeRefs` function. */
+        const inputElement = localInputRef as RefObject<HTMLInputElement | HTMLTextAreaElement>;
 
         if (inputElement && inputElement.current) {
             inputElement.current.focus();


### PR DESCRIPTION
# General summary

Since the autocomplete passes a `mergeRefs` function as inputRef and that the TextField didn't manage this case, the focus was not restored to the input field on clear.

Fixed by adding another "ref" locally to the TextField to manage the focus.

<!-- Please describe the PR content -->

# Screenshots
![autocomplete-focus-on-clear](https://github.com/lumapps/design-system/assets/7147342/6cbf8994-6c15-408b-aa2a-0e2a1cbd57a6)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://fc535bf8--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=289)) **⚠️ Outdated commit** **⚠️ Outdated commit**