### PR TITLE
feat(user-block xs): added a size XS to usr block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `ImageLightbox`: new component providing an image slideshow lightbox with extra features (zoom & a11y).
+-   `UserBlock`: added an XS size.
 
 ### Changed
 

--- a/packages/lumx-core/src/scss/components/user-block/_index.scss
+++ b/packages/lumx-core/src/scss/components/user-block/_index.scss
@@ -15,6 +15,10 @@
     }
 
     &__avatar {
+        #{$self}--orientation-horizontal#{$self}--size-xs & {
+            margin-right: $lumx-spacing-unit;
+        }
+
         #{$self}--orientation-horizontal#{$self}--size-s & {
             margin-right: $lumx-spacing-unit;
         }
@@ -41,6 +45,11 @@
     &__name {
         width: fit-content;
         outline: none;
+
+        #{$self}--size-xs & {
+            @include lumx-typography("body1");
+        }
+
 
         @include lumx-typography("subtitle1");
 

--- a/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.stories.tsx
@@ -9,7 +9,7 @@ import { withCombinations } from '@lumx/react/stories/decorators/withCombination
 import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
 import { UserBlock } from './UserBlock';
 
-const sizes = [Size.s, Size.m, Size.l];
+const sizes = [Size.xs, Size.s, Size.m, Size.l];
 
 export default {
     title: 'LumX components/user-block/UserBlock',

--- a/packages/lumx-react/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-react/src/components/user-block/UserBlock.tsx
@@ -12,7 +12,7 @@ import { AvatarProps } from '../avatar/Avatar';
 /**
  * User block sizes.
  */
-export type UserBlockSize = Extract<Size, 's' | 'm' | 'l'>;
+export type UserBlockSize = Extract<Size, 'xs' | 's' | 'm' | 'l'>;
 
 /**
  * Defines the props of the component.
@@ -128,7 +128,7 @@ export const UserBlock: Comp<UserBlockProps, HTMLDivElement> = forwardRef((props
         return <NameComponent {...nProps}>{name}</NameComponent>;
     }, [avatarProps, isClickable, linkAs, linkProps, name, nameProps, onClick]);
 
-    const fieldsBlock: ReactNode = fields && componentSize !== Size.s && (
+    const fieldsBlock: ReactNode = fields && componentSize !== Size.s && componentSize !== Size.xs && (
         <div className={`${CLASSNAME}__fields`}>
             {fields.map((field: string, idx: number) => (
                 <span key={idx} className={`${CLASSNAME}__field`}>

--- a/packages/lumx-react/src/stories/generated/UserBlock/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/UserBlock/Demos.stories.tsx
@@ -7,4 +7,5 @@ export { App as Extended } from './extended';
 export { App as SizeL } from './size-l';
 export { App as SizeM } from './size-m';
 export { App as SizeS } from './size-s';
+export { App as SizeXs } from './size-xs';
 export { App as Vertical } from './vertical';

--- a/packages/lumx-react/src/stories/generated/UserBlock/size-xs.tsx
+++ b/packages/lumx-react/src/stories/generated/UserBlock/size-xs.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/user-block/react/size-xs.tsx

--- a/packages/site-demo/content/product/components/user-block/index.mdx
+++ b/packages/site-demo/content/product/components/user-block/index.mdx
@@ -4,8 +4,12 @@
 
 ## Sizes
 
-User blocks come in three sizes: `s`, `m`, and `l`.
+User blocks come in four sizes: `xs`, `s`, `m`, and `l`.
 Check [size foundations](/product/foundations/size) for more details.
+
+### Extra Small
+
+<DemoBlock orientation="horizontal" demo="size-xs" withThemeSwitcher />
 
 ### Small
 

--- a/packages/site-demo/content/product/components/user-block/react/size-xs.tsx
+++ b/packages/site-demo/content/product/components/user-block/react/size-xs.tsx
@@ -1,0 +1,14 @@
+import { Size, UserBlock } from '@lumx/react';
+import React from 'react';
+
+export const App = ({ theme }: any) => (
+    <UserBlock
+        theme={theme}
+        name="Emmitt O. Lum"
+        nameProps={{ 'aria-label': 'Emmitt O. Lum - open user profile' }}
+        fields={['Creative developer', 'Denpasar']}
+        avatarProps={{ image: '/demo-assets/persona.png' }}
+        size={Size.xs}
+        onClick={console.log}
+    />
+);


### PR DESCRIPTION
# General summary

A new size for the user block that will better integrate in some designs.

# Screenshots

<img width="794" alt="Capture d’écran 2024-09-02 à 14 51 51" src="https://github.com/user-attachments/assets/5fc30c78-b45c-4890-b8ef-59a4185e715a">


Fix: https://lumapps.atlassian.net/browse/DSW-233


<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
