### PR TITLE
fix(navigation-item): fix border left & right impacting the width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   `Navigation`: fix focus outline in dark theme
+-   `NavigationItem`: fix focus outline in dark theme
 -   `NavigationSection`: fix props forwarding
+-   `NavigationItem`: fix border left & right impacting the width
 
 ### Documentation
 

--- a/packages/lumx-core/src/css/design-tokens.css
+++ b/packages/lumx-core/src/css/design-tokens.css
@@ -1,8 +1,8 @@
-/* stylelint-disable custom-property-pattern, max-line-length, scss/dollar-variable-pattern */
+/* stylelint-disable custom-property-pattern, max-line-length, scss/dollar-variable-pattern, length-zero-no-unit */
 
 /**
  * Do not edit directly
- * Generated on Fri, 29 Nov 2024 10:16:26 GMT
+ * Generated on Wed, 04 Dec 2024 10:53:03 GMT
  */
 
 :root {
@@ -157,10 +157,10 @@
     --lumx-navigation-item-padding-horizontal: var(--lumx-spacing-unit-regular);
     --lumx-navigation-item-min-height: 36px;
     --lumx-navigation-item-border-radius: var(--lumx-border-radius);
-    --lumx-navigation-item-emphasis-low-state-default-border-top-width: 0;
-    --lumx-navigation-item-emphasis-low-state-default-border-right-width: 0;
-    --lumx-navigation-item-emphasis-low-state-default-border-bottom-width: 0;
-    --lumx-navigation-item-emphasis-low-state-default-border-left-width: 0;
+    --lumx-navigation-item-emphasis-low-state-default-border-top-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-default-border-right-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-default-border-bottom-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-default-border-left-width: 0px;
     --lumx-navigation-item-emphasis-low-state-default-theme-light-background-color: transparent;
     --lumx-navigation-item-emphasis-low-state-default-theme-light-border-color: var(--lumx-color-dark-L4);
     --lumx-navigation-item-emphasis-low-state-default-theme-light-icon-color: var(--lumx-color-dark-L1);
@@ -173,10 +173,10 @@
     --lumx-navigation-item-emphasis-low-state-default-theme-dark-label-color: var(--lumx-color-light-N);
     --lumx-navigation-item-emphasis-low-state-default-theme-dark-chevron-background-color: transparent;
     --lumx-navigation-item-emphasis-low-state-default-theme-dark-chevron-color: var(--lumx-color-light-L1);
-    --lumx-navigation-item-emphasis-low-state-hover-border-top-width: 0;
-    --lumx-navigation-item-emphasis-low-state-hover-border-right-width: 0;
-    --lumx-navigation-item-emphasis-low-state-hover-border-bottom-width: 0;
-    --lumx-navigation-item-emphasis-low-state-hover-border-left-width: 0;
+    --lumx-navigation-item-emphasis-low-state-hover-border-top-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-hover-border-right-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-hover-border-bottom-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-hover-border-left-width: 0px;
     --lumx-navigation-item-emphasis-low-state-hover-theme-light-background-color: var(--lumx-color-dark-L5);
     --lumx-navigation-item-emphasis-low-state-hover-theme-light-border-color: var(--lumx-color-dark-L4);
     --lumx-navigation-item-emphasis-low-state-hover-theme-light-icon-color: var(--lumx-color-dark-L1);
@@ -189,10 +189,10 @@
     --lumx-navigation-item-emphasis-low-state-hover-theme-dark-label-color: var(--lumx-color-light-N);
     --lumx-navigation-item-emphasis-low-state-hover-theme-dark-chevron-background-color: var(--lumx-color-light-L5);
     --lumx-navigation-item-emphasis-low-state-hover-theme-dark-chevron-color: var(--lumx-color-light-L1);
-    --lumx-navigation-item-emphasis-low-state-active-border-top-width: 0;
-    --lumx-navigation-item-emphasis-low-state-active-border-right-width: 0;
-    --lumx-navigation-item-emphasis-low-state-active-border-bottom-width: 0;
-    --lumx-navigation-item-emphasis-low-state-active-border-left-width: 0;
+    --lumx-navigation-item-emphasis-low-state-active-border-top-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-active-border-right-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-active-border-bottom-width: 0px;
+    --lumx-navigation-item-emphasis-low-state-active-border-left-width: 0px;
     --lumx-navigation-item-emphasis-low-state-active-theme-light-background-color: var(--lumx-color-dark-L4);
     --lumx-navigation-item-emphasis-low-state-active-theme-light-border-color: var(--lumx-color-dark-L4);
     --lumx-navigation-item-emphasis-low-state-active-theme-light-icon-color: var(--lumx-color-dark-L1);
@@ -205,10 +205,10 @@
     --lumx-navigation-item-emphasis-low-state-active-theme-dark-label-color: var(--lumx-color-light-N);
     --lumx-navigation-item-emphasis-low-state-active-theme-dark-chevron-background-color: var(--lumx-color-light-L4);
     --lumx-navigation-item-emphasis-low-state-active-theme-dark-chevron-color: var(--lumx-color-light-L1);
-    --lumx-navigation-item-emphasis-selected-state-default-border-top-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-default-border-right-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-default-border-bottom-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-default-border-left-width: 0;
+    --lumx-navigation-item-emphasis-selected-state-default-border-top-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-default-border-right-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-default-border-bottom-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-default-border-left-width: 0px;
     --lumx-navigation-item-emphasis-selected-state-default-theme-light-background-color: var(--lumx-color-primary-L5);
     --lumx-navigation-item-emphasis-selected-state-default-theme-light-border-color: var(--lumx-color-primary-N);
     --lumx-navigation-item-emphasis-selected-state-default-theme-light-icon-color: var(--lumx-color-primary-D2);
@@ -221,10 +221,10 @@
     --lumx-navigation-item-emphasis-selected-state-default-theme-dark-label-color: var(--lumx-color-light-N);
     --lumx-navigation-item-emphasis-selected-state-default-theme-dark-chevron-background-color: transparent;
     --lumx-navigation-item-emphasis-selected-state-default-theme-dark-chevron-color: var(--lumx-color-light-N);
-    --lumx-navigation-item-emphasis-selected-state-hover-border-top-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-hover-border-right-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-hover-border-bottom-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-hover-border-left-width: 0;
+    --lumx-navigation-item-emphasis-selected-state-hover-border-top-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-hover-border-right-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-hover-border-bottom-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-hover-border-left-width: 0px;
     --lumx-navigation-item-emphasis-selected-state-hover-theme-light-background-color: var(--lumx-color-primary-L4);
     --lumx-navigation-item-emphasis-selected-state-hover-theme-light-border-color: var(--lumx-color-primary-N);
     --lumx-navigation-item-emphasis-selected-state-hover-theme-light-icon-color: var(--lumx-color-primary-D2);
@@ -237,10 +237,10 @@
     --lumx-navigation-item-emphasis-selected-state-hover-theme-dark-label-color: var(--lumx-color-light-N);
     --lumx-navigation-item-emphasis-selected-state-hover-theme-dark-chevron-background-color: var(--lumx-color-light-L4);
     --lumx-navigation-item-emphasis-selected-state-hover-theme-dark-chevron-color: var(--lumx-color-light-N);
-    --lumx-navigation-item-emphasis-selected-state-active-border-top-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-active-border-right-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-active-border-bottom-width: 0;
-    --lumx-navigation-item-emphasis-selected-state-active-border-left-width: 0;
+    --lumx-navigation-item-emphasis-selected-state-active-border-top-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-active-border-right-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-active-border-bottom-width: 0px;
+    --lumx-navigation-item-emphasis-selected-state-active-border-left-width: 0px;
     --lumx-navigation-item-emphasis-selected-state-active-theme-light-background-color: var(--lumx-color-primary-L3);
     --lumx-navigation-item-emphasis-selected-state-active-theme-light-border-color: var(--lumx-color-primary-N);
     --lumx-navigation-item-emphasis-selected-state-active-theme-light-icon-color: var(--lumx-color-primary-D2);

--- a/packages/lumx-core/src/js/constants/design-tokens.ts
+++ b/packages/lumx-core/src/js/constants/design-tokens.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 29 Nov 2024 10:16:26 GMT
+ * Generated on Wed, 04 Dec 2024 10:53:03 GMT
  */
 
 export const DESIGN_TOKENS = {
@@ -500,10 +500,10 @@ export const DESIGN_TOKENS = {
             'emphasis-low': {
                 'state-default': {
                     border: {
-                        top: { width: { value: '0' } },
-                        right: { width: { value: '0' } },
-                        bottom: { width: { value: '0' } },
-                        left: { width: { value: '0' } },
+                        top: { width: { value: '0px' } },
+                        right: { width: { value: '0px' } },
+                        bottom: { width: { value: '0px' } },
+                        left: { width: { value: '0px' } },
                     },
                     'theme-light': {
                         'background-color': { value: 'transparent' },
@@ -556,10 +556,10 @@ export const DESIGN_TOKENS = {
                 },
                 'state-hover': {
                     border: {
-                        top: { width: { value: '0' } },
-                        right: { width: { value: '0' } },
-                        bottom: { width: { value: '0' } },
-                        left: { width: { value: '0' } },
+                        top: { width: { value: '0px' } },
+                        right: { width: { value: '0px' } },
+                        bottom: { width: { value: '0px' } },
+                        left: { width: { value: '0px' } },
                     },
                     'theme-light': {
                         'background-color': {
@@ -628,10 +628,10 @@ export const DESIGN_TOKENS = {
                 },
                 'state-active': {
                     border: {
-                        top: { width: { value: '0' } },
-                        right: { width: { value: '0' } },
-                        bottom: { width: { value: '0' } },
-                        left: { width: { value: '0' } },
+                        top: { width: { value: '0px' } },
+                        right: { width: { value: '0px' } },
+                        bottom: { width: { value: '0px' } },
+                        left: { width: { value: '0px' } },
                     },
                     'theme-light': {
                         'background-color': {
@@ -702,10 +702,10 @@ export const DESIGN_TOKENS = {
             'emphasis-selected': {
                 'state-default': {
                     border: {
-                        top: { width: { value: '0' } },
-                        right: { width: { value: '0' } },
-                        bottom: { width: { value: '0' } },
-                        left: { width: { value: '0' } },
+                        top: { width: { value: '0px' } },
+                        right: { width: { value: '0px' } },
+                        bottom: { width: { value: '0px' } },
+                        left: { width: { value: '0px' } },
                     },
                     'theme-light': {
                         'background-color': {
@@ -766,10 +766,10 @@ export const DESIGN_TOKENS = {
                 },
                 'state-hover': {
                     border: {
-                        top: { width: { value: '0' } },
-                        right: { width: { value: '0' } },
-                        bottom: { width: { value: '0' } },
-                        left: { width: { value: '0' } },
+                        top: { width: { value: '0px' } },
+                        right: { width: { value: '0px' } },
+                        bottom: { width: { value: '0px' } },
+                        left: { width: { value: '0px' } },
                     },
                     'theme-light': {
                         'background-color': {
@@ -838,10 +838,10 @@ export const DESIGN_TOKENS = {
                 },
                 'state-active': {
                     border: {
-                        top: { width: { value: '0' } },
-                        right: { width: { value: '0' } },
-                        bottom: { width: { value: '0' } },
-                        left: { width: { value: '0' } },
+                        top: { width: { value: '0px' } },
+                        right: { width: { value: '0px' } },
+                        bottom: { width: { value: '0px' } },
+                        left: { width: { value: '0px' } },
                     },
                     'theme-light': {
                         'background-color': {

--- a/packages/lumx-core/src/scss/_design-tokens.scss
+++ b/packages/lumx-core/src/scss/_design-tokens.scss
@@ -1,8 +1,8 @@
-/* stylelint-disable custom-property-pattern, max-line-length, scss/dollar-variable-pattern */
+/* stylelint-disable custom-property-pattern, max-line-length, scss/dollar-variable-pattern, length-zero-no-unit */
 
 /**
  * Do not edit directly
- * Generated on Fri, 29 Nov 2024 10:16:26 GMT
+ * Generated on Wed, 04 Dec 2024 10:53:03 GMT
  */
 
 $lumx-button-height: 36px !default;
@@ -156,10 +156,10 @@ $lumx-material-text-field-input-content-line-height: 20px !default;
 $lumx-navigation-item-padding-horizontal: var(--lumx-spacing-unit-regular) !default;
 $lumx-navigation-item-min-height: 36px !default;
 $lumx-navigation-item-border-radius: var(--lumx-border-radius) !default;
-$lumx-navigation-item-emphasis-low-state-default-border-top-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-default-border-right-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-default-border-bottom-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-default-border-left-width: 0 !default;
+$lumx-navigation-item-emphasis-low-state-default-border-top-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-default-border-right-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-default-border-bottom-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-default-border-left-width: 0px !default;
 $lumx-navigation-item-emphasis-low-state-default-theme-light-background-color: transparent !default;
 $lumx-navigation-item-emphasis-low-state-default-theme-light-border-color: var(--lumx-color-dark-L4) !default;
 $lumx-navigation-item-emphasis-low-state-default-theme-light-icon-color: var(--lumx-color-dark-L1) !default;
@@ -172,10 +172,10 @@ $lumx-navigation-item-emphasis-low-state-default-theme-dark-icon-color: var(--lu
 $lumx-navigation-item-emphasis-low-state-default-theme-dark-label-color: var(--lumx-color-light-N) !default;
 $lumx-navigation-item-emphasis-low-state-default-theme-dark-chevron-background-color: transparent !default;
 $lumx-navigation-item-emphasis-low-state-default-theme-dark-chevron-color: var(--lumx-color-light-L1) !default;
-$lumx-navigation-item-emphasis-low-state-hover-border-top-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-hover-border-right-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-hover-border-bottom-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-hover-border-left-width: 0 !default;
+$lumx-navigation-item-emphasis-low-state-hover-border-top-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-hover-border-right-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-hover-border-bottom-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-hover-border-left-width: 0px !default;
 $lumx-navigation-item-emphasis-low-state-hover-theme-light-background-color: var(--lumx-color-dark-L5) !default;
 $lumx-navigation-item-emphasis-low-state-hover-theme-light-border-color: var(--lumx-color-dark-L4) !default;
 $lumx-navigation-item-emphasis-low-state-hover-theme-light-icon-color: var(--lumx-color-dark-L1) !default;
@@ -188,10 +188,10 @@ $lumx-navigation-item-emphasis-low-state-hover-theme-dark-icon-color: var(--lumx
 $lumx-navigation-item-emphasis-low-state-hover-theme-dark-label-color: var(--lumx-color-light-N) !default;
 $lumx-navigation-item-emphasis-low-state-hover-theme-dark-chevron-background-color: var(--lumx-color-light-L5) !default;
 $lumx-navigation-item-emphasis-low-state-hover-theme-dark-chevron-color: var(--lumx-color-light-L1) !default;
-$lumx-navigation-item-emphasis-low-state-active-border-top-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-active-border-right-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-active-border-bottom-width: 0 !default;
-$lumx-navigation-item-emphasis-low-state-active-border-left-width: 0 !default;
+$lumx-navigation-item-emphasis-low-state-active-border-top-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-active-border-right-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-active-border-bottom-width: 0px !default;
+$lumx-navigation-item-emphasis-low-state-active-border-left-width: 0px !default;
 $lumx-navigation-item-emphasis-low-state-active-theme-light-background-color: var(--lumx-color-dark-L4) !default;
 $lumx-navigation-item-emphasis-low-state-active-theme-light-border-color: var(--lumx-color-dark-L4) !default;
 $lumx-navigation-item-emphasis-low-state-active-theme-light-icon-color: var(--lumx-color-dark-L1) !default;
@@ -204,10 +204,10 @@ $lumx-navigation-item-emphasis-low-state-active-theme-dark-icon-color: var(--lum
 $lumx-navigation-item-emphasis-low-state-active-theme-dark-label-color: var(--lumx-color-light-N) !default;
 $lumx-navigation-item-emphasis-low-state-active-theme-dark-chevron-background-color: var(--lumx-color-light-L4) !default;
 $lumx-navigation-item-emphasis-low-state-active-theme-dark-chevron-color: var(--lumx-color-light-L1) !default;
-$lumx-navigation-item-emphasis-selected-state-default-border-top-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-default-border-right-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-default-border-bottom-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-default-border-left-width: 0 !default;
+$lumx-navigation-item-emphasis-selected-state-default-border-top-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-default-border-right-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-default-border-bottom-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-default-border-left-width: 0px !default;
 $lumx-navigation-item-emphasis-selected-state-default-theme-light-background-color: var(--lumx-color-primary-L5) !default;
 $lumx-navigation-item-emphasis-selected-state-default-theme-light-border-color: var(--lumx-color-primary-N) !default;
 $lumx-navigation-item-emphasis-selected-state-default-theme-light-icon-color: var(--lumx-color-primary-D2) !default;
@@ -220,10 +220,10 @@ $lumx-navigation-item-emphasis-selected-state-default-theme-dark-icon-color: var
 $lumx-navigation-item-emphasis-selected-state-default-theme-dark-label-color: var(--lumx-color-light-N) !default;
 $lumx-navigation-item-emphasis-selected-state-default-theme-dark-chevron-background-color: transparent !default;
 $lumx-navigation-item-emphasis-selected-state-default-theme-dark-chevron-color: var(--lumx-color-light-N) !default;
-$lumx-navigation-item-emphasis-selected-state-hover-border-top-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-hover-border-right-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-hover-border-bottom-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-hover-border-left-width: 0 !default;
+$lumx-navigation-item-emphasis-selected-state-hover-border-top-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-hover-border-right-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-hover-border-bottom-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-hover-border-left-width: 0px !default;
 $lumx-navigation-item-emphasis-selected-state-hover-theme-light-background-color: var(--lumx-color-primary-L4) !default;
 $lumx-navigation-item-emphasis-selected-state-hover-theme-light-border-color: var(--lumx-color-primary-N) !default;
 $lumx-navigation-item-emphasis-selected-state-hover-theme-light-icon-color: var(--lumx-color-primary-D2) !default;
@@ -236,10 +236,10 @@ $lumx-navigation-item-emphasis-selected-state-hover-theme-dark-icon-color: var(-
 $lumx-navigation-item-emphasis-selected-state-hover-theme-dark-label-color: var(--lumx-color-light-N) !default;
 $lumx-navigation-item-emphasis-selected-state-hover-theme-dark-chevron-background-color: var(--lumx-color-light-L4) !default;
 $lumx-navigation-item-emphasis-selected-state-hover-theme-dark-chevron-color: var(--lumx-color-light-N) !default;
-$lumx-navigation-item-emphasis-selected-state-active-border-top-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-active-border-right-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-active-border-bottom-width: 0 !default;
-$lumx-navigation-item-emphasis-selected-state-active-border-left-width: 0 !default;
+$lumx-navigation-item-emphasis-selected-state-active-border-top-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-active-border-right-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-active-border-bottom-width: 0px !default;
+$lumx-navigation-item-emphasis-selected-state-active-border-left-width: 0px !default;
 $lumx-navigation-item-emphasis-selected-state-active-theme-light-background-color: var(--lumx-color-primary-L3) !default;
 $lumx-navigation-item-emphasis-selected-state-active-theme-light-border-color: var(--lumx-color-primary-N) !default;
 $lumx-navigation-item-emphasis-selected-state-active-theme-light-icon-color: var(--lumx-color-primary-D2) !default;

--- a/packages/lumx-core/src/scss/components/navigation/_index.scss
+++ b/packages/lumx-core/src/scss/components/navigation/_index.scss
@@ -1,3 +1,5 @@
+/* stylelint-disable custom-property-pattern */
+
 /* ==========================================================================
    Navigation
    ========================================================================== */
@@ -18,23 +20,35 @@
         max-width: 100%;
         min-height: var(--lumx-navigation-item-min-height);
         padding: 0 var(--lumx-navigation-item-padding-horizontal);
+        padding-right: calc(var(--lumx-navigation-item-padding-horizontal) - var(--_border-right-width));
+        padding-left: calc(var(--lumx-navigation-item-padding-horizontal) - var(--_border-left-width));
         overflow: hidden;
         text-decoration: none;
         cursor: pointer;
+        background-color: var(--_background-color);
+        border-color: var(--_border-color);
+        border-style: solid;
+        border-width:
+            var(--_border-top-width)
+            var(--_border-right-width)
+            var(--_border-bottom-width)
+            var(--_border-left-width);
         border-radius: var(--lumx-navigation-item-border-radius);
         outline: none;
 
         @include lumx-typography("navigation-item", "custom");
     }
 
-    &__label {
+    #{&} &__label {
         overflow: hidden;
+        color: var(--_label-color);
         text-overflow: ellipsis;
         white-space: nowrap;
     }
 
-    &__icon {
+    #{&} &__icon {
         margin-right: $lumx-spacing-unit;
+        color: var(--_icon-color);
     }
 }
 

--- a/packages/lumx-core/src/scss/components/navigation/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/navigation/_mixins.scss
@@ -1,23 +1,17 @@
+/* stylelint-disable custom-property-pattern */
+
 @use "sass:map";
 
 @mixin lumx-navigation-link-borders($emphasis, $state) {
-    border-style: solid;
-    border-width:
-        var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-top-width)
-        var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-right-width)
-        var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-bottom-width)
-        var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-left-width);
+    --_border-top-width: var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-top-width);
+    --_border-right-width: var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-right-width);
+    --_border-bottom-width: var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-bottom-width);
+    --_border-left-width: var(--lumx-navigation-item-#{$emphasis}-#{$state}-border-left-width);
 }
 
 @mixin lumx-navigation-link-colors($emphasis, $state, $theme) {
-    background-color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-background-color);
-    border-color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-border-color);
-
-    .#{$lumx-base-prefix}-navigation-item__label {
-        color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-label-color);
-    }
-
-    .#{$lumx-base-prefix}-navigation-item__icon {
-        color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-icon-color);
-    }
+    --_background-color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-background-color);
+    --_border-color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-border-color);
+    --_label-color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-label-color);
+    --_icon-color: var(--lumx-navigation-item-#{$emphasis}-#{$state}-#{$theme}-icon-color);
 }

--- a/packages/lumx-core/style-dictionary/config/utils/_format-stylelint-disable.js
+++ b/packages/lumx-core/style-dictionary/config/utils/_format-stylelint-disable.js
@@ -3,7 +3,7 @@ const StyleDictionary = require('style-dictionary');
 /**
  * Disabling some rules that can't be respected in auto-generated SCSS/CSS code.
  */
-const DISABLE_COMMENT = `/* stylelint-disable custom-property-pattern, max-line-length, scss/dollar-variable-pattern */`;
+const DISABLE_COMMENT = `/* stylelint-disable custom-property-pattern, max-line-length, scss/dollar-variable-pattern, length-zero-no-unit */`;
 
 /**
  * Wrap a format to prepend stylelint disable comment.

--- a/packages/lumx-core/style-dictionary/properties/components/navigation.json
+++ b/packages/lumx-core/style-dictionary/properties/components/navigation.json
@@ -10,16 +10,16 @@
                 "state-default": {
                     "border": {
                         "top": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "right": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "bottom": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "left": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         }
                     },
                     "theme-light": {
@@ -42,16 +42,16 @@
                 "state-hover": {
                     "border": {
                         "top": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "right": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "bottom": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "left": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         }
                     },
                     "theme-light": {
@@ -74,16 +74,16 @@
                 "state-active": {
                     "border": {
                         "top": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "right": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "bottom": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "left": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         }
                     },
                     "theme-light": {
@@ -108,16 +108,16 @@
                 "state-default": {
                     "border": {
                         "top": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "right": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "bottom": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "left": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         }
                     },
                     "theme-light": {
@@ -140,16 +140,16 @@
                 "state-hover": {
                     "border": {
                         "top": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "right": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "bottom": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "left": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         }
                     },
                     "theme-light": {
@@ -172,16 +172,16 @@
                 "state-active": {
                     "border": {
                         "top": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "right": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "bottom": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         },
                         "left": {
-                            "width": { "value": "0" }
+                            "width": { "value": "0px" }
                         }
                     },
                     "theme-light": {


### PR DESCRIPTION
Rework the navigation item styles to make sure the border left & right does not affect the width

- Refactor navigation item styles to use "private" css variables to indirectly apply the public variables (design tokens)
- Calculate the left padding by removing the current border left width
- Calculate the right padding by removing the current border right width
- Make sure the border width default to `0px` and not `0` (or else it breaks the `calc()`)


StoryBook: https://3ec7fb6e--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=414))