### PR TITLE
fix(mosaic): fix thumbnail focus outline cropped by parent overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `Lightbox`: fix a11y color contrast on the close button.
+-   `Mosaic`: fix thumbnail focus outline cropped by parent overflow.
 
 ## [3.7.5][] - 2024-07-25
 

--- a/packages/lumx-core/src/scss/components/mosaic/_index.scss
+++ b/packages/lumx-core/src/scss/components/mosaic/_index.scss
@@ -9,7 +9,6 @@
 
     position: relative;
     padding-top: map.get($lumx-thumbnail-aspect-ratio, "horizontal");
-    overflow: hidden;
 
     &__wrapper {
         position: absolute;
@@ -49,6 +48,10 @@
         display: flex;
         flex-direction: column;
         margin: 1px;
+
+        &:has([data-focus-visible-added]) {
+            z-index: 1;
+        }
 
         #{$self}--has-1-thumbnail & {
             &:nth-child(1) {


### PR DESCRIPTION
# General summary

Fix Mosaic thumbnail focus outline cropped by parent overflow

DSW-253


Before | After 
--- | ---
<video src=https://github.com/user-attachments/assets/8099f2de-0f86-43e1-83ad-ecafa3ac99fd /> | <video src=https://github.com/user-attachments/assets/b5f1df15-f6ac-4952-acf6-fbc1e8eb5d27 />

