### PR TITLE
feat(tab): add icon customisation with IconProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Tab: add icon customisation with `iconProps`
+
 ## [3.4.0][] - 2023-07-06
 
 ### Changed
@@ -1773,7 +1777,5 @@ _Failed released_
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.3.1...HEAD
 [3.3.1]: https://github.com/lumapps/design-system/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/lumapps/design-system/tree/v3.3.0
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.4.0...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.4.0...HEAD
 [3.4.0]: https://github.com/lumapps/design-system/tree/v3.4.0

--- a/packages/lumx-react/src/components/tabs/Tab.test.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.test.tsx
@@ -38,6 +38,11 @@ describe(`<${Tab.displayName}>`, () => {
         expect(icon).toBeInTheDocument();
     });
 
+    it('should render icon with props', () => {
+        const { icon } = setup({ icon: mdiPlay, iconProps: { color: 'green', colorVariant: 'L2', hasShape: true } });
+        expect(icon).toHaveClass('lumx-icon--color-green', 'lumx-icon--color-variant-L2');
+    });
+
     commonTestsSuiteRTL(setup, {
         baseClassName: CLASSNAME,
         forwardClassName: 'tab',

--- a/packages/lumx-react/src/components/tabs/Tab.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.tsx
@@ -15,6 +15,8 @@ export interface TabProps extends GenericProps {
     children?: never;
     /** Icon (SVG path). */
     icon?: IconProps['icon'];
+    /** Icon component properties. */
+    iconProps?: Omit<IconProps, 'icon'>;
     /** Native id property. */
     id?: string;
     /** Whether the tab is active or not. */
@@ -54,6 +56,7 @@ export const Tab: Comp<TabProps, HTMLButtonElement> = forwardRef((props, ref) =>
         className,
         disabled,
         icon,
+        iconProps = {},
         id,
         isActive: propIsActive,
         isDisabled = disabled,
@@ -110,7 +113,7 @@ export const Tab: Comp<TabProps, HTMLButtonElement> = forwardRef((props, ref) =>
             aria-selected={isActive}
             aria-controls={state?.tabPanelId}
         >
-            {icon && <Icon icon={icon} size={Size.xs} />}
+            {icon && <Icon icon={icon} size={Size.xs} {...iconProps} />}
             {label && <span>{label}</span>}
         </button>
     );

--- a/packages/site-demo/content/product/components/tabs/react/icon-tabs.tsx
+++ b/packages/site-demo/content/product/components/tabs/react/icon-tabs.tsx
@@ -10,7 +10,11 @@ export const App = ({ theme }: any) => {
             <TabProvider activeTabIndex={activeTab} onChange={setActiveTab}>
                 <TabList theme={theme} aria-label="Tab list">
                     <Tab label="Tab 1" icon={mdiBowl} />
-                    <Tab label="Tab 2" icon={mdiBreadSliceOutline} />
+                    <Tab
+                        label="Tab 2"
+                        icon={mdiBreadSliceOutline}
+                        iconProps={{ color: 'red', colorVariant: 'L1', hasShape: false }}
+                    />
                     <Tab label="Tab 3" icon={mdiSilverwareForkKnife} />
                 </TabList>
 


### PR DESCRIPTION
CF-642

# General summary

Add the Icon customisation with `iconProps` inside the Tab component.

<!-- Please describe the PR content -->

# Screenshots
![Screenshot 2023-07-18 at 12 05 15](https://github.com/lumapps/design-system/assets/7592327/e906edfd-056e-4205-97a8-9dfaa36ebcb6)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
