### PR TITLE
fix(chip): trigger onClick event on Enter key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `Chip`: trigger onClick when `Enter` key is pressed  
+
 ## [3.9.4][] - 2024-11-04
 
 ### Fixed

--- a/packages/lumx-react/src/components/chip/Chip.test.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.test.tsx
@@ -168,6 +168,21 @@ describe('<Chip />', () => {
             fireEvent.keyDown(chip, { key: 'A', code: 'KeyA' });
             expect(onKeyDown).toHaveBeenCalled();
         });
+
+        it('should forward key down event and trigger `onClick` when pressing Enter', async () => {
+            const user = userEvent.setup();
+            const onKeyDown = jest.fn();
+            const { chip } = setup({ onClick, onKeyDown });
+
+            await user.tab();
+            expect(chip).toHaveFocus();
+
+            await userEvent.keyboard('{Enter}');
+
+            expect(onKeyDown).toHaveBeenCalled();
+            expect(onClick).toHaveBeenCalled();
+            onClick.mockClear();
+        });
     });
 
     commonTestsSuiteRTL(setup, { baseClassName: CLASSNAME, forwardClassName: 'chip', forwardAttributes: 'chip' });

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -101,7 +101,7 @@ export const Chip: Comp<ChipProps, HTMLAnchorElement> = forwardRef((props, ref) 
     const handleKeyDown = (evt: React.KeyboardEvent) => {
         onKeyDown?.(evt);
         if (hasOnClick) {
-            onEnterPressed(onClick);
+            onEnterPressed(onClick)(evt);
         }
     };
 


### PR DESCRIPTION
DSW-295

# General summary

The "onClick" prop is never triggered when pressing the `Enter` key while focused on the button.
This is because the event wasn't properly forwarded to the prop.

<!-- Please describe the PR content -->

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
