### PR TITLE
feat(image-lightbox): create image ligthbox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `ImageLightbox`: new component providing an image slideshow lightbox with extra features (zoom & a11y).
+
 ## [3.8.1][] - 2024-08-14
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/image-lightbox/_index.scss
+++ b/packages/lumx-core/src/scss/components/image-lightbox/_index.scss
@@ -1,0 +1,68 @@
+@use "sass:map";
+
+/* ==========================================================================
+   Image Lightbox
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-image-lightbox {
+    // Remove lightbox animation & transition (use view transition instead)
+    @supports (view-transition-name: name) {
+        &.#{$lumx-base-prefix}-lightbox {
+            transition: none;
+            animation: none;
+        }
+    }
+
+    .#{$lumx-base-prefix}-lightbox__wrapper {
+        inset: 0;
+    }
+
+    .lumx-slideshow-item-group,
+    .lumx-slideshow-item {
+        display: flex;
+        width: 100%;
+        height: 100%;
+    }
+
+    &__image-slide {
+        overflow: auto;
+
+        // Do not scroll parents when reaching the end of the current scroll area
+        overscroll-behavior: contain;
+
+        // Need to disable native touch actions to implement pinch to zoom
+        touch-action: none;
+
+        // Apply OS dark scheme (for the scrollbar)
+        color-scheme: dark;
+
+        // Transparent scrollbar (fallback to OS dark scheme)
+        scrollbar-color: $lumx-color-light-L4 transparent;
+    }
+
+    &__thumbnail {
+        margin: auto;
+    }
+
+    &__footer {
+        flex-shrink: 0;
+        padding: $lumx-spacing-unit-huge $lumx-spacing-unit;
+        background: $lumx-color-dark-L1;
+    }
+}
+
+// Crop & scale transitioning pair of trigger image + opening image
+::view-transition-image-pair(#{$lumx-base-prefix}-image-lightbox) {
+    overflow: hidden;
+}
+::view-transition-old(#{$lumx-base-prefix}-image-lightbox),
+::view-transition-new(#{$lumx-base-prefix}-image-lightbox) {
+    height: 100%;
+}
+::view-transition-group(#{$lumx-base-prefix}-image-lightbox) {
+    animation-duration: $lumx-lightbox-transition-duration;
+
+    @media (prefers-reduced-motion: reduce) {
+        animation: none;
+    }
+}

--- a/packages/lumx-core/src/scss/lumx.scss
+++ b/packages/lumx-core/src/scss/lumx.scss
@@ -36,6 +36,7 @@
 @import "./components/grid-column/index";
 @import "./components/icon/index";
 @import "./components/image-block/index";
+@import "./components/image-lightbox/index";
 @import "./components/inline-list/index";
 @import "./components/input-helper/index";
 @import "./components/input-label/index";

--- a/packages/lumx-react/src/components/image-lightbox/ImageLightbox.stories.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/ImageLightbox.stories.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { IMAGES } from '@lumx/react/stories/controls/image';
+import { Button, Mosaic, ImageLightbox, ImageLightboxProps, Chip, ChipGroup } from '@lumx/react';
+import { withWrapper } from '@lumx/react/stories/decorators/withWrapper';
+
+const ZOOM_PROPS = {
+    zoomInButtonProps: { label: 'Zoom in' },
+    zoomOutButtonProps: { label: 'Zoom out' },
+};
+
+const SLIDESHOW_PROPS = {
+    slideshowControlsProps: {
+        nextButtonProps: { label: 'Next' },
+        previousButtonProps: { label: 'Previous' },
+        paginationItemProps: (index: number) => ({ label: `Go to slide ${index + 1}` }),
+    },
+};
+
+const MULTIPLE_IMAGES: ImageLightboxProps['images'] = [
+    {
+        image: 'https://picsum.photos/id/237/2000/3000',
+        alt: 'Image 1',
+        title: 'Little puppy',
+        description: 'A black labrador puppy with big brown eyes, looking up with a curious and innocent expression.',
+        tags: (
+            <ChipGroup>
+                <Chip theme="dark" size="s">
+                    Tag 1
+                </Chip>
+                <Chip theme="dark" size="s">
+                    Tag 2
+                </Chip>
+            </ChipGroup>
+        ),
+    },
+    {
+        image: 'https://picsum.photos/id/337/3000/1000',
+        alt: 'Image 2',
+        // Intentionally using the wrong size to see how it renders while loading the image
+        imgProps: { width: '300px', height: '100px' },
+    },
+    {
+        image: 'https://picsum.photos/id/437/2000/2000',
+        alt: 'Image 3',
+    },
+    {
+        image: 'https://picsum.photos/id/537/300/400',
+        alt: 'Image 4',
+    },
+    {
+        image: 'https://picsum.photos/id/637/400/200',
+        alt: 'Image 5',
+    },
+    {
+        image: 'https://picsum.photos/id/737/300/300',
+        alt: 'Image 6',
+    },
+];
+
+export default {
+    title: 'LumX components/image-lightbox/ImageLightbox',
+    component: ImageLightbox,
+    args: {
+        closeButtonProps: { label: 'Close' },
+    },
+    argTypes: {
+        onClose: { action: true },
+    },
+};
+
+/**
+ * Display a single image fullscreen in the ImageLightbox
+ */
+export const SingleImage = {
+    args: {
+        images: [{ image: IMAGES.portrait1s200, alt: 'Image 1' }],
+        isOpen: true,
+    },
+};
+
+/**
+ * Display a single image fullscreen in the ImageLightbox with zoom controls
+ */
+export const SingleImageWithZoom = {
+    ...SingleImage,
+    args: { ...SingleImage.args, ...ZOOM_PROPS },
+};
+
+/**
+ * Display a single image fullscreen in the ImageLightbox with metadata (title, description, etc.)
+ */
+export const SingleImageWithMetadata = {
+    ...SingleImage,
+    args: { ...SingleImage.args, images: [MULTIPLE_IMAGES[0]] },
+};
+
+/**
+ * Display a multiple image fullscreen in the ImageLightbox
+ */
+export const MultipleImages = {
+    args: {
+        images: MULTIPLE_IMAGES,
+        isOpen: true,
+        ...SLIDESHOW_PROPS,
+    },
+};
+
+/**
+ * Display a multiple images fullscreen in the ImageLightbox with zoom controls
+ */
+export const MultipleImagesWithZoom = {
+    ...MultipleImages,
+    args: { ...MultipleImages.args, ...ZOOM_PROPS },
+};
+
+/**
+ * Open ImageLightbox via buttons
+ */
+export const WithButtonTrigger = {
+    decorators: [
+        (Story: any, { args }: any) => {
+            const { getTriggerProps, imageLightboxProps } = ImageLightbox.useImageLightbox({
+                images: [
+                    { image: IMAGES.portrait1s200, alt: 'Image 1' },
+                    { image: IMAGES.landscape1s200, alt: 'Image 2' },
+                ],
+            });
+            return (
+                <>
+                    <Story args={{ ...args, ...imageLightboxProps }} />
+                    <Button {...(getTriggerProps({ activeImageIndex: 0 }) as any)}>Image 1</Button>
+                    <Button {...(getTriggerProps({ activeImageIndex: 1 }) as any)}>Image 2</Button>
+                </>
+            );
+        },
+    ],
+    // Disables Chromatic snapshot (not relevant for this story).
+    parameters: { chromatic: { disable: true } },
+};
+
+/**
+ * Open ImageLightbox with zoom and slideshow via clickable thumbnails in a Mosaic
+ */
+export const WithMosaicTrigger = {
+    args: { ...SLIDESHOW_PROPS, ...ZOOM_PROPS },
+    decorators: [
+        (Story: any, { args }: any) => {
+            const { getTriggerProps, imageLightboxProps } = ImageLightbox.useImageLightbox({ images: MULTIPLE_IMAGES });
+            return (
+                <>
+                    <Story args={{ ...args, ...imageLightboxProps }} />
+                    <Mosaic
+                        thumbnails={MULTIPLE_IMAGES.map((image, index) => ({
+                            ...image,
+                            ...getTriggerProps({ activeImageIndex: index }),
+                        }))}
+                    />
+                </>
+            );
+        },
+        withWrapper({ style: { width: 300 } }),
+    ],
+    // Disables Chromatic snapshot (not relevant for this story).
+    parameters: { chromatic: { disable: true } },
+};

--- a/packages/lumx-react/src/components/image-lightbox/ImageLightbox.test.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/ImageLightbox.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+
+import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
+import { render, within, screen } from '@testing-library/react';
+import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
+import userEvent from '@testing-library/user-event';
+import { useImageSize } from '@lumx/react/hooks/useImageSize';
+import { useSizeOnWindowResize } from '@lumx/react/hooks/useSizeOnWindowResize';
+
+import { ImageLightbox } from './ImageLightbox';
+import { ImageLightboxProps } from './types';
+import Meta, {
+    MultipleImages,
+    MultipleImagesWithZoom,
+    SingleImage,
+    SingleImageWithZoom,
+    WithButtonTrigger,
+    WithMosaicTrigger,
+} from './ImageLightbox.stories';
+
+jest.mock('@lumx/react/hooks/useImageSize');
+jest.mock('@lumx/react/hooks/useSizeOnWindowResize');
+
+const CLASSNAME = ImageLightbox.className as string;
+const baseProps = Meta.args;
+
+const setup = (overrides: Partial<ImageLightboxProps> = {}) => {
+    const props: any = {
+        ...baseProps,
+        isOpen: true,
+        images: [],
+        ...overrides,
+    };
+    const result = render(<ImageLightbox {...props} />);
+    const rerender = () => result.rerender(<ImageLightbox {...props} />);
+    const imageLightbox = queryByClassName(document.body, CLASSNAME);
+    return { props, imageLightbox, rerender };
+};
+
+const queries = {
+    getImageLightbox: () => getByClassName(document.body, CLASSNAME),
+    queryCloseButton: (imageLightbox: HTMLElement) => within(imageLightbox).queryByRole('button', { name: 'Close' }),
+    queryImage: (imageLightbox: HTMLElement, name?: string) => within(imageLightbox).queryByRole('img', { name }),
+    queryScrollArea: (imageLightbox: HTMLElement) =>
+        queryByClassName(imageLightbox, 'lumx-image-lightbox__image-slide'),
+    queryZoomInButton: (imageLightbox: HTMLElement) => within(imageLightbox).queryByRole('button', { name: 'Zoom in' }),
+    queryZoomOutButton: (imageLightbox: HTMLElement) =>
+        within(imageLightbox).queryByRole('button', { name: 'Zoom out' }),
+    queryPrevSlideButton: (imageLightbox: HTMLElement) =>
+        within(imageLightbox).queryByRole('button', { name: 'Previous' }),
+    queryNextSlideButton: (imageLightbox: HTMLElement) => within(imageLightbox).queryByRole('button', { name: 'Next' }),
+    querySlideButton: (imageLightbox: HTMLElement, slide: number) =>
+        within(imageLightbox).queryByRole('tab', { name: `Go to slide ${slide}` }),
+};
+
+describe(`<${ImageLightbox.displayName}>`, () => {
+    beforeEach(() => {
+        (useImageSize as any).mockReturnValue(null);
+        (useSizeOnWindowResize as any).mockReturnValue([null, jest.fn()]);
+    });
+
+    describe('render', () => {
+        it('should render single image', () => {
+            setup(SingleImage.args);
+            const imageLightbox = queries.getImageLightbox();
+
+            // Should render
+            expect(queries.queryCloseButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryImage(imageLightbox, 'Image 1')).toBeInTheDocument();
+
+            // Should not render
+            expect(queries.queryZoomInButton(imageLightbox)).not.toBeInTheDocument();
+            expect(queries.queryZoomOutButton(imageLightbox)).not.toBeInTheDocument();
+            expect(queries.queryPrevSlideButton(imageLightbox)).not.toBeInTheDocument();
+            expect(queries.queryNextSlideButton(imageLightbox)).not.toBeInTheDocument();
+        });
+
+        it('should render single image with zoom', () => {
+            setup(SingleImageWithZoom.args);
+            const imageLightbox = queries.getImageLightbox();
+
+            // Should render
+            expect(queries.queryCloseButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryImage(imageLightbox, 'Image 1')).toBeInTheDocument();
+            expect(queries.queryZoomInButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryZoomOutButton(imageLightbox)).toBeInTheDocument();
+
+            // Should not render
+            expect(queries.queryPrevSlideButton(imageLightbox)).not.toBeInTheDocument();
+            expect(queries.queryNextSlideButton(imageLightbox)).not.toBeInTheDocument();
+        });
+
+        it('should render multiple images', () => {
+            setup(MultipleImages.args);
+            const imageLightbox = queries.getImageLightbox();
+
+            // Should render
+            expect(queries.queryCloseButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryImage(imageLightbox, 'Image 1')).toBeInTheDocument();
+            expect(queries.queryPrevSlideButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryNextSlideButton(imageLightbox)).toBeInTheDocument();
+
+            // Should not render
+            expect(queries.queryZoomInButton(imageLightbox)).not.toBeInTheDocument();
+            expect(queries.queryZoomOutButton(imageLightbox)).not.toBeInTheDocument();
+        });
+
+        it('should render multiple images with set active image', () => {
+            setup({ ...MultipleImages.args, activeImageIndex: 1 });
+            const imageLightbox = queries.getImageLightbox();
+
+            // Should render
+            expect(queries.queryImage(imageLightbox, 'Image 2')).toBeInTheDocument();
+        });
+
+        it('should render multiple images with zoom', () => {
+            setup(MultipleImagesWithZoom.args);
+            const imageLightbox = queries.getImageLightbox();
+
+            // Should render
+            expect(queries.queryCloseButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryImage(imageLightbox, 'Image 1')).toBeInTheDocument();
+            expect(queries.queryPrevSlideButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryNextSlideButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryZoomInButton(imageLightbox)).toBeInTheDocument();
+            expect(queries.queryZoomOutButton(imageLightbox)).toBeInTheDocument();
+        });
+    });
+
+    describe('trigger', () => {
+        it('should move focus on open and close with single image lightbox', async () => {
+            const decorator = WithButtonTrigger.decorators[0];
+            const Story = ({ args }: any) => <ImageLightbox {...args} />;
+            const Render = () => decorator(Story, { args: baseProps });
+            render(<Render />);
+
+            // Focus the second button
+            await userEvent.tab();
+            await userEvent.tab();
+            const buttonTrigger = screen.getByRole('button', { name: 'Image 2' });
+            expect(buttonTrigger).toHaveFocus();
+
+            // Open image lightbox with the button trigger
+            await userEvent.keyboard('{enter}');
+
+            // Focus moved to the close button
+            const imageLightbox = queries.getImageLightbox();
+            expect(queries.queryCloseButton(imageLightbox)).toHaveFocus();
+
+            // Image lightbox opened on the correct image
+            expect(queries.queryImage(imageLightbox, 'Image 2')).toBeInTheDocument();
+
+            // Close on escape
+            await userEvent.keyboard('{escape}');
+            expect(imageLightbox).not.toBeInTheDocument();
+
+            // Focus moved back to the trigger button
+            expect(buttonTrigger).toHaveFocus();
+        });
+
+        it('should move focus on open and close with multiple image lightbox', async () => {
+            const decorator = WithMosaicTrigger.decorators[0];
+            const Story = ({ args }: any) => <ImageLightbox {...args} />;
+            const Render = () => decorator(Story, { args: { ...baseProps, ...WithMosaicTrigger.args } });
+            render(<Render />);
+
+            // Focus the first button & activate to open
+            await userEvent.tab();
+            const buttonTrigger = document.activeElement;
+            await userEvent.keyboard('{enter}');
+
+            // Focus moved to the first slide button
+            const imageLightbox = queries.getImageLightbox();
+            expect(queries.querySlideButton(imageLightbox, 1)).toHaveFocus();
+
+            // Image lightbox opened on the correct image
+            expect(queries.queryImage(imageLightbox, 'Image 1')).toBeInTheDocument();
+
+            // Close on escape
+            await userEvent.keyboard('{escape}');
+            expect(imageLightbox).not.toBeInTheDocument();
+
+            // Focus moved back to the trigger button
+            expect(buttonTrigger).toHaveFocus();
+        });
+    });
+
+    describe('zoom', () => {
+        const scrollAreaSize = { width: 600, height: 600 };
+        beforeEach(() => {
+            (useImageSize as any).mockImplementation((_: any, getInitialSize: any) => getInitialSize?.() || null);
+            (useSizeOnWindowResize as any).mockReturnValue([scrollAreaSize, jest.fn()]);
+        });
+
+        it('should use the image initial size', () => {
+            setup({
+                images: [
+                    { image: 'https://example.com/image.png', alt: 'Image 1', imgProps: { width: 200, height: 200 } },
+                ],
+            });
+            const imageLightbox = queries.getImageLightbox();
+            const image = queries.queryImage(imageLightbox, 'Image 1');
+            expect(image).toHaveStyle({
+                height: `200px`,
+                width: `200px`,
+            });
+        });
+
+        it('should zoom on zoom button pressed', async () => {
+            // Set image size (simulate image loaded)
+            const imageSize = { width: 500, height: 300 };
+            (useImageSize as any).mockReturnValue(imageSize);
+
+            setup(SingleImageWithZoom.args);
+            const imageLightbox = queries.getImageLightbox();
+
+            // Image style
+            const image = queries.queryImage(imageLightbox, 'Image 1');
+            expect(image).toHaveStyle({ width: `${imageSize.width}px`, height: `${imageSize.height}px` });
+
+            // Scroll area is bigger than the image, it should not be focusable
+            expect(queries.queryScrollArea(imageLightbox)).not.toHaveAttribute('tabindex');
+
+            // Zoom in
+            const zoomInButton = queries.queryZoomInButton(imageLightbox) as any;
+            await userEvent.click(zoomInButton);
+            expect(image).toHaveStyle({ height: '450px', width: '750px' });
+
+            // Scroll area is smaller than the image, it should be focusable
+            expect(queries.queryScrollArea(imageLightbox)).toHaveAttribute('tabindex', '0');
+
+            // Zoom out
+            const zoomOutButton = queries.queryZoomOutButton(imageLightbox) as any;
+            await userEvent.click(zoomOutButton);
+            expect(image).toHaveStyle({ width: `${imageSize.width}px`, height: `${imageSize.height}px` });
+        });
+    });
+
+    // Common tests suite.
+    commonTestsSuiteRTL(setup, {
+        baseClassName: CLASSNAME,
+        forwardClassName: 'imageLightbox',
+        forwardAttributes: 'imageLightbox',
+    });
+});

--- a/packages/lumx-react/src/components/image-lightbox/ImageLightbox.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/ImageLightbox.tsx
@@ -1,0 +1,85 @@
+import React, { forwardRef } from 'react';
+
+import classNames from 'classnames';
+import { Lightbox } from '@lumx/react';
+import { ClickAwayProvider } from '@lumx/react/utils';
+import type { Comp } from '@lumx/react/utils/type';
+import { useMergeRefs } from '@lumx/react/utils/mergeRefs';
+
+import { ImageSlideshow } from './internal/ImageSlideshow';
+import { useImageLightbox } from './useImageLightbox';
+import type { ImageLightboxProps } from './types';
+import { CLASSNAME, COMPONENT_NAME } from './constants';
+
+const Inner: Comp<ImageLightboxProps, HTMLDivElement> = forwardRef((props, ref) => {
+    const {
+        className,
+        isOpen,
+        closeButtonProps,
+        onClose,
+        parentElement,
+        activeImageIndex,
+        slideshowControlsProps,
+        slideGroupLabel,
+        images,
+        zoomOutButtonProps,
+        zoomInButtonProps,
+        activeImageRef: propImageRef,
+        ...forwardedProps
+    } = props;
+    const currentPaginationItemRef = React.useRef(null);
+    const footerRef = React.useRef(null);
+    const imageRef = React.useRef(null);
+    const clickAwayChildrenRefs = React.useRef([imageRef, footerRef]);
+
+    const onClickAway = React.useCallback(
+        (evt: Event) => {
+            const targetElement = evt.target;
+            if (!(targetElement instanceof HTMLElement) || !(evt instanceof MouseEvent)) return;
+
+            // Skip click away if clicking on the scrollbar
+            if (targetElement.clientWidth < evt.clientX || targetElement.clientHeight < evt.clientY) return;
+
+            onClose?.();
+        },
+        [onClose],
+    );
+
+    return (
+        <Lightbox
+            ref={ref}
+            className={classNames(className, CLASSNAME)}
+            parentElement={parentElement}
+            isOpen={isOpen}
+            onClose={onClose}
+            closeButtonProps={closeButtonProps}
+            focusElement={currentPaginationItemRef}
+            {...forwardedProps}
+        >
+            <ClickAwayProvider childrenRefs={clickAwayChildrenRefs} callback={onClickAway}>
+                <ImageSlideshow
+                    activeImageIndex={activeImageIndex}
+                    slideGroupLabel={slideGroupLabel}
+                    slideshowControlsProps={slideshowControlsProps}
+                    images={images}
+                    zoomInButtonProps={zoomInButtonProps}
+                    zoomOutButtonProps={zoomOutButtonProps}
+                    footerRef={footerRef}
+                    activeImageRef={useMergeRefs(propImageRef, imageRef)}
+                    currentPaginationItemRef={currentPaginationItemRef}
+                />
+            </ClickAwayProvider>
+        </Lightbox>
+    );
+});
+Inner.displayName = COMPONENT_NAME;
+Inner.className = CLASSNAME;
+
+/**
+ * ImageLightbox component.
+ *
+ * @param  props Component props.
+ * @param  ref   Component ref.
+ * @return React element.
+ */
+export const ImageLightbox = Object.assign(Inner, { useImageLightbox });

--- a/packages/lumx-react/src/components/image-lightbox/constants.ts
+++ b/packages/lumx-react/src/components/image-lightbox/constants.ts
@@ -1,0 +1,11 @@
+import { getRootClassName } from '@lumx/react/utils/className';
+
+/**
+ * Component display name.
+ */
+export const COMPONENT_NAME = 'ImageLightbox';
+
+/**
+ * Component default class name and class prefix.
+ */
+export const CLASSNAME = getRootClassName(COMPONENT_NAME);

--- a/packages/lumx-react/src/components/image-lightbox/index.ts
+++ b/packages/lumx-react/src/components/image-lightbox/index.ts
@@ -1,0 +1,2 @@
+export { ImageLightbox } from './ImageLightbox';
+export type { ImageLightboxProps } from './types';

--- a/packages/lumx-react/src/components/image-lightbox/internal/ImageSlide.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/internal/ImageSlide.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import { SlideshowItem, Thumbnail } from '@lumx/react';
+import { useMergeRefs } from '@lumx/react/utils/mergeRefs';
+import { useSizeOnWindowResize } from '@lumx/react/hooks/useSizeOnWindowResize';
+import { useImageSize } from '@lumx/react/hooks/useImageSize';
+import { getPrefersReducedMotion } from '@lumx/react/utils/browser/getPrefersReducedMotion';
+import { isEqual } from '@lumx/react/utils/object/isEqual';
+
+import { CLASSNAME } from '../constants';
+import { usePointerZoom } from './usePointerZoom';
+import { useAnimateScroll } from './useAnimateScroll';
+import type { ImageProps } from '../types';
+
+export interface ImageSlideProps {
+    image: ImageProps;
+    isActive?: boolean;
+    scale?: number;
+    onScaleChange?: (value: number) => void;
+}
+
+/** Internal image slide component for ImageLightbox */
+export const ImageSlide = React.memo((props: ImageSlideProps) => {
+    const {
+        isActive,
+        scale,
+        onScaleChange,
+        image: { image, imgRef: propImgRef, imgProps, alt, loadingPlaceholderImageRef },
+    } = props;
+
+    // Get scroll area size
+    const scrollAreaRef = React.useRef<HTMLDivElement>(null);
+    const [scrollAreaSize, updateSize] = useSizeOnWindowResize(scrollAreaRef);
+    React.useEffect(() => {
+        // Update size when active
+        if (isActive) updateSize();
+    }, [isActive, updateSize]);
+
+    // Get image size
+    const imgRef = React.useRef<HTMLImageElement>(null);
+    const imageSize = useImageSize(imgRef, () => {
+        const width = Number.parseInt(imgProps?.width as any, 10);
+        const height = Number.parseInt(imgProps?.height as any, 10);
+        return width && height ? { width, height } : null;
+    });
+
+    // Calculate new image size with scale
+    const scaledImageSize = React.useMemo(() => {
+        if (!scrollAreaSize || !imageSize) {
+            return null;
+        }
+        const horizontalScale = scrollAreaSize.width / imageSize.width;
+        const verticalScale = scrollAreaSize.height / imageSize.height;
+        const baseScale = Math.min(1, Math.min(horizontalScale, verticalScale));
+        return {
+            width: imageSize.width * baseScale * (scale ?? 1),
+            height: imageSize.height * baseScale * (scale ?? 1),
+        };
+    }, [scrollAreaSize, imageSize, scale]);
+
+    // Animate scroll to preserve the center of the current visible window in the scroll area
+    const animateScroll = useAnimateScroll(scrollAreaRef);
+
+    // Zoom via mouse wheel or multi-touch pinch zoom
+    const isPointerZooming = usePointerZoom(scrollAreaRef, onScaleChange, animateScroll);
+
+    // Animate scroll on scale change
+    React.useLayoutEffect(() => {
+        if (scale && !isPointerZooming) {
+            animateScroll();
+        }
+    }, [isPointerZooming, scale, animateScroll]);
+
+    const isScrollable =
+        scaledImageSize &&
+        scrollAreaSize &&
+        (scaledImageSize.width > scrollAreaSize.width || scaledImageSize.height > scrollAreaSize.height);
+
+    return (
+        <SlideshowItem
+            ref={scrollAreaRef}
+            // Make it accessible to keyboard nav when the zone is scrollable
+            tabIndex={isScrollable ? 0 : undefined}
+            className={`${CLASSNAME}__image-slide`}
+        >
+            <Thumbnail
+                imgRef={useMergeRefs(imgRef, propImgRef)}
+                image={image}
+                alt={alt}
+                className={`${CLASSNAME}__thumbnail`}
+                imgProps={{
+                    ...imgProps,
+                    style: {
+                        ...imgProps?.style,
+                        ...(scaledImageSize || {
+                            maxHeight: scrollAreaSize?.height,
+                            maxWidth: scrollAreaSize?.width,
+                        }),
+                        // Only animate when scale is set, and we are not pointer zooming and the user does not prefer reduced motion
+                        transition: scale && !isPointerZooming && !getPrefersReducedMotion() ? 'all 250ms' : undefined,
+                    },
+                }}
+                loadingPlaceholderImageRef={loadingPlaceholderImageRef}
+            />
+        </SlideshowItem>
+    );
+}, isEqual);

--- a/packages/lumx-react/src/components/image-lightbox/internal/ImageSlideshow.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/internal/ImageSlideshow.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+
+import { mdiMagnifyMinusOutline, mdiMagnifyPlusOutline } from '@lumx/icons';
+import { FlexBox, IconButton, Slides, SlideshowControls } from '@lumx/react';
+import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+
+import memoize from 'lodash/memoize';
+import { ImageCaption } from '../../image-block/ImageCaption';
+import { CLASSNAME } from '../constants';
+import type { ImagesProps, InheritedSlideShowProps, ZoomButtonProps } from '../types';
+import { ImageSlide } from './ImageSlide';
+
+export interface ImageSlideshowProps extends InheritedSlideShowProps, ZoomButtonProps, ImagesProps {
+    currentPaginationItemRef?: React.Ref<HTMLButtonElement>;
+    footerRef?: React.Ref<HTMLDivElement>;
+}
+
+/** Internal image slideshow component for ImageLightbox */
+export const ImageSlideshow: React.FC<ImageSlideshowProps> = ({
+    activeImageIndex,
+    images,
+    slideGroupLabel,
+    zoomInButtonProps,
+    zoomOutButtonProps,
+    slideshowControlsProps,
+    currentPaginationItemRef,
+    footerRef,
+    activeImageRef,
+}) => {
+    const {
+        activeIndex,
+        slideshowId,
+        setSlideshow,
+        slideshowSlidesId,
+        slidesCount,
+        onNextClick,
+        onPaginationClick,
+        onPreviousClick,
+        toggleAutoPlay,
+    } = SlideshowControls.useSlideshowControls({
+        itemsCount: images.length,
+        activeIndex: activeImageIndex,
+    });
+
+    // Image metadata (caption)
+    const title = images[activeIndex]?.title;
+    const description = images[activeIndex]?.description;
+    const tags = images[activeIndex]?.tags;
+    const metadata =
+        title || description || tags ? (
+            <ImageCaption theme="dark" as="div" title={title} description={description} tags={tags} align="center" />
+        ) : null;
+
+    // Slideshow controls
+    const slideShowControls =
+        slidesCount > 1 && slideshowControlsProps ? (
+            <SlideshowControls
+                theme="dark"
+                activeIndex={activeIndex}
+                slidesCount={slidesCount}
+                onNextClick={onNextClick}
+                onPreviousClick={onPreviousClick}
+                onPaginationClick={onPaginationClick}
+                {...slideshowControlsProps}
+                paginationItemProps={(index: number) => {
+                    const props = slideshowControlsProps?.paginationItemProps?.(index) || {};
+                    return {
+                        ...props,
+                        ref: mergeRefs(
+                            (props as any)?.ref,
+                            // Focus the active pagination item once on mount
+                            activeIndex === index ? currentPaginationItemRef : undefined,
+                        ),
+                    };
+                }}
+            />
+        ) : null;
+
+    // Zoom controls
+    const [scale, setScale] = React.useState<number | undefined>(undefined);
+    const zoomEnabled = zoomInButtonProps && zoomOutButtonProps;
+    const onScaleChange = React.useMemo(() => {
+        if (!zoomEnabled) return undefined;
+        return (newScale: number) => {
+            setScale((prevScale = 1) => Math.max(1, newScale * prevScale));
+        };
+    }, [zoomEnabled]);
+    const zoomIn = React.useCallback(() => onScaleChange?.(1.5), [onScaleChange]);
+    const zoomOut = React.useCallback(() => onScaleChange?.(0.5), [onScaleChange]);
+    React.useEffect(() => {
+        // Reset scale on slide change
+        if (activeIndex) setScale(undefined);
+    }, [activeIndex]);
+    const zoomControls = zoomEnabled && (
+        <>
+            <IconButton
+                {...zoomInButtonProps}
+                theme="dark"
+                emphasis="low"
+                icon={mdiMagnifyPlusOutline}
+                onClick={zoomIn}
+            />
+            <IconButton
+                {...zoomOutButtonProps}
+                theme="dark"
+                emphasis="low"
+                isDisabled={!scale || scale <= 1}
+                icon={mdiMagnifyMinusOutline}
+                onClick={zoomOut}
+            />
+        </>
+    );
+
+    const getImgRef = React.useMemo(
+        () =>
+            memoize(
+                (index: number, isActive: boolean) => {
+                    return mergeRefs(images?.[index].imgRef, isActive ? activeImageRef : undefined);
+                },
+                // memoize based on both arguments
+                (...args) => args.join(),
+            ),
+        [images, activeImageRef],
+    );
+
+    return (
+        <>
+            <Slides
+                activeIndex={activeIndex}
+                theme="dark"
+                slideGroupLabel={slideGroupLabel}
+                fillHeight
+                id={slideshowId}
+                ref={setSlideshow}
+                slidesId={slideshowSlidesId}
+                toggleAutoPlay={toggleAutoPlay}
+            >
+                {images.map(({ image, imgRef, ...imageProps }, index) => {
+                    const isActive = index === activeIndex;
+                    return (
+                        <ImageSlide
+                            isActive={isActive}
+                            key={image}
+                            image={{
+                                ...imageProps,
+                                image,
+                                imgRef: getImgRef(index, isActive),
+                            }}
+                            scale={isActive ? scale : undefined}
+                            onScaleChange={onScaleChange}
+                        />
+                    );
+                })}
+            </Slides>
+            {(metadata || slideShowControls || zoomControls) && (
+                <FlexBox
+                    ref={footerRef}
+                    className={`${CLASSNAME}__footer`}
+                    orientation="vertical"
+                    vAlign="center"
+                    gap="big"
+                >
+                    {metadata}
+
+                    <FlexBox className={`${CLASSNAME}__footer-actions`} orientation="horizontal" gap="regular">
+                        {slideShowControls}
+                        {zoomControls}
+                    </FlexBox>
+                </FlexBox>
+            )}
+        </>
+    );
+};

--- a/packages/lumx-react/src/components/image-lightbox/internal/useAnimateScroll.ts
+++ b/packages/lumx-react/src/components/image-lightbox/internal/useAnimateScroll.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { Point, RectSize } from '@lumx/react/utils/type';
+
+/** Maintains the scroll position centered relative to the original scroll area's dimensions when the content scales. */
+export function useAnimateScroll(scrollAreaRef: React.RefObject<HTMLDivElement>) {
+    return React.useMemo(() => {
+        let animationFrame: number | null = null;
+
+        return function animate(centerPoint?: Point, initialScrollAreaSize?: RectSize) {
+            const scrollArea = scrollAreaRef.current as HTMLDivElement;
+            if (!scrollArea) {
+                return;
+            }
+
+            // Cancel previously running animation
+            if (animationFrame) cancelAnimationFrame(animationFrame);
+
+            // Center on the given point or else on the scroll area visual center
+            const clientHeightRatio = centerPoint?.y ? centerPoint.y / scrollArea.clientHeight : 0.5;
+            const clientWidthRatio = centerPoint?.x ? centerPoint.x / scrollArea.clientWidth : 0.5;
+
+            const initialScrollHeight = initialScrollAreaSize?.height || scrollArea.scrollHeight;
+            const initialScrollWidth = initialScrollAreaSize?.width || scrollArea.scrollWidth;
+
+            const heightCenter = scrollArea.scrollTop + scrollArea.clientHeight * clientHeightRatio;
+            const heightRatio = heightCenter / initialScrollHeight;
+
+            const widthCenter = scrollArea.scrollLeft + scrollArea.clientWidth * clientWidthRatio;
+            const widthRatio = widthCenter / initialScrollWidth;
+
+            let prevScrollHeight = 0;
+            let prevScrollWidth = 0;
+
+            function nextFrame() {
+                const { scrollHeight, scrollWidth, clientHeight, clientWidth } = scrollArea;
+
+                // Scroll area stopped expanding => stop animation
+                if (scrollHeight === prevScrollHeight && scrollWidth === prevScrollWidth) {
+                    animationFrame = null;
+                    return;
+                }
+
+                // Compute next scroll position
+                const top = heightRatio * scrollHeight - clientHeight * clientHeightRatio;
+                const left = widthRatio * scrollWidth - clientWidth * clientWidthRatio;
+
+                scrollArea.scrollTo({ top, left });
+                prevScrollHeight = scrollHeight;
+                prevScrollWidth = scrollWidth;
+                animationFrame = requestAnimationFrame(nextFrame);
+            }
+            animationFrame = requestAnimationFrame(nextFrame);
+        };
+    }, [scrollAreaRef]);
+}

--- a/packages/lumx-react/src/components/image-lightbox/internal/usePointerZoom.ts
+++ b/packages/lumx-react/src/components/image-lightbox/internal/usePointerZoom.ts
@@ -1,0 +1,148 @@
+import React from 'react';
+import type { Point } from '@lumx/react/utils/type';
+import type { useAnimateScroll } from './useAnimateScroll';
+
+/**
+ * Listen to mouse wheel + ctrl and multi-pointer pinch to zoom
+ */
+export function usePointerZoom(
+    scrollAreaRef: React.RefObject<HTMLDivElement>,
+    onScaleChange: ((value: number) => void) | undefined,
+    animateScroll: ReturnType<typeof useAnimateScroll>,
+) {
+    const [isPointerZooming, setPointerZooming] = React.useState(false);
+    React.useEffect(() => {
+        const scrollArea = scrollAreaRef.current as HTMLDivElement;
+        if (!scrollArea || !onScaleChange) {
+            return undefined;
+        }
+
+        let animationFrame: number | null;
+        let zoomStateTimeoutId: ReturnType<typeof setTimeout> | null;
+
+        function updateScaleOnNextFrame(newScale: number, mousePosition: Point): void {
+            // Cancel previously scheduled frame
+            if (animationFrame) cancelAnimationFrame(animationFrame);
+
+            // Cancel previously scheduled zoom state change
+            if (zoomStateTimeoutId) clearTimeout(zoomStateTimeoutId);
+
+            function nextFrame() {
+                setPointerZooming(true);
+                onScaleChange?.(newScale);
+
+                animationFrame = null;
+                // Wait a bit before indicating the pointer zooming is finished
+                zoomStateTimeoutId = setTimeout(() => setPointerZooming(false), 100);
+            }
+            animationFrame = requestAnimationFrame(nextFrame);
+
+            // Animate scroll in parallel (centering on the current mouse position)
+            animateScroll(mousePosition, {
+                width: scrollArea.scrollWidth,
+                height: scrollArea.scrollHeight,
+            });
+        }
+
+        function onWheel(event: WheelEvent) {
+            if (!event.ctrlKey) {
+                return;
+            }
+            event.preventDefault();
+            const newScale = Math.exp(-event.deltaY / 50);
+
+            // Update scale on next frame (focused on the mouse position)
+            updateScaleOnNextFrame(newScale, {
+                x: event.pageX,
+                y: event.pageY,
+            });
+        }
+
+        const activePointers: Record<PointerEvent['pointerId'], PointerEvent> = {};
+        let prevDistance: number | null = null;
+        let previousCenterPoint: Point | null = null;
+
+        function onPointerDown(event: PointerEvent) {
+            activePointers[event.pointerId] = event;
+        }
+        function onPointerMove(event: PointerEvent) {
+            // Update pointer in cache
+            if (activePointers[event.pointerId]) {
+                activePointers[event.pointerId] = event;
+            }
+
+            const pointers = Object.values(activePointers);
+
+            // Make sure we run computation on one of the pointer in the group
+            if (pointers[0].pointerId !== event.pointerId) {
+                return;
+            }
+
+            // Centered point between all pointers
+            const centerPoint: Point = {
+                x: pointers.reduce((x, { clientX }) => x + clientX, 0) / pointers.length,
+                y: pointers.reduce((y, { clientY }) => y + clientY, 0) / pointers.length,
+            };
+
+            // Movement of the center point
+            const deltaCenterPoint = previousCenterPoint && {
+                left: previousCenterPoint.x - centerPoint.x,
+                top: previousCenterPoint.y - centerPoint.y,
+            };
+
+            // Pan X & Y
+            if (deltaCenterPoint) {
+                // Apply movement of the center point to the scroll
+                scrollArea.scrollBy({
+                    top: deltaCenterPoint.top / 2,
+                    left: deltaCenterPoint.left / 2,
+                });
+            }
+
+            // Pinch to zoom
+            if (pointers.length === 2) {
+                const [pointer1, pointer2] = pointers;
+                const distance = Math.hypot(pointer2.clientX - pointer1.clientX, pointer2.clientY - pointer1.clientY);
+
+                if (prevDistance && deltaCenterPoint) {
+                    const delta = prevDistance - distance;
+                    const absDelta = Math.abs(delta);
+
+                    // Zoom only if we are "pinching" more than we are moving the pointers
+                    if (absDelta > Math.abs(deltaCenterPoint.left) && absDelta > Math.abs(deltaCenterPoint.top)) {
+                        // Update scale on next frame (focused on the center point between the two pointers)
+                        const newScale = Math.exp(-delta / 100);
+                        updateScaleOnNextFrame(newScale, centerPoint);
+                    }
+                }
+
+                prevDistance = distance;
+            }
+
+            previousCenterPoint = centerPoint;
+        }
+        function onPointerUp(event: PointerEvent) {
+            prevDistance = null;
+            previousCenterPoint = null;
+            delete activePointers[event.pointerId];
+        }
+
+        scrollArea.addEventListener('wheel', onWheel, { passive: false });
+        const isMultiTouch = navigator.maxTouchPoints >= 2;
+        if (isMultiTouch) {
+            scrollArea.addEventListener('pointerdown', onPointerDown);
+            scrollArea.addEventListener('pointermove', onPointerMove);
+            scrollArea.addEventListener('pointerup', onPointerUp);
+        }
+        return () => {
+            scrollArea.removeEventListener('wheel', onWheel);
+            if (isMultiTouch) {
+                scrollArea.removeEventListener('pointerdown', onPointerDown);
+                scrollArea.removeEventListener('pointermove', onPointerMove);
+                scrollArea.removeEventListener('pointerup', onPointerUp);
+            }
+        };
+    }, [animateScroll, onScaleChange, scrollAreaRef]);
+
+    return isPointerZooming;
+}

--- a/packages/lumx-react/src/components/image-lightbox/types.ts
+++ b/packages/lumx-react/src/components/image-lightbox/types.ts
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import type { IconButtonProps, LightboxProps, SlideshowProps, ThumbnailProps } from '@lumx/react';
+import type { HasClassName } from '@lumx/react/utils/type';
+import type { ImageCaptionMetadata } from '@lumx/react/components/image-block/ImageCaption';
+
+export type InheritedSlideShowProps = Pick<SlideshowProps, 'slideshowControlsProps' | 'slideGroupLabel'>;
+
+export interface ZoomButtonProps {
+    /** Zoom in button props */
+    zoomInButtonProps?: IconButtonProps;
+    /** Zoom out button props */
+    zoomOutButtonProps?: IconButtonProps;
+}
+
+export type InheritedThumbnailProps = Pick<
+    ThumbnailProps,
+    'image' | 'alt' | 'imgProps' | 'imgRef' | 'loadingPlaceholderImageRef'
+>;
+
+export type InheritedImageMetadata = Pick<ImageCaptionMetadata, 'title' | 'description' | 'tags'>;
+
+export type ImageProps = InheritedThumbnailProps & InheritedImageMetadata;
+
+export interface ImagesProps {
+    /** Index of the active image to show on open */
+    activeImageIndex?: number;
+    /** List of images to display */
+    images: Array<ImageProps>;
+    /** Ref of the active image when the lightbox is open */
+    activeImageRef?: React.Ref<HTMLImageElement>;
+}
+
+export type InheritedLightboxProps = Pick<
+    LightboxProps,
+    'isOpen' | 'parentElement' | 'onClose' | 'closeButtonProps' | 'aria-label' | 'aria-labelledby'
+>;
+
+export type ForwardedProps = React.ComponentPropsWithoutRef<'div'>;
+
+/**
+ * ImageLightbox component props
+ */
+export interface ImageLightboxProps
+    extends HasClassName,
+        ZoomButtonProps,
+        ImagesProps,
+        InheritedSlideShowProps,
+        InheritedLightboxProps,
+        ForwardedProps {}

--- a/packages/lumx-react/src/components/image-lightbox/useImageLightbox.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/useImageLightbox.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+
+import memoize from 'lodash/memoize';
+
+import { startViewTransition } from '@lumx/react/utils/DOM/startViewTransition';
+import { findImage } from '@lumx/react/utils/DOM/findImage';
+
+import type { ImageLightboxProps } from './types';
+import { CLASSNAME } from './constants';
+
+/** Subset of the ImageLightboxProps managed by the useImageLightbox hook */
+type ManagedProps = Pick<
+    ImageLightboxProps,
+    'isOpen' | 'images' | 'parentElement' | 'activeImageRef' | 'onClose' | 'activeImageIndex'
+>;
+
+const EMPTY_PROPS: ManagedProps = { isOpen: false, images: [], parentElement: React.createRef() };
+
+type TriggerOptions = Pick<ImageLightboxProps, 'activeImageIndex'>;
+
+/**
+ * Set up an ImageLightbox with images and triggers.
+ *
+ * - Associate a trigger with the lightbox to properly focus the trigger on close
+ * - Associate a trigger with an image to display on open
+ * - Automatically provide a view transition between an image trigger and the displayed image on open & close
+ *
+ * @param initialProps Images to display in the image lightbox
+ */
+export function useImageLightbox<P extends Partial<ImageLightboxProps>>(
+    initialProps: P,
+): {
+    /**
+     * Generates trigger props
+     * @param index Provide an index to choose which image to display when the image lightbox opens.
+     * */
+    getTriggerProps: (options?: TriggerOptions) => { onClick: React.MouseEventHandler; ref: React.Ref<any> };
+    /** Props to forward to the ImageLightbox */
+    imageLightboxProps: ManagedProps & P;
+} {
+    const { images = [], ...otherProps } = initialProps;
+
+    const imagesPropsRef = React.useRef(images);
+    React.useEffect(() => {
+        imagesPropsRef.current = images.map((props) => ({ imgRef: React.createRef(), ...props }));
+    }, [images]);
+
+    const currentImageRef = React.useRef<HTMLImageElement>(null);
+    const [imageLightboxProps, setImageLightboxProps] = React.useState(
+        () => ({ ...EMPTY_PROPS, ...otherProps }) as ManagedProps & P,
+    );
+
+    const getTriggerProps = React.useMemo(() => {
+        const triggerImageRefs: Record<number, React.RefObject<HTMLImageElement>> = {};
+
+        async function close() {
+            const currentImage = currentImageRef.current;
+            if (!currentImage) {
+                return;
+            }
+            const currentIndex = imagesPropsRef.current.findIndex(
+                ({ imgRef }) => (imgRef as any)?.current === currentImage,
+            );
+
+            await startViewTransition({
+                changes() {
+                    // Close lightbox
+                    setImageLightboxProps((prevProps) => ({ ...prevProps, isOpen: false }));
+                },
+                // Morph from the image in lightbox to the image in trigger
+                viewTransitionName: {
+                    source: currentImageRef,
+                    target: triggerImageRefs[currentIndex],
+                    name: CLASSNAME,
+                },
+            });
+        }
+
+        async function open(triggerElement: HTMLElement, { activeImageIndex }: TriggerOptions = {}) {
+            // If we find an image inside the trigger, animate it in transition with the opening image
+            const triggerImage = triggerImageRefs[activeImageIndex as any]?.current || findImage(triggerElement);
+
+            // Inject the trigger image as loading placeholder for better loading state
+            const imagesWithFallbackSize = imagesPropsRef.current.map((image, idx) => {
+                if (triggerImage && idx === activeImageIndex && !image.loadingPlaceholderImageRef) {
+                    return { ...image, loadingPlaceholderImageRef: { current: triggerImage } };
+                }
+                return image;
+            });
+
+            await startViewTransition({
+                changes: () => {
+                    // Open lightbox with setup props
+                    setImageLightboxProps((prevProps) => ({
+                        ...prevProps,
+                        activeImageRef: currentImageRef,
+                        parentElement: { current: triggerElement },
+                        isOpen: true,
+                        onClose: () => {
+                            close();
+                            prevProps?.onClose?.();
+                        },
+                        images: imagesWithFallbackSize,
+                        activeImageIndex: activeImageIndex || 0,
+                    }));
+                },
+                // Morph from the image in trigger to the image in lightbox
+                viewTransitionName: {
+                    source: triggerImage,
+                    target: currentImageRef,
+                    name: CLASSNAME,
+                },
+            });
+        }
+
+        return memoize((options?: TriggerOptions) => ({
+            ref(element: HTMLElement | null) {
+                // Track trigger image ref if any
+                if (options?.activeImageIndex !== undefined && element) {
+                    triggerImageRefs[options.activeImageIndex] = { current: findImage(element) };
+                }
+            },
+            onClick(e: React.MouseEvent) {
+                open(e.target as HTMLElement, options);
+            },
+        }));
+    }, []);
+
+    return { getTriggerProps, imageLightboxProps };
+}

--- a/packages/lumx-react/src/components/thumbnail/useFocusPointStyle.tsx
+++ b/packages/lumx-react/src/components/thumbnail/useFocusPointStyle.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, useEffect, useMemo, useState } from 'react';
 import { AspectRatio } from '@lumx/react/components';
 import { ThumbnailProps } from '@lumx/react/components/thumbnail/Thumbnail';
+import { RectSize } from '@lumx/react/utils/type';
 
 // Calculate shift to center the focus point in the container.
 export function shiftPosition({
@@ -24,8 +25,6 @@ export function shiftPosition({
     return Math.floor(Math.max(Math.min(shift, 1), 0) * 100);
 }
 
-type Size = { width: number; height: number };
-
 // Compute CSS properties to apply the focus point.
 export const useFocusPointStyle = (
     { image, aspectRatio, focusPoint, imgProps: { width, height } = {} }: ThumbnailProps,
@@ -33,7 +32,7 @@ export const useFocusPointStyle = (
     isLoaded: boolean,
 ): CSSProperties => {
     // Get natural image size from imgProps or img element.
-    const imageSize: Size | undefined = useMemo(() => {
+    const imageSize: RectSize | undefined = useMemo(() => {
         // Focus point is not applicable => exit early
         if (!image || aspectRatio === AspectRatio.original || (!focusPoint?.x && !focusPoint?.y)) return undefined;
         if (typeof width === 'number' && typeof height === 'number') return { width, height };
@@ -42,7 +41,7 @@ export const useFocusPointStyle = (
     }, [aspectRatio, element, focusPoint?.x, focusPoint?.y, height, image, isLoaded, width]);
 
     // Get container size (dependant on imageSize).
-    const [containerSize, setContainerSize] = useState<Size | undefined>(undefined);
+    const [containerSize, setContainerSize] = useState<RectSize | undefined>(undefined);
     useEffect(
         function updateContainerSize() {
             const cWidth = element?.offsetWidth;

--- a/packages/lumx-react/src/hooks/useImageSize.ts
+++ b/packages/lumx-react/src/hooks/useImageSize.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import { RectSize } from '@lumx/react/utils/type';
+
+/** Get natural image size after load. */
+export function useImageSize(imgRef: React.RefObject<HTMLImageElement>, getInitialSize?: () => RectSize | null) {
+    const [imageSize, setImageSize] = React.useState<null | RectSize>(getInitialSize || null);
+    React.useEffect(() => {
+        const { current: img } = imgRef;
+        if (!img) {
+            return undefined;
+        }
+        const onLoad = () => setImageSize({ width: img.naturalWidth, height: img.naturalHeight });
+        img.addEventListener('load', onLoad);
+        return () => img.removeEventListener('load', onLoad);
+    }, [imgRef]);
+    return imageSize;
+}

--- a/packages/lumx-react/src/hooks/useSizeOnWindowResize.ts
+++ b/packages/lumx-react/src/hooks/useSizeOnWindowResize.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import throttle from 'lodash/throttle';
+import { RectSize } from '@lumx/react/utils/type';
+
+/**
+ * Observe element size (only works if it's size depends on the window size).
+ *
+ * (Not using ResizeObserver for better browser backward compat)
+ *
+ * @param elementRef Element to observe
+ * @return the size and a manual update callback
+ */
+export function useSizeOnWindowResize(elementRef: React.RefObject<HTMLElement>): [RectSize | null, () => void] {
+    const [size, setSize] = React.useState<null | RectSize>(null);
+    const updateSize = React.useMemo(
+        () =>
+            throttle(() => {
+                const newSize = elementRef.current?.getBoundingClientRect();
+                if (newSize) setSize(newSize);
+            }, 10),
+        [elementRef],
+    );
+    React.useEffect(() => {
+        updateSize();
+        window.addEventListener('resize', updateSize);
+        return () => window.removeEventListener('resize', updateSize);
+    }, [updateSize]);
+    return [size, updateSize];
+}

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -25,6 +25,7 @@ export * from './components/grid';
 export * from './components/grid-column';
 export * from './components/icon';
 export * from './components/image-block';
+export * from './components/image-lightbox';
 export * from './components/inline-list';
 export * from './components/input-helper';
 export * from './components/input-label';

--- a/packages/lumx-react/src/stories/generated/ImageLightbox/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/ImageLightbox/Demos.stories.tsx
@@ -1,0 +1,6 @@
+/**
+ * File generated when storybook is started. Do not edit directly!
+ */
+export default { title: 'LumX components/image-lightbox/ImageLightbox Demos' };
+
+export { App as Default } from './default';

--- a/packages/lumx-react/src/stories/generated/ImageLightbox/default.tsx
+++ b/packages/lumx-react/src/stories/generated/ImageLightbox/default.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/image-lightbox/react/default.tsx

--- a/packages/lumx-react/src/utils/DOM/findImage.tsx
+++ b/packages/lumx-react/src/utils/DOM/findImage.tsx
@@ -1,0 +1,3 @@
+/** Find image in element including the element */
+export const findImage = (element: HTMLElement | null): HTMLImageElement | null =>
+    element?.matches('img') ? (element as HTMLImageElement) : element?.querySelector('img') || null;

--- a/packages/lumx-react/src/utils/DOM/startViewTransition.ts
+++ b/packages/lumx-react/src/utils/DOM/startViewTransition.ts
@@ -1,0 +1,56 @@
+import ReactDOM from 'react-dom';
+
+import { MaybeElementOrRef } from '@lumx/react/utils/type';
+
+import { unref } from '../react/unref';
+import { getPrefersReducedMotion } from '../browser/getPrefersReducedMotion';
+
+function setTransitionViewName(elementRef: MaybeElementOrRef<HTMLElement>, name: string | null | undefined) {
+    const element = unref(elementRef) as any;
+    if (element) element.style.viewTransitionName = name;
+}
+
+/**
+ * Wrapper around the `document.startViewTransition` handling browser incompatibilities, react DOM flush and
+ * user preference.
+ *
+ * @param changes                callback containing the changes to apply within the view transition.
+ * @param setViewTransitionName  set the `viewTransitionName` style on a `source` & `target` to morph these elements.
+ */
+export async function startViewTransition({
+    changes,
+    viewTransitionName,
+}: {
+    changes: () => void;
+    viewTransitionName: {
+        source: MaybeElementOrRef<HTMLElement>;
+        target: MaybeElementOrRef<HTMLElement>;
+        name: string;
+    };
+}) {
+    const start = (document as any)?.startViewTransition?.bind(document);
+    const prefersReducedMotion = getPrefersReducedMotion();
+    const { flushSync } = ReactDOM as any;
+    if (prefersReducedMotion || !start || !flushSync || !viewTransitionName?.source || !viewTransitionName?.target) {
+        // Skip, apply changes without a transition
+        changes();
+        return;
+    }
+
+    // Set transition name on source element
+    setTransitionViewName(viewTransitionName.source, viewTransitionName.name);
+
+    // Start view transition, apply changes & flush to DOM
+    await start(() => {
+        // Un-set transition name on source element
+        setTransitionViewName(viewTransitionName.source, null);
+
+        flushSync(changes);
+
+        // Set transition name on target element
+        setTransitionViewName(viewTransitionName.target, viewTransitionName.name);
+    }).updateCallbackDone;
+
+    // Un-set transition name on target element
+    setTransitionViewName(viewTransitionName.target, null);
+}

--- a/packages/lumx-react/src/utils/browser/getPrefersReducedMotion.ts
+++ b/packages/lumx-react/src/utils/browser/getPrefersReducedMotion.ts
@@ -1,0 +1,6 @@
+import { WINDOW } from '@lumx/react/constants';
+
+/** Check if user prefers reduced motion */
+export function getPrefersReducedMotion() {
+    return WINDOW?.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}

--- a/packages/lumx-react/src/utils/object/isEqual.test.ts
+++ b/packages/lumx-react/src/utils/object/isEqual.test.ts
@@ -1,0 +1,25 @@
+import { isEqual } from './isEqual';
+
+test(isEqual.name, () => {
+    expect(isEqual('', '')).toBe(true);
+    expect(isEqual(0, 0)).toBe(true);
+    expect(isEqual(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY)).toBe(true);
+
+    expect(isEqual('', 0)).toBe(false);
+
+    expect(isEqual({}, {})).toBe(true);
+    expect(isEqual({ a: 1 }, { a: 1 })).toBe(true);
+    expect(isEqual({ a: { a: 1 } }, { a: { a: 1 } })).toBe(true);
+
+    expect(isEqual([], [])).toBe(true);
+
+    expect(isEqual([1], [2])).toBe(false);
+    expect(isEqual([1], [1, 2])).toBe(false);
+    expect(isEqual([1, 2], [2, 1])).toBe(false);
+
+    expect(isEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(isEqual({ a: 1 }, {})).toBe(false);
+    expect(isEqual({}, { a: 1 })).toBe(false);
+    expect(isEqual({ a: { a: 1 } }, { a: { a: 2 } })).toBe(false);
+    expect(isEqual({ a: 1 }, { a: 1, b: 1 })).toBe(false);
+});

--- a/packages/lumx-react/src/utils/object/isEqual.ts
+++ b/packages/lumx-react/src/utils/object/isEqual.ts
@@ -1,0 +1,11 @@
+/** Minimal recursive deep equal of JS values */
+export function isEqual(obj1: any, obj2: any): boolean {
+    if (obj1 === obj2) return true;
+    if (typeof obj1 === 'object' && typeof obj2 === 'object') {
+        const keys1 = Object.keys(obj1);
+        const keys2 = Object.keys(obj2);
+        if (keys1.length !== keys2.length) return false;
+        return keys1.every((key1) => isEqual(obj1[key1], obj2[key1]));
+    }
+    return false;
+}

--- a/packages/lumx-react/src/utils/react/unref.ts
+++ b/packages/lumx-react/src/utils/react/unref.ts
@@ -1,0 +1,7 @@
+import { MaybeElementOrRef } from '@lumx/react/utils/type';
+
+/** Unref a react ref or element */
+export function unref(maybeElement: MaybeElementOrRef<HTMLElement>) {
+    if (maybeElement instanceof HTMLElement) return maybeElement;
+    return maybeElement?.current;
+}

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -139,3 +139,18 @@ export type ComponentRef<C> = C extends keyof JSX.IntrinsicElements
       : C extends React.JSXElementConstructor<{ ref?: infer R }>
         ? R
         : never;
+
+/**
+ * Rectangle size
+ */
+export type RectSize = { width: number; height: number };
+
+/**
+ * Maybe a HTMLElement or a React ref of a HTMLElement
+ */
+export type MaybeElementOrRef<E extends HTMLElement> = E | React.RefObject<E | null> | null | undefined;
+
+/**
+ * A point coordinate in 2D space
+ */
+export type Point = { x: number; y: number };

--- a/packages/site-demo/content/product/components/image-lightbox/index.mdx
+++ b/packages/site-demo/content/product/components/image-lightbox/index.mdx
@@ -1,0 +1,27 @@
+# ImageLightbox
+
+**Reveals an image or image slideshow after clicking on a trigger.**
+
+The image lightbox component is a composition of the [Lightbox](/product/components/lightbox/) and a [Slideshow](/product/components/slideshow/) with extra features (zoom & better a11y defaults).
+
+<DemoBlock demo="default" vAlign="center" />
+
+### Accessibility concerns
+
+All accessibility concern around focus management are handled by the `ImageLightbox.useImageLightbox()` hook as long as you properly attach the trigger props (see demo code).
+
+As this component is composed of a dialog and many action button, you must provide:
+
+- A label via either `aria-label` or `aria-labelledby` props to name the dialog (ex: "Fullscreen image").
+Setting `aria-labelledby` is recommended as it target a visible label rather than adding an invisible `aria-label` on the dialog.
+
+- A label for the close button via `closeButtonProps` (see demo code).
+
+- Labels for the slideshow controls via `slideshowControlsProps` (see demo code).
+
+- Labels for the zoom buttons via `zoomInButtonProps`and `zoomOutButtonProps` (see demo code).
+
+
+### Properties
+
+<PropTable component="ImageLightbox" />

--- a/packages/site-demo/content/product/components/image-lightbox/react/default.tsx
+++ b/packages/site-demo/content/product/components/image-lightbox/react/default.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FlexBox, Message, Text, Thumbnail, ImageLightbox } from '@lumx/react';
+
+const images = [
+    { image: '/demo-assets/portrait1.jpg', alt: 'Portrait 1' },
+    { image: '/demo-assets/portrait2.jpg', alt: 'Portrait 2' },
+    { image: '/demo-assets/landscape3.jpg', alt: 'Landscape 3' },
+    { image: '/demo-assets/landscape2.jpg', alt: 'Landscape 2' },
+];
+
+export const App = () => {
+    const { getTriggerProps, imageLightboxProps } = ImageLightbox.useImageLightbox({ images });
+
+    return (
+        <>
+            <FlexBox orientation="vertical" gap="big">
+                <FlexBox orientation="horizontal" gap="regular">
+                    {images.map(({ image, alt }, index) => (
+                        <Thumbnail
+                            key={image}
+                            image={image}
+                            alt={alt}
+                            size="xl"
+                            aspectRatio="square"
+                            {...getTriggerProps({ activeImageIndex: index })}
+                        />
+                    ))}
+                </FlexBox>
+
+                <Message kind="info" hasBackground>
+                    <Text as="span">Click on a picture to open the image lightbox.</Text>
+                </Message>
+            </FlexBox>
+
+            <ImageLightbox
+                {...imageLightboxProps}
+                aria-label="Fullscreen image slideshow"
+                closeButtonProps={{ label: 'Close' }}
+                zoomInButtonProps={{ label: 'Zoom in' }}
+                zoomOutButtonProps={{ label: 'Zoom out' }}
+                slideshowControlsProps={{
+                    nextButtonProps: { label: 'Next' },
+                    previousButtonProps: { label: 'Previous' },
+                    paginationItemProps: (index: number) => ({ label: `Go to slide ${index + 1}` }),
+                }}
+            />
+        </>
+    );
+};

--- a/packages/site-demo/content/product/components/lightbox/index.mdx
+++ b/packages/site-demo/content/product/components/lightbox/index.mdx
@@ -1,8 +1,10 @@
 # Lightbox
 
-**Reveals elements after clicking on a trigger. Often used to enlarge pictures in a gallery.**
+**Reveals elements above the page and on a backdrop after clicking on a trigger.**
 
-<DemoBlock demo="default" />
+<DemoBlock demo="default" vAlign="center"/>
+
+See the [ImageLightbox](/product/components/image-lightbox) component a fully featured image and image slideshow lightbox.
 
 ### Accessibility concerns
 

--- a/packages/site-demo/content/product/components/lightbox/react/default.tsx
+++ b/packages/site-demo/content/product/components/lightbox/react/default.tsx
@@ -1,109 +1,25 @@
-import {
-    Alignment,
-    AspectRatio,
-    Chip,
-    ChipGroup,
-    FlexBox,
-    ImageBlock,
-    Lightbox,
-    Message,
-    Kind,
-    Orientation,
-    Size,
-    Slideshow,
-    SlideshowItem,
-    Theme,
-    Thumbnail,
-    ThumbnailProps,
-} from '@lumx/react';
-import React, { useCallback, useRef, useState } from 'react';
+import React from 'react';
+import { Lightbox, Button, FlexBox, Thumbnail } from '@lumx/react';
 
-const IMAGES: ThumbnailProps[] = [
-    { image: '/demo-assets/portrait1.jpg', alt: 'Portrait 1' },
-    { image: '/demo-assets/portrait2.jpg', alt: 'Portrait 2' },
-    { image: '/demo-assets/landscape3.jpg', alt: 'Landscape 3' },
-    { image: '/demo-assets/landscape2.jpg', alt: 'Landscape 2' },
-];
-
-export const App = ({ defaultIsOpen }: any) => {
-    const [isOpen, setOpen] = useState(!!defaultIsOpen);
-    const [activeIndex, setActiveIndex] = useState(0);
-
-    const triggerElement = useRef(null);
-
-    const close = useCallback(() => {
-        setOpen(false);
-    }, []);
-
-    const handleClick = useCallback(
-        (newActiveIndex) => () => {
-            setActiveIndex(newActiveIndex);
-            setOpen(!isOpen);
-        },
-        [isOpen],
-    );
+export const App = () => {
+    const [isOpen, setOpen] = React.useState(false);
+    const triggerElement = React.useRef(null);
 
     return (
-        <div style={{ width: 536, margin: '0 auto' }}>
+        <>
+            <Button ref={triggerElement} onClick={() => setOpen(true)}>
+                Open LightBox
+            </Button>
             <Lightbox
                 isOpen={isOpen}
                 parentElement={triggerElement}
-                onClose={close}
+                onClose={() => setOpen(false)}
                 closeButtonProps={{ label: 'Close' }}
             >
-                <Slideshow
-                    activeIndex={activeIndex}
-                    slideshowControlsProps={{
-                        nextButtonProps: { label: 'Next' },
-                        previousButtonProps: { label: 'Previous' },
-                    }}
-                    autoPlay
-                    fillHeight
-                    theme={Theme.dark}
-                >
-                    {IMAGES.map(({ image }) => (
-                        <SlideshowItem key={image}>
-                            <ImageBlock
-                                fillHeight
-                                title="Nice Image"
-                                alt="Nice Image"
-                                description="What an image"
-                                theme={Theme.dark}
-                                image={image}
-                                align={Alignment.center}
-                                tags={
-                                    <ChipGroup align="center">
-                                        <Chip size={Size.s} theme={Theme.dark}>
-                                            Tag 1
-                                        </Chip>
-
-                                        <Chip size={Size.s} theme={Theme.dark}>
-                                            Tag 2
-                                        </Chip>
-                                    </ChipGroup>
-                                }
-                            />
-                        </SlideshowItem>
-                    ))}
-                </Slideshow>
+                <FlexBox vAlign="center" hAlign="center" style={{ height: '100%' }}>
+                    <Thumbnail alt="Portrait image" image="/demo-assets/portrait1.jpg" />
+                </FlexBox>
             </Lightbox>
-
-            <FlexBox orientation={Orientation.horizontal} gap={Size.regular}>
-                {IMAGES.map(({ image, alt }, index) => (
-                    <Thumbnail
-                        key={image}
-                        image={image}
-                        alt={alt}
-                        size={Size.xl}
-                        aspectRatio={AspectRatio.square}
-                        onClick={handleClick(index)}
-                    />
-                ))}
-            </FlexBox>
-
-            <Message className="lumx-spacing-margin-top-big" kind={Kind.info} hasBackground>
-                <span>Click on a picture to lauch a slideshow on lightbox mode.</span>
-            </Message>
-        </div>
+        </>
     );
 };


### PR DESCRIPTION
# General summary

New `ImageLightbox` component and `ImageLightbox.useImageLightbox` hook to easily create lightbox with image or image slideshow and additional features (zoom & better default a11y)

Features:
- Single or multiple image (slideshow)
- Zoom
  - Zoom in/out buttons
  - Ctrl+mouse wheel zoom in/out
  - Multi-touch pinch to zoom
- A11Y
  - Multi image: Focus moved to current slide tab on open   
  - Single image: Focus moved to close button on open
  - Focus trigger button on close
  - Scroll area is focusable   
  - All actions button are labeled

<details><summary>Demo</summary>

https://github.com/user-attachments/assets/79a0ecd8-22ea-414a-80aa-8d3050d8e565

</details>

