### PR TITLE
feat(tooltip): restrict open on focus visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- InputHelper: change of html tag to improve semantic
+-   InputHelper: change of html tag to improve semantic
+
+### Changed
+
+-   Tooltip: do not show on anchor focus if the focus is not visible (keyboard driven)
 
 ## [3.6.3][] - 2024-02-08
 
@@ -1889,7 +1893,5 @@ _Failed released_
 [3.6.1]: https://github.com/lumapps/design-system/tree/v3.6.1
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.6.2...HEAD
 [3.6.2]: https://github.com/lumapps/design-system/tree/v3.6.2
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.6.3...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.6.3...HEAD
 [3.6.3]: https://github.com/lumapps/design-system/tree/v3.6.3

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
@@ -4,10 +4,13 @@ import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import { queryByRole, render } from '@testing-library/react';
 import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import userEvent from '@testing-library/user-event';
+import { isFocusVisible } from '@lumx/react/utils/isFocusVisible';
 
 import { ExpansionPanel, ExpansionPanelProps } from '.';
 
 const CLASSNAME = ExpansionPanel.className as string;
+
+jest.mock('@lumx/react/utils/isFocusVisible');
 
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
@@ -32,6 +35,8 @@ const setup = (propsOverride: Partial<ExpansionPanelProps> = {}) => {
 };
 
 describe(`<${ExpansionPanel.displayName}>`, () => {
+    (isFocusVisible as jest.Mock).mockReturnValue(false);
+
     describe('Render', () => {
         it('should render default', () => {
             const { element, query } = setup();

--- a/packages/lumx-react/src/components/select/Select.test.tsx
+++ b/packages/lumx-react/src/components/select/Select.test.tsx
@@ -7,11 +7,13 @@ import { getByClassName, queryAllByClassName, queryByClassName } from '@lumx/rea
 import { render, within } from '@testing-library/react';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import userEvent from '@testing-library/user-event';
+import { isFocusVisible } from '@lumx/react/utils/isFocusVisible';
 
 import { Select, SelectProps, SelectVariant } from './Select';
 
 const CLASSNAME = Select.className as string;
 
+jest.mock('@lumx/react/utils/isFocusVisible');
 jest.mock('uid', () => ({ uid: () => 'uid' }));
 
 /**
@@ -33,6 +35,8 @@ const setup = (propsOverride: Partial<SelectProps> = {}) => {
 };
 
 describe(`<${Select.displayName}>`, () => {
+    (isFocusVisible as jest.Mock).mockReturnValue(false);
+
     describe('Props', () => {
         it('should have default classNames', () => {
             const { select, getDropdown } = setup();

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -15,9 +15,12 @@ import {
 import partition from 'lodash/partition';
 import userEvent from '@testing-library/user-event';
 
+import { isFocusVisible } from '@lumx/react/utils/isFocusVisible';
 import { TextField, TextFieldProps } from './TextField';
 
 const CLASSNAME = TextField.className as string;
+
+jest.mock('@lumx/react/utils/isFocusVisible');
 
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
@@ -46,6 +49,8 @@ const setup = (propsOverride: Partial<TextFieldProps> = {}) => {
 };
 
 describe(`<${TextField.displayName}>`, () => {
+    (isFocusVisible as jest.Mock).mockReturnValue(false);
+
     describe('Render', () => {
         it('should render defaults', () => {
             const { element, inputNative } = setup({ id: 'fixedId' });

--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -86,3 +86,19 @@ export const HideTooltipOnHiddenAnchor = () => {
         </>
     );
 };
+HideTooltipOnHiddenAnchor.parameters = { chromatic: { disableSnapshot: true } };
+
+/** Test focusing a tooltip anchor programmatically */
+export const TestProgrammaticFocus = () => {
+    const anchorRef = React.useRef<HTMLButtonElement>(null);
+    return (
+        <>
+            <p>The tooltip should open on keyboard focus but not on programmatic focus (ex: after a click)</p>
+            <Tooltip label="label">
+                <Button ref={anchorRef}>button with label</Button>
+            </Tooltip>
+            <Button onClick={() => anchorRef.current?.focus()}>focus the button</Button>
+        </>
+    );
+};
+TestProgrammaticFocus.parameters = { chromatic: { disableSnapshot: true } };

--- a/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
+++ b/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
@@ -2,6 +2,7 @@ import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import { browserDoesNotSupportHover } from '@lumx/react/utils/browserDoesNotSupportHover';
 import { TOOLTIP_HOVER_DELAY, TOOLTIP_LONG_PRESS_DELAY } from '@lumx/react/constants';
 import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
+import { isFocusVisible } from '@lumx/react/utils/isFocusVisible';
 
 /**
  * Hook controlling tooltip visibility using mouse hover the anchor and delay.
@@ -106,8 +107,16 @@ export function useTooltipOpen(delay: number | undefined, anchorElement: HTMLEle
 
         // Events always applied no matter the browser:.
         events.push(
-            // Open on focus.
-            [anchorElement, 'focusin', open],
+            // Open on focus (only if focus is visible).
+            [
+                anchorElement,
+                'focusin',
+                (e: Event) => {
+                    // Skip if focus is not visible
+                    if (!isFocusVisible(e.target as HTMLElement)) return;
+                    open();
+                },
+            ],
             // Close on lost focus.
             [anchorElement, 'focusout', closeImmediately],
         );

--- a/packages/lumx-react/src/utils/isFocusVisible.ts
+++ b/packages/lumx-react/src/utils/isFocusVisible.ts
@@ -1,0 +1,3 @@
+/** Check if the focus is visible on the given element */
+export const isFocusVisible = (element?: HTMLElement) =>
+    element?.matches?.(':focus-visible, [data-focus-visible-added]');


### PR DESCRIPTION
# General summary

Restrict opening Tooltip on anchor focus only when focus is visible (keyboard driven).



StoryBook: https://39ab6f3b--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=335)) **⚠️ Outdated commit**