### PR TITLE
fix(text-field): Display buttons for type number, documentation for number use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   `Tooltip`: increment z-index making them appear above popovers.
+-   `TextField`: display browser native buttons when used with type="number", add "number" use case documentation.
 
 ## [3.9.1][] - 2024-09-17
 

--- a/packages/lumx-core/src/scss/components/date-picker/_index.scss
+++ b/packages/lumx-core/src/scss/components/date-picker/_index.scss
@@ -16,7 +16,7 @@
 
     &__year {
         input[type="number"] {
-            width: 4ch; 
+            width: 6ch;
         }
     }
 

--- a/packages/lumx-core/src/scss/components/text-field/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_mixins.scss
@@ -89,13 +89,11 @@
     border: none;
     outline: none;
 
-    &[type="number"] {
-        appearance: textfield;
-    }
+    // Always show the up/down arrow, not just on hover or focus
+    &[type=number]::-webkit-inner-spin-button,
+    &[type=number]::-webkit-outer-spin-button {
+        opacity: 1;
 
-    &[type="number"]::-webkit-inner-spin-button,
-    &[type="number"]::-webkit-outer-spin-button {
-        appearance: none;
     }
 
     @if $theme == lumx-base-const("theme", "LIGHT") {

--- a/packages/lumx-react/src/stories/generated/TextField/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/TextField/Demos.stories.tsx
@@ -10,6 +10,7 @@ export { App as Disabled } from './disabled';
 export { App as Helper } from './helper';
 export { App as Icon } from './icon';
 export { App as Invalid } from './invalid';
+export { App as Number } from './number';
 export { App as Placeholder } from './placeholder';
 export { App as Required } from './required';
 export { App as TextAreaInvalid } from './text-area-invalid';

--- a/packages/lumx-react/src/stories/generated/TextField/number.tsx
+++ b/packages/lumx-react/src/stories/generated/TextField/number.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/text-field/react/number.tsx

--- a/packages/site-demo/content/product/components/text-field/index.mdx
+++ b/packages/site-demo/content/product/components/text-field/index.mdx
@@ -86,6 +86,12 @@ Use Text areas when users are expected to enter more than one line of text.
 
 <DemoBlock demo="text-area-invalid" withThemeSwitcher />
 
+## Number
+
+Use number input when users are expected to enter numeric values.
+
+<DemoBlock demo="number" withThemeSwitcher />
+
 ### Properties
 
 <PropTable component="TextField" />

--- a/packages/site-demo/content/product/components/text-field/react/number.tsx
+++ b/packages/site-demo/content/product/components/text-field/react/number.tsx
@@ -1,0 +1,8 @@
+import { TextField } from '@lumx/react';
+import React, { useState } from 'react';
+
+export const App = ({ theme }: any) => {
+    const [value, setValue] = useState('');
+
+    return <TextField label="Number" value={value} type="number" onChange={setValue} theme={theme} />;
+};


### PR DESCRIPTION
# General summary

Display again buttons up and down for text-field with type="number" for accessibility.
Added "number" use case in text-field documentation

# Screenshots

## Documentation
<img width="791" alt="Capture d’écran 2024-10-02 à 10 28 12" src="https://github.com/user-attachments/assets/d62d5935-0956-4e44-b4e4-5500d986383d">

## Chrome
<img width="417" alt="Capture d’écran 2024-10-02 à 10 30 42" src="https://github.com/user-attachments/assets/020a2f1c-6e41-47ee-bd11-7939a009c241">
<img width="420" alt="Capture d’écran 2024-10-02 à 10 29 49" src="https://github.com/user-attachments/assets/d9128be7-7b93-40a0-a2c3-4be83bd8a2f8">

## Safari
<img width="492" alt="Capture d’écran 2024-10-02 à 10 28 39" src="https://github.com/user-attachments/assets/006c5280-556c-4049-a1ab-e952d0238023">
<img width="493" alt="Capture d’écran 2024-10-02 à 10 28 45" src="https://github.com/user-attachments/assets/90e33d53-a3a7-4dad-8563-5b1b70af68db">

## Firefox
<img width="370" alt="Capture d’écran 2024-10-02 à 10 28 57" src="https://github.com/user-attachments/assets/e4d7c230-6518-4c13-8611-3b1cb4f16ee2">
<br \>
<img width="364" alt="Capture d’écran 2024-10-02 à 10 29 01" src="https://github.com/user-attachments/assets/f76890c2-d38a-4186-8274-a82fbd5f38b5">

https://lumapps.atlassian.net/browse/DSW-281

StoryBook: https://5991f059--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=400))