### PR TITLE
feat(date-picker): improve display of localized day number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `ImageLightbox`: new component providing an image slideshow lightbox with extra features (zoom & a11y).
 
+### Changed
+
+-   `DatePicker`: improve display of localized day number.
+
 ## [3.8.1][] - 2024-08-14
 
 ### Fixed

--- a/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
+++ b/packages/lumx-react/src/components/date-picker/DatePickerControlled.tsx
@@ -12,6 +12,7 @@ import { usePreviousValue } from '@lumx/react/hooks/usePreviousValue';
 import { getYearDisplayName } from '@lumx/react/utils/date/getYearDisplayName';
 import { onEnterPressed } from '@lumx/react/utils/event';
 import { addMonthResetDay } from '@lumx/react/utils/date/addMonthResetDay';
+import { formatDayNumber } from '@lumx/react/utils/date/formatDayNumber';
 import { CLASSNAME } from './constants';
 
 /**
@@ -198,9 +199,7 @@ export const DatePickerControlled: Comp<DatePickerControlledProps, HTMLDivElemen
                                             type="button"
                                             onClick={() => onChange(date)}
                                         >
-                                            <span aria-hidden>
-                                                {date.toLocaleDateString(locale, { day: 'numeric' })}
-                                            </span>
+                                            <span aria-hidden>{formatDayNumber(locale, date)}</span>
                                             <span className="visually-hidden">
                                                 {date.toLocaleDateString(locale, {
                                                     day: 'numeric',

--- a/packages/lumx-react/src/utils/date/formatDayNumber.test.ts
+++ b/packages/lumx-react/src/utils/date/formatDayNumber.test.ts
@@ -1,0 +1,12 @@
+import { formatDayNumber } from '@lumx/react/utils/date/formatDayNumber';
+
+describe(formatDayNumber, () => {
+    it('should format ', () => {
+        // Standard numerical formatting.
+        expect(formatDayNumber('en', new Date('2024-05-11'))).toEqual('11');
+        // Keep only the numerical part (if any). Raw formatted day number here is '11日'.
+        expect(formatDayNumber('ja', new Date('2024-05-11'))).toEqual('11');
+        // Else Keep the non-numerical formatting
+        expect(formatDayNumber('ar-eg', new Date('2024-05-11'))).toEqual('١١');
+    });
+});

--- a/packages/lumx-react/src/utils/date/formatDayNumber.ts
+++ b/packages/lumx-react/src/utils/date/formatDayNumber.ts
@@ -1,0 +1,5 @@
+export function formatDayNumber(locale: string, date: Date): string {
+    const formattedDate = date.toLocaleDateString(locale, { day: 'numeric' });
+    if (formattedDate.match(/\d/)) return formattedDate.replace(/\D*(\d+)\D*/g, '$1');
+    return formattedDate;
+}


### PR DESCRIPTION
# General summary

Detect if the base translated day number contains some numerical character, in which case we only display them. Or if it doesn't, we display the base translated day number.
Example:
- English => 11
- Japanese => 11日 (original browser translation) => 11 (extracted numerical value)
- Arabic => ١١ (no numerical value)

StoryBook: https://df3a46be--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=387)) **⚠️ Outdated commit**