### PR TITLE
fix(tooltip): avoid removing the anchor aria-describedby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Tooltip: avoid removing the anchor `aria-describedby`
+
 ## [3.6.4][] - 2024-02-20
 
 ### Fixed
@@ -1898,7 +1902,5 @@ _Failed released_
 [3.6.2]: https://github.com/lumapps/design-system/tree/v3.6.2
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.6.3...HEAD
 [3.6.3]: https://github.com/lumapps/design-system/tree/v3.6.3
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.6.4...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.6.4...HEAD
 [3.6.4]: https://github.com/lumapps/design-system/tree/v3.6.4

--- a/packages/lumx-react/src/components/button/IconButton.tsx
+++ b/packages/lumx-react/src/components/button/IconButton.tsx
@@ -61,14 +61,7 @@ export const IconButton: Comp<IconButtonProps, HTMLButtonElement> = forwardRef((
 
     return (
         <Tooltip label={hideTooltip ? '' : label} {...tooltipProps}>
-            <ButtonRoot
-                ref={ref}
-                {...{ emphasis, size, theme, ...forwardedProps }}
-                aria-label={label}
-                variant="icon"
-                // Remove the aria-describedby added by the tooltip when it is the same text as the aria-label
-                aria-describedby={tooltipProps?.label && tooltipProps?.label === label && undefined}
-            >
+            <ButtonRoot ref={ref} {...{ emphasis, size, theme, ...forwardedProps }} aria-label={label} variant="icon">
                 {image ? (
                     <img
                         // no need to set alt as an aria-label is already set on the button

--- a/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button } from '@lumx/react';
+import { Button, IconButton } from '@lumx/react';
 import { screen, render, waitFor } from '@testing-library/react';
 import { queryAllByTagName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
@@ -62,6 +62,35 @@ describe(`<${Tooltip.displayName}>`, () => {
             expect(anchorWrapper).not.toBeInTheDocument();
             const button = screen.queryByRole('button', { name: 'Anchor' });
             expect(button).toHaveAttribute('aria-describedby', tooltip?.id);
+        });
+
+        it('should not add aria-describedby if button label is the same as tooltip label', async () => {
+            const label = 'Tooltip label';
+            render(<IconButton label={label} tooltipProps={{ forceOpen: true }} />);
+            const tooltip = screen.queryByRole('tooltip', { name: label });
+            expect(tooltip).toBeInTheDocument();
+            const button = screen.queryByRole('button', { name: label });
+            expect(button).not.toHaveAttribute('aria-describedby');
+        });
+
+        it('should keep anchor aria-describedby if button label is the same as tooltip label', async () => {
+            const label = 'Tooltip label';
+            render(<IconButton label={label} aria-describedby=":header-1:" tooltipProps={{ forceOpen: true }} />);
+            const tooltip = screen.queryByRole('tooltip', { name: label });
+            expect(tooltip).toBeInTheDocument();
+            const button = screen.queryByRole('button', { name: label });
+            expect(button).toHaveAttribute('aria-describedby', ':header-1:');
+        });
+
+        it('should concat aria-describedby if already exists', async () => {
+            const { tooltip } = await setup({
+                label: 'Tooltip label',
+                children: <Button aria-describedby=":header-1:">Anchor</Button>,
+                forceOpen: true,
+            });
+            expect(tooltip).toBeInTheDocument();
+            const button = screen.queryByRole('button', { name: 'Anchor' });
+            expect(button).toHaveAttribute('aria-describedby', `:header-1: ${tooltip?.id}`);
         });
 
         it('should wrap disabled Button', async () => {

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -87,7 +87,7 @@ export const Tooltip: Comp<TooltipProps, HTMLDivElement> = forwardRef((props, re
     const position = attributes?.popper?.['data-popper-placement'] ?? placement;
     const { isOpen: isActivated, onPopperMount } = useTooltipOpen(delay, anchorElement);
     const isOpen = isActivated || forceOpen;
-    const wrappedChildren = useInjectTooltipRef(children, setAnchorElement, isOpen, id);
+    const wrappedChildren = useInjectTooltipRef(children, setAnchorElement, isOpen, id, label);
 
     return (
         <>


### PR DESCRIPTION
# General summary
Avoid removing the anchor aria-describedby value:
- Concat with the tooltip id if the tooltip label is not the same as the anchor label
- Keep it as-is otherwise
