### PR TITLE
Feat/message notification info color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `DatePicker`: improve display of localized day number.
 -   Reworked internal id generation (linking fields with labels, a11y attributes). Removed the `uid` dependency.
+-   `Message`: changed type "info" color to blue
+-   `Notification`: changed type "info" color to blue
 
 ## [3.8.1][] - 2024-08-14
 

--- a/packages/lumx-core/src/scss/components/notification/_variables.scss
+++ b/packages/lumx-core/src/scss/components/notification/_variables.scss
@@ -1,3 +1,3 @@
 $lumx-notification-height: 52px;
-$lumx-notification-color-palette: ("dark", "yellow", "red", "green");
+$lumx-notification-color-palette: ("blue", "yellow", "red", "green");
 $lumx-notification-transition-duration: 200ms;

--- a/packages/lumx-react/src/components/message/Message.tsx
+++ b/packages/lumx-react/src/components/message/Message.tsx
@@ -45,7 +45,7 @@ const CLASSNAME = getRootClassName(COMPONENT_NAME);
  */
 const CONFIG = {
     [Kind.error]: { color: ColorPalette.red, icon: mdiAlert },
-    [Kind.info]: { color: ColorPalette.dark, icon: mdiInformation },
+    [Kind.info]: { color: ColorPalette.blue, icon: mdiInformation },
     [Kind.success]: { color: ColorPalette.green, icon: mdiCheckCircle },
     [Kind.warning]: { color: ColorPalette.yellow, icon: mdiAlertCircle },
 };

--- a/packages/lumx-react/src/components/notification/constants.ts
+++ b/packages/lumx-react/src/components/notification/constants.ts
@@ -14,7 +14,7 @@ export const NOTIFICATION_CONFIGURATION = {
         icon: mdiAlert,
     },
     info: {
-        color: 'dark',
+        color: 'blue',
         icon: mdiInformation,
     },
     success: {


### PR DESCRIPTION
# General summary

We decided to improve the existing “info” message by changing its color to blue.
Thus it is more visible and aligned with “info” alert dialogs.

Changing also the notification “info” kind color to match.

# Screenshots

<img width="783" alt="Capture d’écran 2024-08-01 à 11 27 02" src="https://github.com/user-attachments/assets/25bfc296-755c-4555-8605-e89e3a731f44">
<img width="784" alt="Capture d’écran 2024-08-01 à 11 27 07" src="https://github.com/user-attachments/assets/fffaa5d4-901f-42d3-a7ab-47ec7a8414ea">
<img width="192" alt="Capture d’écran 2024-08-01 à 11 26 43" src="https://github.com/user-attachments/assets/a5e42367-04a8-4ab5-addb-490abd08355c">
<img width="321" alt="Capture d’écran 2024-08-01 à 11 26 51" src="https://github.com/user-attachments/assets/619b9a1d-7056-4440-b88c-b23f6fdf6453">