### PR TITLE
feat(badge): add a wrapper to enable adding a badge to any component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `ExpansionPanel`: fix children remaining in the DOM when closed
 
+### Added
+
+-   `BadgeWrapper`: add this new component to allow adding a badge to any component.
+
 ### Changed
 
 -   `Mosaic`: removed broken lightboxes on mosaic demos.
@@ -99,8 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `ListItem`: display keyboard focus ring even when not highlighted
-- `Message`: changed spacing between icon and text from 16 to 8
+-   `ListItem`: display keyboard focus ring even when not highlighted
+-   `Message`: changed spacing between icon and text from 16 to 8
 
 ## [3.7.4][] - 2024-06-20
 
@@ -117,7 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `Select`, `SelectMultiple`: add `selectElementRef` prop to reference the actual input field of these components.
+-   `Select`, `SelectMultiple`: add `selectElementRef` prop to reference the actual input field of these components.
 
 ## [3.7.2][] - 2024-05-22
 
@@ -2110,8 +2114,6 @@ _Failed released_
 [3.7.0]: https://github.com/lumapps/design-system/compare/v3.6.8...v3.7.0
 [3.6.8]: https://github.com/lumapps/design-system/compare/v3.6.7...v3.6.8
 [3.6.7]: https://github.com/lumapps/design-system/tree/v3.6.7
-
-
 [Unreleased]: https://github.com/lumapps/design-system/compare/v3.9.3...HEAD
 [3.9.3]: https://github.com/lumapps/design-system/compare/v3.9.2...v3.9.3
 [3.9.2]: https://github.com/lumapps/design-system/compare/v3.9.1...v3.9.2

--- a/packages/lumx-core/src/scss/components/badge/_index.scss
+++ b/packages/lumx-core/src/scss/components/badge/_index.scss
@@ -1,4 +1,5 @@
 @use "sass:map";
+@use "sass:math";
 
 /* ==========================================================================
    Badge
@@ -43,5 +44,20 @@
                 color: lumx-color-variant("light", "N");
             }
         }
+    }
+}
+
+/* Badge wrapper
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-badge-wrapper {
+    position: relative;
+    display: inline-block;
+    outline: none;
+
+    &__badge {
+        position: absolute;
+        right: math.div(-$lumx-spacing-unit, 2);
+        bottom: math.div(-$lumx-spacing-unit, 2);
     }
 }

--- a/packages/lumx-react/src/components/badge/BadgeWrapper.stories.tsx
+++ b/packages/lumx-react/src/components/badge/BadgeWrapper.stories.tsx
@@ -1,0 +1,76 @@
+import { mdiAccount, mdiBee, mdiHeart } from '@lumx/icons';
+import { Badge, BadgeWrapper, Button, Chip, ColorPalette, FlexBox, Icon, Orientation, Size } from '@lumx/react';
+import React from 'react';
+
+export default {
+    title: 'LumX components/badge/BadgeWrapper',
+    component: BadgeWrapper,
+    argTypes: {
+        children: { control: false },
+    },
+};
+
+/**
+ * Using badge wrapper with icon
+ */
+export const WithIcon = {
+    args: {
+        badge: (
+            <Badge color={ColorPalette.red}>
+                <Icon icon={mdiHeart} />
+            </Badge>
+        ),
+        children: <Icon icon={mdiAccount} size={Size.m} color={ColorPalette.dark} />,
+    },
+};
+
+/**
+ * Using badge wrapper with icon
+ */
+export const WithButton = {
+    args: {
+        badge: (
+            <Badge color={ColorPalette.red}>
+                <Icon icon={mdiHeart} />
+            </Badge>
+        ),
+        children: <Button>Some button</Button>,
+    },
+};
+
+export const WithChip = {
+    args: {
+        badge: (
+            <Badge color={ColorPalette.red}>
+                <Icon icon={mdiHeart} />
+            </Badge>
+        ),
+        children: <Chip>Some chip</Chip>,
+    },
+};
+
+const InFlexbox = ({ orientation }: { orientation: Orientation }) => (
+    <FlexBox orientation={orientation} gap={Size.medium} vAlign="left">
+        <BadgeWrapper
+            badge={
+                <Badge color={ColorPalette.yellow}>
+                    <Icon icon={mdiBee} />
+                </Badge>
+            }
+        >
+            <Chip color={ColorPalette.green}>Some chip</Chip>
+        </BadgeWrapper>
+        <BadgeWrapper
+            badge={
+                <Badge color={ColorPalette.red}>
+                    <Icon icon={mdiHeart} />
+                </Badge>
+            }
+        >
+            <Chip color={ColorPalette.blue}>Some other chip</Chip>
+        </BadgeWrapper>
+    </FlexBox>
+);
+
+export const InVerticalFlexbox = () => <InFlexbox orientation={Orientation.vertical} />;
+export const InHorizontalFlexbox = () => <InFlexbox orientation={Orientation.horizontal} />;

--- a/packages/lumx-react/src/components/badge/BadgeWrapper.test.tsx
+++ b/packages/lumx-react/src/components/badge/BadgeWrapper.test.tsx
@@ -1,0 +1,49 @@
+import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
+import React from 'react';
+
+import omit from 'lodash/omit';
+import last from 'lodash/last';
+
+import { mdiAccount, mdiHeart } from '@lumx/icons/override/generated';
+import { Badge, BadgeWrapper, BadgeWrapperProps, ColorPalette, Icon } from '@lumx/react';
+import { getByClassName } from '@lumx/react/testing/utils/queries';
+import { render } from '@testing-library/react';
+
+const CLASSNAME = BadgeWrapper.className as string;
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ */
+const setup = (propsOverride: Partial<BadgeWrapperProps> = {}) => {
+    const props = {
+        badge: (
+            <Badge color={ColorPalette.red}>
+                <Icon icon={mdiHeart} />
+            </Badge>
+        ),
+        children: <Icon icon={mdiAccount} />,
+        ...propsOverride,
+    };
+    render(<BadgeWrapper {...omit(props, 'children')}>{props.children}</BadgeWrapper>);
+    const badgeWrapper = getByClassName(document.body, CLASSNAME);
+    return { badgeWrapper, props };
+};
+
+describe(`<${BadgeWrapper.displayName}>`, () => {
+    describe('Props', () => {
+        it('should render badge', () => {
+            const { badgeWrapper } = setup();
+
+            expect(badgeWrapper).toHaveClass('lumx-badge-wrapper');
+            expect(badgeWrapper.children).toHaveLength(2);
+            expect(last(badgeWrapper.children)).toHaveClass('lumx-badge-wrapper__badge');
+        });
+    });
+
+    commonTestsSuiteRTL(setup, {
+        baseClassName: CLASSNAME,
+        forwardClassName: 'badgeWrapper',
+        forwardAttributes: 'badgeWrapper',
+        forwardRef: 'badgeWrapper',
+    });
+});

--- a/packages/lumx-react/src/components/badge/BadgeWrapper.tsx
+++ b/packages/lumx-react/src/components/badge/BadgeWrapper.tsx
@@ -1,0 +1,36 @@
+import { getRootClassName, handleBasicClasses } from '@lumx/react/utils/className';
+import { DEFAULT_PROPS } from '@lumx/react/components/select/WithSelectContext';
+import { Comp, GenericProps } from '@lumx/react/utils/type';
+import classNames from 'classnames';
+import React, { forwardRef, ReactElement, ReactNode } from 'react';
+
+export interface BadgeWrapperProps extends GenericProps {
+    /** Badge. */
+    badge: ReactElement;
+    /** Node to display the badge on */
+    children: ReactNode;
+}
+
+/**
+ * Component display name.
+ */
+const COMPONENT_NAME = 'BadgeWrapper';
+
+/**
+ * Component default class name and class prefix.
+ */
+const CLASSNAME = getRootClassName(COMPONENT_NAME);
+
+export const BadgeWrapper: Comp<BadgeWrapperProps, HTMLDivElement> = forwardRef((props, ref) => {
+    const { badge, children, className, ...forwardedProps } = props;
+
+    return (
+        <div ref={ref} {...forwardedProps} className={classNames(className, handleBasicClasses({ prefix: CLASSNAME }))}>
+            {children}
+            {badge && <div className={`${CLASSNAME}__badge`}>{badge}</div>}
+        </div>
+    );
+});
+BadgeWrapper.displayName = 'BadgeWrapper';
+BadgeWrapper.className = CLASSNAME;
+BadgeWrapper.defaultProps = DEFAULT_PROPS;

--- a/packages/lumx-react/src/components/badge/index.ts
+++ b/packages/lumx-react/src/components/badge/index.ts
@@ -1,1 +1,2 @@
 export * from './Badge';
+export * from './BadgeWrapper';


### PR DESCRIPTION
# General summary

Add a new component `BadgeWrapper` which allows to wrap any other component to add a badge on it. 

It may be used as follows: 
let's say for instance that I want to display a badge over a chip:
```typescript
<BadgeWrapper
    badge={(
        <Badge color={ColorPalette.red}>
            <Icon icon={mdiHeart} />
        </Badge>
    )}
>
    <Chip>Some chip</Chip>
</BadgeWrapper>
```

**NB: We will add a documentation page later after further discussion with Corgui and Flodi, the task is created in Jira: [DSW-292](https://lumapps.atlassian.net/browse/DSW-292)**

# Screenshots
Example on a chip
![badge-wrapper-chip](https://github.com/user-attachments/assets/cc084bda-374e-4668-937e-5b43804cc3e4)

Example on an icon
![badge-wrapper-icon](https://github.com/user-attachments/assets/9171b5e8-4311-492e-ae89-3ab6e8d88b60)

Example on a button
![badge-wrapper-button](https://github.com/user-attachments/assets/0ad3a5e0-568f-437f-be74-adf14661e8fa)



<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [x] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


[DSW-292]: https://lumapps.atlassian.net/browse/DSW-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ