### PR TITLE
docs(mosaic): removed broken lightboxes on mosaic demos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `ExpansionPanel`: fix children remaining in the DOM when closed
 
+### Changed
+
+-   `Mosaic`: removed broken lightboxes on mosaic demos.
+
 ## [3.9.3][] - 2024-10-09
 
 ### Fixed

--- a/packages/lumx-react/src/stories/generated/Mosaic/Demos.stories.tsx
+++ b/packages/lumx-react/src/stories/generated/Mosaic/Demos.stories.tsx
@@ -3,6 +3,7 @@
  */
 export default { title: 'LumX components/mosaic/Mosaic Demos' };
 
+export { App as Clickable } from './clickable';
 export { App as FourImages } from './four-images';
 export { App as MoreImages } from './more-images';
 export { App as ThreeImages } from './three-images';

--- a/packages/lumx-react/src/stories/generated/Mosaic/clickable.tsx
+++ b/packages/lumx-react/src/stories/generated/Mosaic/clickable.tsx
@@ -1,0 +1,1 @@
+../../../../../site-demo/content/product/components/mosaic/react/clickable.tsx

--- a/packages/site-demo/content/product/components/image-lightbox/react/default.tsx
+++ b/packages/site-demo/content/product/components/image-lightbox/react/default.tsx
@@ -19,7 +19,7 @@ export const App = () => {
                         <Thumbnail
                             key={image}
                             image={image}
-                            alt={alt}
+                            alt={`${alt}; Open in a fullscreen image slideshow`}
                             size="xl"
                             aspectRatio="square"
                             {...getTriggerProps({ activeImageIndex: index })}

--- a/packages/site-demo/content/product/components/mosaic/index.mdx
+++ b/packages/site-demo/content/product/components/mosaic/index.mdx
@@ -28,7 +28,9 @@ In this example there are 6 images in total, 4 are shown, 2 aren’t.
 
 ## Click on thumbnail
 
-Thumbnails are clickable. On click, it should open a [slideshow](/product/components/slideshow) in a [lightbox](/product/components/lightbox) with every image.
+Mosaic's thumbnails can be clickable to attach an [image lightbox](/product/components/image-lightbox) that displays the images in a full screen image slideshow.
+
+<DemoBlock orientation="horizontal" demo="clickable" />
 
 ### Accessibility concerns
 

--- a/packages/site-demo/content/product/components/mosaic/react/clickable.tsx
+++ b/packages/site-demo/content/product/components/mosaic/react/clickable.tsx
@@ -1,0 +1,39 @@
+import { ImageLightbox, Mosaic, ThumbnailProps } from '@lumx/react';
+import React from 'react';
+
+const IMAGES: ThumbnailProps[] = [
+    { image: '/demo-assets/landscape1.jpg', alt: 'Landscape 1' },
+    { image: '/demo-assets/landscape2.jpg', alt: 'Landscape 2' },
+    { image: '/demo-assets/landscape3.jpg', alt: 'Landscape 3' },
+    { image: '/demo-assets/portrait1.jpg', alt: 'Portrait 1' },
+    { image: '/demo-assets/portrait2.jpg', alt: 'Portrait 2' },
+    { image: '/demo-assets/portrait3.jpg', alt: 'Portrait 3' },
+];
+
+export const App = () => {
+    const { getTriggerProps, imageLightboxProps } = ImageLightbox.useImageLightbox({ images: IMAGES });
+    const thumbnails = IMAGES.map((image, index) => ({
+        ...image,
+        ...getTriggerProps({ activeImageIndex: index }),
+        alt: `${image.alt}; Open in a fullscreen image slideshow`,
+    }));
+
+    return (
+        <div style={{ width: 250 }}>
+            <Mosaic thumbnails={thumbnails} />
+
+            <ImageLightbox
+                {...imageLightboxProps}
+                aria-label="Fullscreen image slideshow"
+                closeButtonProps={{ label: 'Close' }}
+                zoomInButtonProps={{ label: 'Zoom in' }}
+                zoomOutButtonProps={{ label: 'Zoom out' }}
+                slideshowControlsProps={{
+                    nextButtonProps: { label: 'Next image' },
+                    previousButtonProps: { label: 'Previous image' },
+                    paginationItemProps: (index: number) => ({ label: `Go to slide ${index + 1}` }),
+                }}
+            />
+        </div>
+    );
+};

--- a/packages/site-demo/content/product/components/mosaic/react/four-images.tsx
+++ b/packages/site-demo/content/product/components/mosaic/react/four-images.tsx
@@ -1,5 +1,5 @@
-import { Alignment, ImageBlock, Lightbox, Mosaic, Slideshow, SlideshowItem, Theme, ThumbnailProps } from '@lumx/react';
-import React, { useRef, useState } from 'react';
+import { Mosaic, ThumbnailProps } from '@lumx/react';
+import React from 'react';
 
 const IMAGES: ThumbnailProps[] = [
     { image: '/demo-assets/landscape1.jpg', alt: 'Landscape 1' },
@@ -9,25 +9,9 @@ const IMAGES: ThumbnailProps[] = [
 ];
 
 export const App = () => {
-    const [activeIndex, setActiveIndex] = useState<number>();
-    const triggerElement = useRef(null);
-    const close = () => setActiveIndex(undefined);
-
     return (
-        <>
-            <div style={{ width: 250 }}>
-                <Mosaic thumbnails={IMAGES} onImageClick={setActiveIndex} />
-            </div>
-
-            <Lightbox isOpen={activeIndex !== undefined} parentElement={triggerElement} onClose={close}>
-                <Slideshow activeIndex={activeIndex} hasControls autoPlay fillHeight theme={Theme.dark}>
-                    {IMAGES.map(({ image, alt }) => (
-                        <SlideshowItem key={image}>
-                            <ImageBlock image={image} alt={alt} fillHeight align={Alignment.center} />
-                        </SlideshowItem>
-                    ))}
-                </Slideshow>
-            </Lightbox>
-        </>
+        <div style={{ width: 250 }}>
+            <Mosaic thumbnails={IMAGES} />
+        </div>
     );
 };

--- a/packages/site-demo/content/product/components/mosaic/react/more-images.tsx
+++ b/packages/site-demo/content/product/components/mosaic/react/more-images.tsx
@@ -1,5 +1,5 @@
-import { Alignment, ImageBlock, Lightbox, Mosaic, Slideshow, SlideshowItem, Theme, ThumbnailProps } from '@lumx/react';
-import React, { useRef, useState } from 'react';
+import { Mosaic, ThumbnailProps } from '@lumx/react';
+import React from 'react';
 
 const IMAGES: ThumbnailProps[] = [
     { image: '/demo-assets/landscape1.jpg', alt: 'Landscape 1' },
@@ -11,25 +11,9 @@ const IMAGES: ThumbnailProps[] = [
 ];
 
 export const App = () => {
-    const [activeIndex, setActiveIndex] = useState<number>();
-    const triggerElement = useRef(null);
-    const close = () => setActiveIndex(undefined);
-
     return (
-        <>
-            <div style={{ width: 250 }}>
-                <Mosaic thumbnails={IMAGES} onImageClick={setActiveIndex} />
-            </div>
-
-            <Lightbox isOpen={activeIndex !== undefined} parentElement={triggerElement} onClose={close}>
-                <Slideshow activeIndex={activeIndex} hasControls autoPlay fillHeight theme={Theme.dark}>
-                    {IMAGES.map(({ image, alt }) => (
-                        <SlideshowItem key={image}>
-                            <ImageBlock image={image} alt={alt} fillHeight align={Alignment.center} />
-                        </SlideshowItem>
-                    ))}
-                </Slideshow>
-            </Lightbox>
-        </>
+        <div style={{ width: 250 }}>
+            <Mosaic thumbnails={IMAGES} />
+        </div>
     );
 };

--- a/packages/site-demo/content/product/components/mosaic/react/three-images.tsx
+++ b/packages/site-demo/content/product/components/mosaic/react/three-images.tsx
@@ -1,5 +1,5 @@
-import { Alignment, ImageBlock, Lightbox, Mosaic, Slideshow, SlideshowItem, Theme, ThumbnailProps } from '@lumx/react';
-import React, { useRef, useState } from 'react';
+import { Mosaic, ThumbnailProps } from '@lumx/react';
+import React from 'react';
 
 const IMAGES: ThumbnailProps[] = [
     { image: '/demo-assets/landscape1.jpg', alt: 'Landscape' },
@@ -8,25 +8,9 @@ const IMAGES: ThumbnailProps[] = [
 ];
 
 export const App = () => {
-    const [activeIndex, setActiveIndex] = useState<number>();
-    const triggerElement = useRef(null);
-    const close = () => setActiveIndex(undefined);
-
     return (
-        <>
-            <div style={{ width: 250 }}>
-                <Mosaic thumbnails={IMAGES} onImageClick={setActiveIndex} />
-            </div>
-
-            <Lightbox isOpen={activeIndex !== undefined} parentElement={triggerElement} onClose={close}>
-                <Slideshow activeIndex={activeIndex} hasControls autoPlay fillHeight theme={Theme.dark}>
-                    {IMAGES.map(({ image, alt }) => (
-                        <SlideshowItem key={image}>
-                            <ImageBlock image={image} alt={alt} fillHeight align={Alignment.center} />
-                        </SlideshowItem>
-                    ))}
-                </Slideshow>
-            </Lightbox>
-        </>
+        <div style={{ width: 250 }}>
+            <Mosaic thumbnails={IMAGES} />
+        </div>
     );
 };

--- a/packages/site-demo/content/product/components/mosaic/react/two-images.tsx
+++ b/packages/site-demo/content/product/components/mosaic/react/two-images.tsx
@@ -1,5 +1,5 @@
-import { Alignment, ImageBlock, Lightbox, Mosaic, Slideshow, SlideshowItem, Theme, ThumbnailProps } from '@lumx/react';
-import React, { useRef, useState } from 'react';
+import { Mosaic, ThumbnailProps } from '@lumx/react';
+import React from 'react';
 
 const IMAGES: ThumbnailProps[] = [
     { image: '/demo-assets/portrait1.jpg', alt: 'Portrait 1' },
@@ -7,25 +7,9 @@ const IMAGES: ThumbnailProps[] = [
 ];
 
 export const App = () => {
-    const [activeIndex, setActiveIndex] = useState<number>();
-    const triggerElement = useRef(null);
-    const close = () => setActiveIndex(undefined);
-
     return (
-        <>
-            <div style={{ width: 250 }}>
-                <Mosaic ref={triggerElement} thumbnails={IMAGES} onImageClick={setActiveIndex} />
-            </div>
-
-            <Lightbox isOpen={activeIndex !== undefined} parentElement={triggerElement} onClose={close}>
-                <Slideshow activeIndex={activeIndex} hasControls autoPlay fillHeight theme={Theme.dark}>
-                    {IMAGES.map(({ image, alt }) => (
-                        <SlideshowItem key={image}>
-                            <ImageBlock image={image} alt={alt} fillHeight align={Alignment.center} />
-                        </SlideshowItem>
-                    ))}
-                </Slideshow>
-            </Lightbox>
-        </>
+        <div style={{ width: 250 }}>
+            <Mosaic thumbnails={IMAGES} />
+        </div>
     );
 };


### PR DESCRIPTION
# General summary

With recent improvements on Lightbox the Mosaic demos were broken (no more Slideshow controls in the demos Lightboxes), we decided to remove the Lightboxes from the demo as the Mosaic do not provide automatically a Lightbox component.

The "Click on thumbnail" part of the documentation is also changed to reflect that having a Lightbox on Mosaic is a possibility not a obligation. 

# Screenshots

<img width="935" alt="Capture d’écran 2024-10-23 à 18 04 29" src="https://github.com/user-attachments/assets/f3f22fd2-0e3e-471e-9eb6-69279b41a9e4">

Fix https://lumapps.atlassian.net/browse/DSW-285