### PR TITLE
fix(side-navigation): fix selected style rule no constrained enough

### DIFF
--- a/packages/lumx-core/src/scss/components/side-navigation/_index.scss
+++ b/packages/lumx-core/src/scss/components/side-navigation/_index.scss
@@ -64,6 +64,7 @@
     @include lumx-list-item-clickable;
 }
 
-.#{$lumx-base-prefix}-side-navigation-item--is-selected .#{$lumx-base-prefix}-side-navigation-item__link {
+.#{$lumx-base-prefix}-side-navigation-item--is-selected > .#{$lumx-base-prefix}-side-navigation-item__link,
+.#{$lumx-base-prefix}-side-navigation-item--is-selected > .#{$lumx-base-prefix}-side-navigation-item__wrapper > .#{$lumx-base-prefix}-side-navigation-item__link {
     @include lumx-list-item-selected('side-navigation-item');
 }


### PR DESCRIPTION
Fix a bug where all the children of a selected side navigation would get the selected style

(Not adding in the changelog since it does not appear in the current release of lumx)

StoryBook: [Deploying...](https://github.com/lumapps/design-system/actions/runs/12237776357?pr=1226)