### PR TITLE
feat(tooltip): add `closeMode` and `ariaLinkMode` modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Tooltip`: Add `closeMode` to hide the tooltip instead of unmounting it
+-   `Tooltip`: Add `closeMode` to hide the tooltip instead of unmounting it
+-   `Tooltip`: Add `ariaLinkMode` to use tooltip as label instead of description
 
 ## [3.9.1][] - 2024-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `Slideshow`: changed active pagination item width for better a11y.
 -   `ImageLightbox`: fix closing animation cut short because of unstable image reference.
 
+### Added
+
+- `Tooltip`: Add `closeMode` to hide the tooltip instead of unmounting it
+
 ## [3.9.1][] - 2024-09-17
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/tooltip/_index.scss
+++ b/packages/lumx-core/src/scss/components/tooltip/_index.scss
@@ -17,6 +17,10 @@
     border-radius: var(--lumx-border-radius);
     will-change: transform;
 
+    &--is-hidden {
+        visibility: hidden;
+    }
+
     &__arrow {
         position: absolute;
         width: 0;

--- a/packages/lumx-react/src/components/image-lightbox/ImageLightbox.test.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/ImageLightbox.test.tsx
@@ -145,10 +145,17 @@ describe(`<${ImageLightbox.displayName}>`, () => {
 
             // Focus moved to the close button
             const imageLightbox = queries.getImageLightbox();
-            expect(queries.queryCloseButton(imageLightbox)).toHaveFocus();
+            const closeButton = queries.queryCloseButton(imageLightbox);
+            expect(closeButton).toHaveFocus();
+            const tooltip = screen.getByRole('tooltip', { name: 'Close' });
+            expect(tooltip).toBeInTheDocument();
 
             // Image lightbox opened on the correct image
             expect(queries.queryImage(imageLightbox, 'Image 2')).toBeInTheDocument();
+
+            // Close tooltip
+            await userEvent.keyboard('{escape}');
+            expect(tooltip).not.toBeInTheDocument();
 
             // Close on escape
             await userEvent.keyboard('{escape}');

--- a/packages/lumx-react/src/components/popover/usePopoverStyle.tsx
+++ b/packages/lumx-react/src/components/popover/usePopoverStyle.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { usePopper } from 'react-popper';
 import memoize from 'lodash/memoize';
 import { detectOverflow } from '@popperjs/core';
 
 import { DOCUMENT, WINDOW } from '@lumx/react/constants';
 import { PopoverProps } from '@lumx/react/components/popover/Popover';
+import { usePopper } from '@lumx/react/hooks/usePopper';
 import { ARROW_SIZE, FitAnchorWidth, Placement } from './constants';
 
 /**
@@ -104,12 +104,6 @@ export function usePopoverStyle({
 }: Options): Output {
     const [popperElement, setPopperElement] = useState<null | HTMLElement>(null);
 
-    if (navigator.userAgent.includes('jsdom')) {
-        // Skip all logic; we don't need popover positioning in jsdom.
-        return { styles: {}, attributes: {}, isPositioned: true, popperElement, setPopperElement };
-    }
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [arrowElement, setArrowElement] = useState<null | HTMLElement>(null);
 
     const actualOffset: [number, number] = [offset?.along ?? 0, (offset?.away ?? 0) + (hasArrow ? ARROW_SIZE : 0)];
@@ -142,16 +136,13 @@ export function usePopoverStyle({
         );
     }
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { styles, attributes, state, update } = usePopper(anchorRef.current, popperElement, { placement, modifiers });
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
         update?.();
     }, [children, update]);
 
     const position = state?.placement ?? placement;
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const popoverStyle = useMemo(() => {
         const newStyles = { ...style, ...styles.popper, zIndex };
 

--- a/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
+++ b/packages/lumx-react/src/components/side-navigation/SideNavigationItem.tsx
@@ -7,7 +7,7 @@ import { mdiChevronDown, mdiChevronUp } from '@lumx/icons';
 
 import { Emphasis, Icon, Size, IconButton, IconButtonProps } from '@lumx/react';
 
-import { Comp, GenericProps, isComponent } from '@lumx/react/utils/type';
+import { Comp, GenericProps, HasCloseMode, isComponent } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { renderLink } from '@lumx/react/utils/renderLink';
 import { renderButtonOrLink } from '@lumx/react/utils/renderButtonOrLink';
@@ -16,7 +16,7 @@ import { useId } from '@lumx/react/hooks/useId';
 /**
  * Defines the props of the component.
  */
-export interface SideNavigationItemProps extends GenericProps {
+export interface SideNavigationItemProps extends GenericProps, HasCloseMode {
     /** SideNavigationItem elements. */
     children?: ReactNode;
     /** Emphasis variant. */
@@ -36,11 +36,6 @@ export interface SideNavigationItemProps extends GenericProps {
     /** Props to pass to the toggle button (minus those already set by the SideNavigationItem props). */
     toggleButtonProps: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color' | 'size'>;
-    /**
-     * Choose how the children are hidden when closed
-     * ('hide' keeps the children in DOM but hide them, 'unmount' remove the children from the DOM).
-     */
-    closeMode?: 'hide' | 'unmount';
     /** On action button click callback. */
     onActionClick?(evt: React.MouseEvent): void;
     /** On click callback. */

--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -2,8 +2,10 @@ import { Button, Dialog, Dropdown, Placement, Tooltip } from '@lumx/react';
 import React, { useState } from 'react';
 import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
 import { withChromaticForceScreenSize } from '@lumx/react/stories/decorators/withChromaticForceScreenSize';
+import { ARIA_LINK_MODES } from '@lumx/react/components/tooltip/constants';
 
 const placements = [Placement.TOP, Placement.BOTTOM, Placement.RIGHT, Placement.LEFT];
+const CLOSE_MODES = ['hide', 'unmount'];
 
 export default {
     title: 'LumX components/tooltip/Tooltip',
@@ -11,6 +13,9 @@ export default {
     args: Tooltip.defaultProps,
     argTypes: {
         placement: getSelectArgType(placements),
+        children: { control: false },
+        closeMode: { control: { type: 'inline-radio' }, options: CLOSE_MODES },
+        ariaLinkMode: { control: { type: 'inline-radio' }, options: ARIA_LINK_MODES },
     },
     decorators: [
         // Force minimum chromatic screen size to make sure the dialog appears in view.

--- a/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.stories.tsx
@@ -42,6 +42,14 @@ export const ForceOpen = {
     },
 };
 
+/** Hide on close instead of unmounting */
+export const CloseModeHide = {
+    args: {
+        ...OnAButton.args,
+        closeMode: 'hide',
+    },
+};
+
 /** Display a multiline tooltip */
 export const MultilineTooltip = {
     args: {

--- a/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button, IconButton } from '@lumx/react';
-import { screen, render, waitFor } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import { queryAllByTagName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import userEvent from '@testing-library/user-event';
@@ -48,8 +48,21 @@ describe(`<${Tooltip.displayName}>`, () => {
                 forceOpen: true,
             });
             expect(tooltip).toBeInTheDocument();
+            // Default placement
+            expect(tooltip).toHaveAttribute('data-popper-placement', 'bottom');
             expect(anchorWrapper).toBeInTheDocument();
             expect(anchorWrapper).toHaveAttribute('aria-describedby', tooltip?.id);
+        });
+
+        it('should render with custom placement', async () => {
+            const { tooltip } = await setup({
+                label: 'Tooltip label',
+                children: 'Anchor',
+                forceOpen: true,
+                placement: 'top',
+            });
+            // Custom placement
+            expect(tooltip).toHaveAttribute('data-popper-placement', 'top');
         });
 
         it('should wrap unknown children and not add aria-describedby when closed', async () => {
@@ -159,17 +172,17 @@ describe(`<${Tooltip.displayName}>`, () => {
             expect(ref.current === element).toBe(true);
         });
 
-        it.only('should render in closeMode=hide', async () => {
-            const { tooltip, anchorWrapper } = await setup({
+        it('should render in closeMode=hide', async () => {
+            const { tooltip } = await setup({
                 label: 'Tooltip label',
                 children: <Button>Anchor</Button>,
                 closeMode: 'hide',
+                forceOpen: false,
             });
             expect(tooltip).toBeInTheDocument();
-            expect(anchorWrapper).toBeInTheDocument();
-            expect(anchorWrapper).toHaveAttribute('aria-describedby', tooltip?.id);
+            expect(tooltip).toHaveClass('lumx-tooltip--is-hidden');
             const button = screen.queryByRole('button', { name: 'Anchor' });
-            expect(button?.parentElement).toBe(anchorWrapper);
+            expect(button).toHaveAttribute('aria-describedby', tooltip?.id);
         });
     });
 
@@ -193,12 +206,11 @@ describe(`<${Tooltip.displayName}>`, () => {
             expect(button).toHaveAttribute('aria-describedby', tooltip?.id);
 
             // Un-hover anchor button
-            userEvent.unhover(button);
-            await waitFor(() => {
-                expect(button).not.toHaveFocus();
-                // Tooltip closed
-                expect(tooltip).not.toBeInTheDocument();
-            });
+            await userEvent.unhover(button);
+
+            expect(button).not.toHaveFocus();
+            // Tooltip closed
+            expect(tooltip).not.toBeInTheDocument();
         });
 
         it('should activate on hover anchor and then tooltip', async () => {
@@ -225,12 +237,10 @@ describe(`<${Tooltip.displayName}>`, () => {
             expect(button).toHaveAttribute('aria-describedby', tooltip?.id);
 
             // Un-hover tooltip
-            userEvent.unhover(tooltip);
-            await waitFor(() => {
-                expect(button).not.toHaveFocus();
-                // Tooltip closed
-                expect(tooltip).not.toBeInTheDocument();
-            });
+            await userEvent.unhover(tooltip);
+            expect(button).not.toHaveFocus();
+            // Tooltip closed
+            expect(tooltip).not.toBeInTheDocument();
         });
 
         it('should activate on anchor focus visible and close on escape', async () => {

--- a/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
@@ -158,6 +158,19 @@ describe(`<${Tooltip.displayName}>`, () => {
             // Children ref is stable
             expect(ref.current === element).toBe(true);
         });
+
+        it.only('should render in closeMode=hide', async () => {
+            const { tooltip, anchorWrapper } = await setup({
+                label: 'Tooltip label',
+                children: <Button>Anchor</Button>,
+                closeMode: 'hide',
+            });
+            expect(tooltip).toBeInTheDocument();
+            expect(anchorWrapper).toBeInTheDocument();
+            expect(anchorWrapper).toHaveAttribute('aria-describedby', tooltip?.id);
+            const button = screen.queryByRole('button', { name: 'Anchor' });
+            expect(button?.parentElement).toBe(anchorWrapper);
+        });
     });
 
     describe('activation', () => {

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -1,20 +1,20 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import React, { forwardRef, ReactNode, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { usePopper } from 'react-popper';
 
 import classNames from 'classnames';
 
 import { DOCUMENT } from '@lumx/react/constants';
 import { Comp, GenericProps, HasCloseMode } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
-import { mergeRefs } from '@lumx/react/utils/mergeRefs';
+import { useMergeRefs } from '@lumx/react/utils/mergeRefs';
 import { Placement } from '@lumx/react/components/popover';
 import { TooltipContextProvider } from '@lumx/react/components/tooltip/context';
 import { useId } from '@lumx/react/hooks/useId';
 
 import { useInjectTooltipRef } from './useInjectTooltipRef';
 import { useTooltipOpen } from './useTooltipOpen';
+import { usePopper } from '@lumx/react/hooks/usePopper';
 
 /** Position of the tooltip relative to the anchor element. */
 export type TooltipPlacement = Extract<Placement, 'top' | 'right' | 'bottom' | 'left'>;
@@ -94,13 +94,14 @@ export const Tooltip: Comp<TooltipProps, HTMLDivElement> = forwardRef((props, re
 
     const labelLines = label ? label.split('\n') : [];
 
+    const tooltipRef = useMergeRefs(ref, setPopperElement, onPopperMount);
     return (
         <>
             <TooltipContextProvider>{wrappedChildren}</TooltipContextProvider>
             {isMounted &&
                 createPortal(
                     <div
-                        ref={mergeRefs(ref, setPopperElement, onPopperMount)}
+                        ref={tooltipRef}
                         {...forwardedProps}
                         id={id}
                         role="tooltip"

--- a/packages/lumx-react/src/components/tooltip/constants.ts
+++ b/packages/lumx-react/src/components/tooltip/constants.ts
@@ -1,0 +1,1 @@
+export const ARIA_LINK_MODES = ['aria-describedby', 'aria-labelledby'] as const;

--- a/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
+++ b/packages/lumx-react/src/components/tooltip/useTooltipOpen.tsx
@@ -1,6 +1,6 @@
 import { MutableRefObject, useEffect, useRef, useState } from 'react';
 import { browserDoesNotSupportHover } from '@lumx/react/utils/browserDoesNotSupportHover';
-import { TOOLTIP_HOVER_DELAY, TOOLTIP_LONG_PRESS_DELAY } from '@lumx/react/constants';
+import { IS_BROWSER, TOOLTIP_HOVER_DELAY, TOOLTIP_LONG_PRESS_DELAY } from '@lumx/react/constants';
 import { useCallbackOnEscape } from '@lumx/react/hooks/useCallbackOnEscape';
 import { isFocusVisible } from '@lumx/react/utils/isFocusVisible';
 
@@ -31,9 +31,12 @@ export function useTooltipOpen(delay: number | undefined, anchorElement: HTMLEle
         // Run timer to defer updating the isOpen state.
         const deferUpdate = (duration: number) => {
             if (timer) clearTimeout(timer);
-            timer = setTimeout(() => {
+            const update = () => {
                 setIsOpen(!!shouldOpen);
-            }, duration) as any;
+            };
+            // Skip timeout in fake browsers
+            if (!IS_BROWSER) update();
+            else timer = setTimeout(update, duration) as any;
         };
 
         const hoverNotSupported = browserDoesNotSupportHover();

--- a/packages/lumx-react/src/constants.ts
+++ b/packages/lumx-react/src/constants.ts
@@ -15,3 +15,8 @@ export const WINDOW = typeof window !== 'undefined' ? window : undefined;
  * Optional global `document` instance (not defined when running SSR).
  */
 export const DOCUMENT = typeof document !== 'undefined' ? document : undefined;
+
+/**
+ * Check if we are running in a true browser
+ */
+export const IS_BROWSER = typeof navigator !== 'undefined' && !navigator.userAgent.includes('jsdom');

--- a/packages/lumx-react/src/hooks/usePopper.ts
+++ b/packages/lumx-react/src/hooks/usePopper.ts
@@ -1,0 +1,9 @@
+import { usePopper as usePopperHook } from 'react-popper';
+import { IS_BROWSER } from '@lumx/react/constants';
+
+/** Stub usePopper for use outside of browsers */
+const useStubPopper: typeof usePopperHook = (_a, _p, { placement }: any) =>
+    ({ attributes: { popper: { 'data-popper-placement': placement } }, styles: {} }) as any;
+
+/** Switch hook implementation between environment */
+export const usePopper: typeof usePopperHook = IS_BROWSER ? usePopperHook : useStubPopper;

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -59,7 +59,6 @@ export interface HasClassName {
     className?: string;
 }
 
-
 export interface HasCloseMode {
     /**
      * Choose how the children are hidden when closed

--- a/packages/lumx-react/src/utils/type.ts
+++ b/packages/lumx-react/src/utils/type.ts
@@ -59,6 +59,15 @@ export interface HasClassName {
     className?: string;
 }
 
+
+export interface HasCloseMode {
+    /**
+     * Choose how the children are hidden when closed
+     * ('hide' keeps the children in DOM but hide them, 'unmount' remove the children from the DOM).
+     */
+    closeMode?: 'hide' | 'unmount';
+}
+
 /**
  * Define a generic props types.
  */

--- a/packages/site-demo/content/product/components/tooltip/index.mdx
+++ b/packages/site-demo/content/product/components/tooltip/index.mdx
@@ -25,6 +25,10 @@ Tooltips implement the [WAI-ARIA tooltip role](https://www.w3.org/WAI/ARIA/apg/p
 
 Tooltip messages should be concise, directly describing the element that triggered it and should not contain essential information.
 
+By default, the tooltip is linked to the anchor via `aria-describedby`, meaning as a description of the anchor element. Use `ariaLinkMode="aria-labelledby"` to link to the anchor via `aria-labelledby` and thus using the tooltip as the label for the anchor.
+
+Use `closeMode="hide"` to render the tooltip hidden when not activated and keep to more accessible to screen readers. By default `closeMode="unmount"` is used and the tooltip only render when activated.
+
 Consider using the [Popover](/product/components/popover/#accessibility-concerns) as a disclosure element to show longer or richer messages.
 
 ### Properties


### PR DESCRIPTION
- **feat(tooltip): add `closeMode` to hide instead of unmount when closed**
- **chore(tooltip): skip async state updates in jsdom env**
- **feat(tooltip): add `ariaLinkMode` to use tooltip as label instead of description**

StoryBook: https://d9f4b170--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=396)) **⚠️ Outdated commit**