### PR TITLE
feat(thumbnail): add loading placeholder image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -  `Heading`: fix the default typography when the `as` prop is set.
 -  `ImageBlock`: internal changes on caption styles (simply and make reusable).
 
+### Added
+
+-  `Thumbnail`: add `loadingPlaceholderImageRef` to re-use a loaded image as the loading placeholder.
+
 ## [3.7.5][] - 2024-07-25
 
 ### Changed

--- a/packages/lumx-core/src/scss/components/thumbnail/_index.scss
+++ b/packages/lumx-core/src/scss/components/thumbnail/_index.scss
@@ -58,6 +58,9 @@
         max-width: 100%;
         max-height: 100%;
         font-size: 0;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: var(--lumx-thumbnail-image-object-fit, cover);
 
         &--has-defined-size {
             width: fit-content;

--- a/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
+++ b/packages/lumx-react/src/components/thumbnail/Thumbnail.stories.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
+import uniqueId from 'lodash/uniqueId';
+
 import { mdiAbTesting } from '@lumx/icons';
 import {
     Alignment,
     AspectRatio,
     Badge,
+    Button,
     FlexBox,
     GridColumn,
     Icon,
@@ -411,3 +414,35 @@ export const ObjectFit = {
         withWrapper({ maxColumns: 3, itemMinWidth: 350 }, GridColumn),
     ],
 };
+
+/**
+ * Demonstrate loading a small image and then use it as the loading placeholder image when loading a bigger image
+ */
+export const LoadingPlaceholderImage = () => {
+    const [isShown, setShown] = React.useState(false);
+    const imgRef = React.useRef() as React.RefObject<HTMLImageElement>;
+    return (
+        <>
+            <Button onClick={() => setShown((shown) => !shown)}>
+                Display bigger image using the small image as a placeholder
+            </Button>
+            <FlexBox orientation="horizontal">
+                <Thumbnail alt="Small image" imgRef={imgRef} image="https://picsum.photos/id/15/128/85" />
+                {isShown && (
+                    <div style={{ maxHeight: 400 }}>
+                        <Thumbnail
+                            image={`https://picsum.photos/id/15/2500/1667?cacheBust${uniqueId()}`}
+                            alt="Large image"
+                            // Loading placeholder image
+                            loadingPlaceholderImageRef={imgRef}
+                            // Reserve space
+                            imgProps={{ width: 2500, height: 1667 }}
+                        />
+                    </div>
+                )}
+            </FlexBox>
+        </>
+    );
+};
+// Disables Chromatic snapshot (not relevant for this story).
+LoadingPlaceholderImage.parameters = { chromatic: { disable: true } };

--- a/packages/site-demo/content/product/components/thumbnail/index.mdx
+++ b/packages/site-demo/content/product/components/thumbnail/index.mdx
@@ -61,6 +61,10 @@ Three type of size constraints can be used:
 - using `fillHeight` to fit the parent height.
 - using a fixed ratio (any ratio except `free` and `original`) and a width constraint (using `size` prop or manual CSS).
 
+When loading a larger version of an image already loaded in the current page, the `loadingPlaceholderImageRef` can be
+used to provide the reference to the smaller image that will be used as a placeholder image displayed while the larger
+image loads.
+
 ## Error state
 
 Thumbnails will display an error state by default when the image fails to load correctly.


### PR DESCRIPTION
# General summary


Add `loadingPlaceholderImageRef` prop to re-use a loaded image as the loading placeholder.

If the given placeholder image is indeed already loaded, we use it as the background of the loading image.

This is useful when a small thumbnail is clicked to trigger the loading of a larger version of the same image

<details><summary>Demo</summary>

https://github.com/user-attachments/assets/5a55263f-98af-4976-933f-f225593e60e3

</details>


StoryBook: https://fd90435f--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=380)) **⚠️ Outdated commit**