### PR TITLE
feat(inline-list): add `wrap` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/core`: lumx-color-variant, add fallback to default variant
 
+### Added
+
+-   InlineList: add `wrap` prop to activate line wrap on overflow
+
 ## [3.7.0][] - 2024-04-29
 
 ### Added

--- a/packages/lumx-core/src/scss/components/inline-list/_index.scss
+++ b/packages/lumx-core/src/scss/components/inline-list/_index.scss
@@ -9,6 +9,10 @@
     align-items: center;
     list-style: none;
 
+    &--wrap {
+        flex-wrap: wrap;
+    }
+
     &__item {
         display: contents;
     }

--- a/packages/lumx-react/src/components/inline-list/InlineList.stories.tsx
+++ b/packages/lumx-react/src/components/inline-list/InlineList.stories.tsx
@@ -54,3 +54,25 @@ export const MixedNoWrapAndTruncate = {
     },
     decorators: [withResizableBox({ width: 400 })],
 };
+
+/**
+ * Line wrap on overflow
+ */
+export const Wrap = {
+    args: {
+        wrap: true,
+        children: [
+            <Text key="1" as="span">
+                Very very very very very long text
+            </Text>,
+            <Text key="2" as="span">
+                <Icon icon={mdiEarth} />
+                Some text
+            </Text>,
+            <Text key="3" as="span">
+                Very very very very very long text
+            </Text>,
+        ],
+    },
+    decorators: [withResizableBox({ width: 400 })],
+};

--- a/packages/lumx-react/src/components/inline-list/InlineList.tsx
+++ b/packages/lumx-react/src/components/inline-list/InlineList.tsx
@@ -22,6 +22,10 @@ export interface InlineListProps extends GenericProps {
      * Typography variant.
      */
     typography?: Typography;
+    /**
+     * Activate line wrap on overflow.
+     */
+    wrap?: boolean;
 }
 
 /**
@@ -47,7 +51,7 @@ const DEFAULT_PROPS = {} as const;
  * @return React element.
  */
 export const InlineList: Comp<InlineListProps> = forwardRef((props, ref) => {
-    const { className, color, colorVariant, typography, children, ...forwardedProps } = props;
+    const { className, color, colorVariant, typography, children, wrap, ...forwardedProps } = props;
     const fontColorClassName = color && getFontColorClassName(color, colorVariant);
     const typographyClassName = typography && getTypographyClassName(typography);
     return (
@@ -55,7 +59,13 @@ export const InlineList: Comp<InlineListProps> = forwardRef((props, ref) => {
         <ul
             {...forwardedProps}
             ref={ref as any}
-            className={classNames(className, CLASSNAME, fontColorClassName, typographyClassName)}
+            className={classNames(
+                className,
+                CLASSNAME,
+                wrap && `${CLASSNAME}--wrap`,
+                fontColorClassName,
+                typographyClassName,
+            )}
             // Lists with removed bullet style can lose their a11y list role on some browsers
             role="list"
         >

--- a/packages/site-demo/content/product/components/inline-list/index.mdx
+++ b/packages/site-demo/content/product/components/inline-list/index.mdx
@@ -41,6 +41,20 @@ Inline lists pair well with [text](/product/components/text/) `noWrap` property 
     </InlineList>
 </DemoBlock>
 
+Inversely, the use of the `wrap` property will activate line wrap on overflow.
+
+<DemoBlock orientation="horizontal" vAlign="space-around">
+    <InlineList typography="body1" color="dark" colorVariant="L2" wrap style={{ maxWidth: 275 }}>
+        <Text as="span">
+            <Icon icon={mdiEarth} />
+            Some text
+        </Text>
+        <Text as="span">
+            Very very very very very long text
+        </Text>
+    </InlineList>
+</DemoBlock>
+
 ### Accessibility concerns
 
 Inline lists use standard `ul` list element and are read as such by screen readers.


### PR DESCRIPTION
DSW-185

# General summary

Add option to activate line wrap on parent overflow

![](https://github.com/lumapps/design-system/assets/939567/e99b3564-e580-434a-99f8-612b731745b0)


StoryBook: https://abc2a6e5--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=370))