### PR TITLE
feat(thumbnail): add object fit prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   InlineList: add `wrap` prop to activate line wrap on overflow
+-   Thumbnail: add `objectFit` prop to control how the image fit in a constrained aspect ratio.
+    Defaults to `cover` to scale & crop the image (like before).
+    Can be changed to `contain` to avoid cropping the image (aka letterboxing).
 
 ## [3.7.0][] - 2024-04-29
 

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -105,7 +105,7 @@
 
 .#{$lumx-base-prefix}-thumbnail:not(.#{$lumx-base-prefix}-thumbnail--aspect-ratio-original) {
     .#{$lumx-base-prefix}-thumbnail__image {
-        object-fit: cover;
+        object-fit: var(--lumx-thumbnail-image-object-fit, cover);
         object-position: center;
         width: 100%;
         height: 100%;
@@ -141,6 +141,17 @@
             padding-top: $aspect-ratio;
         }
     }
+}
+
+/* Thumbnail object fit
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-thumbnail--object-fit-cover {
+    --lumx-thumbnail-image-object-fit: cover;
+}
+
+.#{$lumx-base-prefix}-thumbnail--object-fit-contain {
+    --lumx-thumbnail-image-object-fit: contain;
 }
 
 /* Thumbnail states

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
 
 import { mdiAbTesting } from '@lumx/icons';
-import { Alignment, AspectRatio, Badge, FlexBox, Icon, Size, Thumbnail, ThumbnailVariant } from '@lumx/react';
+import {
+    Alignment,
+    AspectRatio,
+    Badge,
+    FlexBox,
+    GridColumn,
+    Icon,
+    Size,
+    Thumbnail,
+    ThumbnailObjectFit,
+    ThumbnailVariant,
+} from '@lumx/react';
 import { CustomLink } from '@lumx/react/stories/utils/CustomLink';
 import { IMAGE_SIZES, imageArgType, IMAGES } from '@lumx/react/stories/controls/image';
 import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
@@ -375,3 +386,28 @@ export const Square = () => (
         </FlexBox>
     </>
 );
+
+export const ObjectFit = {
+    args: { size: Size.xl },
+    decorators: [
+        withCombinations({
+            cellStyle: { border: '1px solid lightgray' },
+            combinations: {
+                cols: {
+                    'Default (cover)': {},
+                    contain: { objectFit: ThumbnailObjectFit.contain },
+                },
+                rows: {
+                    'Ratio square': { aspectRatio: AspectRatio.square },
+                    'Ratio wide': { aspectRatio: AspectRatio.wide },
+                    'Ratio vertical': { aspectRatio: AspectRatio.vertical },
+                },
+                sections: {
+                    'Portrait image': { image: IMAGES.portrait1 },
+                    'Landscape image': { image: IMAGES.landscape1 },
+                },
+            },
+        }),
+        withWrapper({ maxColumns: 3, itemMinWidth: 350 }, GridColumn),
+    ],
+};

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.tsx
@@ -11,7 +11,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { AspectRatio, HorizontalAlignment, Icon, Size, Theme } from '@lumx/react';
+import { AspectRatio, HorizontalAlignment, Icon, Size, Theme, ThumbnailObjectFit } from '@lumx/react';
 
 import { Comp, Falsy, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
@@ -52,6 +52,8 @@ export interface ThumbnailProps extends GenericProps, HasTheme {
     imgRef?: Ref<HTMLImageElement>;
     /** Set to true to force the display of the loading skeleton. */
     isLoading?: boolean;
+    /** Set how the image should fit when its aspect ratio is constrained */
+    objectFit?: ThumbnailObjectFit;
     /** Size variant of the component. */
     size?: ThumbnailSize;
     /** Image loading mode. */
@@ -111,6 +113,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
         imgProps,
         imgRef: propImgRef,
         isLoading: isLoadingProp,
+        objectFit,
         loading,
         size,
         theme,
@@ -175,6 +178,7 @@ export const Thumbnail: Comp<ThumbnailProps> = forwardRef((props, ref) => {
                     hasIconErrorFallback,
                     hasCustomErrorFallback,
                     isLoading,
+                    objectFit,
                     hasBadge: !!badge,
                 }),
                 fillHeight && `${CLASSNAME}--fill-height`,

--- a/packages/lumx-react/src/components/thumbnail/types.ts
+++ b/packages/lumx-react/src/components/thumbnail/types.ts
@@ -37,3 +37,12 @@ export const ThumbnailVariant = {
     rounded: 'rounded',
 } as const;
 export type ThumbnailVariant = ValueOf<typeof ThumbnailVariant>;
+
+/**
+ * Thumbnail object fit.
+ */
+export const ThumbnailObjectFit = {
+    cover: 'cover',
+    contain: 'contain',
+} as const;
+export type ThumbnailObjectFit = ValueOf<typeof ThumbnailObjectFit>;

--- a/packages/site-demo/content/product/components/thumbnail/index.mdx
+++ b/packages/site-demo/content/product/components/thumbnail/index.mdx
@@ -1,3 +1,5 @@
+import { Thumbnail } from '@lumx/react';
+
 # Thumbnail
 
 **Thumbnails display formatted images.**
@@ -23,6 +25,19 @@ Thumbnails come in 6 aspect ratios: `free`, `horizontal`, `original`, `square`, 
 *For any ratio except `original` the source image might be cropped.*
 
 <DemoBlock orientation="horizontal" demo="ratios" />
+
+*Setting the `objectFit` property to `contain` avoids cropping the image (letterboxing).*
+
+<DemoBlock orientation="horizontal">
+    <Thumbnail
+        image="/demo-assets/landscape3.jpg"
+        alt="Square"
+        size="xl"
+        aspectRatio="wide"
+        objectFit="contain"
+        style={{ background: 'black' }}
+    />
+</DemoBlock>
 
 ## Variants
 


### PR DESCRIPTION
Added `objectFit` prop to adapt how the image should fit when it's aspect ratio is contained.
    Defaults to `cover` to scale & crop the image (like before) but can be changed to `contain` to avoid cropping the
    image (aka letterboxing)


![image](https://github.com/lumapps/design-system/assets/939567/dc63ad3c-035f-4853-a9f8-66f7ab076757)

StoryBook: https://6bde4117--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=372)) **⚠️ Outdated commit**