### PR TITLE
fix(list-item): display focus ring even when not marked as highlighted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `ListItem`: display keyboard focus ring even when not highlighted
 - `Message`: changed spacing between icon and text from 16 to 8
 
 ## [3.7.4][] - 2024-06-20

--- a/packages/lumx-core/src/scss/components/list/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/list/_mixins.scss
@@ -29,6 +29,11 @@
 
     cursor: pointer;
 
+    &[data-focus-visible-added] {
+        outline: 2px solid lumx-color-variant("dark", "N");
+        outline-offset: -2px;
+    }
+
     &:hover,
     &[data-focus-visible-added] {
         @include lumx-state(lumx-base-const("state", "HOVER"), lumx-base-const("emphasis", "LOW"), "dark");
@@ -44,11 +49,6 @@
 
     @include lumx-state(lumx-base-const("state", "HOVER"), lumx-base-const("emphasis", "LOW"), "dark");
 
-    &[data-focus-visible-added] {
-        outline: 2px solid lumx-color-variant("dark", "N");
-        outline-offset: -2px;
-    }
-    
     &:active {
         @include lumx-state(lumx-base-const("state", "ACTIVE"), lumx-base-const("emphasis", "LOW"), "dark");
     }


### PR DESCRIPTION
# General summary

Make sure to display the keyboard focus ring on list item even when it is not marked with `isHighlighted`

