### PR TITLE
fix(avatar): fix Chrome behavior when downscaling avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Lightbox, Dialog, Notification: fix remove from DOM when closing while the opening transition isn't finished.
+-   Avatar: fixed Chrome behavior when down-scaling avatar so it is not pixelated anymore
 
 ## [3.6.1][] - 2024-01-05
 

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -105,6 +105,10 @@
         object-position: center;
         width: 100%;
         height: 100%;
+        // When using object-fit:cover + ratio 1/1, Chrome switches to pixelated downsizing algo https://stackoverflow.com/a/77059936
+        // The following prevent this so the image is correctly downsized using blurrying effect
+        overflow-clip-margin: unset;
+        overflow: visible;
 
         @supports not (aspect-ratio: 1 / 1) {
             position: absolute;
@@ -119,7 +123,7 @@
 @supports (aspect-ratio: 1 / 1) {
     @each $key, $aspect-ratio-fraction in $lumx-thumbnail-aspect-ratio-fraction {
         .#{$lumx-base-prefix}-thumbnail--aspect-ratio-#{$key}:not(.#{$lumx-base-prefix}-thumbnail--fill-height)
-        .#{$lumx-base-prefix}-thumbnail__image {
+            .#{$lumx-base-prefix}-thumbnail__image {
             aspect-ratio: var(--lumx-thumbnail-aspect-ratio, string.unquote($aspect-ratio-fraction));
         }
     }
@@ -128,7 +132,7 @@
 @supports not (aspect-ratio: 1 / 1) {
     @each $key, $aspect-ratio in $lumx-thumbnail-aspect-ratio {
         .#{$lumx-base-prefix}-thumbnail--aspect-ratio-#{$key}:not(.#{$lumx-base-prefix}-thumbnail--fill-height)
-        .#{$lumx-base-prefix}-thumbnail__background {
+            .#{$lumx-base-prefix}-thumbnail__background {
             padding-top: $aspect-ratio;
         }
     }
@@ -154,18 +158,18 @@
         bottom: 0;
         left: 0;
         pointer-events: none;
-        content: "";
+        content: '';
     }
 
     /* Hover */
     &:hover::after,
     &:focus::after {
-        @include lumx-state(lumx-base-const("state", "HOVER"), lumx-base-const("emphasis", "LOW"), "dark");
+        @include lumx-state(lumx-base-const('state', 'HOVER'), lumx-base-const('emphasis', 'LOW'), 'dark');
     }
 
     /* Active */
     &:active::after {
-        @include lumx-state(lumx-base-const("state", "ACTIVE"), lumx-base-const("emphasis", "LOW"), "dark");
+        @include lumx-state(lumx-base-const('state', 'ACTIVE'), lumx-base-const('emphasis', 'LOW'), 'dark');
     }
 }
 
@@ -179,25 +183,25 @@
 /* Focused (light theme) */
 .#{$lumx-base-prefix}-thumbnail--theme-light.#{$lumx-base-prefix}-thumbnail--is-clickable {
     &[data-focus-visible-added]::after {
-        @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "dark");
+        @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'dark');
     }
 }
 
 /* Focused (dark theme) */
 .#{$lumx-base-prefix}-thumbnail--theme-dark.#{$lumx-base-prefix}-thumbnail--is-clickable {
     &[data-focus-visible-added]::after {
-        @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "light");
+        @include lumx-state(lumx-base-const('state', 'FOCUS'), lumx-base-const('emphasis', 'LOW'), 'light');
     }
 }
 
 /* Loading state */
 .#{$lumx-base-prefix}-thumbnail--is-loading {
     &.#{$lumx-base-prefix}-thumbnail--theme-light .#{$lumx-base-prefix}-thumbnail__background {
-        @include lumx-skeleton("light");
+        @include lumx-skeleton('light');
     }
 
     &.#{$lumx-base-prefix}-thumbnail--theme-dark .#{$lumx-base-prefix}-thumbnail__background {
-        @include lumx-skeleton("dark");
+        @include lumx-skeleton('dark');
     }
 }
 
@@ -217,11 +221,11 @@
         }
 
         &.#{$lumx-base-prefix}-thumbnail--theme-light .#{$lumx-base-prefix}-thumbnail__fallback {
-            background-color: lumx-color-variant("dark", "L6");
+            background-color: lumx-color-variant('dark', 'L6');
         }
 
         &.#{$lumx-base-prefix}-thumbnail--theme-dark .#{$lumx-base-prefix}-thumbnail__fallback {
-            background-color: lumx-color-variant("light", "L6");
+            background-color: lumx-color-variant('light', 'L6');
         }
     }
 
@@ -237,16 +241,15 @@
 /* Thumbnail badge mask
    ========================================================================== */
 
-$badge-radius-size: math.div(map.get($lumx-sizes, lumx-base-const("size", "XS")), 2) + 2;
+$badge-radius-size: math.div(map.get($lumx-sizes, lumx-base-const('size', 'XS')), 2) + 2;
 
 .#{$lumx-base-prefix}-thumbnail--has-badge {
     .#{$lumx-base-prefix}-thumbnail__background,
     .#{$lumx-base-prefix}-thumbnail__fallback {
-        mask-image:
-            radial-gradient(
-                circle at calc(100% - #{$badge-radius-size - 6}) calc(100% - #{$badge-radius-size - 6}),
-                transparent $badge-radius-size,
-                black $badge-radius-size + 1
-            );
+        mask-image: radial-gradient(
+            circle at calc(100% - #{$badge-radius-size - 6}) calc(100% - #{$badge-radius-size - 6}),
+            transparent $badge-radius-size,
+            black $badge-radius-size + 1
+        );
     }
 }


### PR DESCRIPTION
When using object-fit:cover + ratio 1/1, Chrome switches to pixelated downsizing algo which makes the avatar pixelated, add css rules to make Chrome reuse the bilinear algo so it's smoother for Avatar component

SUP-4461

# General summary

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

![Peek 11-01-2024 09-16](https://github.com/lumapps/design-system/assets/63426102/124183ad-2cb5-4520-8d46-07e0ac3eb6ed)

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [X] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [X] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [X] (if fix or feature) Add `need: test` label
-   [X] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://f132033c--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=326)) **⚠️ Outdated commit**