### PR TITLE
feat(date-picker): fixed row count layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chip: fix chip not receives focus when used as link
 - Chip: Make it possible to override the following props: `role`, `tabIndex`
 
+### Changed
+
+-   DatePicker: force a constant number of rows in the month calendar to avoid layout shift
+
 ## [3.6.7][] - 2024-04-02
 
 ### Fixed

--- a/packages/lumx-react/src/utils/date/getMonthCalendar.test.ts
+++ b/packages/lumx-react/src/utils/date/getMonthCalendar.test.ts
@@ -57,6 +57,8 @@ describe(getMonthCalendar.name, () => {
                     '1': { date: new Date('2017-02-27') },
                     '2': { date: new Date('2017-02-28') },
                 },
+                // Empty row (used for padding to avoid layout shift)
+                {},
             ],
         });
     });
@@ -117,6 +119,8 @@ describe(getMonthCalendar.name, () => {
                     '1': { date: new Date('2017-02-27'), isOutOfRange: true },
                     '2': { date: new Date('2017-02-28'), isOutOfRange: true },
                 },
+                // Empty row (used for padding to avoid layout shift)
+                {},
             ],
         });
     });

--- a/packages/lumx-react/src/utils/date/getMonthCalendar.ts
+++ b/packages/lumx-react/src/utils/date/getMonthCalendar.ts
@@ -11,6 +11,9 @@ interface MonthCalendar {
     weeks: Array<AnnotatedWeek>;
 }
 
+/** Up to 6 rows can appear in a month calendar => 4 weeks + 1 start of month partial week + 1 send of month partial week */
+const MONTH_ROW_COUNT = 6;
+
 /**
  * Get month calendar.
  * A list of weeks with days indexed by week day number
@@ -30,7 +33,8 @@ export const getMonthCalendar = (
 
     const weeks: Array<AnnotatedWeek> = [];
     let week: AnnotatedWeek = {};
-    while (iterDate.getMonth() === month) {
+    let rowCount = 0;
+    while (rowCount < MONTH_ROW_COUNT) {
         const weekDayNumber = iterDate.getDay();
         const day: AnnotatedDay = { date: new Date(iterDate.getTime()) };
 
@@ -39,9 +43,13 @@ export const getMonthCalendar = (
             day.isOutOfRange = true;
         }
 
-        week[weekDayNumber] = day;
+        if (iterDate.getMonth() === month) {
+            week[weekDayNumber] = day;
+        }
+
         if (weekDayNumber === lastDayOfWeek.number) {
             weeks.push(week);
+            rowCount += 1;
             week = {};
         }
         iterDate.setDate(iterDate.getDate() + 1);


### PR DESCRIPTION
https://lumapps.atlassian.net/browse/DSW-146

# General summary

Depending on the month/year, the month calendar can display from 4 to 6 rows of days. This PR forces this to 6 rows to make sure we have no layout shift when switching month.



StoryBook: https://9ae8998d--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=363)) **⚠️ Outdated commit**