### PR TITLE
fix(site): fix some broken links

### DIFF
--- a/packages/site-demo/content/product/components/list/index.mdx
+++ b/packages/site-demo/content/product/components/list/index.mdx
@@ -15,7 +15,7 @@ Use this size for any other cases.
 
 ### Tiny
 Tiny list items have a minimum height of `36px`.
-Use this size for dense lists with single line items like menus made of [dropdown](../dropdown).
+Use this size for dense lists with single line items like menus made of [dropdown](../product/components/dropdown).
 
 <DemoBlock demo="tiny" />
 

--- a/packages/site-demo/content/product/components/select/index.mdx
+++ b/packages/site-demo/content/product/components/select/index.mdx
@@ -37,7 +37,7 @@ There are three states: _disabled_, _valid_, and _invalid_.
 
 ## Chip variant
 
-Use chip variant when selects behave like filters (see [filter chip](../chip)).
+Use chip variant when selects behave like filters (see [filter chip](../product/components/chip)).
 
 <DemoBlock demo="select-chip" withThemeSwitcher />
 

--- a/packages/site-demo/content/product/components/thumbnail/index.mdx
+++ b/packages/site-demo/content/product/components/thumbnail/index.mdx
@@ -71,7 +71,7 @@ You **should define the `alt` attribute**, with a string indicating where the li
 You **should define the `alt` attribute**, with a string indicating the purpose of the button.
 (See [the W3C reference page for Functional images](https://www.w3.org/WAI/tutorials/images/functional/) for more details)
 - **Badged thumbnail** if you have a badge on your Thumbnail, then the badge should handle the accessibility of its information.
-(See the [badge page](../badge#accessibility-concerns) for the accessibility concerns on badged thumbnails.)
+(See the [badge page](../product/components/badge#accessibility-concerns) for the accessibility concerns on badged thumbnails.)
 
 If you have some troubles to define how to fill the `alt` attribute, you can use the [Alt decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/).
 


### PR DESCRIPTION
DSW-72

# General summary
Fix some broken links on demo site in these pages: 

- https://design.lumapps.com/product/components/select/ filter (fliter chip in Chip variant paragraph)
- https://design.lumapps.com/product/components/thumbnail/ (bage page in Accessibility concerns)
- https://design.lumapps.com/product/components/list/ dropdown (Dropdown in Tiny paragraph)

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
