### PR TITLE
fix(tooltip): remove aria-label that breaks labelled by link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `IconButton`: remove the children prop as it's not actually supported by the component
 -   `Popover`: fix improper first placement on React 18
 -   `Popover`: update placement on both anchor and popover resize
+-   `Tooltip`: remove un-necessary tooltip `aria-label` that would break `aria-labelledby` link to anchor
 
 ## [3.11.0][] - 2025-02-05
 

--- a/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.test.tsx
@@ -26,7 +26,7 @@ jest.mock('@lumx/react/constants', () => ({
 const setup = async (propsOverride: Partial<TooltipProps> = {}) => {
     const props: any = { forceOpen: true, label: 'Tooltip label', children: 'Anchor', ...propsOverride };
     const result = render(<Tooltip {...props} />);
-    const tooltip = screen.queryByRole('tooltip', { name: props.label });
+    const tooltip = screen.queryByRole('tooltip');
     const anchorWrapper = queryByClassName(document.body, 'lumx-tooltip-anchor-wrapper');
     return { props, tooltip, anchorWrapper, result };
 };

--- a/packages/lumx-react/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-react/src/components/tooltip/Tooltip.tsx
@@ -135,7 +135,6 @@ export const Tooltip = forwardRef<TooltipProps, HTMLDivElement>((props, ref) => 
                         {...forwardedProps}
                         id={id}
                         role="tooltip"
-                        aria-label={label || ''}
                         className={classNames(
                             className,
                             handleBasicClasses({


### PR DESCRIPTION
# General summary

Fix "labelled by" link broken because of the aria label on the tooltip

