### PR TITLE
feat(text): add whiteSpace support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   Text: add style customisation with `whiteSpace` props
 -   Add new design token `medium` for `font-weight`.
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/text/_index.scss
+++ b/packages/lumx-core/src/scss/components/text/_index.scss
@@ -3,11 +3,14 @@
    ========================================================================== */
 
 .#{$lumx-base-prefix}-text {
+    white-space: var(--lumx-text-white-space);
+
     &--is-truncated {
+        --lumx-text-white-space: nowrap;
+
         display: block;
         overflow: hidden;
         text-overflow: ellipsis;
-        white-space: nowrap;
     }
 
     &--is-truncated-multiline {
@@ -19,7 +22,7 @@
     }
 
     &--no-wrap {
-        white-space: nowrap;
+        --lumx-text-white-space: nowrap;
     }
 
     // Fix icon alignment

--- a/packages/lumx-react/src/components/index.ts
+++ b/packages/lumx-react/src/components/index.ts
@@ -173,6 +173,19 @@ export const Kind = {
 export type Kind = ValueOf<typeof Kind>;
 
 /**
+ * All available white-space values
+ * */
+export const WhiteSpace = {
+    normal: 'normal',
+    nowrap: 'nowrap',
+    pre: 'pre',
+    'pre-wrap': 'pre-wrap',
+    'pre-line': 'pre-line',
+    'break-spaces': 'break-spaces',
+};
+export type WhiteSpace = ValueOf<typeof WhiteSpace>;
+
+/**
  * Re-exporting some utils types.
  */
 export type { HeadingElement, TextElement, GenericProps, Callback } from '../utils/type';

--- a/packages/lumx-react/src/components/text/Text.stories.tsx
+++ b/packages/lumx-react/src/components/text/Text.stories.tsx
@@ -6,9 +6,10 @@ import { textElementArgType } from '@lumx/react/stories/controls/element';
 import { withUndefined } from '@lumx/react/stories/controls/withUndefined';
 import { loremIpsum } from '@lumx/react/stories/utils/lorem';
 import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
-import { ColorPalette, ColorVariant, Icon } from '@lumx/react';
+import { ColorPalette, ColorVariant, Icon, WhiteSpace } from '@lumx/react';
 import { mdiEarth, mdiHeart } from '@lumx/icons';
 import { withResizableBox } from '@lumx/react/stories/decorators/withResizableBox';
+import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
 
 import { Text } from './Text';
 
@@ -22,6 +23,7 @@ export default {
         typography: allTypographyArgType,
         color: colorArgType,
         colorVariant: colorVariantArgType,
+        whiteSpace: getSelectArgType(WhiteSpace),
     },
 };
 
@@ -69,6 +71,29 @@ export const NoWrap = {
         ...LongText.args,
         noWrap: true,
     },
+};
+
+/**
+ * Long text with line breaks
+ */
+export const AllWhiteSpace = {
+    args: {
+        ...Default.args,
+        children: `
+        But ere she from the church-door stepped She smiled and told us why: 'It was a wicked woman's curse,' Quoth she,
+        'and what care I?' She smiled, and smiled, and passed it off Ere from the door she stept—
+      `,
+    },
+    decorators: [
+        withCombinations({
+            combinations: {
+                rows: { key: 'whiteSpace', options: Object.values(WhiteSpace) },
+            },
+            tableStyle: { width: 500, tableLayout: 'fixed' },
+            firstColStyle: { width: 100 },
+            cellStyle: { border: '1px solid #000', width: '100%' },
+        }),
+    ],
 };
 
 /**

--- a/packages/lumx-react/src/components/text/Text.test.tsx
+++ b/packages/lumx-react/src/components/text/Text.test.tsx
@@ -61,6 +61,12 @@ describe(`<${Text.displayName}>`, () => {
             expect(element).toHaveClass('lumx-text--no-wrap');
         });
 
+        it('should render with custom whiteSpace', () => {
+            const { element } = setup({ whiteSpace: 'pre-wrap' });
+            expect(element.tagName).toBe('SPAN');
+            expect(element).toHaveStyle({ '--lumx-text-white-space': 'pre-wrap' });
+        });
+
         it('should wrap icons with spaces', () => {
             const { element } = setup({ children: ['Some text', <Icon key="icon" icon={mdiEarth} />, 'with icon'] });
             // Spaces have been inserted around the icon.

--- a/packages/lumx-react/src/components/text/Text.tsx
+++ b/packages/lumx-react/src/components/text/Text.tsx
@@ -1,6 +1,6 @@
 import React, { Children, Fragment, forwardRef } from 'react';
 
-import { Icon, ColorPalette, ColorVariant, Typography } from '@lumx/react';
+import { Icon, ColorPalette, ColorVariant, Typography, WhiteSpace } from '@lumx/react';
 import { Comp, GenericProps, TextElement, isComponent } from '@lumx/react/utils/type';
 import {
     getFontColorClassName,
@@ -41,6 +41,12 @@ export interface TextProps extends GenericProps {
      * (automatically activated when single line text truncate is activated).
      */
     noWrap?: boolean;
+    /**
+     * WhiteSpace variant
+     * Ignored when `noWrap` is set to true
+     * Ignored when `truncate` is set to true or lines: 1
+     * */
+    whiteSpace?: WhiteSpace;
 }
 
 /**
@@ -75,6 +81,7 @@ export const Text: Comp<TextProps> = forwardRef((props, ref) => {
         noWrap,
         typography,
         truncate,
+        whiteSpace,
         style,
         ...forwardedProps
     } = props;
@@ -87,6 +94,15 @@ export const Text: Comp<TextProps> = forwardRef((props, ref) => {
         truncate.lines > 1 && { '--lumx-text-truncate-lines': truncate.lines };
     const isTruncatedMultiline = !!truncateLinesStyle;
     const isTruncated = !!truncate;
+
+    /**
+     * Add custom white-space style if specified
+     * Disabled if noWrap is specified
+     * Disabled if truncated on one-line
+     * */
+    const whiteSpaceStyle = !noWrap &&
+        !(isTruncated && !isTruncatedMultiline) &&
+        whiteSpace && { '--lumx-text-white-space': whiteSpace };
 
     return (
         <Component
@@ -102,7 +118,7 @@ export const Text: Comp<TextProps> = forwardRef((props, ref) => {
                 colorClass,
                 noWrap && `${CLASSNAME}--no-wrap`,
             )}
-            style={{ ...truncateLinesStyle, ...style }}
+            style={{ ...truncateLinesStyle, ...whiteSpaceStyle, ...style }}
             {...forwardedProps}
         >
             {children &&


### PR DESCRIPTION
# General summary

Proposition to update the design-system `Text` component, and add a new `whiteSpace` property, to customise the `Text` CSS style.

This will let the user choose the CSS `white-space` property he want for the text. The use case that motivated this PR was to show the `Text` string, with it's formatting intact (line break, spaces, ...) using `white-space: pre-wrap`.

<!-- Please describe the PR content -->

# Screenshots
<img width="1192" alt="Screenshot 2023-12-20 at 14 53 39" src="https://github.com/lumapps/design-system/assets/7592327/811b9121-2b4e-420f-8832-1ea504ce922a">

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://50cad0c2--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=322)) **⚠️ Outdated commit**