### PR TITLE
fix(tooltip): fix unstable anchor ref with memoize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Tooltip: avoid removing the anchor `aria-describedby`
+-   Tooltip: fix unstable anchor ref with memoize (breaking popover restore focus on trigger with tooltip)
 
 ## [3.6.4][] - 2024-02-20
 

--- a/packages/lumx-react/src/components/popover-dialog/PopoverDialog.stories.tsx
+++ b/packages/lumx-react/src/components/popover-dialog/PopoverDialog.stories.tsx
@@ -1,11 +1,38 @@
 import React from 'react';
 import { useBooleanState } from '@lumx/react/hooks/useBooleanState';
+import { mdiMenuDown } from '@lumx/icons';
 import { PopoverDialog } from '.';
-import { Button } from '../button';
+import { Button, IconButton } from '../button';
 
 export default {
     title: 'LumX components/popover-dialog/PopoverDialog',
     component: PopoverDialog,
+    parameters: { chromatic: { disableSnapshot: true } },
+};
+
+/**
+ * Example PopoverDialog using an IconButton as a trigger
+ */
+export const WithIconButtonTrigger = () => {
+    const anchorRef = React.useRef(null);
+    const [isOpen, close, open] = useBooleanState(false);
+
+    return (
+        <>
+            <IconButton id="trigger-button-1" label="Open popover" ref={anchorRef} onClick={open} icon={mdiMenuDown} />
+            <PopoverDialog
+                aria-labelledby="trigger-button-1"
+                anchorRef={anchorRef}
+                isOpen={isOpen}
+                onClose={close}
+                placement="bottom"
+            >
+                <Button className="lumx-spacing-margin-huge" onClick={close}>
+                    Close
+                </Button>
+            </PopoverDialog>
+        </>
+    );
 };
 
 /**

--- a/packages/lumx-react/src/components/popover-dialog/PopoverDialog.test.tsx
+++ b/packages/lumx-react/src/components/popover-dialog/PopoverDialog.test.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { WithIconButtonTrigger } from './PopoverDialog.stories';
 import { PopoverDialog } from './PopoverDialog';
 
 const DialogWithButton = (forwardedProps: any) => {
@@ -53,6 +54,31 @@ describe(`<${PopoverDialog.displayName}>`, () => {
         await userEvent.tab();
 
         // As there is no more button, focus should loop back to first button.
+        expect(dialogButtons[0]).toHaveFocus();
+
+        // Close the popover
+        await userEvent.keyboard('{escape}');
+
+        expect(screen.queryByRole('dialog', { name: label })).not.toBeInTheDocument();
+        /** Anchor should retrieve the focus */
+        expect(triggerElement).toHaveFocus();
+    });
+
+    it('should work on icon button', async () => {
+        const label = 'Open popover';
+        render(<WithIconButtonTrigger />);
+
+        /** Open the popover */
+        const triggerElement = screen.getByRole('button', { name: label });
+        await userEvent.click(triggerElement);
+
+        const dialog = await screen.findByRole('dialog', { name: label });
+        const withinDialog = within(dialog);
+
+        /** Get buttons within dialog */
+        const dialogButtons = withinDialog.getAllByRole('button');
+
+        // First button should have focus by default on opening
         expect(dialogButtons[0]).toHaveFocus();
 
         // Close the popover

--- a/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
+++ b/packages/lumx-react/src/components/tooltip/useInjectTooltipRef.tsx
@@ -1,12 +1,11 @@
-import get from 'lodash/get';
 import React, { cloneElement, ReactNode, useMemo } from 'react';
 
-import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+import { useMergeRefs } from '@lumx/react/utils/mergeRefs';
 
 /**
  * Add ref and ARIA attribute(s) in tooltip children or wrapped children.
  * Button, IconButton, Icon and React HTML elements don't need to be wrapped but any other kind of children (array, fragment, custom components)
- * will be wrapped in a <span>.
+ * will be wrapped.
  *
  * @param  children         Original tooltip anchor.
  * @param  setAnchorElement Set tooltip anchor element.
@@ -22,18 +21,13 @@ export const useInjectTooltipRef = (
     id: string,
     label: string,
 ): ReactNode => {
+    const element = React.isValidElement(children) ? (children as any) : null;
+    const ref = useMergeRefs(element?.ref, setAnchorElement);
+
     return useMemo(() => {
-        if (
-            children &&
-            get(children, '$$typeof') &&
-            get(children, 'props.disabled') !== true &&
-            get(children, 'props.isDisabled') !== true
-        ) {
-            const element = children as any;
-            const props = {
-                ...element.props,
-                ref: mergeRefs(element.ref, setAnchorElement),
-            };
+        // Non-disabled element
+        if (element && element.props?.disabled !== true && element.props?.isDisabled !== true) {
+            const props = { ...element.props, ref };
 
             // Add current tooltip to the aria-describedby if the label is not already present
             if (label !== props['aria-label']) {
@@ -43,14 +37,11 @@ export const useInjectTooltipRef = (
             return cloneElement(element, props);
         }
 
+        // Else add a wrapper around the children
         return (
-            <div
-                className="lumx-tooltip-anchor-wrapper"
-                ref={setAnchorElement}
-                aria-describedby={isOpen ? id : undefined}
-            >
+            <div className="lumx-tooltip-anchor-wrapper" ref={ref} aria-describedby={isOpen ? id : undefined}>
                 {children}
             </div>
         );
-    }, [children, setAnchorElement, isOpen, id, label]);
+    }, [element, children, isOpen, id, ref, label]);
 };

--- a/packages/lumx-react/src/utils/isFocusVisible.ts
+++ b/packages/lumx-react/src/utils/isFocusVisible.ts
@@ -1,3 +1,9 @@
 /** Check if the focus is visible on the given element */
-export const isFocusVisible = (element?: HTMLElement) =>
-    element?.matches?.(':focus-visible, [data-focus-visible-added]');
+export const isFocusVisible = (element?: HTMLElement) => {
+    try {
+        return element?.matches?.(':focus-visible, [data-focus-visible-added]');
+    } catch (_ignored) {
+        // Can fail on non browser env
+        return false;
+    }
+};


### PR DESCRIPTION
# General summary

Fixing unstable anchor ref due to ref merging. Adding memoization

Fixes improper focus restore on trigger when closing popover

