### PR TITLE
fix(thumbnail): fix child DOM tag semantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Thumbnail: use `span` instead of `div` in children elements to avoid semantic error on clickable thumbnails (button).
+
 ## [3.6.5][] - 2024-02-21
 
 ### Fixed
@@ -1911,7 +1915,5 @@ _Failed released_
 [3.6.3]: https://github.com/lumapps/design-system/tree/v3.6.3
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.6.4...HEAD
 [3.6.4]: https://github.com/lumapps/design-system/tree/v3.6.4
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.6.5...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.6.5...HEAD
 [3.6.5]: https://github.com/lumapps/design-system/tree/v3.6.5

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -44,6 +44,7 @@
 
     &__background {
         position: relative;
+        display: block;
         width: 100%;
         overflow: hidden;
 
@@ -83,6 +84,10 @@
         position: absolute;
         right: math.div(-$lumx-spacing-unit, 2);
         bottom: math.div(-$lumx-spacing-unit, 2);
+    }
+
+    &__fallback {
+        display: block;
     }
 }
 

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -180,7 +180,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
                 fillHeight && `${CLASSNAME}--fill-height`,
             )}
         >
-            <div className={`${CLASSNAME}__background`}>
+            <span className={`${CLASSNAME}__background`}>
                 <img
                     {...imgProps}
                     style={{
@@ -203,15 +203,15 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
                     loading={loading}
                 />
                 {!isLoading && hasError && (
-                    <div className={`${CLASSNAME}__fallback`}>
+                    <span className={`${CLASSNAME}__fallback`}>
                         {hasIconErrorFallback ? (
                             <Icon icon={fallback as string} size={Size.xxs} theme={theme} />
                         ) : (
                             fallback
                         )}
-                    </div>
+                    </span>
                 )}
-            </div>
+            </span>
             {badge &&
                 React.cloneElement(badge, { className: classNames(`${CLASSNAME}__badge`, badge.props.className) })}
         </Wrapper>


### PR DESCRIPTION
# General summary

https://lumapps.atlassian.net/browse/DSW-135


Use `span` instead of `div` in children thumbnail elements to avoid semantic error on clickable thumbnails (button).

**Test scenario**: non-regression visual tests on thumbnails
- Check clickable and non clickable thumbnails
- Check with or without aspect ratio
- Check image fallback


StoryBook: https://5fbfb1d508c0520021560f10-lwksiktedo.chromatic.com/
