### PR TITLE
fix(generic-block): fix shrinking of the content section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `GenericBlock`: fix shrinking content with `min-width: 0`.
+
 ## [3.7.3][] - 2024-06-19
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/generic-block/_index.scss
+++ b/packages/lumx-core/src/scss/components/generic-block/_index.scss
@@ -7,5 +7,6 @@
         // Prevent blocks in content from overflowing
         overflow: clip;
         max-width: 100%;
+        min-width: 0;
     }
 }


### PR DESCRIPTION
# General summary

Fix shrinking the generic block content instead of overflowing