### PR TITLE
chore(tooltip): fix escape key handler only when open

### DIFF
--- a/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
+++ b/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
@@ -17,7 +17,7 @@ export function useTooltipOpen(delay: number | undefined, anchorElement: HTMLEle
 
     // Global close on escape
     const [closeCallback, setCloseCallback] = useState<undefined | (() => void)>(undefined);
-    useCallbackOnEscape(closeCallback);
+    useCallbackOnEscape(isOpen ? closeCallback : undefined);
 
     useEffect(() => {
         if (!anchorElement) {


### PR DESCRIPTION
- chore(tooltip): make sure to only listen escape key on open
- chore(tooltip): add tests on close on escape

Not modifying the CHANGELOG because this fix is on a bug not yet releases



StoryBook: https://5991f7f4--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=323))