### PR TITLE
Feat/message spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Message`: changed spacing between icon and text from 16 to 8
+
 ## [3.7.4][] - 2024-06-20
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/message/_index.scss
+++ b/packages/lumx-core/src/scss/components/message/_index.scss
@@ -13,7 +13,7 @@
 
     &__icon {
         flex-shrink: 0;
-        margin-right: $lumx-spacing-unit * 2;
+        margin-right: $lumx-spacing-unit;
     }
 
     &__text {


### PR DESCRIPTION
# General summary

Changed spacing between icon and text from 16 to 8 to better integrate into designs and be consistent with other components like [User-block](https://design.lumapps.com/product/components/user-block/)

# Screenshots
<img width="791" alt="Capture d’écran 2024-07-15 à 11 56 50" src="https://github.com/user-attachments/assets/8e1c229b-71b7-428b-9a8e-5fc4607bdce7">

Fix https://lumapps.atlassian.net/browse/DSW-213
