### PR TITLE
fix(input-helper): replace span with p element to improve semantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- InputHelper: change of html tag to improve semantic
+
 ## [3.6.3][] - 2024-02-08
 
 ### Fixed

--- a/packages/lumx-react/src/components/input-helper/InputHelper.tsx
+++ b/packages/lumx-react/src/components/input-helper/InputHelper.tsx
@@ -41,18 +41,18 @@ const DEFAULT_PROPS: Partial<InputHelperProps> = {
  * @param  ref   Component ref.
  * @return React element.
  */
-export const InputHelper: Comp<InputHelperProps, HTMLSpanElement> = forwardRef((props, ref) => {
+export const InputHelper: Comp<InputHelperProps, HTMLParagraphElement> = forwardRef((props, ref) => {
     const { children, className, kind, theme, ...forwardedProps } = props;
     const { color } = INPUT_HELPER_CONFIGURATION[kind as any] || {};
 
     return (
-        <span
+        <p
             ref={ref}
             {...forwardedProps}
             className={classNames(className, handleBasicClasses({ prefix: CLASSNAME, color, theme }))}
         >
             {children}
-        </span>
+        </p>
     );
 });
 


### PR DESCRIPTION
# General summary

For a11y, improve the semantic of the inputHelper component by using a semantic `<p>` tag instead of a `<span>`.

# Screenshots

No visual changes, only the markup changes.

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [x] Add `need: review-frontend` label
-   [x] Update the `CHANGELOG.md` file
-   [x] Check component tests, an update wasn't needed
-   [ ] Add `need: test` label
-   [x] Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
