### PR TITLE
fix(chip-group): use gap instead of margin and depreciate the align property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Thumbnail: use `span` instead of `div` in children elements to avoid semantic error on clickable thumbnails (button).
 -   PopoverDialog: fix the `aria-label` prop not properly forwarded to the dialog.
+-   ChipGroup: fix unwanted extra negative margin around chips (deprecating the `align` prop)
 
 ### Added
 

--- a/packages/lumx-core/src/scss/components/chip/_index.scss
+++ b/packages/lumx-core/src/scss/components/chip/_index.scss
@@ -135,22 +135,5 @@
 .#{$lumx-base-prefix}-chip-group {
     display: flex;
     flex-wrap: wrap;
-    margin: -$lumx-chip-group-spacing 0;
-
-    .#{$lumx-base-prefix}-chip {
-        margin: $lumx-chip-group-spacing 0;
-    }
-
-    &--align-left .#{$lumx-base-prefix}-chip {
-        margin-right: $lumx-chip-group-spacing * 2;
-    }
-
-    &--align-center .#{$lumx-base-prefix}-chip {
-        margin-right: $lumx-chip-group-spacing;
-        margin-left: $lumx-chip-group-spacing;
-    }
-
-    &--align-right .#{$lumx-base-prefix}-chip {
-        margin-left: $lumx-chip-group-spacing * 2;
-    }
+    gap: $lumx-chip-group-spacing * 2;
 }

--- a/packages/lumx-core/src/scss/components/text-field/_index.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_index.scss
@@ -138,7 +138,6 @@
             flex: 1 1 auto;
             width: auto;
             min-width: $lumx-text-field-min-width;
-            margin: $lumx-chip-group-spacing 0;
             line-height: var(--lumx-material-chip-size-s-height);
         }
 

--- a/packages/lumx-core/src/scss/components/text-field/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_mixins.scss
@@ -140,10 +140,6 @@
     flex: 1 1 auto;
     flex-wrap: wrap;
     align-items: center;
-    margin: calc((var(--lumx-text-field-input-min-height) - var(--lumx-size-s) - 6px) / 2) 0;
-
-    .#{$lumx-base-prefix}-chip {
-        margin: $lumx-chip-group-spacing 0;
-        margin-right: $lumx-chip-group-spacing * 2;
-    }
+    margin: calc((var(--lumx-text-field-input-min-height) - var(--lumx-size-s) - 6px) / 2 + $lumx-chip-group-spacing) 0;
+    gap: $lumx-chip-group-spacing * 2;
 }

--- a/packages/lumx-react/src/components/chip/ChipGroup.stories.tsx
+++ b/packages/lumx-react/src/components/chip/ChipGroup.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { Chip, ChipGroup, Size } from '@lumx/react';
+
+export default {
+    title: 'LumX components/chip/ChipGroup',
+    component: ChipGroup,
+    args: ChipGroup.defaultProps,
+    argTypes: {},
+};
+
+const chips = (
+    <>
+        <Chip size={Size.s}>Apricot</Chip>
+        <Chip size={Size.s}>Apple</Chip>
+        <Chip size={Size.s}>Banana</Chip>
+        <Chip size={Size.s}>Blueberry</Chip>
+        <Chip size={Size.s}>Lemon</Chip>
+        <Chip size={Size.s}>Orange</Chip>
+        <Chip size={Size.s}>Peach</Chip>
+        <Chip size={Size.s}>Pear</Chip>
+        <Chip size={Size.s}>Pineapple</Chip>
+        <Chip size={Size.s}>Melon</Chip>
+        <Chip size={Size.s}>Raspberry</Chip>
+        <Chip size={Size.s}>Strawberry</Chip>
+        <Chip size={Size.s}>Watermelon</Chip>
+    </>
+);
+
+/**
+ * Default chip group
+ */
+export const Default = {
+    args: {
+        children: chips,
+    },
+};
+
+/**
+ * Small chip group
+ */
+export const Small = {
+    args: {
+        children: chips,
+        style: {
+            width: '200px',
+        },
+    },
+};

--- a/packages/lumx-react/src/components/chip/ChipGroup.test.tsx
+++ b/packages/lumx-react/src/components/chip/ChipGroup.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { getByClassName } from '@lumx/react/testing/utils/queries';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
-import { Alignment } from '@lumx/react';
 import { ChipGroup, ChipGroupProps } from './ChipGroup';
 import { Chip } from './Chip';
 
@@ -29,12 +28,6 @@ describe('<ChipGroup />', () => {
             const { chipGroup } = setup();
             expect(chipGroup).toBeInTheDocument();
             expect(chipGroup).toHaveClass(CLASSNAME);
-            expect(chipGroup).toHaveClass(`${CLASSNAME}--align-left`);
-        });
-
-        it('should render with align', () => {
-            const { chipGroup } = setup({ align: Alignment.right });
-            expect(chipGroup).toHaveClass(`${CLASSNAME}--align-right`);
         });
     });
 

--- a/packages/lumx-react/src/components/chip/ChipGroup.tsx
+++ b/packages/lumx-react/src/components/chip/ChipGroup.tsx
@@ -1,4 +1,4 @@
-import { Alignment, HorizontalAlignment } from '@lumx/react/components';
+import { HorizontalAlignment } from '@lumx/react/components';
 import React, { forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
@@ -12,7 +12,10 @@ import { useChipGroupNavigation } from '@lumx/react/hooks/useChipGroupNavigation
  * Defines the props of the component.
  */
 export interface ChipGroupProps extends GenericProps {
-    /** Chip horizontal alignment. */
+    /**
+     * Chip horizontal alignment.
+     * @deprecated
+     */
     align?: HorizontalAlignment;
     /** List of Chip. */
     children: ReactNode;
@@ -21,9 +24,7 @@ export interface ChipGroupProps extends GenericProps {
 /**
  * Component default props.
  */
-const DEFAULT_PROPS: Partial<ChipGroupProps> = {
-    align: Alignment.left,
-};
+const DEFAULT_PROPS: Partial<ChipGroupProps> = {};
 
 /**
  * Component display name.
@@ -45,7 +46,6 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
 const InternalChipGroup: Comp<ChipGroupProps, HTMLDivElement> = forwardRef((props, ref) => {
     const { align, children, className, ...forwardedProps } = props;
     const chipGroupClassName = handleBasicClasses({
-        align,
         prefix: CLASSNAME,
     });
 


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Replace the margin with a gap.
Depreciate the align property of the component since it's no more applicable.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->
![image](https://github.com/lumapps/design-system/assets/45238844/04b6afef-69c2-44b3-ae56-fcec43010c63)
<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://fe16c477--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=345)) **⚠️ Outdated commit**