### PR TITLE
feat(date-picker): improve a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Thumbnail: use `span` instead of `div` in children elements to avoid semantic error on clickable thumbnails (button).
 
+### Added
+
+-   `@lumx/core`: add `.visually-hidden` a11y helper class to use on elements that should be read by screen readers but not shown.
+
 ## [3.6.5][] - 2024-02-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `@lumx/core`: add `.visually-hidden` a11y helper class to use on elements that should be read by screen readers but not shown.
+-   DatePicker: improve screen reader text
 
 ## [3.6.5][] - 2024-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Thumbnail: use `span` instead of `div` in children elements to avoid semantic error on clickable thumbnails (button).
+-   PopoverDialog: fix the `aria-label` prop not properly forwarded to the dialog.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/core`: add `.visually-hidden` a11y helper class to use on elements that should be read by screen readers but not shown.
 -   DatePicker: improve screen reader text
+-   TextField: add `labelProps` prop to forward to the label element
 
 ## [3.6.5][] - 2024-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/core`: add `.visually-hidden` a11y helper class to use on elements that should be read by screen readers but not shown.
 -   DatePicker: improve screen reader text
 -   TextField: add `labelProps` prop to forward to the label element
+-   DatePickerField: improve date picker dialog a11y
 
 ## [3.6.5][] - 2024-02-21
 

--- a/packages/lumx-core/src/scss/core/base/_helpers.scss
+++ b/packages/lumx-core/src/scss/core/base/_helpers.scss
@@ -19,3 +19,17 @@
 .#{$lumx-base-prefix}-base-display-block {
     display: block;
 }
+
+/* A11Y
+   ========================================================================== */
+
+.visually-hidden {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    border: 0 !important;
+}

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
@@ -38,7 +38,7 @@ describe(`<${DatePickerControlled.displayName}>`, () => {
         expect(month).toHaveTextContent('février 2017');
 
         const selected = queryByClassName(datePickerControlled, `${CLASSNAME}__month-day--is-selected`);
-        expect(selected).toBe(screen.queryByRole('button', { name: '22' }));
+        expect(selected).toBe(screen.queryByRole('button', { name: /22 février 2017/i }));
     });
 
     commonTestsSuiteRTL(setup, {

--- a/packages/lumx-react/src/components/popover-dialog/PopoverDialog.test.tsx
+++ b/packages/lumx-react/src/components/popover-dialog/PopoverDialog.test.tsx
@@ -22,6 +22,17 @@ describe(`<${PopoverDialog.displayName}>`, () => {
         expect(within(dialog).getAllByRole('button')[0]).toHaveFocus();
     });
 
+    it('should work with aria-label', async () => {
+        const label = 'Test Label';
+        render(<WithButtonTrigger aria-label={label} />);
+
+        // Open popover
+        const triggerElement = screen.getByRole('button', { name: 'Open popover' });
+        await userEvent.click(triggerElement);
+
+        expect(await screen.findByRole('dialog', { name: label })).toBeInTheDocument();
+    });
+
     it('should trap focus', async () => {
         const label = 'Test Label';
         render(<WithButtonTrigger label={label} />);

--- a/packages/lumx-react/src/components/popover-dialog/PopoverDialog.tsx
+++ b/packages/lumx-react/src/components/popover-dialog/PopoverDialog.tsx
@@ -35,7 +35,15 @@ const DEFAULT_PROPS: Partial<PopoverDialogProps> = {};
  * * Closes on click away and escape.
  */
 export const PopoverDialog: Comp<PopoverDialogProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const { children, isOpen, focusElement, label, className, ...forwardedProps } = props;
+    const {
+        children,
+        isOpen,
+        focusElement,
+        'aria-label': ariaLabel,
+        label = ariaLabel,
+        className,
+        ...forwardedProps
+    } = props;
 
     return (
         <Popover

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -15,7 +15,18 @@ import get from 'lodash/get';
 import { uid } from 'uid';
 
 import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from '@lumx/icons';
-import { Emphasis, Icon, IconButton, IconButtonProps, InputHelper, InputLabel, Kind, Size, Theme } from '@lumx/react';
+import {
+    Emphasis,
+    Icon,
+    IconButton,
+    IconButtonProps,
+    InputHelper,
+    InputLabel,
+    InputLabelProps,
+    Kind,
+    Size,
+    Theme,
+} from '@lumx/react';
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
@@ -53,6 +64,8 @@ export interface TextFieldProps extends GenericProps, HasTheme {
     isValid?: boolean;
     /** Label text. */
     label?: string;
+    /** Additional label props. */
+    labelProps?: InputLabelProps;
     /** Max string length the input accepts (constrains the input and displays a character counter). */
     maxLength?: number;
     /** Minimum number of rows displayed in multiline mode (requires `multiline` to be enabled). */
@@ -266,6 +279,7 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
         isRequired,
         isValid,
         label,
+        labelProps,
         maxLength,
         minimumRows,
         multiline,
@@ -355,6 +369,7 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
                 <div className={`${CLASSNAME}__header`}>
                     {label && (
                         <InputLabel
+                            {...labelProps}
                             htmlFor={textFieldId}
                             className={`${CLASSNAME}__label`}
                             isRequired={isRequired}

--- a/packages/lumx-react/src/hooks/usePreviousValue.ts
+++ b/packages/lumx-react/src/hooks/usePreviousValue.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * Returns the value from the previous render.
+ */
+export function usePreviousValue<V>(value: V): V | undefined {
+    const prevValueRef = React.useRef<V>();
+    const prevValue = prevValueRef.current;
+    React.useEffect(() => {
+        prevValueRef.current = value;
+    }, [value]);
+    return prevValue;
+}

--- a/packages/lumx-react/src/utils/date/getMonthCalendar.test.ts
+++ b/packages/lumx-react/src/utils/date/getMonthCalendar.test.ts
@@ -10,13 +10,13 @@ describe(getMonthCalendar.name, () => {
 
         expect(month).toEqual({
             weekDays: [
-                { letter: 'L', number: 1 },
-                { letter: 'M', number: 2 },
-                { letter: 'M', number: 3 },
-                { letter: 'J', number: 4 },
-                { letter: 'V', number: 5 },
-                { letter: 'S', number: 6 },
-                { letter: 'D', number: 0 },
+                { long: 'lundi', letter: 'L', number: 1 },
+                { long: 'mardi', letter: 'M', number: 2 },
+                { long: 'mercredi', letter: 'M', number: 3 },
+                { long: 'jeudi', letter: 'J', number: 4 },
+                { long: 'vendredi', letter: 'V', number: 5 },
+                { long: 'samedi', letter: 'S', number: 6 },
+                { long: 'dimanche', letter: 'D', number: 0 },
             ],
             weeks: [
                 {
@@ -70,13 +70,13 @@ describe(getMonthCalendar.name, () => {
 
         expect(month).toEqual({
             weekDays: [
-                { letter: 'S', number: 0 },
-                { letter: 'M', number: 1 },
-                { letter: 'T', number: 2 },
-                { letter: 'W', number: 3 },
-                { letter: 'T', number: 4 },
-                { letter: 'F', number: 5 },
-                { letter: 'S', number: 6 },
+                { long: 'Sunday', letter: 'S', number: 0 },
+                { long: 'Monday', letter: 'M', number: 1 },
+                { long: 'Tuesday', letter: 'T', number: 2 },
+                { long: 'Wednesday', letter: 'W', number: 3 },
+                { long: 'Thursday', letter: 'T', number: 4 },
+                { long: 'Friday', letter: 'F', number: 5 },
+                { long: 'Saturday', letter: 'S', number: 6 },
             ],
             weeks: [
                 {

--- a/packages/lumx-react/src/utils/date/getWeekDays.test.ts
+++ b/packages/lumx-react/src/utils/date/getWeekDays.test.ts
@@ -10,39 +10,39 @@ describe(getWeekDays.name, () => {
     it('should list french week days', () => {
         const weekDays = getWeekDays(french);
         expect(weekDays).toEqual([
-            { letter: 'L', number: 1 },
-            { letter: 'M', number: 2 },
-            { letter: 'M', number: 3 },
-            { letter: 'J', number: 4 },
-            { letter: 'V', number: 5 },
-            { letter: 'S', number: 6 },
-            { letter: 'D', number: 0 },
+            { long: 'lundi', letter: 'L', number: 1 },
+            { long: 'mardi', letter: 'M', number: 2 },
+            { long: 'mercredi', letter: 'M', number: 3 },
+            { long: 'jeudi', letter: 'J', number: 4 },
+            { long: 'vendredi', letter: 'V', number: 5 },
+            { long: 'samedi', letter: 'S', number: 6 },
+            { long: 'dimanche', letter: 'D', number: 0 },
         ]);
     });
 
     it('should list US week days', () => {
         const weekDays = getWeekDays(englishUS);
         expect(weekDays).toEqual([
-            { letter: 'S', number: 0 },
-            { letter: 'M', number: 1 },
-            { letter: 'T', number: 2 },
-            { letter: 'W', number: 3 },
-            { letter: 'T', number: 4 },
-            { letter: 'F', number: 5 },
-            { letter: 'S', number: 6 },
+            { long: 'Sunday', letter: 'S', number: 0 },
+            { long: 'Monday', letter: 'M', number: 1 },
+            { long: 'Tuesday', letter: 'T', number: 2 },
+            { long: 'Wednesday', letter: 'W', number: 3 },
+            { long: 'Thursday', letter: 'T', number: 4 },
+            { long: 'Friday', letter: 'F', number: 5 },
+            { long: 'Saturday', letter: 'S', number: 6 },
         ]);
     });
 
     it('should list fa-ir week days', () => {
         const weekDays = getWeekDays(farsi);
         expect(weekDays).toEqual([
-            { letter: 'ش', number: 6 },
-            { letter: 'ی', number: 0 },
-            { letter: 'د', number: 1 },
-            { letter: 'س', number: 2 },
-            { letter: 'چ', number: 3 },
-            { letter: 'پ', number: 4 },
-            { letter: 'ج', number: 5 },
+            { long: 'شنبه', letter: 'ش', number: 6 },
+            { long: 'یکشنبه', letter: 'ی', number: 0 },
+            { long: 'دوشنبه', letter: 'د', number: 1 },
+            { long: 'سه‌شنبه', letter: 'س', number: 2 },
+            { long: 'چهارشنبه', letter: 'چ', number: 3 },
+            { long: 'پنجشنبه', letter: 'پ', number: 4 },
+            { long: 'جمعه', letter: 'ج', number: 5 },
         ]);
     });
 });

--- a/packages/lumx-react/src/utils/date/getWeekDays.ts
+++ b/packages/lumx-react/src/utils/date/getWeekDays.ts
@@ -1,7 +1,7 @@
 import { Locale } from '@lumx/react/utils/locale/types';
 import { getFirstDayOfWeek } from './getFirstDayOfWeek';
 
-export type WeekDayInfo = { letter: string; number: number };
+export type WeekDayInfo = { letter: string; number: number; long: string };
 
 export const DAYS_PER_WEEK = 7;
 
@@ -22,10 +22,12 @@ export const getWeekDays = (locale: Locale): Array<WeekDayInfo> => {
     for (let i = 0; i < DAYS_PER_WEEK; i++) {
         // Single letter week day (ex: "M" for "Monday", "L" for "Lundi", etc.)
         const letter = iterDate.toLocaleDateString(locale.code, { weekday: 'narrow' });
+        // Weed day long notation
+        const long = iterDate.toLocaleDateString(locale.code, { weekday: 'long' });
         // Day number (1-based index starting on Monday)
         const number = iterDate.getDay();
 
-        weekDays.push({ letter, number });
+        weekDays.push({ letter, number, long });
         iterDate.setDate(iterDate.getDate() + 1);
     }
     return weekDays;


### PR DESCRIPTION
# General summary
https://lumapps.atlassian.net/browse/DSW-147

## Date Picker
- Make the month+year announced by screen readers when changing month 
- Add visually hidden week day full name for screen readers
- Add visually hidden full date for screen readers

https://github.com/lumapps/design-system/assets/939567/aebdf738-7b25-4543-a33d-ebc47c45f897


## Date Picker Field
- Replace Popover with PopoverDialog to use the proper aria dialog pattern
- On open > focus the selected date or today

**We can probably improve more on the date picker with a grid pattern and on the date picker field with an actual editable text field (combox dialog pattern)** 

StoryBook: https://2e283d9d--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=341))