### PR TITLE
fix(chip): fix tabindex when chip is a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Chip: fix chip not receives focus when used as link
+- Chip: Make it possible to override the following props: `role`, `tabIndex`
+
 ## [3.6.7][] - 2024-04-02
 
 ### Fixed

--- a/packages/lumx-react/src/components/chip/Chip.test.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Theme } from '@lumx/react';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import userEvent from '@testing-library/user-event';
 import { Chip, ChipProps } from './Chip';
@@ -48,6 +48,24 @@ describe('<Chip />', () => {
             expect(chip.className).toMatchInlineSnapshot(
                 '"lumx-chip lumx-chip--is-clickable lumx-chip--color-dark lumx-chip--size-m lumx-chip--is-unselected"',
             );
+        });
+
+        it('should render a link', () => {
+            setup({ children: 'Chip text', href: 'https://google.com', target: '_blank' });
+            const chip = screen.getByRole('link', { name: 'Chip text' });
+            expect(chip).toHaveAttribute('href', 'https://google.com');
+            expect(chip).toHaveAttribute('target', '_blank');
+            expect(chip).toHaveAttribute('tabIndex', '0');
+        });
+
+        it('should override the role', () => {
+            setup({ children: 'Chip text', role: 'radio' });
+            expect(screen.getByRole('radio', { name: 'Chip text' })).toBeInTheDocument();
+        });
+
+        it('should override the tabIndex', () => {
+            const { chip } = setup({ children: 'Chip text', tabIndex: -1 });
+            expect(chip).toHaveAttribute('tabIndex', '-1');
         });
     });
 

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -74,7 +74,7 @@ export const Chip: Comp<ChipProps, HTMLAnchorElement> = forwardRef((props, ref) 
         className,
         color,
         disabled,
-        isClickable,
+        isClickable: propIsClickable,
         isDisabled = disabled,
         isHighlighted,
         isSelected,
@@ -83,11 +83,14 @@ export const Chip: Comp<ChipProps, HTMLAnchorElement> = forwardRef((props, ref) 
         onClick,
         size,
         theme,
+        href,
         ...forwardedProps
     } = props;
     const hasAfterClick = isFunction(onAfterClick);
     const hasBeforeClick = isFunction(onBeforeClick);
     const hasOnClick = isFunction(onClick);
+    const isButton = hasOnClick && !href;
+    const isClickable = Boolean(hasOnClick) || Boolean(href) || propIsClickable;
 
     // Adapt color to the theme.
     const chipColor = color || (theme === Theme.light ? ColorPalette.dark : ColorPalette.light);
@@ -98,12 +101,15 @@ export const Chip: Comp<ChipProps, HTMLAnchorElement> = forwardRef((props, ref) 
     return (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <a
+            role={isButton ? 'button' : undefined}
+            tabIndex={isClickable ? 0 : undefined}
             {...forwardedProps}
+            href={href}
             ref={ref}
             className={classNames(
                 className,
                 handleBasicClasses({
-                    clickable: Boolean(hasOnClick) || isClickable,
+                    clickable: isClickable,
                     color: chipColor,
                     isDisabled,
                     hasAfter: Boolean(after),
@@ -115,9 +121,7 @@ export const Chip: Comp<ChipProps, HTMLAnchorElement> = forwardRef((props, ref) 
                     unselected: Boolean(!isSelected),
                 }),
             )}
-            role={hasOnClick ? 'button' : undefined}
-            tabIndex={isDisabled || !hasOnClick ? -1 : 0}
-            aria-disabled={(hasOnClick && isDisabled) || undefined}
+            aria-disabled={(isClickable && isDisabled) || undefined}
             onClick={hasOnClick ? onClick : undefined}
             onKeyDown={hasOnClick ? onEnterPressed(onClick) : undefined}
         >


### PR DESCRIPTION
# General summary

Make the `Chip` component focusable when used as `link` (with `href` prop).

# Test scenarios
1. Go on the `/story/lumx-components-chip-chip--chip-link` story
2. Make sure you can focus the chip using your keyboard (using Tab key)
3. Make sure you can trigger the link using your keyboard (user Enter key)
4. Make sure you open the link in a new tab using `ctrl + Enter`.
5. Make sure these behaviors still work properly using a mouse.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://9baffa29--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=364)) **⚠️ Outdated commit**