### PR TITLE
fix(heading): fix default typography when ̀`as` is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `Mosaic`: fix thumbnail focus outline cropped by parent overflow.
 -   `SlideShow`: fix pagination item focus outline cropped by parent overflow.
 
+### Changed
+
+- `Heading`: fix the default typography when the `as` prop is set.
+
 ## [3.7.5][] - 2024-07-25
 
 ### Changed

--- a/packages/lumx-react/src/components/heading/Heading.test.tsx
+++ b/packages/lumx-react/src/components/heading/Heading.test.tsx
@@ -21,13 +21,15 @@ describe(`<${Heading.displayName}>`, () => {
             const heading = screen.getByRole('heading', { level: 1, name: 'Some text' });
             expect(heading).toBeInTheDocument();
             expect(heading).toHaveClass(CLASSNAME);
+            expect(heading).toHaveClass('lumx-typography-display1');
         });
 
-        it('should render with as', () => {
+        it('should render with as with the correct default typography', () => {
             setup({ children: 'Some text', as: 'h2' });
             const heading = screen.getByRole('heading', { level: 2, name: 'Some text' });
             expect(heading).toBeInTheDocument();
             expect(heading).toHaveClass(CLASSNAME);
+            expect(heading).toHaveClass('lumx-typography-headline');
         });
 
         it('should correctly render levels nested in HeadingLevel', () => {

--- a/packages/lumx-react/src/components/heading/Heading.tsx
+++ b/packages/lumx-react/src/components/heading/Heading.tsx
@@ -40,6 +40,7 @@ export const Heading: Comp<HeadingProps> = forwardRef((props, ref) => {
     const { children, as, className, ...forwardedProps } = props;
     const { headingElement } = useHeadingLevel();
 
+    const computedHeadingElement = as || headingElement;
     return (
         <Text
             ref={ref}
@@ -49,8 +50,8 @@ export const Heading: Comp<HeadingProps> = forwardRef((props, ref) => {
                     prefix: CLASSNAME,
                 }),
             )}
-            as={as || headingElement}
-            typography={DEFAULT_TYPOGRAPHY_BY_LEVEL[headingElement]}
+            as={computedHeadingElement}
+            typography={DEFAULT_TYPOGRAPHY_BY_LEVEL[computedHeadingElement]}
             {...forwardedProps}
         >
             {children}


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->
When the `as` prop was set on `Heading` component, the default `typography` was not set correctly. It was only checking the calulated heading level, coming from an hypothetic HeadingLevelContext. If the context was not provided, it was using `h1` typography even for other levels.


# Screenshots
|Before   |After   |
|---|---|
|  ![image](https://github.com/user-attachments/assets/d50a1aa2-fedc-473f-bdf9-2a354f1fe4dc) |![image](https://github.com/user-attachments/assets/75e80c07-4180-4f57-ab06-94bba36ff262) |


<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
