### PR TITLE
fix(color): add fallback to default variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `@lumx/core`: lumx-color-variant, add fallback to default variant
+
 ## [3.7.0][] - 2024-04-29
 
 ### Added
@@ -22,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Chip: fix chip not receives focus when used as link
-- Chip: Make it possible to override the following props: `role`, `tabIndex`
+-   Chip: fix chip not receives focus when used as link
+-   Chip: Make it possible to override the following props: `role`, `tabIndex`
 
 ### Changed
 
@@ -1969,9 +1973,7 @@ _Failed released_
 [3.6.5]: https://github.com/lumapps/design-system/tree/v3.6.5
 [unreleased]: https://github.com/lumapps/design-system/compare/v3.6.6...HEAD
 [3.6.6]: https://github.com/lumapps/design-system/tree/v3.6.6
-
-
-[Unreleased]: https://github.com/lumapps/design-system/compare/v3.7.0...HEAD
+[unreleased]: https://github.com/lumapps/design-system/compare/v3.7.0...HEAD
 [3.7.0]: https://github.com/lumapps/design-system/compare/v3.6.8...v3.7.0
 [3.6.8]: https://github.com/lumapps/design-system/compare/v3.6.7...v3.6.8
 [3.6.7]: https://github.com/lumapps/design-system/tree/v3.6.7

--- a/packages/lumx-core/src/scss/core/color/_functions.scss
+++ b/packages/lumx-core/src/scss/core/color/_functions.scss
@@ -1,6 +1,12 @@
+@use "sass:map";
+
 @function lumx-color-variant($color, $variant) {
     @if map-has-key($lumx-color-palette, $color) {
-        @return var(--lumx-color-#{$color}-#{$variant});
+        @if map.has-key(map.get($lumx-color-palette, $color), $variant) {
+            @return var(--lumx-color-#{$color}-#{$variant});
+        } @else {
+            @return var(--lumx-color-#{$color}-N);
+        }
     } @else {
         @return var(--lumx-color-dark-N);
     }


### PR DESCRIPTION
# General summary

Fix an issue introduce in this PR https://github.com/lumapps/design-system/pull/1105, we have issues with the change introduce here : https://github.com/lumapps/design-system/pull/1105/files#diff-e9c65473a041d47079ec7b0eb7892fa6f29a0be893a1fa17138777d5a16f1ac5R87 that's trying to apply a `D2` variant, to colours that does not possess this variant (`light` / `dark`, ...). 

To fix this issue there is multiple solution, we could revert / condition the fixe that has been made, to only apply the D2 only to the "Green" / "Red" colour, like it was meant in the first change, but that does not seem to be a strong fix, to add specific if condition based on the colour.

I've opted to a more global solution, and patching the `lumx-color-variant` function, to add a fallback to the default "N" variant, that should be in theory present in all colours. 

If we want to add an extra layer of safety, in case there is colours without the N variant, we could add another fallback to the dark colour, but it seems a bit much for a use case that will most likely never happened.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [x] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [x] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://1dfbf592--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=369))