### PR TITLE
fix(slideshow): fix pagination item focus outline cut by overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `Lightbox`: fix a11y color contrast on the close button.
 -   `Mosaic`: fix thumbnail focus outline cropped by parent overflow.
+-   `SlideShow`: fix pagination item focus outline cropped by parent overflow.
 
 ## [3.7.5][] - 2024-07-25
 

--- a/packages/lumx-core/src/scss/components/slideshow/_index.scss
+++ b/packages/lumx-core/src/scss/components/slideshow/_index.scss
@@ -80,6 +80,10 @@
    ========================================================================== */
 
 .#{$lumx-base-prefix}-slideshow-controls {
+    $item-max-count: 6;
+    $item-size: $lumx-spacing-unit;
+    $item-margin-inline: 2px;
+    $item-focus-outline: 4px;
     $self: &;
 
     display: flex;
@@ -88,15 +92,15 @@
 
     &__pagination {
         align-items: center;
-        max-width: 60px;
-        margin: 0 math.div($lumx-spacing-unit, 2);
+        // Compute max width for N items based on their size, margin and focus outline
+        max-width: ($item-max-count * ($item-size + $item-margin-inline)) + $item-focus-outline;
         overflow: hidden;
     }
 
     &__pagination-items {
         display: flex;
         align-items: center;
-        padding: 4px 0;
+        padding: $item-focus-outline;
         transition: transform $lumx-slideshow-transition-duration;
 
         @media (prefers-reduced-motion: reduce) {
@@ -108,11 +112,10 @@
         $item: &;
 
         flex-shrink: 0;
-        width: 8px;
-        height: 8px;
+        width: $item-size;
+        height: $item-size;
         padding: 0;
-        margin: 0;
-        margin: 0 2px;
+        margin: 0 $item-margin-inline;
         text-decoration: none;
         cursor: pointer;
         user-select: none;


### PR DESCRIPTION
# General summary

Fixed focus outline on slideshow pagination items cropped by the parent overflow style


| Before | After |
| --- | --- |
|![image](https://github.com/user-attachments/assets/cff9d885-819e-4f67-ae62-99a4f996a977)  | ![image](https://github.com/user-attachments/assets/2f95c88c-1fa4-4be3-833e-0c0787921b39) |

DSW-252