### PR TITLE
feat(message): add a close button to the message component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   DatePicker: add an input to change the displayed year
-
+-   Message: add a `closeButtonProps` prop to add a close button in the message. Only available for `info` kind messages with a background.
+ 
 ## [3.6.6][] - 2024-03-15
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/message/_index.scss
+++ b/packages/lumx-core/src/scss/components/message/_index.scss
@@ -22,6 +22,10 @@
         flex: 1 1 auto;
         color: lumx-color-variant("dark", "N");
     }
+
+    &__close-button {
+        flex-shrink: 0;
+    }
 }
 
 /* Message kind

--- a/packages/lumx-react/src/components/message/Message.stories.tsx
+++ b/packages/lumx-react/src/components/message/Message.stories.tsx
@@ -5,6 +5,7 @@ import { loremIpsum } from '@lumx/react/stories/utils/lorem';
 import { iconArgType } from '@lumx/react/stories/controls/icons';
 import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
 import { withUndefined } from '@lumx/react/stories/controls/withUndefined';
+import { withNestedProps } from '../../stories/decorators/withNestedProps';
 
 export default {
     title: 'LumX components/message/Message',
@@ -53,4 +54,19 @@ export const CustomIcon = {
     args: {
         icon: mdiDelete,
     },
+};
+
+/**
+ * With close button (has background and kind info)
+ */
+export const ClosableMessage = {
+    args: {
+        'closeButtonProps.label': 'Close',
+        hasBackground: true,
+        kind: 'info',
+    },
+    argTypes: {
+        'closeButtonProps.onClick': { action: true },
+    },
+    decorators: [withNestedProps()],
 };

--- a/packages/lumx-react/src/components/message/Message.test.tsx
+++ b/packages/lumx-react/src/components/message/Message.test.tsx
@@ -2,9 +2,11 @@ import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import { Kind } from '@lumx/react';
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { queryByRole, render } from '@testing-library/react';
 import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import { mdiAbTesting } from '@lumx/icons';
+
+import userEvent from '@testing-library/user-event';
 import { Message, MessageProps } from './Message';
 
 const CLASSNAME = Message.className as string;
@@ -19,7 +21,8 @@ const setup = (propsOverride: SetupProps = {}) => {
     render(<Message {...props} />);
     const message = getByClassName(document.body, CLASSNAME);
     const icon = queryByClassName(message, `${CLASSNAME}__icon`);
-    return { message, icon, props };
+    const closeButton = queryByRole(message, 'button', { name: props.closeButtonProps?.label });
+    return { message, icon, closeButton, props };
 };
 
 describe(`<${Message.displayName}>`, () => {
@@ -44,9 +47,28 @@ describe(`<${Message.displayName}>`, () => {
         });
 
         it.each(Object.values(Kind))('should render kind %s', (kind) => {
-            const { message, icon } = setup({ kind });
+            const { message, icon, closeButton } = setup({ kind });
             expect(message.className).toEqual(expect.stringMatching(/\blumx-message--color-\w+\b/));
             expect(icon).toBeInTheDocument();
+            expect(closeButton).not.toBeInTheDocument();
+        });
+
+        it('should render close button', async () => {
+            const onClick = jest.fn();
+            const { closeButton } = setup({
+                hasBackground: true,
+                kind: 'info',
+                closeButtonProps: {
+                    label: 'Close',
+                    onClick,
+                },
+            });
+
+            expect(closeButton).toBeInTheDocument();
+
+            await userEvent.click(closeButton as HTMLElement);
+
+            expect(onClick).toHaveBeenCalled();
         });
     });
 

--- a/packages/lumx-react/src/components/message/Message.tsx
+++ b/packages/lumx-react/src/components/message/Message.tsx
@@ -1,5 +1,5 @@
-import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons';
-import { ColorPalette, Icon, Kind, Size } from '@lumx/react';
+import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiClose, mdiInformation } from '@lumx/icons';
+import { ColorPalette, Emphasis, Icon, IconButton, Kind, Size } from '@lumx/react';
 import { Comp, GenericProps } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import classNames from 'classnames';
@@ -17,6 +17,17 @@ export interface MessageProps extends GenericProps {
     kind?: Kind;
     /** Message custom icon SVG path. */
     icon?: string;
+    /**
+     * Displays a close button.
+     *
+     * NB: only available if `kind === 'info' && hasBackground === true`
+     */
+    closeButtonProps?: {
+        /** The callback called when the button is clicked */
+        onClick: () => void;
+        /** The label of the close button. */
+        label: string;
+    };
 }
 
 /**
@@ -47,8 +58,10 @@ const CONFIG = {
  * @return React element.
  */
 export const Message: Comp<MessageProps, HTMLDivElement> = forwardRef((props, ref) => {
-    const { children, className, hasBackground, kind, icon: customIcon, ...forwardedProps } = props;
+    const { children, className, hasBackground, kind, icon: customIcon, closeButtonProps, ...forwardedProps } = props;
     const { color, icon } = CONFIG[kind as Kind] || {};
+    const { onClick, label: closeButtonLabel } = closeButtonProps || {};
+    const isCloseButtonDisplayed = hasBackground && kind === 'info' && onClick && closeButtonLabel;
 
     return (
         <div
@@ -67,8 +80,18 @@ export const Message: Comp<MessageProps, HTMLDivElement> = forwardRef((props, re
                 <Icon className={`${CLASSNAME}__icon`} icon={customIcon || icon} size={Size.xs} color={color} />
             )}
             <div className={`${CLASSNAME}__text`}>{children}</div>
+            {isCloseButtonDisplayed && (
+                <IconButton
+                    className={`${CLASSNAME}__close-button`}
+                    icon={mdiClose}
+                    onClick={onClick}
+                    label={closeButtonLabel}
+                    emphasis={Emphasis.low}
+                />
+            )}
         </div>
     );
 });
+
 Message.displayName = COMPONENT_NAME;
 Message.className = CLASSNAME;

--- a/packages/lumx-react/src/stories/generated/Message/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/Message/Demos.stories.tsx
@@ -3,6 +3,7 @@
  */
 export default { title: 'LumX components/message/Message Demos' };
 
+export { App as Closable } from './closable';
 export { App as Error } from './error';
 export { App as Info } from './info';
 export { App as Success } from './success';

--- a/packages/lumx-react/src/stories/generated/Message/closable.tsx
+++ b/packages/lumx-react/src/stories/generated/Message/closable.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/message/react/closable.tsx

--- a/packages/site-demo/content/product/components/message/index.mdx
+++ b/packages/site-demo/content/product/components/message/index.mdx
@@ -34,6 +34,12 @@ Use trimmed when you don't need a background color, left and right spacing.
 
 <DemoBlock demo="trimmed" />
 
+## Closable
+
+Use closable when you need to make the message closable by the user. This option is only available for the `info` kind with a background. It won't display in any other configuration. 
+
+<DemoBlock hAlign="center" vAlign="center" demo="closable" />
+
 ### Accessibility concerns
 
 Messages do not use any special semantic or ARIA role by default.

--- a/packages/site-demo/content/product/components/message/react/closable.tsx
+++ b/packages/site-demo/content/product/components/message/react/closable.tsx
@@ -1,0 +1,23 @@
+import { Message, Kind, Button } from '@lumx/react';
+import React from 'react';
+
+export const App = () => {
+    const [isMessageDispayed, setMessageDisplay] = React.useState(true);
+
+    return isMessageDispayed ? (
+        <Message
+            kind={Kind.info}
+            hasBackground
+            closeButtonProps={{ label: 'Close', onClick: () => setMessageDisplay(false) }}
+        >
+            <p>
+                Message text quisque tincidunt lobortis dui non auctor. Donec porta, ligula volutpat vehicula aliquet,
+                dui sapien tempus felis, sed cursus diam ante.
+            </p>
+        </Message>
+    ) : (
+        <>
+            <Button onClick={() => setMessageDisplay(true)}>Reset message display</Button>
+        </>
+    );
+};


### PR DESCRIPTION

# General summary
https://lumapps.atlassian.net/browse/DSW-137

<!-- Please describe the PR content -->
## Message
- Adds a new prop `closeButtonProps` to handle a new close button. Only the `info` kind with a background supports it. The button won't render for any other configuration. The label is required.


# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->
![image](https://github.com/lumapps/design-system/assets/10506209/e59dabcf-4ea5-4fb5-8947-2dba2e1ef0f3)
<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://86b3eb90--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=359)) **⚠️ Outdated commit**