### PR TITLE
fix(textfield): fix forward aria-describedby prop to input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `Chip`: fix forward key down event on clickable chip
+-   `TextField`: fix forward aria-describedby prop to input
 
 ## [3.7.2][] - 2024-05-22
 

--- a/packages/lumx-react/src/components/text-field/TextField.test.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.test.tsx
@@ -124,7 +124,7 @@ describe(`<${TextField.displayName}>`, () => {
             });
 
             expect(helper).toHaveTextContent('helper');
-            expect(inputNative).toHaveAttribute('aria-describedby');
+            expect(inputNative).toHaveAccessibleDescription('helper');
         });
 
         it('should have error text', () => {
@@ -137,7 +137,7 @@ describe(`<${TextField.displayName}>`, () => {
 
             expect(error).toHaveTextContent('error');
             expect(inputNative).toHaveAttribute('aria-invalid', 'true');
-            expect(inputNative).toHaveAttribute('aria-describedby');
+            expect(inputNative).toHaveAccessibleDescription('error');
         });
 
         it('should not have error text', () => {
@@ -151,7 +151,7 @@ describe(`<${TextField.displayName}>`, () => {
         });
 
         it('should have error and helper text', () => {
-            const { error, helper } = setup({
+            const { error, helper, inputNative } = setup({
                 error: 'error',
                 hasError: true,
                 helper: 'helper',
@@ -160,6 +160,21 @@ describe(`<${TextField.displayName}>`, () => {
             });
             expect(error).toHaveTextContent('error');
             expect(helper).toHaveTextContent('helper');
+            expect(inputNative).toHaveAccessibleDescription('error helper');
+        });
+
+        it('should have error and helper text and custom aria describedby', () => {
+            const { error, helper, inputNative } = setup({
+                error: 'error',
+                hasError: true,
+                helper: 'helper',
+                label: 'test',
+                placeholder: 'test',
+                'aria-describedby': 'aria-description',
+            });
+            expect(error).toHaveTextContent('error');
+            expect(helper).toHaveTextContent('helper');
+            expect(inputNative).toHaveAttribute('aria-describedby', expect.stringContaining('aria-description'));
         });
     });
 

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -309,7 +309,7 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
      */
     const helperId = helper ? `text-field-helper-${uid()}` : undefined;
     const errorId = error ? `text-field-error-${uid()}` : undefined;
-    const describedByIds = [errorId, helperId].filter(Boolean);
+    const describedByIds = [errorId, helperId, forwardedProps['aria-describedby']].filter(Boolean);
     const describedById = describedByIds.length === 0 ? undefined : describedByIds.join(' ');
 
     const [isFocus, setFocus] = useState(false);


### PR DESCRIPTION
# General summary

It was not possible to add an `aria-describedby` to a TextField without overriding those set by the error and helper.
Fixed by forwarding the prop and merging it with the error and helper.
 
<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
