### PR TITLE
fix(transition-visibility): fix handling when closing prematurely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Lightbox, Dialog, Notification: fix remove from DOM when closing while the opening transition isn't finished.
+
 ## [3.6.1][] - 2024-01-05
 
 ### Added
@@ -1858,7 +1862,5 @@ _Failed released_
 [3.6.0]: https://github.com/lumapps/design-system/compare/v3.5.5...v3.6.0
 [3.5.5]: https://github.com/lumapps/design-system/compare/v3.5.4...v3.5.5
 [3.5.4]: https://github.com/lumapps/design-system/tree/v3.5.4
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.6.1...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.6.1...HEAD
 [3.6.1]: https://github.com/lumapps/design-system/tree/v3.6.1

--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import { Progress, ProgressVariant, Size } from '@lumx/react';
 
-import { DOCUMENT } from '@lumx/react/constants';
+import { DIALOG_TRANSITION_DURATION, DOCUMENT } from '@lumx/react/constants';
 import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useIntersectionObserver } from '@lumx/react/hooks/useIntersectionObserver';
@@ -185,7 +185,7 @@ export const Dialog: Comp<DialogProps, HTMLDivElement> = forwardRef((props, ref)
     const rootRef = useRef<HTMLDivElement>(null);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const isVisible = useTransitionVisibility(rootRef, Boolean(isOpen), onVisibilityChange);
+    const isVisible = useTransitionVisibility(rootRef, Boolean(isOpen), DIALOG_TRANSITION_DURATION, onVisibilityChange);
 
     const shouldPreventCloseOnClickAway = preventAutoClose || preventCloseOnClick;
 

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 
 import { mdiClose } from '@lumx/icons';
 import { ColorPalette, Emphasis, IconButton, IconButtonProps } from '@lumx/react';
-import { DOCUMENT } from '@lumx/react/constants';
+import { DIALOG_TRANSITION_DURATION, DOCUMENT } from '@lumx/react/constants';
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
@@ -88,7 +88,7 @@ export const Lightbox: Comp<LightboxProps, HTMLDivElement> = forwardRef((props, 
     useDisableBodyScroll(isOpen && wrapperRef.current);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const isVisible = useTransitionVisibility(wrapperRef, !!isOpen);
+    const isVisible = useTransitionVisibility(wrapperRef, !!isOpen, DIALOG_TRANSITION_DURATION);
 
     // Handle focus trap.
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/lumx-react/src/components/notification/Notification.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.tsx
@@ -7,7 +7,7 @@ import isFunction from 'lodash/isFunction';
 
 import { Button, Emphasis, Icon, Kind, Size, Theme } from '@lumx/react';
 
-import { DOCUMENT } from '@lumx/react/constants';
+import { DOCUMENT, NOTIFICATION_TRANSITION_DURATION } from '@lumx/react/constants';
 import { NOTIFICATION_CONFIGURATION } from '@lumx/react/components/notification/constants';
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
@@ -80,7 +80,7 @@ export const Notification: Comp<NotificationProps, HTMLDivElement> = forwardRef(
     }
     const { color, icon } = NOTIFICATION_CONFIGURATION[type as Kind] || {};
     const rootRef = useRef<HTMLDivElement>(null);
-    const isVisible = useTransitionVisibility(rootRef, !!isOpen);
+    const isVisible = useTransitionVisibility(rootRef, !!isOpen, NOTIFICATION_TRANSITION_DURATION);
     const hasAction: boolean = Boolean(onActionClick) && Boolean(actionLabel);
 
     const handleCallback = (evt: React.MouseEvent) => {


### PR DESCRIPTION
# General summary

Lightbox, Dialog, Notification: fix remove from DOM when closing while the opening transition isn't finished.

https://lumapps.atlassian.net/browse/DSW-107

StoryBook: https://0b59f5b0--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=325))