### PR TITLE
feat(date-picker): add text field for year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/core`: fix customization of selected button CSS variables
 -   `@lumx/core`: red/D2, red/N and green/N colors to fix color contrast a11y
 
+### Added
+
+-   DatePicker: add an input to change the displayed year
+
 ## [3.6.6][] - 2024-03-15
 
 ### Fixed
@@ -1933,7 +1937,5 @@ _Failed released_
 [3.6.4]: https://github.com/lumapps/design-system/tree/v3.6.4
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.6.5...HEAD
 [3.6.5]: https://github.com/lumapps/design-system/tree/v3.6.5
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.6.6...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.6.6...HEAD
 [3.6.6]: https://github.com/lumapps/design-system/tree/v3.6.6

--- a/packages/lumx-core/src/scss/components/date-picker/_index.scss
+++ b/packages/lumx-core/src/scss/components/date-picker/_index.scss
@@ -14,6 +14,12 @@
         text-align: center;
     }
 
+    &__year {
+        input[type="number"] {
+            width: 4ch; 
+        }
+    }
+
     &__calendar {
         padding: $lumx-spacing-unit * 2;
         padding-top: 0;

--- a/packages/lumx-react/src/components/date-picker/DatePicker.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.test.tsx
@@ -10,6 +10,9 @@ import { CLASSNAME } from './constants';
 
 const mockedDate = new Date(1487721600000);
 Date.now = jest.fn(() => mockedDate.valueOf());
+jest.mock('@lumx/react/utils/date/getYearDisplayName', () => ({
+    getYearDisplayName: () => 'année',
+}));
 
 const setup = (propsOverride: Partial<DatePickerProps> = {}) => {
     const props: DatePickerProps = {

--- a/packages/lumx-react/src/components/date-picker/DatePicker.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePicker.tsx
@@ -23,17 +23,13 @@ export const DatePicker: Comp<DatePickerProps, HTMLDivElement> = forwardRef((pro
         referenceDate = new Date();
     }
 
-    const [monthOffset, setMonthOffset] = useState(0);
-
-    const setPrevMonth = () => setMonthOffset(monthOffset - 1);
-    const setNextMonth = () => setMonthOffset(monthOffset + 1);
+    const [selectedMonth, setSelectedMonth] = useState(referenceDate);
+    const setPrevMonth = () => setSelectedMonth((current) => addMonthResetDay(current, -1));
+    const setNextMonth = () => setSelectedMonth((current) => addMonthResetDay(current, +1));
 
     const onDatePickerChange = (newDate?: Date) => {
         onChange(newDate);
-        setMonthOffset(0);
     };
-
-    const selectedMonth = addMonthResetDay(referenceDate, monthOffset);
 
     return (
         <DatePickerControlled
@@ -46,6 +42,7 @@ export const DatePicker: Comp<DatePickerProps, HTMLDivElement> = forwardRef((pro
             onNextMonthChange={setNextMonth}
             selectedMonth={selectedMonth}
             onChange={onDatePickerChange}
+            onMonthChange={setSelectedMonth}
         />
     );
 });

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.test.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 
+import userEvent from '@testing-library/user-event';
 import { DatePickerControlled, DatePickerControlledProps } from './DatePickerControlled';
 import { CLASSNAME } from './constants';
 
 const mockedDate = new Date(1487721600000);
 Date.now = jest.fn(() => mockedDate.valueOf());
+jest.mock('@lumx/react/utils/date/getYearDisplayName', () => ({
+    getYearDisplayName: () => 'année',
+}));
 
 type SetupProps = Partial<DatePickerControlledProps>;
 
@@ -22,11 +26,20 @@ const setup = (propsOverride: SetupProps = {}) => {
         value: mockedDate,
         nextButtonProps: { label: 'Next month' },
         previousButtonProps: { label: 'Previous month' },
+        onMonthChange: jest.fn(),
         ...propsOverride,
     };
     render(<DatePickerControlled {...props} />);
     const datePickerControlled = getByClassName(document.body, CLASSNAME);
     return { props, datePickerControlled };
+};
+
+const queries = {
+    getYear: () =>
+        screen.getByRole('spinbutton', {
+            name: /année/i,
+        }),
+    getAccessibleMonthYear: (container: HTMLElement) => getByClassName(container, 'visually-hidden'),
 };
 
 describe(`<${DatePickerControlled.displayName}>`, () => {
@@ -35,10 +48,41 @@ describe(`<${DatePickerControlled.displayName}>`, () => {
         expect(datePickerControlled).toBeInTheDocument();
 
         const month = queryByClassName(datePickerControlled, `${CLASSNAME}__month`);
-        expect(month).toHaveTextContent('février 2017');
+        expect(month).toHaveTextContent('février');
+
+        expect(queries.getYear()).toBeInTheDocument();
+        expect(queries.getYear()).toHaveAttribute('value', '2017');
+        expect(queries.getYear()).toHaveAttribute('aria-label', 'année');
+
+        const toolbar = getByClassName(document.body, 'lumx-toolbar__label');
+        expect(queries.getAccessibleMonthYear(toolbar)).toBeInTheDocument();
+        expect(queries.getAccessibleMonthYear(toolbar)).toHaveTextContent('février 2017');
 
         const selected = queryByClassName(datePickerControlled, `${CLASSNAME}__month-day--is-selected`);
         expect(selected).toBe(screen.queryByRole('button', { name: /22 février 2017/i }));
+    });
+
+    it('should validate year when pressing Enter', async () => {
+        const { datePickerControlled, props } = setup();
+        expect(datePickerControlled).toBeInTheDocument();
+
+        expect(queries.getYear()).toHaveAttribute('value', '2017');
+
+        await userEvent.type(queries.getYear(), '{Backspace}6{Enter}'); // set year to 2016
+        await waitFor(() => expect(props.onMonthChange).toHaveBeenCalledTimes(1));
+        expect(props.onMonthChange).toHaveBeenCalledWith(new Date(1454284800000)); // 2017 - 12 months = 2016
+    });
+
+    it('should validate year when on Blur', async () => {
+        const { datePickerControlled, props } = setup();
+        expect(datePickerControlled).toBeInTheDocument();
+
+        expect(queries.getYear()).toHaveAttribute('value', '2017');
+
+        await userEvent.type(queries.getYear(), '{Backspace}5'); // change value to 2015
+        await userEvent.tab(); // set year to 2015
+        await waitFor(() => expect(props.onMonthChange).toHaveBeenCalledTimes(1));
+        expect(props.onMonthChange).toHaveBeenCalledWith(new Date(1422748800000)); // 2017 - 24 months = 2015
     });
 
     commonTestsSuiteRTL(setup, {

--- a/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerField.test.tsx
@@ -11,6 +11,9 @@ import { CLASSNAME } from './constants';
 
 const mockedDate = new Date(1487721600000);
 Date.now = jest.fn(() => mockedDate.valueOf());
+jest.mock('@lumx/react/utils/date/getYearDisplayName', () => ({
+    getYearDisplayName: () => 'année',
+}));
 
 const setup = (propsOverride: Partial<DatePickerFieldProps> = {}) => {
     const props: DatePickerFieldProps = {

--- a/packages/lumx-react/src/utils/date/getYearDisplayName.test.ts
+++ b/packages/lumx-react/src/utils/date/getYearDisplayName.test.ts
@@ -1,0 +1,20 @@
+import { getYearDisplayName } from './getYearDisplayName';
+
+describe(getYearDisplayName, () => {
+    beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        jest.spyOn(Intl, 'DisplayNames').mockImplementation(() => ({
+            resolvedOptions: () => ({
+                fallback: 'code',
+                locale: 'fr',
+                style: 'short',
+                type: 'dateTimeField',
+            }),
+            of: () => 'année',
+        }));
+    });
+    it('should return a label', () => {
+        expect(getYearDisplayName('fr-FR')).toEqual('année');
+    });
+});

--- a/packages/lumx-react/src/utils/date/getYearDisplayName.ts
+++ b/packages/lumx-react/src/utils/date/getYearDisplayName.ts
@@ -1,0 +1,12 @@
+export const getYearDisplayName = (locale: string) => {
+    let label: string | undefined;
+    try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const displayNames = new Intl.DisplayNames(locale, { type: 'dateTimeField' });
+        label = displayNames.of('year');
+    } catch (error) {
+        label = '';
+    }
+    return label;
+};


### PR DESCRIPTION
DSW-143

# General summary

Add TextField for DatePicker to allow user to select year using keyboard.
Year is validated only when pressing enter or on blur.
It does not select a new date but set the month offset to the corresponding value.

Localization has been considered as well and TextField position is set based on the locale.  

Accessibility has been taken into account and month year is read when validating a new year.

<!-- Please describe the PR content -->

# Screenshots
![datePicker](https://github.com/lumapps/design-system/assets/63648264/1b85aa57-f635-4597-bc3c-ac77d44bbae0)

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://91f6a16e--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=360))