### PR TITLE
chore(ci): add code type check

### DIFF
--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -39,6 +39,21 @@ jobs:
                     sudo timedatectl set-timezone Europe/Paris
                     yarn test
 
+    type-check:
+        if: github.event.pull_request.draft == false
+        timeout-minutes: 30
+        runs-on: ubuntu-latest
+        steps:
+            -   name: "Checkout repository"
+                uses: actions/checkout@v3
+
+            -   name: "Setup"
+                uses: ./.github/actions/setup
+
+            -   name: "Run code type check"
+                run: yarn type-check
+
+
     Github-actions-validator:
         if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "setup:git-hooks": "yarn husky uninstall && yarn husky install || exit 0",
         "start": "yarn workspace lumx-site-demo start",
         "test": "yarn workspace @lumx/react test",
+        "type-check": "yarn tsc -p tsconfig.json",
         "storybook:react": "yarn workspace @lumx/react start:storybook",
         "storybook": "yarn storybook:react",
         "generate:design-tokens": "yarn workspace @lumx/core generate:design-tokens"

--- a/packages/lumx-react/src/components/navigation/NavigationItem.tsx
+++ b/packages/lumx-react/src/components/navigation/NavigationItem.tsx
@@ -7,7 +7,7 @@ import { forwardRefPolymorphic } from '@lumx/react/utils/forwardRefPolymorphic';
 import { ThemeContext } from '@lumx/react/utils/ThemeContext';
 
 type BaseNavigationItemProps = {
-    /* Icon (SVG path). */
+    /** Icon (SVG path). */
     icon?: string;
     /** Label content. */
     label: ReactNode;
@@ -65,7 +65,7 @@ export const NavigationItem = Object.assign(
                             prefix: `${CLASSNAME}__link`,
                             isSelected: isCurrentPage,
                         })}
-                        ref={ref}
+                        ref={ref as React.Ref<any>}
                         aria-current={isCurrentPage ? 'page' : undefined}
                         {...buttonProps}
                         {...forwardedProps}

--- a/packages/lumx-react/src/components/uploader/Uploader.test.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.test.tsx
@@ -72,7 +72,7 @@ describe(`<${Uploader.displayName}>`, () => {
         it('should render file input', () => {
             const label = 'Label';
             const accept = '*';
-            const { uploader } = setup({ label, fileInputProps: { accept } });
+            const { uploader } = setup({ label, fileInputProps: { accept } as any });
 
             expect(uploader.tagName).toBe('LABEL');
             expect(uploader).toHaveTextContent(label);

--- a/packages/lumx-react/src/utils/forwardRefPolymorphic.ts
+++ b/packages/lumx-react/src/utils/forwardRefPolymorphic.ts
@@ -4,6 +4,6 @@ import { ComponentRef } from '@lumx/react/utils/type';
 /** Same as `React.forwardRef` but inferring Ref type from the `as` prop. */
 export function forwardRefPolymorphic<E extends ElementType, P extends { as?: E }>(
     render: (props: P, ref: ComponentRef<E>) => React.ReactElement | null,
-) {
-    return React.forwardRef(render as any) as (props: P & { ref?: ComponentRef<E> }) => React.ReactElement | null;
+): (props: P & { ref?: ComponentRef<E> }) => React.ReactElement | null {
+    return React.forwardRef(render as any) as any;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8528,18 +8528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:>=16":
-  version: 18.2.45
-  resolution: "@types/react@npm:18.2.45"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: 40b256bdce67b026348022b4f8616a693afdad88cf493b77f7b4e6c5f4b0e4ba13a6068e690b9b94572920840ff30d501ea3d8518e1f21cc8fb8204d4b140c8a
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^17, @types/react@npm:^17.0.2":
+"@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^17, @types/react@npm:^17.0.2":
   version: 17.0.73
   resolution: "@types/react@npm:17.0.73"
   dependencies:


### PR DESCRIPTION
# General summary

Context: I recently, unknowingly merged with types error in the PR  https://github.com/lumapps/design-system/pull/1035 because the type checking is not checked in CI 😬 

In this PR:
1. Add code type check to the CI
2. Fix type errors (cause by the update of react types)

After this PR is merges, i'm making this CI check required in the repo configuration: https://github.com/lumapps/github-automation/pull/1680



