### PR TITLE
chore(demo-site): render code hidden

### DIFF
--- a/packages/site-demo/src/components/content/CodeBlock/CodeBlock.scss
+++ b/packages/site-demo/src/components/content/CodeBlock/CodeBlock.scss
@@ -14,4 +14,24 @@
     background-color: transparent;
     border: 1px solid $lumx-color-dark-L4;
     border-radius: var(--lumx-border-radius);
+
+    details summary {
+        padding: $lumx-spacing-unit-tiny;
+        margin: -$lumx-spacing-unit-tiny;
+    }
+
+    details:not([open]) {
+        margin-bottom: 1rem;
+    }
+
+    details[open] summary {
+        display: none;
+    }
+
+    code.token {
+        padding: 0;
+        font-size: inherit;
+        font-weight: inherit;
+        background: none;
+    }
 }

--- a/packages/site-demo/src/components/content/CodeBlock/CodeBlock.tsx
+++ b/packages/site-demo/src/components/content/CodeBlock/CodeBlock.tsx
@@ -17,6 +17,7 @@ interface Props {
     language?: Language | 'tsx';
 }
 
+/** Display syntax highlighted code */
 export const CodeBlock: React.FC<Props> = ({ className, codeString, language: propLanguage, children }) => {
     const language = propLanguage || className?.match(/language-(\w+)/)?.[1];
     if (!language) {

--- a/packages/site-demo/src/components/content/CodeBlock/renderJSXLinesWithCollapsedImports.tsx
+++ b/packages/site-demo/src/components/content/CodeBlock/renderJSXLinesWithCollapsedImports.tsx
@@ -2,13 +2,14 @@ import filter from 'lodash/filter';
 import first from 'lodash/first';
 import last from 'lodash/last';
 import partition from 'lodash/partition';
-import React, { ReactElement, useMemo, useState } from 'react';
+import React, { ReactElement } from 'react';
 import { renderLines } from '@lumx/demo/components/content/CodeBlock/renderLines';
 import { RenderLineParams, Token, TokenLines } from './types';
 
 const isToken = (token: Token | undefined, type: string, content: string) =>
     token?.types?.includes(type) && token?.content === content;
 
+/** Split import lines from other lines */
 export function partitionImports(tokenLines: TokenLines): { imports: TokenLines; others: TokenLines } {
     const state = {
         finished: false,
@@ -44,39 +45,24 @@ export function partitionImports(tokenLines: TokenLines): { imports: TokenLines;
     return { imports, others };
 }
 
-export const CollapsedImports: React.FC<RenderLineParams> = (props) => {
-    const [collapsed, setCollapsed] = useState(true);
-    const toggleCollapsed = () => setCollapsed(!collapsed);
-    const renderedImports = useMemo(() => renderLines(props) as any, [props]);
-
-    return !collapsed ? (
-        renderedImports
-    ) : (
-        <>
-            <button
-                {...props.getLineProps({ key: 'collapsed-imports' })}
-                style={{ border: 'none', background: 'none', padding: 0 }}
-                onClick={toggleCollapsed}
-                aria-label="Expand imports"
-                title="Expand imports"
-                type="button"
-            >
-                <span {...props.getTokenProps({ token: { types: ['keyword'], content: 'import' } })} />
-                <span className="lumx-spacing-margin-left-tiny lumx-spacing-padding-horizontal  lumx-color-background-dark-L5">
-                    …
-                </span>
-            </button>
-            {renderLines({ ...props, tokens: [[{ types: ['plain'], content: '', empty: true }]] })}
-        </>
-    );
-};
-
+/** Render code lines with collapsed imports */
 export const renderJSXLinesWithCollapsedImports = (renderParams: RenderLineParams): ReactElement => {
     const { imports, others } = partitionImports(renderParams.tokens);
 
     return (
         <>
-            {imports.length ? <CollapsedImports {...renderParams} tokens={imports} /> : null}
+            {imports.length ? (
+                <details>
+                    <summary
+                        className="lumx-button lumx-button--emphasis-medium lumx-button--color-dark"
+                        aria-label="Expand imports"
+                        title="Expand imports"
+                    >
+                        import …
+                    </summary>
+                    {renderLines({ ...renderParams, tokens: imports })}
+                </details>
+            ) : null}
             {renderLines({ ...renderParams, tokens: others })}
         </>
     );

--- a/packages/site-demo/src/components/content/CodeBlock/renderLines.tsx
+++ b/packages/site-demo/src/components/content/CodeBlock/renderLines.tsx
@@ -5,7 +5,7 @@ export const renderLines = ({ tokens, getLineProps, getTokenProps }: RenderLineP
     tokens.map((line, i) => (
         <div key={line} {...getLineProps({ line, key: i })}>
             {line.map((token, key) => (
-                <span key={token} {...getTokenProps({ token, key })} />
+                <code key={token} {...getTokenProps({ token, key })} />
             ))}
         </div>
     ));

--- a/packages/site-demo/src/components/content/DemoBlock/DemoBlock.scss
+++ b/packages/site-demo/src/components/content/DemoBlock/DemoBlock.scss
@@ -38,9 +38,14 @@
     }
 
     &__code {
+        display: none;
         border: none;
         border-top: 1px solid $lumx-color-dark-L4;
         border-radius: 0;
+
+        &--shown {
+            display: block;
+        }
     }
 
     &__filename {

--- a/packages/site-demo/src/components/content/DemoBlock/DemoBlock.tsx
+++ b/packages/site-demo/src/components/content/DemoBlock/DemoBlock.tsx
@@ -100,9 +100,11 @@ export const DemoBlock: React.FC<DemoBlockProps> = ({
                 )}
             </div>
 
-            {showCode && codeString && (
-                <CodeBlock className="demo-block__code" codeString={codeString} language="tsx" />
-            )}
+            <CodeBlock
+                className={classNames('demo-block__code', showCode && codeString && 'demo-block__code--shown')}
+                codeString={codeString}
+                language="tsx"
+            />
         </div>
     );
 };


### PR DESCRIPTION
Render code block visually hidden instead of removed from the DOM

- Improve SEO, webscraping
- Improve semantic and a11y (using `<details><summary>` and `<code>`)

https://github.com/lumapps/design-system/assets/939567/3a5fb266-8175-4879-ac8c-4de1fbe5a153



