### PR TITLE
fix(image-lightbox): fix zoom on mouse wheel cursor position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `useImageLightbox`: update props each time the lightbox opens.
 -   `ImageLightbox`: fix reset zoom scale when switching to the first item.
 -   `ButtonGroup`: fixed border radius style with single button or `.visually-hidden` children.
+-   `ImageLightbox`: fix zoom center based on mouse position on mouse wheel zoom.
 
 ## [3.9.0][] - 2024-09-03
 

--- a/packages/lumx-react/src/components/image-lightbox/internal/usePointerZoom.ts
+++ b/packages/lumx-react/src/components/image-lightbox/internal/usePointerZoom.ts
@@ -53,8 +53,8 @@ export function usePointerZoom(
 
             // Update scale on next frame (focused on the mouse position)
             updateScaleOnNextFrame(newScale, {
-                x: event.pageX,
-                y: event.pageY,
+                x: event.clientX,
+                y: event.clientY,
             });
         }
 


### PR DESCRIPTION
# General summary

pageY & pageX we used for the cursor position for the zoom center actually depended on the page scroll position but we wanted the cursor position in the window (since the image lightbox is always fullscreen)