### PR TITLE
Fix macOS Chrome v121+ font weight bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Thumbnail: fix warnings on image overflow style
+-   `@lumx/core`: remove font smoothing that seems to produce incorrect font weight with macOS system font on Chrome v121
 
 ## [3.6.2][] - 2024-01-16
 

--- a/packages/lumx-core/src/scss/core/typography/_mixins.scss
+++ b/packages/lumx-core/src/scss/core/typography/_mixins.scss
@@ -2,8 +2,8 @@
 
 @mixin lumx-typography-base() {
     font-family: var(--lumx-typography-font-family);
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: auto;
+    -webkit-font-smoothing: auto;
 }
 
 @mixin lumx-typography($key, $type: "interface") {


### PR DESCRIPTION
# General summary

Remove font smoothing that seems to produce incorrect font weight with macOS system font on Chrome v121

**Before**: https://befe7ff--5fbfb1d508c0520021560f10.chromatic.com/?path=/story/lumx-components-text-text--all-typography
**After**: https://dbaf184f--5fbfb1d508c0520021560f10.chromatic.com/?path=/story/lumx-components-text-text--all-typography

|                   | Before | After | 
|-------------------|--------|-------|
| macOS Chrome v121 |  ![Capture d’écran 2024-01-30 à 16 27 58](https://github.com/lumapps/design-system/assets/939567/97e7f499-81a9-4ac1-b067-1590bb390e97)      |  ![Capture d’écran 2024-01-30 à 16 29 00](https://github.com/lumapps/design-system/assets/939567/bf7da8bf-4c83-4b66-89a7-541b69fa0870)     | 
| macOS Safari      |   ![Capture d’écran 2024-01-30 à 16 29 59](https://github.com/lumapps/design-system/assets/939567/65359371-e509-4eb6-8c9a-266a670c5b01)     |    ![Capture d’écran 2024-01-30 à 16 30 05](https://github.com/lumapps/design-system/assets/939567/96f22dbb-9b97-4184-91a0-7f730e7bca9b)| 



StoryBook: https://dbaf184f--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=332))