### PR TITLE
feat(notification): add `usePortal` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Popover: reworked arrow style to be bigger and with a correct drop shadow
+-   Notification: add `usePortal` (default value is `true`) to be able to not use a portal in some cases.
 
 ## [3.6.2][] - 2024-01-16
 

--- a/packages/lumx-react/src/components/notification/Notification.test.tsx
+++ b/packages/lumx-react/src/components/notification/Notification.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Kind } from '@lumx/react';
-import { render, within } from '@testing-library/react';
+import { render, within, screen } from '@testing-library/react';
 import { queryByClassName } from '@lumx/react/testing/utils/queries';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import userEvent from '@testing-library/user-event';
@@ -65,6 +65,18 @@ describe(`<${Notification.displayName}>`, () => {
         // Click notification
         await userEvent.click(notification as any);
         expect(onClick).toHaveBeenCalled();
+    });
+
+    it('should render outside a portal', () => {
+        const parentId = '123';
+        render(
+            <div data-testid={parentId}>
+                <Notification isOpen type="info" usePortal={false} />
+            </div>,
+        );
+        const parent = screen.getByTestId(parentId);
+        const notification = queryByClassName(parent, CLASSNAME);
+        expect(notification).toBeInTheDocument();
     });
 
     // Common tests suite.

--- a/packages/lumx-react/src/components/notification/Notifications.stories.tsx
+++ b/packages/lumx-react/src/components/notification/Notifications.stories.tsx
@@ -80,3 +80,13 @@ export const InfoWithAction = {
         isOpen: true,
     },
 };
+
+/**
+ * Info notification rendered outside a React portal
+ */
+export const InfoWithoutPortal = {
+    args: {
+        ...Info.args,
+        usePortal: false,
+    },
+};


### PR DESCRIPTION
# General summary

Add `usePortal` prop on the notification component to make it render outside the default React portal

