### PR TITLE
feat(button): add support for `isSelected` in `low` emphasis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `Button`: add support of `isSelected` in `low` emphasis (in addition to `medium`).
+
 ### Changed
 
 -   `DatePicker`: update day buttons to use standard button styles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `DatePicker`: update day buttons to use standard button styles
 -   `Chip`: add border and background color CSS variable theming on selected state.
 -   `SideNavigationItem`: add border CSS variable theming on selected state.
+-   `Button`: deprecated variables `--lumx-button-emphasis-selected-state-default-padding-horizontal`,
+     `--lumx-button-emphasis-selected-hover-hover-padding-horizontal` and
+     `--lumx-button-emphasis-selected-hover-active-padding-horizontal` (use the base `low` or `medium` emphasis padding)
 
 ### Fixed
 

--- a/packages/lumx-core/src/css/design-tokens.css
+++ b/packages/lumx-core/src/css/design-tokens.css
@@ -2,7 +2,7 @@
 
 /**
  * Do not edit directly
- * Generated on Wed, 04 Dec 2024 10:53:03 GMT
+ * Generated on Fri, 06 Dec 2024 13:46:59 GMT
  */
 
 :root {
@@ -80,7 +80,7 @@
     --lumx-button-emphasis-low-state-active-theme-dark-background-color: var(--lumx-color-light-L4);
     --lumx-button-emphasis-low-state-active-theme-dark-color: var(--lumx-color-light-L1);
     --lumx-button-emphasis-low-state-active-theme-dark-border-color: transparent;
-    --lumx-button-emphasis-selected-state-default-padding-horizontal: var(--lumx-spacing-unit-big);
+    --lumx-button-emphasis-selected-state-default-padding-horizontal: 16px; /* deprecated (use base emphasis padding) */
     --lumx-button-emphasis-selected-state-default-border-width: 0;
     --lumx-button-emphasis-selected-state-default-theme-light-background-color: var(--lumx-color-primary-L5);
     --lumx-button-emphasis-selected-state-default-theme-light-color: var(--lumx-color-primary-D2);
@@ -88,7 +88,7 @@
     --lumx-button-emphasis-selected-state-default-theme-dark-background-color: var(--lumx-color-light-L3);
     --lumx-button-emphasis-selected-state-default-theme-dark-color: var(--lumx-color-light-N);
     --lumx-button-emphasis-selected-state-default-theme-dark-border-color: transparent;
-    --lumx-button-emphasis-selected-state-hover-padding-horizontal: var(--lumx-spacing-unit-big);
+    --lumx-button-emphasis-selected-state-hover-padding-horizontal: 16px; /* deprecated (use base emphasis padding) */
     --lumx-button-emphasis-selected-state-hover-border-width: 0;
     --lumx-button-emphasis-selected-state-hover-theme-light-background-color: var(--lumx-color-primary-L4);
     --lumx-button-emphasis-selected-state-hover-theme-light-color: var(--lumx-color-primary-D2);
@@ -96,7 +96,7 @@
     --lumx-button-emphasis-selected-state-hover-theme-dark-background-color: var(--lumx-color-light-L4);
     --lumx-button-emphasis-selected-state-hover-theme-dark-color: var(--lumx-color-light-N);
     --lumx-button-emphasis-selected-state-hover-theme-dark-border-color: transparent;
-    --lumx-button-emphasis-selected-state-active-padding-horizontal: var(--lumx-spacing-unit-big);
+    --lumx-button-emphasis-selected-state-active-padding-horizontal: 16px; /* deprecated (use base emphasis padding) */
     --lumx-button-emphasis-selected-state-active-border-width: 0;
     --lumx-button-emphasis-selected-state-active-theme-light-background-color: var(--lumx-color-primary-L3);
     --lumx-button-emphasis-selected-state-active-theme-light-color: var(--lumx-color-primary-D2);

--- a/packages/lumx-core/src/js/constants/design-tokens.ts
+++ b/packages/lumx-core/src/js/constants/design-tokens.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 04 Dec 2024 10:53:03 GMT
+ * Generated on Fri, 06 Dec 2024 13:46:59 GMT
  */
 
 export const DESIGN_TOKENS = {
@@ -283,7 +283,7 @@ export const DESIGN_TOKENS = {
         },
         'emphasis-selected': {
             'state-default': {
-                padding: { horizontal: { value: 'var(--lumx-spacing-unit-big)', $aliasedFrom: 'spacing.unit.big' } },
+                padding: { horizontal: { comment: 'deprecated (use base emphasis padding)', value: '16px' } },
                 'border-width': { value: '0' },
                 'theme-light': {
                     'background-color': {
@@ -313,7 +313,7 @@ export const DESIGN_TOKENS = {
                 },
             },
             'state-hover': {
-                padding: { horizontal: { value: 'var(--lumx-spacing-unit-big)', $aliasedFrom: 'spacing.unit.big' } },
+                padding: { horizontal: { comment: 'deprecated (use base emphasis padding)', value: '16px' } },
                 'border-width': { value: '0' },
                 'theme-light': {
                     'background-color': {
@@ -343,7 +343,7 @@ export const DESIGN_TOKENS = {
                 },
             },
             'state-active': {
-                padding: { horizontal: { value: 'var(--lumx-spacing-unit-big)', $aliasedFrom: 'spacing.unit.big' } },
+                padding: { horizontal: { comment: 'deprecated (use base emphasis padding)', value: '16px' } },
                 'border-width': { value: '0' },
                 'theme-light': {
                     'background-color': {

--- a/packages/lumx-core/src/scss/_design-tokens.scss
+++ b/packages/lumx-core/src/scss/_design-tokens.scss
@@ -2,7 +2,7 @@
 
 /**
  * Do not edit directly
- * Generated on Wed, 04 Dec 2024 10:53:03 GMT
+ * Generated on Fri, 06 Dec 2024 13:46:59 GMT
  */
 
 $lumx-button-height: 36px !default;
@@ -79,7 +79,7 @@ $lumx-button-emphasis-low-state-active-theme-light-border-color: transparent !de
 $lumx-button-emphasis-low-state-active-theme-dark-background-color: var(--lumx-color-light-L4) !default;
 $lumx-button-emphasis-low-state-active-theme-dark-color: var(--lumx-color-light-L1) !default;
 $lumx-button-emphasis-low-state-active-theme-dark-border-color: transparent !default;
-$lumx-button-emphasis-selected-state-default-padding-horizontal: var(--lumx-spacing-unit-big) !default;
+$lumx-button-emphasis-selected-state-default-padding-horizontal: 16px !default; // deprecated (use base emphasis padding)
 $lumx-button-emphasis-selected-state-default-border-width: 0 !default;
 $lumx-button-emphasis-selected-state-default-theme-light-background-color: var(--lumx-color-primary-L5) !default;
 $lumx-button-emphasis-selected-state-default-theme-light-color: var(--lumx-color-primary-D2) !default;
@@ -87,7 +87,7 @@ $lumx-button-emphasis-selected-state-default-theme-light-border-color: transpare
 $lumx-button-emphasis-selected-state-default-theme-dark-background-color: var(--lumx-color-light-L3) !default;
 $lumx-button-emphasis-selected-state-default-theme-dark-color: var(--lumx-color-light-N) !default;
 $lumx-button-emphasis-selected-state-default-theme-dark-border-color: transparent !default;
-$lumx-button-emphasis-selected-state-hover-padding-horizontal: var(--lumx-spacing-unit-big) !default;
+$lumx-button-emphasis-selected-state-hover-padding-horizontal: 16px !default; // deprecated (use base emphasis padding)
 $lumx-button-emphasis-selected-state-hover-border-width: 0 !default;
 $lumx-button-emphasis-selected-state-hover-theme-light-background-color: var(--lumx-color-primary-L4) !default;
 $lumx-button-emphasis-selected-state-hover-theme-light-color: var(--lumx-color-primary-D2) !default;
@@ -95,7 +95,7 @@ $lumx-button-emphasis-selected-state-hover-theme-light-border-color: transparent
 $lumx-button-emphasis-selected-state-hover-theme-dark-background-color: var(--lumx-color-light-L4) !default;
 $lumx-button-emphasis-selected-state-hover-theme-dark-color: var(--lumx-color-light-N) !default;
 $lumx-button-emphasis-selected-state-hover-theme-dark-border-color: transparent !default;
-$lumx-button-emphasis-selected-state-active-padding-horizontal: var(--lumx-spacing-unit-big) !default;
+$lumx-button-emphasis-selected-state-active-padding-horizontal: 16px !default; // deprecated (use base emphasis padding)
 $lumx-button-emphasis-selected-state-active-border-width: 0 !default;
 $lumx-button-emphasis-selected-state-active-theme-light-background-color: var(--lumx-color-primary-L3) !default;
 $lumx-button-emphasis-selected-state-active-theme-light-color: var(--lumx-color-primary-D2) !default;

--- a/packages/lumx-core/src/scss/components/button/_index.scss
+++ b/packages/lumx-core/src/scss/components/button/_index.scss
@@ -30,23 +30,13 @@
                 }
             }
 
-            &.#{$lumx-base-prefix}-button--emphasis-medium:not(.#{$lumx-base-prefix}-button--is-selected) {
+            &.#{$lumx-base-prefix}-button--emphasis-medium {
                 &.#{$lumx-base-prefix}-button--variant-button {
                     @include lumx-button-size(lumx-base-const("emphasis", "MEDIUM"), "button", $key);
                 }
 
                 &.#{$lumx-base-prefix}-button--variant-icon {
                     @include lumx-button-size(lumx-base-const("emphasis", "MEDIUM"), "icon", $key);
-                }
-            }
-
-            &.#{$lumx-base-prefix}-button--emphasis-medium.#{$lumx-base-prefix}-button--is-selected {
-                &.#{$lumx-base-prefix}-button--variant-button {
-                    @include lumx-button-size(lumx-base-const("emphasis", "SELECTED"), "button", $key);
-                }
-
-                &.#{$lumx-base-prefix}-button--variant-icon {
-                    @include lumx-button-size(lumx-base-const("emphasis", "SELECTED"), "icon", $key);
                 }
             }
 
@@ -107,16 +97,29 @@
 
 @each $key, $color in $lumx-color-palette {
     .#{$lumx-base-prefix}-button--color-#{$key} {
-        &:not(.#{$lumx-base-prefix}-button--is-selected).#{$lumx-base-prefix}-button--emphasis-medium {
+        &.#{$lumx-base-prefix}-button--emphasis-medium {
             @include lumx-button-color(lumx-base-const("emphasis", "MEDIUM"), $key);
         }
 
-        &:not(.#{$lumx-base-prefix}-button--is-selected).#{$lumx-base-prefix}-button--emphasis-low {
+        &.#{$lumx-base-prefix}-button--emphasis-low {
             @include lumx-button-color(lumx-base-const("emphasis", "LOW"), $key);
         }
+    }
+}
 
-        &.#{$lumx-base-prefix}-button--is-selected {
-            @include lumx-button-color(lumx-base-const("emphasis", "SELECTED"), $key);
+
+/* Button selected
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-button.#{$lumx-base-prefix}-button--is-selected.#{$lumx-base-prefix}-button--emphasis-medium,
+.#{$lumx-base-prefix}-button.#{$lumx-base-prefix}-button--is-selected.#{$lumx-base-prefix}-button--emphasis-low, {
+    @include lumx-button-size(lumx-base-const("emphasis", "SELECTED"));
+
+    @each $key, $color in $lumx-color-palette {
+        &.#{$lumx-base-prefix}-button--color-#{$key} {
+            &.#{$lumx-base-prefix}-button--is-selected {
+                @include lumx-button-color(lumx-base-const("emphasis", "SELECTED"), $key);
+            }
         }
     }
 }

--- a/packages/lumx-core/src/scss/components/button/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/button/_mixins.scss
@@ -28,11 +28,13 @@
     }
 }
 
-@mixin lumx-button-size($emphasis, $variant, $size) {
-    @if $size == lumx-base-const("size", "M") {
-        height: var(--lumx-button-height);
-    } @else if $size == lumx-base-const("size", "S") {
-        height: calc(var(--lumx-button-height) / 1.5);
+@mixin lumx-button-size($emphasis, $variant: null, $size: null) {
+    @if $variant {
+        @if $size == lumx-base-const("size", "M") {
+            height: var(--lumx-button-height);
+        } @else if $size == lumx-base-const("size", "S") {
+            height: calc(var(--lumx-button-height) / 1.5);
+        }
     }
 
     @if $variant == "button" {

--- a/packages/lumx-core/src/scss/components/date-picker/_index.scss
+++ b/packages/lumx-core/src/scss/components/date-picker/_index.scss
@@ -65,9 +65,5 @@
         &--is-today span {
             font-weight: var(--lumx-button-font-weight);
         }
-
-        &--is-selected {
-            @include lumx-button-is-selected(lumx-base-const("theme", "LIGHT"));
-        }
     }
 }

--- a/packages/lumx-core/style-dictionary/properties/components/button.json
+++ b/packages/lumx-core/style-dictionary/properties/components/button.json
@@ -155,7 +155,7 @@
         "emphasis-selected": {
             "state-default": {
                 "padding": {
-                    "horizontal": "{spacing.unit.big}"
+                    "horizontal": { "value": "{spacing.unit.big.value}", "comment": "deprecated (use base emphasis padding)" }
                 },
                 "border-width": { "value": "0" },
                 "theme-light": {
@@ -171,7 +171,7 @@
             },
             "state-hover": {
                 "padding": {
-                    "horizontal": "{spacing.unit.big}"
+                    "horizontal": { "value": "{spacing.unit.big.value}", "comment":  "deprecated (use base emphasis padding)" }
                 },
                 "border-width": { "value": "0" },
                 "theme-light": {
@@ -187,7 +187,7 @@
             },
             "state-active": {
                 "padding": {
-                    "horizontal": "{spacing.unit.big}"
+                    "horizontal": { "value": "{spacing.unit.big.value}", "comment":  "deprecated (use base emphasis padding)" }
                 },
                 "border-width": { "value": "0" },
                 "theme-light": {

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -22,9 +22,9 @@ const buttonEmphasis = [Emphasis.high, Emphasis.medium, Emphasis.low];
 // Combination of props that should be avoided
 const excludeCombination = ({ isSelected, emphasis, hasBackground }: any) => {
     // isSelected is only supported in medium emphasis
-    if (isSelected && emphasis && emphasis !== 'medium') return true;
+    if (isSelected && emphasis && emphasis !== Emphasis.medium && emphasis !== Emphasis.low) return true;
     // hasBackground is only supported in low emphasis
-    if (hasBackground && emphasis && emphasis !== 'low') return true;
+    if (hasBackground && emphasis && emphasis !== Emphasis.low) return true;
     return false;
 };
 

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -31,7 +31,7 @@ export interface BaseButtonProps
     href?: string;
     /** Whether the component is disabled or not. */
     isDisabled?: boolean;
-    /** Whether the component is selected or not. */
+    /** Whether the component is selected or not (unsupported in `high` emphasis). */
     isSelected?: boolean;
     /** Native button name property. */
     name?: string;

--- a/packages/lumx-react/src/stories/utils/theming.tsx
+++ b/packages/lumx-react/src/stories/utils/theming.tsx
@@ -133,7 +133,9 @@ export function withTheming<P extends PropertyTree>({
                     return (varName: string) =>
                         // Has the given arg with value
                         varName.match(new RegExp(`${argName}-${argValue}`)) ||
-                        (argName === 'emphasis' && argValue === 'medium' && varName.match(/emphasis-selected/)) ||
+                        (argName === 'emphasis' &&
+                            (argValue === 'medium' || argValue === 'low') &&
+                            varName.match(/emphasis-selected/)) ||
                         // Or does not have the arg at all
                         !varName.match(new RegExp(`${argName}-\\w+`));
                 }


### PR DESCRIPTION
- Reworked button styles so that the selected state can apply on top of both `medium` and `low` emphasis
- Deprecate selected state padding variables as we prefer to keep the base emphasis style for sizing

Selected state in low and medium emphasis is testable here: https://4436b6bb--5fbfb1d508c0520021560f10.chromatic.com/?path=/story/lumx-components-button-button--state-variations

StoryBook: https://1e0d3d2e--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=416)) **⚠️ Outdated commit**