### PR TITLE
chore(ci): fix mark outdated storybook URL

### DIFF
--- a/.github/actions/update-pr-body/index.js
+++ b/.github/actions/update-pr-body/index.js
@@ -1,9 +1,7 @@
 /**
  * Match a pattern in the PR body, replace with a replace pattern.
- * If the pattern as multiple matches, all but the last one are removed and the last one is replaced.
  *
- * Can fall back to appending the replace pattern to the end of the body if the pattern is not found.
- * Can skip replace if a condition is met on the match instance.
+ * See `action.yml` for details on the params in `inputs`.
  */
 async function main({ inputs, github, context }) {
     const { pattern: patternString, replace, whenNotFound, skipReplaceIf, keepLastMatch } = inputs;
@@ -12,22 +10,25 @@ async function main({ inputs, github, context }) {
     const { owner, repo } = context.repo;
     const pull_number = context.issue.number;
 
-    const body = context.payload.pull_request.body;
+    const body = context.payload.pull_request.body || '';
     const matches = Array.from(body.matchAll(pattern));
     const lastMatch = matches[matches.length - 1];
 
     let updatedBody = body;
     if (!lastMatch) {
+        // No match
         console.log(`Pattern ${pattern} does not match`);
         if (whenNotFound === 'append') {
-            console.log('  Appending replace string to the end of the body');
+            console.log('> Appending replace string to the end of the body');
             updatedBody += `\n\n${replace}`;
         } else if (whenNotFound !== 'ignore') {
-            throw new Error(`  No match found for pattern '${pattern}'`);
+            throw new Error(`> No match found for pattern '${pattern}'`);
         }
-        console.log('  Nothing to do', { whenNotFound });
+        console.log('> Nothing to do', { whenNotFound });
     } else {
-        console.log(`Pattern ${pattern} matches`);
+        console.log(`Pattern \`${pattern}\` has ${matches.length} match(es)`);
+
+        // Replace each match one by one.
         updatedBody = body.replaceAll(
             pattern,
             (...groups) => {
@@ -37,6 +38,7 @@ async function main({ inputs, github, context }) {
                 const offset = groups.pop();
 
                 if (keepLastMatch === 'true' && offset !== lastMatch.index) {
+                    console.log(`Removing non-last match (\`keepLastMatch: true\`)`);
                     // Not the last occurrence => removing it
                     return '';
                 }
@@ -44,16 +46,16 @@ async function main({ inputs, github, context }) {
                 const [match, ...captureGroups] = groups;
                 // Skip if condition met
                 if (skipReplaceIf && eval(skipReplaceIf)) {
-                    console.log(`Condition "${skipReplaceIf}" met.`);
-                    console.log(`  Not replacing the match "${match}"`);
+                    console.log(`Condition met in \`skipReplaceIf: ${skipReplaceIf.replace(/\n/g, ' ').trim()}\``);
+                    console.log(`> Skipping the replacement of match "${match}"`);
                     return match;
                 }
                 // Replace $1, $2, etc. with captured elements
                 const replaceText = captureGroups.reduce((a, b, i) => a.replace(`$${i + 1}`, b), replace);
-                console.log(`  Replacing match: "${match}"`);
-                console.log(`  With replace pattern: "${replace}"`);
+                console.log(`Replacing match: "${match}"`);
+                console.log(`> With replace pattern: "${replace}"`);
                 if (replaceText !== replace)
-                    console.log(`  Replace pattern resolved as: "${replaceText}"`);
+                    console.log(`> Replace pattern resolved as: "${replaceText}"`);
                 return replaceText;
             },
         );

--- a/.github/workflows/deploy-chromatic-pull-request.yaml
+++ b/.github/workflows/deploy-chromatic-pull-request.yaml
@@ -89,14 +89,14 @@ jobs:
                 id: short_sha
                 run: echo "short_sha=$(git rev-parse --short ${{github.event.pull_request.head.sha}})" >> $GITHUB_OUTPUT
 
-            -   name: "Mark storybook as outdated"
+            -   name: "Mark storybook URL as outdated"
                 uses: ./.github/actions/update-pr-body
                 with:
                     pattern: 'StoryBook: ((https:\/\/([a-z0-9]+)--[^ ]*).*)'
-                    # Ignore if the short SHA in the storybook URL is up-to-date
+                    # Ignore if the short SHA in the storybook URL is up-to-date or if it was already marked as outdated
                     skipReplaceIf: |
                         groups[3] === "${{steps.short_sha.outputs.short_sha}}"
-                        && !groups[0].includes("Outdated commit")
+                        || groups[0].includes("Outdated commit")
                     replace: 'StoryBook: $1 **⚠️ Outdated commit**'
                     whenNotFound: 'ignore'
                     keepLastMatch: true


### PR DESCRIPTION
- Fix CI job "Mark storybook URL as outdated" that would continue appending `**⚠️ Outdated commit**` even when the storybook URL was already marked as outdated.
- Improve logs

StoryBook: https://b9672b96--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=293)) **⚠️ Outdated commit**