### PR TITLE
refactor(utils): rework internal unique id generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   `DatePicker`: improve display of localized day number.
+-   Reworked internal id generation (linking fields with labels, a11y attributes). Removed the `uid` dependency.
 
 ## [3.8.1][] - 2024-08-14
 

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -12,8 +12,7 @@
         "body-scroll-lock": "^3.1.5",
         "classnames": "^2.3.2",
         "react-is": ">=16.13.0",
-        "react-popper": "^2.2.4",
-        "uid": "^2.0.0"
+        "react-popper": "^2.2.4"
     },
     "devDependencies": {
         "@babel/core": "^7.18.13",

--- a/packages/lumx-react/src/components/alert-dialog/AlertDialog.test.tsx
+++ b/packages/lumx-react/src/components/alert-dialog/AlertDialog.test.tsx
@@ -5,7 +5,7 @@ import { queryByClassName } from '@lumx/react/testing/utils/queries';
 import { render } from '@testing-library/react';
 import { AlertDialog, AlertDialogProps } from './AlertDialog';
 
-jest.mock('uid', () => ({ uid: () => 'uid' }));
+jest.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
 
 const CLASSNAME = AlertDialog.className as string;
 

--- a/packages/lumx-react/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/lumx-react/src/components/alert-dialog/AlertDialog.tsx
@@ -16,9 +16,9 @@ import {
 } from '@lumx/react';
 
 import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons';
-import { uid } from 'uid';
 import { Comp } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { useId } from '@lumx/react/hooks/useId';
 
 export interface AlertDialogProps extends Omit<DialogProps, 'header' | 'footer'> {
     /** Message variant. */
@@ -86,7 +86,8 @@ export const AlertDialog: Comp<AlertDialogProps, HTMLDivElement> = forwardRef((p
     const { color, icon } = CONFIG[kind as Kind] || {};
 
     // Define a unique ID to target title and description for aria attributes.
-    const uniqueId = React.useMemo(() => id || uid(), [id]);
+    const generatedId = useId();
+    const uniqueId = id || generatedId;
     const titleId = `${uniqueId}-title`;
     const descriptionId = `${uniqueId}-description`;
 

--- a/packages/lumx-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-react/src/components/checkbox/Checkbox.tsx
@@ -1,13 +1,13 @@
-import React, { forwardRef, InputHTMLAttributes, ReactNode, SyntheticEvent, useMemo } from 'react';
+import React, { forwardRef, InputHTMLAttributes, ReactNode, SyntheticEvent } from 'react';
 
 import classNames from 'classnames';
-import { uid } from 'uid';
 
 import { mdiCheck, mdiMinus } from '@lumx/icons';
 
 import { Icon, InputHelper, InputLabel, Theme } from '@lumx/react';
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { useId } from '@lumx/react/hooks/useId';
 import { useMergeRefs } from '@lumx/react/utils/mergeRefs';
 
 /**
@@ -84,7 +84,8 @@ export const Checkbox: Comp<CheckboxProps, HTMLDivElement> = forwardRef((props, 
         ...forwardedProps
     } = props;
     const localInputRef = React.useRef<HTMLInputElement>(null);
-    const inputId = useMemo(() => id || `${CLASSNAME.toLowerCase()}-${uid()}`, [id]);
+    const generatedInputId = useId();
+    const inputId = id || generatedInputId;
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {

--- a/packages/lumx-react/src/components/navigation/NavigationSection.tsx
+++ b/packages/lumx-react/src/components/navigation/NavigationSection.tsx
@@ -1,12 +1,13 @@
-import React, { forwardRef, ReactNode, useRef, useState, useMemo, useContext } from 'react';
+import React, { forwardRef, ReactNode, useRef, useState, useContext } from 'react';
 
 import { mdiChevronDown, mdiChevronUp } from '@lumx/icons';
 import { Icon, Size, Text, Orientation, Popover, Placement, Theme } from '@lumx/react';
-import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { HasClassName } from '@lumx/react/utils/type';
 import { ThemeContext } from '@lumx/react/utils/ThemeContext';
+import { useId } from '@lumx/react/hooks/useId';
+
 import { CLASSNAME as ITEM_CLASSNAME } from './NavigationItem';
 import { NavigationContext } from './context';
 
@@ -34,7 +35,7 @@ export const NavigationSection = Object.assign(
         const { children, className, label, icon, ...forwardedProps } = props;
         const [isOpen, setIsOpen] = useState(false);
         const buttonRef = useRef<HTMLButtonElement>(null);
-        const sectionId = useMemo(() => uniqueId('section'), []);
+        const sectionId = useId();
         const { orientation } = useContext(NavigationContext) || {};
         const theme = useContext(ThemeContext);
         const isDropdown = orientation === Orientation.horizontal;

--- a/packages/lumx-react/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-react/src/components/radio-button/RadioButton.tsx
@@ -1,12 +1,12 @@
-import React, { useMemo, forwardRef, ReactNode, SyntheticEvent, InputHTMLAttributes } from 'react';
+import React, { forwardRef, ReactNode, SyntheticEvent, InputHTMLAttributes } from 'react';
 
 import classNames from 'classnames';
-import { uid } from 'uid';
 
 import { InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { useId } from '@lumx/react/hooks/useId';
 
 /**
  * Defines the props of the component.
@@ -76,7 +76,8 @@ export const RadioButton: Comp<RadioButtonProps, HTMLDivElement> = forwardRef((p
         inputProps,
         ...forwardedProps
     } = props;
-    const inputId = useMemo(() => id || `${CLASSNAME.toLowerCase()}-${uid()}`, [id]);
+    const generatedInputId = useId();
+    const inputId = id || generatedInputId;
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {

--- a/packages/lumx-react/src/components/select/Select.test.tsx
+++ b/packages/lumx-react/src/components/select/Select.test.tsx
@@ -14,7 +14,7 @@ import { Select, SelectProps, SelectVariant } from './Select';
 const CLASSNAME = Select.className as string;
 
 jest.mock('@lumx/react/utils/isFocusVisible');
-jest.mock('uid', () => ({ uid: () => 'uid' }));
+jest.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
 
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.

--- a/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
+++ b/packages/lumx-react/src/components/select/SelectMultiple.test.tsx
@@ -18,7 +18,7 @@ import { SelectVariant } from './constants';
 
 const CLASSNAME = SelectMultiple.className as string;
 
-jest.mock('uid', () => ({ uid: () => 'uid' }));
+jest.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
 
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.

--- a/packages/lumx-react/src/components/select/WithSelectContext.tsx
+++ b/packages/lumx-react/src/components/select/WithSelectContext.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
-import React, { Ref, useCallback, useMemo, useRef } from 'react';
-import { uid } from 'uid';
+import React, { Ref, useCallback, useRef } from 'react';
 
 import { Placement } from '@lumx/react';
 import { Kind, Theme } from '@lumx/react/components';
@@ -11,6 +10,7 @@ import { useListenFocus } from '@lumx/react/hooks/useListenFocus';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 
+import { useId } from '@lumx/react/hooks/useId';
 import { CoreSelectProps, SelectVariant } from './constants';
 
 /** The display name of the component. */
@@ -56,7 +56,8 @@ export const WithSelectContext = (
     }: CoreSelectProps,
     ref: Ref<HTMLDivElement>,
 ): React.ReactElement => {
-    const selectId = useMemo(() => id || `select-${uid()}`, [id]);
+    const generatedSelectId = useId();
+    const selectId = id || generatedSelectId;
     const anchorRef = useRef<HTMLElement>(null);
     const selectRef = useRef<HTMLDivElement>(null);
     const dropdownRef = useRef<HTMLDivElement>(null);

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.test.tsx
@@ -10,7 +10,7 @@ const CLASSNAME = SideNavigationItem.className as string;
 
 const toggleButtonProps = { label: 'Toggle' };
 
-jest.mock('uid', () => ({ uid: () => 'id' }));
+jest.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
 
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -2,7 +2,6 @@ import React, { Children, forwardRef, ReactNode } from 'react';
 
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
-import { uid } from 'uid';
 
 import { mdiChevronDown, mdiChevronUp } from '@lumx/icons';
 
@@ -12,6 +11,7 @@ import { Comp, GenericProps, isComponent } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { renderLink } from '@lumx/react/utils/renderLink';
 import { renderButtonOrLink } from '@lumx/react/utils/renderButtonOrLink';
+import { useId } from '@lumx/react/hooks/useId';
 
 /**
  * Defines the props of the component.
@@ -95,7 +95,7 @@ export const SideNavigationItem: Comp<SideNavigationItemProps, HTMLLIElement> = 
     const shouldSplitActions = Boolean(onActionClick);
     const showChildren = hasContent && isOpen;
 
-    const contentId = React.useMemo(uid, []);
+    const contentId = useId();
     const ariaProps: any = {};
     if (hasContent) {
         ariaProps['aria-expanded'] = !!showChildren;

--- a/packages/lumx-react/src/components/slider/Slider.test.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.test.tsx
@@ -7,7 +7,7 @@ import { Slider, SliderProps } from './Slider';
 
 const CLASSNAME = Slider.className as string;
 
-jest.mock('uid', () => ({ uid: () => 'uid' }));
+jest.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
 
 const setup = (props: Partial<SliderProps> = {}) => {
     render(<Slider {...(props as any)} />);

--- a/packages/lumx-react/src/components/slider/Slider.tsx
+++ b/packages/lumx-react/src/components/slider/Slider.tsx
@@ -9,8 +9,8 @@ import useEventCallback from '@lumx/react/hooks/useEventCallback';
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 
-import { uid } from 'uid';
 import { clamp } from '@lumx/react/utils/clamp';
+import { useId } from '@lumx/react/hooks/useId';
 
 /**
  * Defines the props of the component.
@@ -111,7 +111,8 @@ export const Slider: Comp<SliderProps, HTMLDivElement> = forwardRef((props, ref)
         value,
         ...forwardedProps
     } = props;
-    const sliderId = useMemo(() => id || `slider-${uid()}`, [id]);
+    const generatedId = useId();
+    const sliderId = id || generatedId;
     const sliderLabelId = useMemo(() => `label-${sliderId}`, [sliderId]);
     const sliderRef = useRef<HTMLDivElement>(null);
 

--- a/packages/lumx-react/src/components/switch/Switch.test.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.test.tsx
@@ -24,7 +24,7 @@ const setup = (propsOverride: SetupProps = {}) => {
     return { switchWrapper, input, helper, label, props };
 };
 
-jest.mock('uid', () => ({ uid: () => 'uid' }));
+jest.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
 
 describe(`<${Switch.displayName}>`, () => {
     describe('Props', () => {

--- a/packages/lumx-react/src/components/switch/Switch.tsx
+++ b/packages/lumx-react/src/components/switch/Switch.tsx
@@ -1,7 +1,6 @@
-import React, { Children, forwardRef, InputHTMLAttributes, SyntheticEvent, useMemo } from 'react';
+import React, { Children, forwardRef, InputHTMLAttributes, SyntheticEvent } from 'react';
 
 import classNames from 'classnames';
-import { uid } from 'uid';
 
 import isEmpty from 'lodash/isEmpty';
 
@@ -9,6 +8,7 @@ import { Alignment, InputHelper, InputLabel, Theme } from '@lumx/react';
 
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { useId } from '@lumx/react/hooks/useId';
 
 /**
  * Defines the props of the component.
@@ -75,7 +75,8 @@ export const Switch: Comp<SwitchProps, HTMLDivElement> = forwardRef((props, ref)
         inputProps = {},
         ...forwardedProps
     } = props;
-    const inputId = useMemo(() => id || `switch-${uid()}`, [id]);
+    const generatedInputId = useId();
+    const inputId = id || generatedInputId;
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
             onChange(!isChecked, value, name, event);

--- a/packages/lumx-react/src/components/tabs/state.ts
+++ b/packages/lumx-react/src/components/tabs/state.ts
@@ -1,5 +1,5 @@
 import { Dispatch, createContext, useCallback, useContext, useEffect, useMemo } from 'react';
-import { uid } from 'uid';
+import { useId } from '@lumx/react/hooks/useId';
 
 type TabType = 'tab' | 'tabPanel';
 
@@ -76,11 +76,9 @@ export const useTabProviderContext = (type: TabType, originalId?: string): undef
     const [state, dispatch] = context;
 
     // Current tab or tab panel id.
-    const id = useMemo(
-        () => originalId || `${type}-${uid()}`,
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [],
-    );
+    const generatedId = useId();
+    const id = originalId || generatedId;
+
     useEffect(
         () => {
             // On mount: register tab or tab panel id.

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -1,18 +1,7 @@
-import React, {
-    forwardRef,
-    ReactNode,
-    Ref,
-    RefObject,
-    SyntheticEvent,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import React, { forwardRef, ReactNode, Ref, RefObject, SyntheticEvent, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 import get from 'lodash/get';
-import { uid } from 'uid';
 
 import { mdiAlertCircle, mdiCheckCircle, mdiCloseCircle } from '@lumx/icons';
 import {
@@ -30,6 +19,7 @@ import {
 import { Comp, GenericProps, HasTheme } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+import { useId } from '@lumx/react/hooks/useId';
 
 /**
  * Defines the props of the component.
@@ -296,7 +286,8 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
         afterElement,
         ...forwardedProps
     } = props;
-    const textFieldId = useMemo(() => id || `text-field-${uid()}`, [id]);
+    const generatedTextFieldId = useId();
+    const textFieldId = id || generatedTextFieldId;
     /** Keep a clean local input ref to manage focus */
     const localInputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
     /** Merge prop input ref and local input ref */
@@ -307,8 +298,8 @@ export const TextField: Comp<TextFieldProps, HTMLDivElement> = forwardRef((props
      * we want to first use the most important one, which is the errorId. That way, screen readers will read first
      * the error and then the helper
      */
-    const helperId = helper ? `text-field-helper-${uid()}` : undefined;
-    const errorId = error ? `text-field-error-${uid()}` : undefined;
+    const helperId = helper ? `text-field-helper-${generatedTextFieldId}` : undefined;
+    const errorId = error ? `text-field-error-${generatedTextFieldId}` : undefined;
     const describedByIds = [errorId, helperId, forwardedProps['aria-describedby']].filter(Boolean);
     const describedById = describedByIds.length === 0 ? undefined : describedByIds.join(' ');
 

--- a/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
@@ -12,7 +12,7 @@ import { Tooltip, TooltipProps } from './Tooltip';
 const CLASSNAME = Tooltip.className as string;
 
 jest.mock('@lumx/react/utils/isFocusVisible');
-jest.mock('uid', () => ({ uid: () => 'uid' }));
+jest.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
 // Skip delays
 jest.mock('@lumx/react/constants', () => ({
     ...jest.requireActual('@lumx/react/constants'),

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import React, { forwardRef, ReactNode, useMemo, useState } from 'react';
+import React, { forwardRef, ReactNode, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
-import { uid } from 'uid';
 
 import classNames from 'classnames';
 
@@ -11,8 +10,9 @@ import { Comp, GenericProps } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { mergeRefs } from '@lumx/react/utils/mergeRefs';
 import { Placement } from '@lumx/react/components/popover';
-
 import { TooltipContextProvider } from '@lumx/react/components/tooltip/context';
+import { useId } from '@lumx/react/hooks/useId';
+
 import { useInjectTooltipRef } from './useInjectTooltipRef';
 import { useTooltipOpen } from './useTooltipOpen';
 
@@ -71,7 +71,7 @@ export const Tooltip: Comp<TooltipProps, HTMLDivElement> = forwardRef((props, re
         return <TooltipContextProvider>{children}</TooltipContextProvider>;
     }
 
-    const id = useMemo(() => `tooltip-${uid()}`, []);
+    const id = useId();
 
     const [popperElement, setPopperElement] = useState<null | HTMLElement>(null);
     const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);

--- a/packages/lumx-react/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-react/src/components/uploader/Uploader.tsx
@@ -1,11 +1,11 @@
 import React, { forwardRef, MouseEventHandler } from 'react';
 import classNames from 'classnames';
-import uniqueId from 'lodash/uniqueId';
 
 import { AspectRatio, Icon, Size, Theme } from '@lumx/react';
 import { Comp, GenericProps, HasTheme, ValueOf } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { useBooleanState } from '@lumx/react/hooks/useBooleanState';
+import { useId } from '@lumx/react/hooks/useId';
 
 /**
  * Uploader variants.
@@ -81,7 +81,8 @@ export const Uploader: Comp<UploaderProps> = forwardRef((props, ref) => {
     // Adjust to square aspect ratio when using circle variants.
     const adjustedAspectRatio = variant === UploaderVariant.circle ? AspectRatio.square : aspectRatio;
 
-    const inputId = React.useMemo(() => fileInputProps?.id || uniqueId('uploader-input-'), [fileInputProps?.id]);
+    const generatedInputId = useId();
+    const inputId = fileInputProps?.id || generatedInputId;
     const [isDragHovering, unsetDragHovering, setDragHovering] = useBooleanState(false);
     const wrapper = fileInputProps
         ? { Component: 'label' as const, props: { htmlFor: inputId } as const }

--- a/packages/lumx-react/src/hooks/useId.test.tsx
+++ b/packages/lumx-react/src/hooks/useId.test.tsx
@@ -1,0 +1,23 @@
+import { useId } from '@lumx/react/hooks/useId';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+function setup() {
+    const Component = (): any => useId();
+    const result = render(<Component />);
+    const rerender = () => result.rerender(<Component />);
+    return { ...result, rerender };
+}
+
+describe(useId, () => {
+    it('should render a unique id stable after re-renders', () => {
+        const result = setup();
+        // Id generated
+        const initialId = result.container.textContent;
+        expect(initialId).toMatch(/:lumx\d+:/);
+
+        // Id is stable after re-render
+        result.rerender();
+        expect(result.container.textContent).toEqual(initialId);
+    });
+});

--- a/packages/lumx-react/src/hooks/useId.ts
+++ b/packages/lumx-react/src/hooks/useId.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+let i = 0;
+
+/**
+ * Generate a unique id (for use in a11y or other id based DOM linking).
+ *
+ * (Tries to emulate React 18 useId hook, to remove once we upgrade React)
+ */
+export function useId() {
+    return React.useMemo(() => {
+        i += 1;
+        return `:lumx${i}:`;
+    }, []);
+}

--- a/packages/lumx-react/src/hooks/useSlideshowControls.ts
+++ b/packages/lumx-react/src/hooks/useSlideshowControls.ts
@@ -1,8 +1,8 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 import { useInterval } from '@lumx/react/hooks/useInterval';
-import uniqueId from 'lodash/uniqueId';
 import { AUTOPLAY_DEFAULT_INTERVAL } from '@lumx/react/components/slideshow/constants';
+import { useId } from '@lumx/react/hooks/useId';
 
 export interface UseSlideshowControlsOptions {
     /** default active index to be displayed */
@@ -193,8 +193,11 @@ export const useSlideshowControls = ({
         onChange(currentIndex);
     }, [currentIndex, onChange]);
 
-    const slideshowId = useMemo(() => id || uniqueId('slideshow'), [id]);
-    const slideshowSlidesId = useMemo(() => slidesId || uniqueId('slideshow-slides'), [slidesId]);
+    const generatedSlideshowId = useId();
+    const slideshowId = id || generatedSlideshowId;
+
+    const generatedSlidesId = useId();
+    const slideshowSlidesId = slidesId || generatedSlidesId;
 
     const toggleAutoPlay = () => {
         if (isSlideshowAutoPlaying) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3708,13 +3708,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lukeed/csprng@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@lukeed/csprng@npm:1.0.0"
-  checksum: 331cdeb48f716c5d905d1ff7c0df36ff2cc294bce7e266196d75d130609685d6d37f6f8ac683b4c9bfa6a98cd4884f4e974e810a11c291d98b4af4eefa15c3b5
-  languageName: node
-  linkType: hard
-
 "@lumx/angularjs@^3.8.1, @lumx/angularjs@workspace:packages/lumx-angularjs":
   version: 0.0.0-use.local
   resolution: "@lumx/angularjs@workspace:packages/lumx-angularjs"
@@ -3909,7 +3902,6 @@ __metadata:
     rollup-plugin-typescript-paths: ^1.2.2
     storybook: ^7.6.3
     typescript: ^5.4.3
-    uid: ^2.0.0
     vite: ^4.2.1
     vite-tsconfig-paths: ^4.0.7
     yargs: ^15.4.1
@@ -33791,15 +33783,6 @@ resolve@^1.9.0:
   version: 0.0.6
   resolution: "uid-number@npm:0.0.6"
   checksum: ff17525bb9b17313b839222efa1fe69baf136992cf675e8d1d50e9b1ef4563742968e390a96a57645d99cf8b283866c36ef9747bbf186bbbf2ef601b60ed4443
-  languageName: node
-  linkType: hard
-
-"uid@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "uid@npm:2.0.0"
-  dependencies:
-    "@lukeed/csprng": ^1.0.0
-  checksum: c9333014d9ecc33d6c92ca8e9af8c52f172704b07af3a142879af368b7636f6ffff48cf87bc6021d4c85c7a0b255665ff0fe733f4b4a842f7bfd75638d31dd48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# General summary

- Refactor internal id generation (emulate react 18 useId)
- Remove uid lib & use of lodash uniqueId



StoryBook: https://afa3d84f--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=386)) **⚠️ Outdated commit**