### PR TITLE
chore(slideshow): fix small error in pagination items width

### DIFF
--- a/packages/lumx-core/src/scss/components/slideshow/_index.scss
+++ b/packages/lumx-core/src/scss/components/slideshow/_index.scss
@@ -93,7 +93,7 @@
     &__pagination {
         align-items: center;
         // Compute max width for N items based on their size, margin and focus outline
-        max-width: ($item-max-count * ($item-size + $item-margin-inline)) + $item-focus-outline;
+        max-width: ($item-max-count * ($item-size + $item-margin-inline)) + $item-focus-outline * 2;
         overflow: hidden;
     }
 


### PR DESCRIPTION
# General summary

Fixed a small oversight from https://github.com/lumapps/design-system/pull/1149 where the focus outline would still be cropped when selecting the right-most pagination item.

(not updating the CHANGELOG because there is already an entry talking about the fix from #1149)
