### PR TITLE
chore(thumbnail): deal with empty image source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Thumbnail: synchronously set error for image with empty source.
+
 ## [3.5.0][] - 2023-07-27
 
 ### Added
@@ -1785,7 +1789,5 @@ _Failed released_
 [3.3.0]: https://github.com/lumapps/design-system/tree/v3.3.0
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.4.0...HEAD
 [3.4.0]: https://github.com/lumapps/design-system/tree/v3.4.0
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.5.0...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.5.0...HEAD
 [3.5.0]: https://github.com/lumapps/design-system/tree/v3.5.0

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { mdiAbTesting } from '@lumx/icons';
+import { mdiAbTesting, mdiImageBroken } from '@lumx/icons';
 import { Alignment, AspectRatio, Badge, FlexBox, Icon, Size, Thumbnail, ThumbnailVariant } from '@lumx/react';
 import { CustomLink } from '@lumx/react/stories/utils/CustomLink';
 import { IMAGE_SIZES, imageArgType, IMAGES } from '@lumx/react/stories/controls/image';
@@ -42,6 +42,10 @@ export const Simple = {
 /** Loading state*/
 export const IsLoading = {
     args: { ...Simple.args, isLoading: true },
+};
+
+export const WithoutSource = {
+    args: { image: IMAGES.emptyImage, size: Size.xxl, aspectRatio: AspectRatio.square },
 };
 
 /** Thumbnail error fallback and size variants */

--- a/packages/lumx-react/src/components/thumbnail/useImageLoad.ts
+++ b/packages/lumx-react/src/components/thumbnail/useImageLoad.ts
@@ -3,8 +3,9 @@ import { useEffect, useState } from 'react';
 export type LoadingState = 'isLoading' | 'isLoaded' | 'hasError';
 
 function getState(img: HTMLImageElement | null | undefined, event?: Event) {
-    // Error event occurred.
-    if (event?.type === 'error') {
+    // Error event occurred or image has no source.
+    if (event?.type === 'error' || (img?.complete && !img.getAttribute('src'))) {
+        console.log('HAS ERROR');
         return 'hasError';
     }
     // Image is undefined or incomplete.

--- a/packages/lumx-react/src/stories/controls/image.ts
+++ b/packages/lumx-react/src/stories/controls/image.ts
@@ -15,13 +15,22 @@ const portrait3 = '/demo-assets/portrait3.jpg';
 const square1 = '/demo-assets/square1.jpg';
 const square2 = '/demo-assets/square2.jpg';
 const defaultSvg = '/demo-assets/defaultSvg.svg';
+const emptyImage = '';
 
 export const AVATAR_IMAGES = { avatar1, avatar2, avatar3, avatar4 };
 export const SQUARE_IMAGES = { square1, square2 };
 export const SVG_IMAGES = { defaultSvg };
+export const EMPTY_IMAGES = { emptyImage };
 export const LANDSCAPE_IMAGES = { landscape1, landscape1s200, landscape2, landscape3 };
 export const PORTRAIT_IMAGES = { portrait1, portrait1s200, portrait2, portrait3 };
-export const IMAGES = { ...LANDSCAPE_IMAGES, ...PORTRAIT_IMAGES, ...SQUARE_IMAGES, ...AVATAR_IMAGES, ...SVG_IMAGES };
+export const IMAGES = {
+    ...LANDSCAPE_IMAGES,
+    ...PORTRAIT_IMAGES,
+    ...SQUARE_IMAGES,
+    ...AVATAR_IMAGES,
+    ...SVG_IMAGES,
+    ...EMPTY_IMAGES,
+};
 
 export const avatarImageArgType = getSelectArgType(AVATAR_IMAGES);
 export const squareImageArgType = getSelectArgType(SQUARE_IMAGES);
@@ -56,10 +65,14 @@ export const PORTRAIT_IMAGE_SIZES: Record<keyof typeof PORTRAIT_IMAGES, Size> = 
 export const SVG_IMAGE_SIZES: Record<keyof typeof SVG_IMAGES, Size> = {
     defaultSvg: { width: 0, height: 0 },
 };
+export const EMPTY_IMAGES_SIZES: Record<keyof typeof EMPTY_IMAGES, Size> = {
+    emptyImage: { width: 0, height: 0 },
+};
 export const IMAGE_SIZES: Record<keyof typeof IMAGES, Size> = {
     ...LANDSCAPE_IMAGE_SIZES,
     ...PORTRAIT_IMAGE_SIZES,
     ...SQUARE_IMAGE_SIZES,
     ...AVATAR_IMAGE_SIZES,
     ...SVG_IMAGE_SIZES,
+    ...EMPTY_IMAGES_SIZES,
 };


### PR DESCRIPTION
# General summary

Improvement proposal, following this task : https://github.com/lumapps/design-system/pull/1006 

This PR aim at acknowledging the fact that the image source can be empty, even tho it's required, the props can be an empty string. And deal with that in a synchronous way.

Before the previously mentioned PR, the empty string source use case was dealt by the test on the natural sizes of the image; an empty `src` attribute means no natural sizes. This was an unintended side effect of the code.

Since the removal of the test on the image natural sizes, we do not immediately treat the image as in error, when the `src` is empty. It's done with the `onerror` listener, asynchronously. 
There is no visual differences, since the `onerror` trigger immediately when the empty `src` tag is rendered. 

However, since the `error` is now set in async, issues may arises in the tests. We now need to add async testing where it was not needed.

Ideally, we would not use the `<Thumbnail />` without a real source image, since it's not how it was intended to be used that way. However, in the global lumapps project (and maybe in other project), we have many implementation of the `<Thumbnail />` without a source image. This is to take advantage of the default `fallback` icons.

We cannot remove those use cases from the project, at least not easily. And since the empty image is available in the `Thumbnail` we cannot expect that it wont be used.

We could leave the thumbnail as it is, and expect all the users of the DS to update their tests, to add async testing. But this seem to be not ideal, the impact would be some heavy work, and the creation of many async test that are notoriously more instable than the sync ones.

This is why I propose to add this bit of code, in a patch to the 3.5.0.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
