### PR TITLE
fix(expansion-panel): fix children remaining in DOM when isOpen changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `Chip`: trigger onClick when `Enter` key is pressed  
+-   `ExpansionPanel`: fix children remaining in the DOM when `isOpen` prop changes
 
 ## [3.9.4][] - 2024-11-04
 

--- a/packages/lumx-core/src/js/constants/index.ts
+++ b/packages/lumx-core/src/js/constants/index.ts
@@ -13,6 +13,7 @@ export * from './keycodes';
  * you need to update their scss counterpart as well
  */
 export const DIALOG_TRANSITION_DURATION = 400;
+export const EXPANSION_PANEL_TRANSITION_DURATION = 400;
 export const NOTIFICATION_TRANSITION_DURATION = 200;
 export const SLIDESHOW_TRANSITION_DURATION = 5000;
 

--- a/packages/site-demo/content/product/components/expansion-panel/react/examples.tsx
+++ b/packages/site-demo/content/product/components/expansion-panel/react/examples.tsx
@@ -1,6 +1,16 @@
 import { mdiDotsVertical } from '@lumx/icons';
 
-import { Divider, ExpansionPanel, FlexBox, GenericBlock, Heading, IconButton, Text, Thumbnail } from '@lumx/react';
+import {
+    Button,
+    Divider,
+    ExpansionPanel,
+    FlexBox,
+    GenericBlock,
+    Heading,
+    IconButton,
+    Text,
+    Thumbnail,
+} from '@lumx/react';
 import React, { useState } from 'react';
 
 export const App = () => {
@@ -11,8 +21,19 @@ export const App = () => {
     const [isOpen5, setOpen5] = useState(false);
     const stopPropagation = (evt: Event) => evt.stopPropagation();
 
+    const handleCloseAll = () => {
+        setOpen1(false);
+        setOpen2(false);
+        setOpen3(false);
+        setOpen4(false);
+        setOpen5(false);
+    };
+
     return (
         <>
+            <Button type="button" onClick={handleCloseAll}>
+                Close all
+            </Button>
             <ExpansionPanel
                 hasBackground
                 hasHeaderDivider


### PR DESCRIPTION
DSW-294

# General summary

Due to a recent change, the `ExpansionPanel` was only removing the children from the DOM when clicking on the header/toggle button.
However, we have some cases where the panel closes without the header receiving a click (ex: when another panel is opened).

In these cases, the children remained in the DOM.

Fixed by using the `useVisibilityTransition` hook.

A `Close all` button has been added on a story to properly test it.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
