### PR TITLE
feat(popover): rework arrow style and add dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Thumbnail: fix warnings on image overflow style
 
+### Changed
+
+-   Popover: reworked arrow style to be bigger and with a correct drop shadow
+
 ## [3.6.2][] - 2024-01-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Thumbnail: fix warnings on image overflow style
 
+### Added
+
+-   Popover: add dark theme
+
 ### Changed
 
 -   Popover: reworked arrow style to be bigger and with a correct drop shadow

--- a/packages/lumx-core/src/scss/components/popover/_index.scss
+++ b/packages/lumx-core/src/scss/components/popover/_index.scss
@@ -22,34 +22,42 @@
     }
 
     &__arrow {
-        &,
-        &::before {
-            position: absolute;
-            z-index: -1;
-            width: $lumx-popover-arrow-size;
-            height: $lumx-popover-arrow-size;
-        }
+        position: absolute;
+        z-index: -1;
+        width: $lumx-popover-arrow-size;
+        height: $lumx-popover-arrow-size;
+        fill: lumx-color-variant("light", "N");
 
-        &::before {
-            content: "";
-            background: lumx-color-variant("light", "N");
-            transform: rotate(45deg);
+        svg {
+            display: block;
         }
 
         #{$self}[data-popper-placement^='top'] & {
-            bottom: math.div(-$lumx-popover-arrow-size, 2);
+            bottom: -$lumx-popover-arrow-size;
+
+            svg {
+                transform: rotate(180deg);
+            }
         }
 
         #{$self}[data-popper-placement^='bottom'] & {
-            top: math.div(-$lumx-popover-arrow-size, 2);
+            top: -$lumx-popover-arrow-size;
         }
 
         #{$self}[data-popper-placement^='left'] & {
-            right: math.div(-$lumx-popover-arrow-size, 2);
+            right: -$lumx-popover-arrow-size;
+
+            svg {
+                transform: rotate(90deg);
+            }
         }
 
-        #{$self}[data-popper-placement^='righ'] & {
-            left: math.div(-$lumx-popover-arrow-size, 2);
+        #{$self}[data-popper-placement^='right'] & {
+            left: -$lumx-popover-arrow-size;
+
+            svg {
+                transform: rotate(-90deg);
+            }
         }
     }
 }
@@ -59,6 +67,6 @@
 
 @each $depth, $shadow in $lumx-elevation-shadows {
     .#{$lumx-base-prefix}-popover--elevation-#{$depth} {
-        @include lumx-elevation($depth);
+        @include lumx-elevation-drop-shadow($depth);
     }
 }

--- a/packages/lumx-core/src/scss/components/popover/_index.scss
+++ b/packages/lumx-core/src/scss/components/popover/_index.scss
@@ -60,6 +60,14 @@
             }
         }
     }
+
+    &--theme-dark {
+        background: lumx-color-variant("dark", "N");
+
+        #{$self}__arrow {
+            fill: lumx-color-variant("dark", "N");
+        }
+    }
 }
 
 /* Elevations

--- a/packages/lumx-core/src/scss/components/popover/_variables.scss
+++ b/packages/lumx-core/src/scss/components/popover/_variables.scss
@@ -1,1 +1,1 @@
-$lumx-popover-arrow-size: 5px;
+$lumx-popover-arrow-size: 14px;

--- a/packages/lumx-core/src/scss/core/elevation/_mixins.scss
+++ b/packages/lumx-core/src/scss/core/elevation/_mixins.scss
@@ -1,4 +1,5 @@
 @use "sass:map";
+@use "sass:math";
 @use "sass:string";
 
 // Elevation using box-shadow
@@ -15,7 +16,8 @@
     @if $elevation > 0 {
         $offset-x: 0;
         $offset-y: map.get($lumx-elevation-shadow-offset-y, $elevation);
-        $blur: map.get($lumx-elevation-shadow-blur, $elevation);
+        // Adjust the blur value so it matches visually to the box-shadow blur
+        $blur: math.div(map.get($lumx-elevation-shadow-blur, $elevation), 2);
 
         filter:
             drop-shadow(

--- a/packages/lumx-core/src/scss/core/elevation/_mixins.scss
+++ b/packages/lumx-core/src/scss/core/elevation/_mixins.scss
@@ -1,10 +1,28 @@
 @use "sass:map";
 @use "sass:string";
 
+// Elevation using box-shadow
 @mixin lumx-elevation($elevation, $variant: "L4") {
     @if $elevation == 0 {
         box-shadow: none;
     } @else {
         box-shadow: string.unquote(map.get($lumx-elevation-shadows, $elevation)) lumx-color-variant("dark", $variant);
+    }
+}
+
+// Elevation using filter drop-shadow
+@mixin lumx-elevation-drop-shadow($elevation, $variant: "L4") {
+    @if $elevation > 0 {
+        $offset-x: 0;
+        $offset-y: map.get($lumx-elevation-shadow-offset-y, $elevation);
+        $blur: map.get($lumx-elevation-shadow-blur, $elevation);
+
+        filter:
+            drop-shadow(
+                $offset-x
+                $offset-y
+                $blur
+                lumx-color-variant("dark", $variant)
+            );
     }
 }

--- a/packages/lumx-core/src/scss/core/elevation/_variables.scss
+++ b/packages/lumx-core/src/scss/core/elevation/_variables.scss
@@ -1,7 +1,28 @@
-$lumx-elevation-shadows: (
-    1: "0 0 2px 0",
-    2: "0 1px 4px 0",
-    3: "0 2px 8px 0",
-    4: "0 4px 16px 0",
-    5: "0 8px 32px 0",
+@use "sass:map";
+
+$lumx-elevation-shadow-offset-y: (
+    1: 0,
+    2: 1px,
+    3: 2px,
+    4: 4px,
+    5: 8px,
 );
+$lumx-elevation-shadow-blur: (
+    1: 2px,
+    2: 4px,
+    3: 8px,
+    4: 16px,
+    5: 32px,
+);
+$lumx-elevation-shadows: ();
+
+@each $depth in (1, 2, 3, 4, 5) {
+    $offset-y: map.get($lumx-elevation-shadow-offset-y, $depth);
+    $blur: map.get($lumx-elevation-shadow-blur, $depth);
+    $lumx-elevation-shadows: map.set(
+        $lumx-elevation-shadows,
+        $depth,
+        // box-shadow <offset-x> <offset-y> <blur-radius> <spread-radius>
+        "0 " + $offset-y + " " + $blur + " 0"
+    );
+}

--- a/packages/lumx-react/.storybook/story-block/StoryBlock.tsx
+++ b/packages/lumx-react/.storybook/story-block/StoryBlock.tsx
@@ -18,7 +18,7 @@ const CLASSNAME = 'story-block';
 export const StoryBlock: React.FC<StoryBlockProps> = (props) => {
     const { Story, context } = props;
     const { theme, materialTheme } = context.globals;
-    const args = {...context.args, theme};
+    const args = { theme, ...context.args };
 
 
     // Hard code today date for stable chromatic stories snapshots.

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -67,6 +67,22 @@ export const Simple = {
 };
 
 /**
+ * Dark theme
+ */
+export const DarkTheme = {
+    ...Simple,
+    args: {
+        theme: 'dark',
+        children: (
+            <Text as="p" color="light" className="lumx-spacing-padding-big">
+                Popover
+            </Text>
+        ),
+        hasArrow: true,
+    },
+};
+
+/**
  * Popover not using React.createPortal
  */
 export const WithoutPortal = { ...Simple, args: { ...Simple.args, usePortal: false } };

--- a/packages/lumx-react/src/components/popover/Popover.stories.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.stories.tsx
@@ -29,6 +29,12 @@ export default {
         hasArrow: { control: 'boolean' },
         placement: getSelectArgType(Placement),
         elevation: getSelectArgType<Elevation>([1, 2, 3, 4, 5]),
+        ref: { control: false },
+        parentElement: { control: false },
+        focusElement: { control: false },
+        anchorRef: { control: false },
+        boundaryRef: { control: false },
+        children: { control: false },
     },
     decorators: [
         // Force minimum chromatic screen size to make sure the dialog appears in view.

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -209,7 +209,13 @@ const _InnerPopover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, ref
                   {...attributes.popper}
               >
                   <ClickAwayProvider callback={closeOnClickAway && handleClose} childrenRefs={clickAwayRefs}>
-                      {hasArrow && <div ref={setArrowElement} className={`${CLASSNAME}__arrow`} style={styles.arrow} />}
+                      {hasArrow && (
+                          <div ref={setArrowElement} className={`${CLASSNAME}__arrow`} style={styles.arrow}>
+                              <svg viewBox="0 0 14 14" aria-hidden>
+                                  <path d="M8 3.49C7.62 2.82 6.66 2.82 6.27 3.48L.04 14 14.04 14 8 3.49Z" />
+                              </svg>
+                          </div>
+                      )}
                       {children}
                   </ClickAwayProvider>
               </Component>,

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -7,7 +7,7 @@ import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { useFocus } from '@lumx/react/hooks/useFocus';
 import { ClickAwayProvider } from '@lumx/react/utils/ClickAwayProvider';
 import { DOCUMENT } from '@lumx/react/constants';
-import { Comp, GenericProps } from '@lumx/react/utils/type';
+import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { useFocusWithin } from '@lumx/react/hooks/useFocusWithin';
@@ -21,7 +21,7 @@ import { FitAnchorWidth, Elevation, Offset, Placement } from './constants';
 /**
  * Defines the props of the component.
  */
-export interface PopoverProps extends GenericProps {
+export interface PopoverProps extends GenericProps, HasTheme {
     /** Reference to the DOM element used to set the position of the popover. */
     anchorRef: React.RefObject<HTMLElement>;
     /** Customize the root element. (Must accept ref forwarding and props forwarding!). */
@@ -118,6 +118,7 @@ const _InnerPopover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, ref
         offset,
         placement,
         style,
+        theme,
         zIndex,
         ...forwardedProps
     } = props;
@@ -203,7 +204,12 @@ const _InnerPopover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, ref
                   ref={mergeRefs<HTMLDivElement>(setPopperElement, ref, clickAwayRef, contentRef)}
                   className={classNames(
                       className,
-                      handleBasicClasses({ prefix: CLASSNAME, elevation: Math.min(elevation || 0, 5), position }),
+                      handleBasicClasses({
+                          prefix: CLASSNAME,
+                          theme,
+                          elevation: Math.min(elevation || 0, 5),
+                          position,
+                      }),
                   )}
                   style={styles.popover}
                   {...attributes.popper}

--- a/packages/lumx-react/src/components/popover/constants.ts
+++ b/packages/lumx-react/src/components/popover/constants.ts
@@ -54,4 +54,4 @@ export type FitAnchorWidth = ValueOf<typeof FitAnchorWidth>;
 /**
  * Arrow size (in pixel).
  */
-export const ARROW_SIZE = 8;
+export const ARROW_SIZE = 14;

--- a/packages/lumx-react/src/components/popover/usePopoverStyle.tsx
+++ b/packages/lumx-react/src/components/popover/usePopoverStyle.tsx
@@ -120,7 +120,13 @@ export function usePopoverStyle({
         },
     ];
     if (hasArrow && arrowElement) {
-        modifiers.push({ name: 'arrow', options: { element: arrowElement, padding: ARROW_SIZE } });
+        modifiers.push({
+            name: 'arrow',
+            options: {
+                element: arrowElement,
+                padding: ARROW_SIZE / 2,
+            },
+        });
     }
     if (fitToAnchorWidth) {
         const fitWidth = typeof fitToAnchorWidth === 'string' ? fitToAnchorWidth : FitAnchorWidth.MIN_WIDTH;

--- a/packages/lumx-react/src/stories/controls/selectArgType.ts
+++ b/packages/lumx-react/src/stories/controls/selectArgType.ts
@@ -1,4 +1,7 @@
+import isPlainObject from 'lodash/isPlainObject';
+
 export const getSelectArgType = <E>(options: Array<E> | Record<string, E>) => ({
     control: { type: 'select' },
-    options,
+    options: Object.values(options),
+    mapping: isPlainObject(options) ? options : undefined,
 });


### PR DESCRIPTION
https://lumapps.atlassian.net/browse/DSW-43

- feat(popover): rework arrow style
  Make arrow bigger and make the drop shadow fit better with the whole popover
  | before | after |
  | --- | --- |
  | ![image](https://github.com/lumapps/design-system/assets/939567/b4fdee55-01a9-400a-8564-ea910cf91ee8) | ![image](https://github.com/lumapps/design-system/assets/939567/25f15d1b-abda-4fad-82fe-50d3681c4611) |
  
  Test on: https://257497c2--5fbfb1d508c0520021560f10.chromatic.com/?path=/story/lumx-components-popover-popover--simple&args=hasArrow:true

- feat(popover): add dark theme
  Add dark theme changing the popover and arrow background
  ![image](https://github.com/lumapps/design-system/assets/939567/e7d19760-2074-45f4-bb79-75a1d6deccf1)

  Test on: https://257497c2--5fbfb1d508c0520021560f10.chromatic.com/?path=/story/lumx-components-popover-popover--dark-theme


StoryBook: https://257497c2--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=330))