### PR TITLE
fix(popover): restore focus on trigger on closed externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   InputHelper: change of html tag to improve semantic
+-   Popover: restore focus on trigger on closed externally
 
 ### Changed
 

--- a/packages/lumx-react/src/components/popover/useRestoreFocusOnClose.tsx
+++ b/packages/lumx-react/src/components/popover/useRestoreFocusOnClose.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { getFirstAndLastFocusable } from '@lumx/react/utils/focus/getFirstAndLastFocusable';
+import { useBeforeUnmountSentinel } from '@lumx/react/utils/useBeforeUnmountSentinel';
+import type { PopoverProps } from './Popover';
+
+/**
+ * Provides an unmount sentinel to inject in the popover to detect when it closes and restore the focus to the
+ * anchor if needed.
+ */
+export function useRestoreFocusOnClose(
+    props: Pick<PopoverProps, 'focusAnchorOnClose' | 'anchorRef' | 'parentElement'>,
+    popoverElement?: HTMLElement | null,
+) {
+    const onBeforeUnmount = React.useMemo(() => {
+        if (!popoverElement || !props.focusAnchorOnClose) return undefined;
+        return () => {
+            const isFocusWithin = popoverElement?.contains(document.activeElement);
+            if (!isFocusWithin) return;
+
+            const anchor = props.anchorRef.current;
+            const elementToFocus =
+                // Provided parent element
+                props.parentElement?.current ||
+                // Or first focusable element in anchor
+                (anchor ? getFirstAndLastFocusable(anchor).first : undefined) ||
+                // Fallback to anchor
+                anchor;
+
+            elementToFocus?.focus({ preventScroll: true });
+        };
+    }, [popoverElement, props.anchorRef, props.focusAnchorOnClose, props.parentElement]);
+    return useBeforeUnmountSentinel(onBeforeUnmount);
+}

--- a/packages/lumx-react/src/utils/mergeRefs.ts
+++ b/packages/lumx-react/src/utils/mergeRefs.ts
@@ -1,5 +1,5 @@
 import { Falsy } from '@lumx/react/utils/type';
-import { MutableRefObject } from 'react';
+import { MutableRefObject, useMemo } from 'react';
 
 type FnRef<T> = (value: T) => void;
 
@@ -20,3 +20,14 @@ export function mergeRefs<T>(...refs: Array<MutableRefObject<T | null> | FnRef<T
             }
         });
 }
+
+/**
+ * Same as `mergeRefs` but memoized
+ */
+export const useMergeRefs = <T>(...refs: Array<MutableRefObject<T | null> | FnRef<T> | Falsy>) => {
+    return useMemo(
+        () => mergeRefs(...refs),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        refs,
+    );
+};

--- a/packages/lumx-react/src/utils/useBeforeUnmountSentinel.tsx
+++ b/packages/lumx-react/src/utils/useBeforeUnmountSentinel.tsx
@@ -1,0 +1,17 @@
+import React, { useLayoutEffect } from 'react';
+
+/** Small helper component using useLayoutEffect to trigger a callback on before unmount. */
+const OnUnmount = ({ onBeforeUnmount }: { onBeforeUnmount: () => void }) => {
+    useLayoutEffect(() => onBeforeUnmount, [onBeforeUnmount]);
+    return null;
+};
+
+/**
+ * Provides a sentinel to inject the React tree that triggers the callback on before unmount.
+ */
+export function useBeforeUnmountSentinel(onBeforeUnmount?: () => void) {
+    return React.useMemo(() => {
+        if (!onBeforeUnmount) return undefined;
+        return <OnUnmount onBeforeUnmount={onBeforeUnmount} />;
+    }, [onBeforeUnmount]);
+}


### PR DESCRIPTION
https://lumapps.atlassian.net/browse/DSW-36

# General summary

Fix restore focus on trigger on closed externally and not just when closed with Escape or closed on click away

Before: https://55e3a19--5fbfb1d508c0520021560f10.chromatic.com/?path=/story/lumx-components-popover-dialog-popoverdialog--with-button-trigger

After: https://5fbfb1d508c0520021560f10-pylwvppsxi.chromatic.com/?path=/story/lumx-components-popover-dialog-popoverdialog--with-button-trigger
