### PR TITLE
chore(dependencies): fix eslint dev package version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
         "changelog-verify": "^1.1.2",
         "es-abstract": "1.17.6",
         "eslint": "^8.57.0",
-        "eslint-config-lumapps": "3.6.7",
         "husky": "^5.0.4",
         "jsx-ast-utils": "^3.1.0",
         "lerna": "^3.18.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,7 +3830,6 @@ __metadata:
     changelog-verify: ^1.1.2
     es-abstract: 1.17.6
     eslint: ^8.57.0
-    eslint-config-lumapps: 3.6.7
     husky: ^5.0.4
     jsx-ast-utils: ^3.1.0
     lerna: ^3.18.4
@@ -14398,7 +14397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-lumapps@3.6.7, eslint-config-lumapps@workspace:dev-packages/eslint-config-lumapps":
+"eslint-config-lumapps@workspace:dev-packages/eslint-config-lumapps":
   version: 0.0.0-use.local
   resolution: "eslint-config-lumapps@workspace:dev-packages/eslint-config-lumapps"
   dependencies:


### PR DESCRIPTION
# General summary

Removing the eslint dev package from root package.json as it breaks the release workflow and it's not actually required

