### PR TITLE
fix(expansion-panel): fix children remaining in the DOM when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `ExpansionPanel`: fix children remaining in the DOM when closed
+
 ## [3.9.3][] - 2024-10-09
 
 ### Fixed

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
-import { queryByRole, render } from '@testing-library/react';
+import { queryByRole, render, screen } from '@testing-library/react';
 import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import userEvent from '@testing-library/user-event';
 import { isFocusVisible } from '@lumx/react/utils/isFocusVisible';
@@ -12,12 +12,15 @@ const CLASSNAME = ExpansionPanel.className as string;
 
 jest.mock('@lumx/react/utils/isFocusVisible');
 
+const mockChildrenContent = 'children content';
+
 /**
  * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
  */
 const setup = (propsOverride: Partial<ExpansionPanelProps> = {}) => {
     const props = {
         toggleButtonProps: { label: 'Toggle' },
+        children: mockChildrenContent,
         ...propsOverride,
     };
     const { container } = render(<ExpansionPanel {...props} />);
@@ -28,7 +31,7 @@ const setup = (propsOverride: Partial<ExpansionPanelProps> = {}) => {
         query: {
             toggleButton: () => queryByRole(container, 'button', { name: /Toggle/i }),
             header: () => queryByClassName(container, `${CLASSNAME}__header`),
-            content: () => queryByClassName(container, `${CLASSNAME}__wrapper`),
+            content: () => screen.queryByText(mockChildrenContent),
         },
         props,
     };

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.tsx
@@ -12,6 +12,7 @@ import { ColorPalette, DragHandle, Emphasis, IconButton, IconButtonProps, Theme 
 import { Comp, GenericProps, HasTheme, isComponent } from '@lumx/react/utils/type';
 import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
 import { partitionMulti } from '@lumx/react/utils/partitionMulti';
+import { WINDOW } from '@lumx/react/constants';
 
 /**
  * Defines the props of the component.
@@ -80,6 +81,7 @@ export const ExpansionPanel: Comp<ExpansionPanelProps, HTMLDivElement> = forward
         ...forwardedProps
     } = props;
 
+    const [isChildrenVisible, setIsChildrenVisible] = useState(isOpen);
     const children: ReactNode[] = Children.toArray(anyChildren);
 
     // Partition children by types.
@@ -94,15 +96,34 @@ export const ExpansionPanel: Comp<ExpansionPanelProps, HTMLDivElement> = forward
     );
 
     const toggleOpen = (event: React.MouseEvent) => {
+        const hasReducedMotionEnabled = WINDOW?.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
         const shouldOpen = !isOpen;
+
         if (isFunction(onOpen) && shouldOpen) {
             onOpen(event);
+            // On open, we immediately show children
+            setIsChildrenVisible(true);
         }
         if (isFunction(onClose) && !shouldOpen) {
             onClose(event);
+            /**
+             * On close, we only show children immediately if reduced motion is enabled
+             * When disabled, the children will be hidden via the `onTransitionEnd` prop.
+             */
+            if (hasReducedMotionEnabled) {
+                setIsChildrenVisible(false);
+            }
         }
         if (isFunction(onToggleOpen)) {
             onToggleOpen(shouldOpen, event);
+            /**
+             * On toggle, we forward the show state if
+             * * the toggle will open the expansion panel
+             * * reduced motion is enabled. When disabled, the children will be hidden via the `onTransitionEnd` prop.
+             * */
+            if (shouldOpen || hasReducedMotionEnabled) {
+                setIsChildrenVisible(shouldOpen);
+            }
         }
     };
 
@@ -123,7 +144,6 @@ export const ExpansionPanel: Comp<ExpansionPanelProps, HTMLDivElement> = forward
     );
 
     const wrapperRef = useRef<HTMLDivElement>(null);
-    const isContentVisible = (): boolean => get(wrapperRef.current, 'clientHeight', 0) > 0;
 
     // Switch max height on/off to activate the CSS transition (updates when children changes).
     const [maxHeight, setMaxHeight] = useState('0');
@@ -153,8 +173,17 @@ export const ExpansionPanel: Comp<ExpansionPanelProps, HTMLDivElement> = forward
                 </div>
             </header>
 
-            {(isOpen || isContentVisible()) && (
-                <div className={`${CLASSNAME}__wrapper`} style={{ maxHeight }}>
+            {(isOpen || isChildrenVisible) && (
+                <div
+                    className={`${CLASSNAME}__wrapper`}
+                    style={{ maxHeight }}
+                    // At the end of the closing transition, remove the children from the DOM
+                    onTransitionEnd={() => {
+                        if (!isOpen) {
+                            setIsChildrenVisible(false);
+                        }
+                    }}
+                >
                     <div className={`${CLASSNAME}__container`} ref={wrapperRef}>
                         <div className={`${CLASSNAME}__content`}>{content}</div>
 


### PR DESCRIPTION
DSW-290

# General summary

When the expansion panel was closed, the children remained in the DOM and unhidden.
This could cause issues if content of expansion panel were interactive (such as inputs / buttons etc).

Fixed by removing the element from the DOM once the close animation finished.

Also checks the "reduced-motion" preference to immediately remove the children.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
