### PR TITLE
feat(list-item): add focus visible class to use with virtual focus

### DIFF
--- a/packages/lumx-core/src/scss/components/list/_index.scss
+++ b/packages/lumx-core/src/scss/components/list/_index.scss
@@ -38,6 +38,11 @@
         @include lumx-list-item-highlighted;
     }
 
+    &__link--focus-visible,
+    &__link[data-focus-visible-added] {
+        @include lumx-list-item-focus-visible;
+    }
+
     &__link--is-selected {
         @include lumx-list-item-selected;
     }

--- a/packages/lumx-core/src/scss/components/list/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/list/_mixins.scss
@@ -44,14 +44,14 @@
 
     @include lumx-state(lumx-base-const("state", "HOVER"), lumx-base-const("emphasis", "LOW"), "dark");
 
-    &[data-focus-visible-added] {
-        outline: 2px solid lumx-color-variant("dark", "N");
-        outline-offset: -2px;
-    }
-    
     &:active {
         @include lumx-state(lumx-base-const("state", "ACTIVE"), lumx-base-const("emphasis", "LOW"), "dark");
     }
+}
+
+@mixin lumx-list-item-focus-visible() {
+    outline: 2px solid lumx-color-variant("dark", "N");
+    outline-offset: -2px;
 }
 
 @mixin lumx-list-item-selected() {


### PR DESCRIPTION
Move the outline style on key nav to make it also available via a class `.lumx-list-item__link--focus-visible` to be used in virtual focus (like in select/autocomplete, where the list item __appears__ focused but the input is the element focused)

TODO:
- [ ] Use in autocomplete/select ?
- [ ] Add as prop to ListItem ?
- [ ] Validate

