### PR TITLE
fix(slideshow-contrast): improve contrast of non-selected bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   `Tabs`: add tab label truncate on constrained width.
+-   `TextField`: change theme light border color for better contrast
+-   `SlideShow`: rework control button color contrast for better a11y.
 
 ## [3.9.7][] - 2025-01-07
 
 ### Changed
 
--   `TextField`: change theme light border color for better contrast
+-   `Tabs`: add tab label truncate on constrained width.
 
 ## [3.9.6][] - 2024-12-04
 

--- a/packages/lumx-core/src/scss/components/slideshow/_index.scss
+++ b/packages/lumx-core/src/scss/components/slideshow/_index.scss
@@ -119,7 +119,8 @@
         text-decoration: none;
         cursor: pointer;
         user-select: none;
-        border: none;
+        background: none;
+        border-style: solid;
         border-radius: 50%;
         outline: none;
         transition: transform $lumx-slideshow-transition-duration;
@@ -130,7 +131,8 @@
         }
 
         #{$self}--theme-light & {
-            background-color:lumx-color-variant("dark", "L5");
+            border-color:lumx-color-variant("dark", "L2");
+            border-width: 2px;
 
             &[data-focus-visible-added] {
                 @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "dark");
@@ -138,11 +140,13 @@
 
             &:hover {
                 background-color: lumx-color-variant("primary", "N");
+                border-width: 0;
             }
             &--is-active {
                 background-color: lumx-color-variant("primary", "N");
                 width: $item-size*2;
                 border-radius: $lumx-border-radius;
+                border-width: 0;
                 
                 &[data-focus-visible-added] {
                     @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "primary");
@@ -151,7 +155,7 @@
         }
 
         #{$self}--theme-dark & {
-            background-color: lumx-color-variant("light", "L5");
+            border-color: lumx-color-variant("light", "L2");
 
             &[data-focus-visible-added] {
                 @include lumx-state(lumx-base-const("state", "FOCUS"), lumx-base-const("emphasis", "LOW"), "light");


### PR DESCRIPTION
# General summary
User reported non-suffisant contrast ratio on non-active bullet of the slide show controller.

This work improve the contrast by changing the style of non-selected bullets.

# Screenshots
## Before
<img width="388" alt="Capture d’écran 2025-01-03 à 09 01 52" src="https://github.com/user-attachments/assets/4fcb9457-935c-424f-b0a0-076c9b8659fe" /><img width="370" alt="Capture d’écran 2025-01-03 à 10 40 11" src="https://github.com/user-attachments/assets/5d64489b-0d1c-4758-aef4-a9ca5ac905ad" />

## After
<img width="402" alt="Capture d’écran 2025-01-03 à 09 01 42" src="https://github.com/user-attachments/assets/2a56c110-668e-417c-91ee-3f3af9fa103b" /><img width="382" alt="Capture d’écran 2025-01-03 à 10 40 05" src="https://github.com/user-attachments/assets/7747cac8-8529-482d-8b42-1cc02d5db4a6" />

Fix https://lumapps.atlassian.net/browse/DSW-333

StoryBook: https://babbb781--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=426)) **⚠️ Outdated commit**