### PR TITLE
refactor(image-block): simplify caption styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Heading`: fix the default typography when the `as` prop is set.
+-  `Heading`: fix the default typography when the `as` prop is set.
+-  `ImageBlock`: internal changes on caption styles (simply and make reusable).
 
 ## [3.7.5][] - 2024-07-25
 

--- a/packages/lumx-core/src/scss/components/image-block/_index.scss
+++ b/packages/lumx-core/src/scss/components/image-block/_index.scss
@@ -14,23 +14,12 @@
     }
 
     &__wrapper {
-        display: flex;
-        flex-direction: column;
+        > * {
+            max-width: 100%;
+        }
 
         #{$self}--fill-height & {
             flex-shrink: 0;
-        }
-
-        #{$self}--align-left & {
-            align-items: flex-start;
-        }
-
-        #{$self}--align-center & {
-            align-items: center;
-        }
-
-        #{$self}--align-right & {
-            align-items: flex-end;
         }
 
         #{$self}--caption-position-below & {
@@ -52,43 +41,6 @@
         #{$self}--theme-dark#{$self}--caption-position-over & {
             background-color: lumx-color-variant("dark", "L1");
         }
-    }
-
-    &__caption {
-        #{$self}--caption-position-over & {
-            max-width: 100%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-    }
-
-    &__title {
-        @include lumx-typography("subtitle1");
-
-        #{$self}--theme-light & {
-            color: lumx-color-variant("dark", "N");
-        }
-
-        #{$self}--theme-dark & {
-            color: lumx-color-variant("light", "N");
-        }
-    }
-
-    &__description {
-        @include lumx-typography("body1");
-
-        #{$self}--theme-light & {
-            color: lumx-color-variant("dark", "L2");
-        }
-
-        #{$self}--theme-dark & {
-            color: lumx-color-variant("light", "L2");
-        }
-    }
-
-    &__tags {
-        margin-top: $lumx-spacing-unit;
     }
 
     &__actions {

--- a/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.stories.tsx
@@ -15,94 +15,105 @@ import {
 import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
 import { imageArgType, PORTRAIT_IMAGES, LANDSCAPE_IMAGES } from '@lumx/react/stories/controls/image';
 import { mdiFileEdit } from '@lumx/icons';
-import { toNestedProps } from '@lumx/react/stories/decorators/withNestedProps';
+import { withNestedProps } from '@lumx/react/stories/decorators/withNestedProps';
 import { focusPoint } from '@lumx/react/stories/controls/focusPoint';
+import { withWrapper } from '@lumx/react/stories/decorators/withWrapper';
 
 export default {
     title: 'LumX components/image-block/Image Block',
+    component: ImageBlock,
     argTypes: {
         size: getSelectArgType<ImageBlockSize>([Size.xl, Size.xxl]),
         image: imageArgType,
         captionPosition: getSelectArgType(ImageBlockCaptionPosition),
         'thumbnailProps.aspectRatio': getSelectArgType(AspectRatio),
         align: getSelectArgType<HorizontalAlignment>([Alignment.left, Alignment.center, Alignment.right]),
+        tags: { control: false },
+        actions: { control: false },
     },
     args: { ...ImageBlock.defaultProps, image: LANDSCAPE_IMAGES.landscape1 },
+    decorators: [withNestedProps()],
 };
 
-export const Default = (props: any) => {
-    const nestedProps = toNestedProps(props) as any;
-    return <ImageBlock {...nestedProps} />;
+export const WithCaptionBelow = {
+    args: {
+        captionPosition: ImageBlockCaptionPosition.below,
+        size: Size.xxl,
+        title: 'Image block title',
+        description: 'Image block description',
+    },
 };
 
-export const WithCaptionBelow: any = Default.bind({});
-WithCaptionBelow.args = {
-    captionPosition: ImageBlockCaptionPosition.below,
-    size: Size.xxl,
-    title: 'Image block title',
-    description: 'Image block description',
+export const WithCaptionOver = {
+    args: {
+        captionPosition: ImageBlockCaptionPosition.over,
+        size: Size.xxl,
+        title: 'Image block title',
+        description: 'Image block description',
+    },
 };
 
-export const WithCaptionOver: any = Default.bind({});
-WithCaptionOver.args = {
-    captionPosition: ImageBlockCaptionPosition.over,
-    size: Size.xxl,
-    title: 'Image block title',
-    description: 'Image block description',
+export const WithAlign = {
+    args: {
+        ...WithCaptionBelow.args,
+        image: LANDSCAPE_IMAGES.landscape1s200,
+        size: undefined,
+        align: Alignment.center,
+    },
 };
 
-export const WithAlign: any = Default.bind({});
-WithAlign.args = {
-    ...WithCaptionBelow.args,
-    image: LANDSCAPE_IMAGES.landscape1s200,
-    size: undefined,
-    align: Alignment.center,
+export const WithTags = {
+    args: {
+        size: Size.xxl,
+        tags: (
+            <ChipGroup align={Alignment.left}>
+                <Chip size={Size.s}>Tag 1</Chip>
+                <Chip size={Size.s}>Tag 2</Chip>
+            </ChipGroup>
+        ),
+    },
 };
 
-export const WithTags: any = Default.bind({});
-WithTags.argTypes = {
-    tags: { control: false },
-};
-WithTags.args = {
-    size: Size.xxl,
-    tags: (
-        <ChipGroup align={Alignment.left}>
-            <Chip size={Size.s}>Tag 1</Chip>
-            <Chip size={Size.s}>Tag 2</Chip>
-        </ChipGroup>
-    ),
+export const WithActions = {
+    args: {
+        size: Size.xxl,
+        actions: <IconButton label="Edit" icon={mdiFileEdit} />,
+    },
 };
 
-export const WithActions: any = Default.bind({});
-WithActions.argTypes = {
-    actions: { control: false },
-};
-WithActions.args = {
-    size: Size.xxl,
-    actions: <IconButton label="Edit" icon={mdiFileEdit} />,
-};
-
-export const WithFocusPointHorizontal: any = Default.bind({});
-WithFocusPointHorizontal.args = {
-    size: Size.xxl,
-    'thumbnailProps.aspectRatio': AspectRatio.vertical,
-    'thumbnailProps.focusPoint.x': 1,
-    'thumbnailProps.focusPoint.y': 0,
-};
-WithFocusPointHorizontal.argTypes = {
-    'thumbnailProps.focusPoint.x': focusPoint,
-    'thumbnailProps.focusPoint.y': focusPoint,
+export const WithFocusPointHorizontal = {
+    args: {
+        size: Size.xxl,
+        'thumbnailProps.aspectRatio': AspectRatio.vertical,
+        'thumbnailProps.focusPoint.x': 1,
+        'thumbnailProps.focusPoint.y': 0,
+    },
+    argTypes: {
+        'thumbnailProps.focusPoint.x': focusPoint,
+        'thumbnailProps.focusPoint.y': focusPoint,
+    },
 };
 
-export const WithFocusPointVertical: any = Default.bind({});
-WithFocusPointVertical.args = {
-    size: Size.xxl,
-    image: PORTRAIT_IMAGES.portrait1,
-    'thumbnailProps.aspectRatio': AspectRatio.horizontal,
-    'thumbnailProps.focusPoint.x': 0,
-    'thumbnailProps.focusPoint.y': 1,
+export const WithFocusPointVertical = {
+    args: {
+        size: Size.xxl,
+        image: PORTRAIT_IMAGES.portrait1,
+        'thumbnailProps.aspectRatio': AspectRatio.horizontal,
+        'thumbnailProps.focusPoint.x': 0,
+        'thumbnailProps.focusPoint.y': 1,
+    },
+    argTypes: {
+        'thumbnailProps.focusPoint.x': focusPoint,
+        'thumbnailProps.focusPoint.y': focusPoint,
+    },
 };
-WithFocusPointVertical.argTypes = {
-    'thumbnailProps.focusPoint.x': focusPoint,
-    'thumbnailProps.focusPoint.y': focusPoint,
+export const FullFeatured = {
+    args: {
+        ...WithCaptionBelow.args,
+        ...WithTags.args,
+        ...WithActions.args,
+        ...WithFocusPointVertical.args,
+        ...WithAlign.args,
+    },
+    decorators: [withWrapper({ style: { width: 400, height: 300 } })],
 };

--- a/packages/lumx-react/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageBlock.tsx
@@ -1,14 +1,14 @@
-import React, { CSSProperties, forwardRef, ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
-
-import isObject from 'lodash/isObject';
 
 import { Alignment, HorizontalAlignment, Size, Theme, Thumbnail } from '@lumx/react';
 
 import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+
 import { ThumbnailProps } from '../thumbnail/Thumbnail';
+import { ImageCaption, ImageCaptionMetadata } from './ImageCaption';
 
 /**
  * Image block variants.
@@ -27,7 +27,7 @@ export type ImageBlockSize = Extract<Size, 'xl' | 'xxl'>;
 /**
  * Defines the props of the component.
  */
-export interface ImageBlockProps extends GenericProps, HasTheme {
+export interface ImageBlockProps extends GenericProps, HasTheme, ImageCaptionMetadata {
     /** Action toolbar content. */
     actions?: ReactNode;
     /** Alignment. */
@@ -36,22 +36,14 @@ export interface ImageBlockProps extends GenericProps, HasTheme {
     alt: string;
     /** Caption position. */
     captionPosition?: ImageBlockCaptionPosition;
-    /** Caption custom CSS style. */
-    captionStyle?: CSSProperties;
-    /** Image description. Can be either a string, or sanitized html. */
-    description?: string | { __html: string };
     /** Whether the image has to fill its container height or not. */
     fillHeight?: boolean;
     /** Image URL. */
     image: string;
     /** Size variant. */
     size?: ImageBlockSize;
-    /** Tag content. */
-    tags?: ReactNode;
     /** Props to pass to the thumbnail (minus those already set by the ImageBlock props). */
     thumbnailProps?: Omit<ThumbnailProps, 'image' | 'size' | 'theme' | 'align' | 'fillHeight'>;
-    /** Image title to display in the caption. */
-    title?: string;
 }
 
 /**
@@ -124,24 +116,17 @@ export const ImageBlock: Comp<ImageBlockProps, HTMLDivElement> = forwardRef((pro
                 theme={theme}
                 alt={(alt || title) as string}
             />
-            {(title || description || tags) && (
-                <figcaption className={`${CLASSNAME}__wrapper`} style={captionStyle}>
-                    {(title || description) && (
-                        <div className={`${CLASSNAME}__caption`}>
-                            {title && <span className={`${CLASSNAME}__title`}>{title}</span>}
-                            {/* Add an `&nbsp;` when there is description and title. */}
-                            {title && description && '\u00A0'}
-                            {isObject(description) && description.__html ? (
-                                // eslint-disable-next-line react/no-danger
-                                <span dangerouslySetInnerHTML={description} className={`${CLASSNAME}__description`} />
-                            ) : (
-                                <span className={`${CLASSNAME}__description`}>{description}</span>
-                            )}
-                        </div>
-                    )}
-                    {tags && <div className={`${CLASSNAME}__tags`}>{tags}</div>}
-                </figcaption>
-            )}
+            <ImageCaption
+                as="figcaption"
+                className={`${CLASSNAME}__wrapper`}
+                theme={theme}
+                title={title}
+                description={description}
+                tags={tags}
+                captionStyle={captionStyle}
+                align={align}
+                truncate={captionPosition === 'over'}
+            />
             {actions && <div className={`${CLASSNAME}__actions`}>{actions}</div>}
         </figure>
     );

--- a/packages/lumx-react/src/components/image-block/ImageCaption.tsx
+++ b/packages/lumx-react/src/components/image-block/ImageCaption.tsx
@@ -1,0 +1,68 @@
+import React, { CSSProperties, ReactNode } from 'react';
+
+import { FlexBox, HorizontalAlignment, Text, TextProps } from '@lumx/react';
+import { HasClassName, HasPolymorphicAs, HasTheme } from '@lumx/react/utils/type';
+
+type As = 'div' | 'figcaption';
+
+export type ImageCaptionMetadata = {
+    /** Image title to display in the caption. */
+    title?: string;
+    /** Image description. Can be either a string, or sanitized html. */
+    description?: string | { __html: string };
+    /** Tag content. */
+    tags?: ReactNode;
+    /** Caption custom CSS style. */
+    captionStyle?: CSSProperties;
+};
+
+export type ImageCaptionProps<AS extends As = 'figcaption'> = HasTheme &
+    HasClassName &
+    HasPolymorphicAs<AS> &
+    ImageCaptionMetadata & {
+        /** Alignment. */
+        align?: HorizontalAlignment;
+        /** Truncate text on title & description (no line wrapping). */
+        truncate?: TextProps['truncate'];
+    };
+
+/** Internal component used to render image captions */
+export const ImageCaption = <AS extends As>(props: ImageCaptionProps<AS>) => {
+    const { className, theme, as = 'figcaption', title, description, tags, captionStyle, align, truncate } = props;
+    if (!title && !description && !tags) return null;
+
+    const titleColor = { color: theme === 'dark' ? 'light' : 'dark' } as const;
+    const baseColor = { color: theme === 'dark' ? 'light' : 'dark', colorVariant: 'L2' } as const;
+
+    // Display description as string or HTML
+    const descriptionContent =
+        typeof description === 'string' ? { children: description } : { dangerouslySetInnerHTML: description };
+
+    return (
+        <FlexBox
+            as={as}
+            className={className}
+            style={captionStyle}
+            orientation="vertical"
+            vAlign={align}
+            hAlign={align === 'center' ? align : undefined}
+            gap="regular"
+        >
+            {(title || description) && (
+                <Text as="p" truncate={truncate} {...baseColor}>
+                    {title && (
+                        <Text as="span" typography="subtitle1" {...titleColor}>
+                            {title}
+                        </Text>
+                    )}{' '}
+                    {description && <Text as="span" typography="body1" {...descriptionContent} />}
+                </Text>
+            )}
+            {tags && (
+                <FlexBox orientation="horizontal" vAlign={align}>
+                    {tags}
+                </FlexBox>
+            )}
+        </FlexBox>
+    );
+};


### PR DESCRIPTION
# General summary

- Extract image caption rendering in an internal component (not exposed in the lib but will be reused in the ImageLightbox)
- Removing custom styles (use inline component styles from FlexBox, Text, etc.)


These changes should not impact usage or render of the existing ImageBlock

StoryBook: https://a010d7cc--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=381)) **⚠️ Outdated commit**