### PR TITLE
fix(side-navigation): improve and document a11y ARCH-48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Uploader: use button element by default
 -   Uploader: use label and input file elements when providing `fileInputProps`
 -   Autocomplete: fix focus field when clear button is triggered
+-   SideNavigationItem: fix closed/opened state accessibility
 
 ## [3.3.1][] - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Uploader: use label and input file elements when providing `fileInputProps`
 -   Autocomplete: fix focus field when clear button is triggered
 -   SideNavigationItem: fix closed/opened state accessibility
+-   SideNavigationItem: use button element by default for better accessibility
 
 ## [3.3.1][] - 2023-06-12
 

--- a/packages/lumx-core/src/scss/components/side-navigation/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/side-navigation/_mixins.scss
@@ -22,9 +22,12 @@
     align-items: center;
     min-height: map.get($lumx-sizes, lumx-base-const("size", "M"));
     padding: 0 $lumx-spacing-unit;
+    text-align: start;
     text-decoration: none;
+    border: none;
     border-radius: var(--lumx-border-radius);
     outline: none;
+    appearance: none;
 }
 
 @mixin lumx-side-navigation-link-icon($position) {

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
@@ -39,6 +39,7 @@ describe(`<${SideNavigationItem.displayName}>`, () => {
         expect(sideNavigation).toBe(screen.queryByRole('listitem'));
 
         expect(link).toBeInTheDocument();
+        expect(link).toBe(screen.queryByRole('button', { name: label }));
         expect(link).not.toHaveAttribute('aria-expanded');
     });
 

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -8,10 +8,10 @@ import { mdiChevronDown, mdiChevronUp } from '@lumx/icons';
 
 import { Emphasis, Icon, Size, IconButton, IconButtonProps } from '@lumx/react';
 
-import { Callback, Comp, GenericProps, isComponent } from '@lumx/react/utils/type';
+import { Comp, GenericProps, isComponent } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
-import { onEnterPressed } from '@lumx/react/utils/event';
 import { renderLink } from '@lumx/react/utils/renderLink';
+import { renderButtonOrLink } from '@lumx/react/utils/renderButtonOrLink';
 
 /**
  * Defines the props of the component.
@@ -142,14 +142,13 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
                     />
                 </div>
             ) : (
-                renderLink(
+                renderButtonOrLink(
                     {
                         linkAs,
                         ...linkProps,
                         className: `${CLASSNAME}__link`,
                         tabIndex: 0,
                         onClick,
-                        onKeyDown: onClick ? onEnterPressed(onClick as Callback) : undefined,
                         ...ariaProps,
                     },
                     icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />,

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -2,6 +2,7 @@ import React, { Children, forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
+import { uid } from 'uid';
 
 import { mdiChevronDown, mdiChevronUp } from '@lumx/icons';
 
@@ -94,6 +95,14 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
     const shouldSplitActions = Boolean(onActionClick);
     const showChildren = hasContent && isOpen;
 
+    const contentId = React.useMemo(uid, []);
+    const ariaProps: any = {};
+    if (hasContent) {
+        ariaProps['aria-expanded'] = !!showChildren;
+        // Associate with content ID only if in DOM (shown or hidden and not unmounted)
+        ariaProps['aria-controls'] = showChildren || closeMode === 'hide' ? contentId : undefined;
+    }
+
     return (
         <li
             ref={ref}
@@ -129,6 +138,7 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
                         size={Size.m}
                         emphasis={Emphasis.low}
                         onClick={onActionClick}
+                        {...ariaProps}
                     />
                 </div>
             ) : (
@@ -140,6 +150,7 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
                         tabIndex: 0,
                         onClick,
                         onKeyDown: onClick ? onEnterPressed(onClick as Callback) : undefined,
+                        ...ariaProps,
                     },
                     icon && <Icon className={`${CLASSNAME}__icon`} icon={icon} size={Size.xs} />,
                     <span>{label}</span>,
@@ -153,7 +164,11 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
                 )
             )}
 
-            {(closeMode === 'hide' || showChildren) && <ul className={`${CLASSNAME}__children`}>{content}</ul>}
+            {(closeMode === 'hide' || showChildren) && (
+                <ul className={`${CLASSNAME}__children`} id={contentId}>
+                    {content}
+                </ul>
+            )}
         </li>
     );
 });

--- a/packages/lumx-react/src/utils/renderButtonOrLink.tsx
+++ b/packages/lumx-react/src/utils/renderButtonOrLink.tsx
@@ -1,0 +1,16 @@
+import React, { ReactElement, ReactNode } from 'react';
+import { renderLink } from '@lumx/react/utils/renderLink';
+
+interface Props {
+    linkAs?: any;
+    href?: any;
+}
+
+/**
+ * Render <button> HTML component, fallbacks to `<a>` when a `href` is provided or a custom component with `linkAs`.
+ */
+export const renderButtonOrLink = <P extends Props>(props: P, ...children: ReactNode[]): ReactElement => {
+    const { linkAs, href, ...forwardedProps } = props;
+    if (linkAs || href) return renderLink(props, ...children);
+    return React.createElement('button', { type: 'button', ...forwardedProps }, ...children);
+};

--- a/packages/lumx-react/src/utils/renderLink.tsx
+++ b/packages/lumx-react/src/utils/renderLink.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react';
 
 interface Props {
-    linkAs: any;
+    linkAs?: any;
 }
 
 /**

--- a/packages/site-demo/content/product/components/side-navigation/index.mdx
+++ b/packages/site-demo/content/product/components/side-navigation/index.mdx
@@ -28,6 +28,14 @@ Side navigation items have three emphasises: `low`, `medium`, and `high`. Defaul
 
 <DemoBlock demo="emphasis" />
 
+### Accessibility concerns
+
+Side navigations use standard HTML nested unordered list. Consider wrapping the `SideNavigation` in a `<nav>` to mark the navigation region.
+
+Side navigation items default to a list item with a button inside. Adding a `linkProps.href` or `linkAs` prop will transform it into a link (or use the custom link component you provided).
+
+Side navigation items with children use the [ARIA disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/) using the `isOpen` prop to control the expand/close state that should be toggled when the `onClick` is called. Combining `linkProps.href` and `onActionClick` will split the toggle button and the link.
+
 ### SideNavigation properties
 
 <PropTable component="SideNavigation" />


### PR DESCRIPTION
- fix(side-navigation): fix open/close accessibility state
- fix(side-navigation): default to button when not explicitly a link
- docs(side-navigation): add accessibility concerns section



StoryBook: https://b7137fe3--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=292)) **⚠️ Outdated commit**