### PR TITLE
chore(popover): allow to set the element to set a focus trap on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   DatePicker: add an input to change the displayed year
 -   Message: add a `closeButtonProps` prop to add a close button in the message. Only available for `info` kind messages with a background.
+-   Popover: add a `focusTrapZoneElement` prop to specify the element in which the focus trap should be applied.
 
 ### Changed
 

--- a/packages/lumx-react/src/components/popover/Popover.tsx
+++ b/packages/lumx-react/src/components/popover/Popover.tsx
@@ -60,6 +60,8 @@ export interface PopoverProps extends GenericProps, HasTheme {
     placement?: Placement;
     /** Whether the popover should be rendered into a DOM node that exists outside the DOM hierarchy of the parent component. */
     usePortal?: boolean;
+    /** The element in which the focus trap should be set. Default to popover. */
+    focusTrapZoneElement?: RefObject<HTMLElement>;
     /** Z-axis position. */
     zIndex?: number;
     /** On close callback (on click away or Escape pressed). */
@@ -115,6 +117,7 @@ const _InnerPopover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, ref
         boundaryRef,
         fitToAnchorWidth,
         fitWithinViewportHeight,
+        focusTrapZoneElement,
         offset,
         placement,
         style,
@@ -146,12 +149,13 @@ const _InnerPopover: Comp<PopoverProps, HTMLDivElement> = forwardRef((props, ref
     });
 
     const unmountSentinel = useRestoreFocusOnClose({ focusAnchorOnClose, anchorRef, parentElement }, popperElement);
+    const focusZoneElement = focusTrapZoneElement?.current || popoverRef?.current;
 
     useCallbackOnEscape(onClose, isOpen && closeOnEscape);
 
     /** Only set focus within if the focus trap is disabled as they interfere with one another. */
     useFocus(focusElement?.current, !withFocusTrap && isOpen && isPositioned);
-    useFocusTrap(withFocusTrap && isOpen && popoverRef?.current, focusElement?.current);
+    useFocusTrap(withFocusTrap && isOpen && focusZoneElement, focusElement?.current);
 
     const clickAwayRefs = useRef([popoverRef, anchorRef]);
     const mergedRefs = useMergeRefs<HTMLDivElement>(setPopperElement, ref, popoverRef);

--- a/packages/lumx-react/src/utils/focus/getFirstAndLastFocusable.ts
+++ b/packages/lumx-react/src/utils/focus/getFirstAndLastFocusable.ts
@@ -6,7 +6,7 @@ import { getFocusableElements } from './getFocusableElements';
  * @param parentElement The element in which to search focusable elements.
  * @return first and last focusable elements
  */
-export function getFirstAndLastFocusable(parentElement: HTMLElement) {
+export function getFirstAndLastFocusable(parentElement: HTMLElement | ShadowRoot) {
     const focusableElements = getFocusableElements(parentElement);
 
     // First non disabled element.

--- a/packages/lumx-react/src/utils/focus/getFocusableElements.ts
+++ b/packages/lumx-react/src/utils/focus/getFocusableElements.ts
@@ -2,6 +2,6 @@ import { DISABLED_SELECTOR, TABBABLE_ELEMENTS_SELECTOR } from './constants';
 
 const isNotDisabled = (element: HTMLElement) => !element.matches(DISABLED_SELECTOR);
 
-export function getFocusableElements(element: HTMLElement): HTMLElement[] {
+export function getFocusableElements(element: HTMLElement | ShadowRoot): HTMLElement[] {
     return Array.from(element.querySelectorAll<HTMLElement>(TABBABLE_ELEMENTS_SELECTOR)).filter(isNotDisabled);
 }


### PR DESCRIPTION
# General summary
Add a focusZoneElement prop on the Popover component allowing to specify the element in which the focus trap should be applied.
Make focus trap works with element with shadow root
<!-- Please describe the PR content -->



<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
