### PR TITLE
fix(subheader): change color to dark-L2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react` no long depend on `moment` or `moment-range` to generate the date picker.
 -   Deprecated `@lumx/core/js/date-picker` functions that **will be removed in the next major version** along with `moment` and `moment-range`.
 -   DatePicker & DatePickerField: `locale` prop is now optional (uses browser locale by default)
+-   ListSubHeader: darken text color for better accessibility
 
 ## [3.5.3][] - 2023-08-30
 

--- a/packages/lumx-core/src/scss/components/list/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/list/_mixins.scss
@@ -102,7 +102,7 @@
     display: flex;
     align-items: center;
     height: map.get($lumx-list-item-sizes, "tiny");
-    color: lumx-color-variant("dark", "L3");
+    color: lumx-color-variant("dark", "L2");
 }
 
 @mixin lumx-list-subheader-icon {


### PR DESCRIPTION
[CF-486](https://lumapps.atlassian.net/browse/CF-486)

# General summary

In order to fix insufficient contrast ratio with SubHeader component, changed color from `dark-L3` to `dark-L2`.
<!-- Please describe the PR content -->

# Screenshots

using dark L3:
![darkl3](https://github.com/lumapps/design-system/assets/63648264/8599ee7f-78ca-4773-9b2b-2aee7c3b82bd)

using dark L2:
![darkl2](https://github.com/lumapps/design-system/assets/63648264/78801715-f0a4-4b5f-9d87-033b2b9f53cd)


<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [x] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


[CF-486]: https://lumapps.atlassian.net/browse/CF-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

StoryBook: https://b59d5881--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=305)) **⚠️ Outdated commit**