### PR TITLE
fix(color-a11y): changed red and green, changed low and medium text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `@lumx/core`: fix customization of selected button CSS variables
+-   `@lumx/core`: red/D2, red/N and green/N colors to fix color contrast a11y
 
 ## [3.6.6][] - 2024-03-15
 

--- a/packages/lumx-core/src/css/design-tokens.css
+++ b/packages/lumx-core/src/css/design-tokens.css
@@ -2,7 +2,7 @@
 
 /**
  * Do not edit directly
- * Generated on Thu, 04 Jan 2024 13:59:14 GMT
+ * Generated on Tue, 19 Mar 2024 13:36:08 GMT
  */
 
 :root {
@@ -369,7 +369,7 @@
     --lumx-color-blue-L4: rgb(36 91 231 / 0.2); /* Base blue color with 20% opacity */
     --lumx-color-blue-L5: rgb(36 91 231 / 0.1); /* Base blue color with 10% opacity */
     --lumx-color-blue-L6: rgb(36 91 231 / 0.05); /* Base blue color with 5% opacity */
-    --lumx-color-green-D2: rgb(26 110 89); /* Darkest green color */
+    --lumx-color-green-D2: rgb(25 109 88); /* Darkest green color */
     --lumx-color-green-D1: rgb(23 122 97); /* Dark green color */
     --lumx-color-green-N: rgb(19 134 105); /* Neutral green color */
     --lumx-color-green-L1: rgb(19 134 105 / 0.8); /* Base green color with 80% opacity */
@@ -387,15 +387,15 @@
     --lumx-color-yellow-L4: rgb(255 196 37 / 0.48); /* Base yellow color with 40% opacity */
     --lumx-color-yellow-L5: rgb(255 196 37 / 0.24); /* Base yellow color with 20% opacity */
     --lumx-color-yellow-L6: rgb(255 196 37 / 0.12); /* Base yellow color with 10% opacity */
-    --lumx-color-red-D2: rgb(190 30 70); /* Darkest red color */
+    --lumx-color-red-D2: rgb(188 9 48); /* Darkest red color */
     --lumx-color-red-D1: rgb(212 33 72); /* Dark red color */
-    --lumx-color-red-N: rgb(223 48 80); /* Neutral red color */
-    --lumx-color-red-L1: rgb(223 48 80 / 0.8); /* Base red color with 80% opacity */
-    --lumx-color-red-L2: rgb(223 48 80 / 0.6); /* Base red color with 60% opacity */
-    --lumx-color-red-L3: rgb(223 48 80 / 0.4); /* Base red color with 40% opacity */
-    --lumx-color-red-L4: rgb(223 48 80 / 0.2); /* Base red color with 20% opacity */
-    --lumx-color-red-L5: rgb(223 48 80 / 0.1); /* Base red color with 10% opacity */
-    --lumx-color-red-L6: rgb(223 48 80 / 0.05); /* Base red color with 5% opacity */
+    --lumx-color-red-N: rgb(223 42 75); /* Neutral red color */
+    --lumx-color-red-L1: rgb(223 42 75 / 0.8); /* Base red color with 80% opacity */
+    --lumx-color-red-L2: rgb(223 42 75 / 0.6); /* Base red color with 60% opacity */
+    --lumx-color-red-L3: rgb(223 42 75 / 0.4); /* Base red color with 40% opacity */
+    --lumx-color-red-L4: rgb(223 42 75 / 0.2); /* Base red color with 20% opacity */
+    --lumx-color-red-L5: rgb(223 42 75 / 0.1); /* Base red color with 10% opacity */
+    --lumx-color-red-L6: rgb(223 42 75 / 0.05); /* Base red color with 5% opacity */
     --lumx-color-grey-N: rgb(117 117 117); /* Neutral grey color */
     --lumx-color-grey-L1: rgb(117 117 117 / 0.8); /* Base grey color with 80% opacity */
     --lumx-color-grey-L2: rgb(117 117 117 / 0.6); /* Base grey color with 60% opacity */
@@ -412,7 +412,7 @@
     --lumx-color-primary-L4: rgb(36 91 231 / 0.2); /* Base blue color with 20% opacity */
     --lumx-color-primary-L5: rgb(36 91 231 / 0.1); /* Base blue color with 10% opacity */
     --lumx-color-primary-L6: rgb(36 91 231 / 0.05); /* Base blue color with 5% opacity */
-    --lumx-color-secondary-D2: rgb(26 110 89); /* Darkest green color */
+    --lumx-color-secondary-D2: rgb(25 109 88); /* Darkest green color */
     --lumx-color-secondary-D1: rgb(23 122 97); /* Dark green color */
     --lumx-color-secondary-N: rgb(19 134 105); /* Neutral green color */
     --lumx-color-secondary-L1: rgb(19 134 105 / 0.8); /* Base green color with 80% opacity */
@@ -421,7 +421,7 @@
     --lumx-color-secondary-L4: rgb(19 134 105 / 0.2); /* Base green color with 20% opacity */
     --lumx-color-secondary-L5: rgb(19 134 105 / 0.1); /* Base green color with 10% opacity */
     --lumx-color-secondary-L6: rgb(19 134 105 / 0.05); /* Base green color with 5% opacity */
-    --lumx-color-accent-D2: rgb(26 110 89); /* Darkest green color */
+    --lumx-color-accent-D2: rgb(25 109 88); /* Darkest green color */
     --lumx-color-accent-D1: rgb(23 122 97); /* Dark green color */
     --lumx-color-accent-N: rgb(19 134 105); /* Neutral green color */
     --lumx-color-accent-L1: rgb(19 134 105 / 0.8); /* Base green color with 80% opacity */

--- a/packages/lumx-core/src/js/constants/design-tokens.ts
+++ b/packages/lumx-core/src/js/constants/design-tokens.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 04 Jan 2024 13:59:14 GMT
+ * Generated on Tue, 19 Mar 2024 13:36:08 GMT
  */
 
 export const DESIGN_TOKENS = {
@@ -1497,8 +1497,8 @@ export const DESIGN_TOKENS = {
             D2: {
                 version: '0.22',
                 comment: 'Darkest green color',
-                value: 'rgb(26, 110, 89)',
-                attributes: { hex: '1a6e59', rgb: { r: 26, g: 110, b: 89, a: 1 } },
+                value: 'rgb(25, 109, 88)',
+                attributes: { hex: '196d58', rgb: { r: 25, g: 109, b: 88, a: 1 } },
             },
             D1: {
                 version: '0.22',
@@ -1609,8 +1609,8 @@ export const DESIGN_TOKENS = {
             D2: {
                 version: '0.22',
                 comment: 'Darkest red color',
-                value: 'rgb(190, 30, 70)',
-                attributes: { hex: 'be1e46', rgb: { r: 190, g: 30, b: 70, a: 1 } },
+                value: 'rgb(188, 9, 48)',
+                attributes: { hex: 'bc0930', rgb: { r: 188, g: 9, b: 48, a: 1 } },
             },
             D1: {
                 version: '0.22',
@@ -1621,44 +1621,44 @@ export const DESIGN_TOKENS = {
             N: {
                 version: '0.22',
                 comment: 'Neutral red color',
-                value: 'rgb(223, 48, 80)',
-                attributes: { hex: 'df3050', rgb: { r: 223, g: 48, b: 80, a: 1 } },
+                value: 'rgb(223, 42, 75)',
+                attributes: { hex: 'df2a4b', rgb: { r: 223, g: 42, b: 75, a: 1 } },
             },
             L1: {
                 version: '0.22',
                 comment: 'Base red color with 80% opacity',
-                value: 'rgba(223, 48, 80, 0.8)',
-                attributes: { hex: 'df3050', rgb: { r: 223, g: 48, b: 80, a: 0.8 } },
+                value: 'rgba(223, 42, 75, 0.8)',
+                attributes: { hex: 'df2a4b', rgb: { r: 223, g: 42, b: 75, a: 0.8 } },
             },
             L2: {
                 version: '0.22',
                 comment: 'Base red color with 60% opacity',
-                value: 'rgba(223, 48, 80, 0.6)',
-                attributes: { hex: 'df3050', rgb: { r: 223, g: 48, b: 80, a: 0.6 } },
+                value: 'rgba(223, 42, 75, 0.6)',
+                attributes: { hex: 'df2a4b', rgb: { r: 223, g: 42, b: 75, a: 0.6 } },
             },
             L3: {
                 version: '0.22',
                 comment: 'Base red color with 40% opacity',
-                value: 'rgba(223, 48, 80, 0.4)',
-                attributes: { hex: 'df3050', rgb: { r: 223, g: 48, b: 80, a: 0.4 } },
+                value: 'rgba(223, 42, 75, 0.4)',
+                attributes: { hex: 'df2a4b', rgb: { r: 223, g: 42, b: 75, a: 0.4 } },
             },
             L4: {
                 version: '0.22',
                 comment: 'Base red color with 20% opacity',
-                value: 'rgba(223, 48, 80, 0.2)',
-                attributes: { hex: 'df3050', rgb: { r: 223, g: 48, b: 80, a: 0.2 } },
+                value: 'rgba(223, 42, 75, 0.2)',
+                attributes: { hex: 'df2a4b', rgb: { r: 223, g: 42, b: 75, a: 0.2 } },
             },
             L5: {
                 version: '0.22',
                 comment: 'Base red color with 10% opacity',
-                value: 'rgba(223, 48, 80, 0.1)',
-                attributes: { hex: 'df3050', rgb: { r: 223, g: 48, b: 80, a: 0.1 } },
+                value: 'rgba(223, 42, 75, 0.1)',
+                attributes: { hex: 'df2a4b', rgb: { r: 223, g: 42, b: 75, a: 0.1 } },
             },
             L6: {
                 version: '0.22',
                 comment: 'Base red color with 5% opacity',
-                value: 'rgba(223, 48, 80, 0.05)',
-                attributes: { hex: 'df3050', rgb: { r: 223, g: 48, b: 80, a: 0.05 } },
+                value: 'rgba(223, 42, 75, 0.05)',
+                attributes: { hex: 'df2a4b', rgb: { r: 223, g: 42, b: 75, a: 0.05 } },
             },
         },
         grey: {
@@ -1765,8 +1765,8 @@ export const DESIGN_TOKENS = {
             D2: {
                 version: '0.22',
                 comment: 'Darkest green color',
-                value: 'rgb(26, 110, 89)',
-                attributes: { hex: '1a6e59', rgb: { r: 26, g: 110, b: 89, a: 1 } },
+                value: 'rgb(25, 109, 88)',
+                attributes: { hex: '196d58', rgb: { r: 25, g: 109, b: 88, a: 1 } },
             },
             D1: {
                 version: '0.22',
@@ -1821,8 +1821,8 @@ export const DESIGN_TOKENS = {
             D2: {
                 version: '0.22',
                 comment: 'Darkest green color',
-                value: 'rgb(26, 110, 89)',
-                attributes: { hex: '1a6e59', rgb: { r: 26, g: 110, b: 89, a: 1 } },
+                value: 'rgb(25, 109, 88)',
+                attributes: { hex: '196d58', rgb: { r: 25, g: 109, b: 88, a: 1 } },
             },
             D1: {
                 version: '0.22',

--- a/packages/lumx-core/src/scss/_design-tokens.scss
+++ b/packages/lumx-core/src/scss/_design-tokens.scss
@@ -2,7 +2,7 @@
 
 /**
  * Do not edit directly
- * Generated on Thu, 04 Jan 2024 13:59:14 GMT
+ * Generated on Tue, 19 Mar 2024 13:36:08 GMT
  */
 
 $lumx-button-height: 36px !default;
@@ -368,7 +368,7 @@ $lumx-color-blue-L3: rgb(36 91 231 / 0.4) !default; // Base blue color with 40% 
 $lumx-color-blue-L4: rgb(36 91 231 / 0.2) !default; // Base blue color with 20% opacity
 $lumx-color-blue-L5: rgb(36 91 231 / 0.1) !default; // Base blue color with 10% opacity
 $lumx-color-blue-L6: rgb(36 91 231 / 0.05) !default; // Base blue color with 5% opacity
-$lumx-color-green-D2: rgb(26 110 89) !default; // Darkest green color
+$lumx-color-green-D2: rgb(25 109 88) !default; // Darkest green color
 $lumx-color-green-D1: rgb(23 122 97) !default; // Dark green color
 $lumx-color-green-N: rgb(19 134 105) !default; // Neutral green color
 $lumx-color-green-L1: rgb(19 134 105 / 0.8) !default; // Base green color with 80% opacity
@@ -386,15 +386,15 @@ $lumx-color-yellow-L3: rgb(255 196 37 / 0.6) !default; // Base yellow color with
 $lumx-color-yellow-L4: rgb(255 196 37 / 0.48) !default; // Base yellow color with 40% opacity
 $lumx-color-yellow-L5: rgb(255 196 37 / 0.24) !default; // Base yellow color with 20% opacity
 $lumx-color-yellow-L6: rgb(255 196 37 / 0.12) !default; // Base yellow color with 10% opacity
-$lumx-color-red-D2: rgb(190 30 70) !default; // Darkest red color
+$lumx-color-red-D2: rgb(188 9 48) !default; // Darkest red color
 $lumx-color-red-D1: rgb(212 33 72) !default; // Dark red color
-$lumx-color-red-N: rgb(223 48 80) !default; // Neutral red color
-$lumx-color-red-L1: rgb(223 48 80 / 0.8) !default; // Base red color with 80% opacity
-$lumx-color-red-L2: rgb(223 48 80 / 0.6) !default; // Base red color with 60% opacity
-$lumx-color-red-L3: rgb(223 48 80 / 0.4) !default; // Base red color with 40% opacity
-$lumx-color-red-L4: rgb(223 48 80 / 0.2) !default; // Base red color with 20% opacity
-$lumx-color-red-L5: rgb(223 48 80 / 0.1) !default; // Base red color with 10% opacity
-$lumx-color-red-L6: rgb(223 48 80 / 0.05) !default; // Base red color with 5% opacity
+$lumx-color-red-N: rgb(223 42 75) !default; // Neutral red color
+$lumx-color-red-L1: rgb(223 42 75 / 0.8) !default; // Base red color with 80% opacity
+$lumx-color-red-L2: rgb(223 42 75 / 0.6) !default; // Base red color with 60% opacity
+$lumx-color-red-L3: rgb(223 42 75 / 0.4) !default; // Base red color with 40% opacity
+$lumx-color-red-L4: rgb(223 42 75 / 0.2) !default; // Base red color with 20% opacity
+$lumx-color-red-L5: rgb(223 42 75 / 0.1) !default; // Base red color with 10% opacity
+$lumx-color-red-L6: rgb(223 42 75 / 0.05) !default; // Base red color with 5% opacity
 $lumx-color-grey-N: rgb(117 117 117) !default; // Neutral grey color
 $lumx-color-grey-L1: rgb(117 117 117 / 0.8) !default; // Base grey color with 80% opacity
 $lumx-color-grey-L2: rgb(117 117 117 / 0.6) !default; // Base grey color with 60% opacity

--- a/packages/lumx-core/src/scss/core/state/_mixins.scss
+++ b/packages/lumx-core/src/scss/core/state/_mixins.scss
@@ -42,7 +42,7 @@
         @if $color == "yellow" {
             color: lumx-color-variant("dark", "L1");
         } @else {
-            color: lumx-color-variant($color, "N");
+            color: lumx-color-variant($color, "D2");
         }
     } @else if $state == lumx-base-const("state", "HOVER") {
         background-color: lumx-color-variant($color, "L4");
@@ -84,7 +84,7 @@
 
 @mixin lumx-state-low($state, $color) {
     @if $state == lumx-base-const("state", "DEFAULT") {
-        color: lumx-color-variant($color, "N");
+        color: lumx-color-variant($color, "D2");
         background-color: transparent;
     } @else if $state == lumx-base-const("state", "HOVER") {
         background-color: lumx-color-variant($color, "L5");

--- a/packages/lumx-core/style-dictionary/properties/core/color.json
+++ b/packages/lumx-core/style-dictionary/properties/core/color.json
@@ -165,7 +165,7 @@
         },
         "green": {
             "D2": {
-                "value": "#1a6e59",
+                "value": "#196D58",
                 "version": "0.22",
                 "comment": "Darkest green color",
                 "preferCSSVariable": true
@@ -289,7 +289,7 @@
         },
         "red": {
             "D2": {
-                "value": "#be1E46",
+                "value": "#BC0930",
                 "version": "0.22",
                 "comment": "Darkest red color",
                 "preferCSSVariable": true
@@ -301,7 +301,7 @@
                 "preferCSSVariable": true
             },
             "N": {
-                "value": "#df3050",
+                "value": "#DF2A4B",
                 "version": "0.22",
                 "comment": "Neutral red color",
                 "preferCSSVariable": true


### PR DESCRIPTION
# General summary

To fix a contrast issue on red and green buttons:

1. red/D2, red/N and green/N color values are changed.
2. Colored Low and medium button texts are now using the D2 color instead of N color.



# Screenshots

![image](https://github.com/lumapps/design-system/assets/15898440/ad6852ce-2bce-4a03-b70a-62c6afbdfc25)
![image](https://github.com/lumapps/design-system/assets/15898440/c06ce163-2ba6-4208-b007-ee33eecbe3d2)
![image](https://github.com/lumapps/design-system/assets/15898440/e1b79c7a-61cc-43f9-894a-80ca5db09e94)
![image](https://github.com/lumapps/design-system/assets/15898440/1489b3dc-8cb5-4b69-8bc1-9d49bfcb19ce)

StoryBook: https://e5f9ee1c--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=347)) **⚠️ Outdated commit**