### PR TITLE
fix(slideshow-a11y): Changed active pagination item width for a11y improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Slideshow`: Changed active pagination item width for better a11y.
+
 ## [3.9.1][] - 2024-09-17
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/slideshow/_index.scss
+++ b/packages/lumx-core/src/scss/components/slideshow/_index.scss
@@ -93,7 +93,7 @@
     &__pagination {
         align-items: center;
         // Compute max width for N items based on their size, margin and focus outline
-        max-width: ($item-max-count * ($item-size + $item-margin-inline)) + $item-focus-outline * 2;
+        max-width: ($item-max-count * ($item-size + $item-margin-inline)) + $item-focus-outline * 2 + $item-size;
         overflow: hidden;
     }
 
@@ -130,16 +130,20 @@
         }
 
         #{$self}--theme-light & {
-            background-color: lumx-color-variant("dark", "L4");
+            background-color:lumx-color-variant("dark", "L5");
 
             &[data-focus-visible-added] {
                 @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "dark");
             }
 
-            &:hover,
+            &:hover {
+                background-color: lumx-color-variant("primary", "N");
+            }
             &--is-active {
                 background-color: lumx-color-variant("primary", "N");
-
+                width: $item-size*2;
+                border-radius: $lumx-border-radius;
+                
                 &[data-focus-visible-added] {
                     @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "primary");
                 }
@@ -147,15 +151,19 @@
         }
 
         #{$self}--theme-dark & {
-            background-color: lumx-color-variant("light", "L4");
+            background-color: lumx-color-variant("light", "L5");
 
             &[data-focus-visible-added] {
                 @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "light");
             }
 
-            &:hover,
+            &:hover {
+                background-color: lumx-color-variant("light", "N");
+            }
             &--is-active {
                 background-color: lumx-color-variant("light", "N");
+                width: $item-size*2;
+                border-radius: $lumx-border-radius;
 
                 &[data-focus-visible-added] {
                     @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "light");


### PR DESCRIPTION
# General summary

Customer reported that only a change of color for pagination item was a bit weak for accessibility.
The fix increases the width of the active pagination item to have another way to distinguish the active item.

# Screenshots

## Before
<img width="393" alt="Capture d’écran 2024-09-18 à 15 55 18" src="https://github.com/user-attachments/assets/0e64c9b5-2b17-4c8c-a2f2-dcdeddda5b57">
<img width="387" alt="Capture d’écran 2024-09-18 à 15 55 22" src="https://github.com/user-attachments/assets/3e16ecf3-9c74-4b77-8dba-575f7b3638be">

## After
<img width="384" alt="Capture d’écran 2024-09-18 à 15 55 31" src="https://github.com/user-attachments/assets/a81adb37-30b3-4d63-b8b7-b9dd10059e5d">
<img width="379" alt="Capture d’écran 2024-09-18 à 15 55 37" src="https://github.com/user-attachments/assets/da9a28d0-da89-47d7-9405-a05cef1024d2">


Fixes https://lumapps.atlassian.net/browse/DSW-276