### PR TITLE
fix(mosaic): fix parent overflow issue caused by negative inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `Tooltip`: remove placement style when hidden (closeMode=hide) to fix overflow issue
+-   `Mosaic`: remove negative inset that could break overflow of parent element
 
 ## [3.11.2][] - 2025-02-18
 

--- a/packages/lumx-core/src/scss/components/mosaic/_index.scss
+++ b/packages/lumx-core/src/scss/components/mosaic/_index.scss
@@ -12,11 +12,12 @@
 
     &__wrapper {
         position: absolute;
-        top: -1px;
-        right: -1px;
-        bottom: -1px;
-        left: -1px;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
         display: grid;
+        gap: 2px;
 
         #{$self}--has-1-thumbnail & {
             grid: minmax(0, 1fr) / 1fr;
@@ -47,7 +48,6 @@
         position: relative;
         display: flex;
         flex-direction: column;
-        margin: 1px;
 
         &:has([data-focus-visible-added]) {
             z-index: 1;


### PR DESCRIPTION
# General summary

remove negative inset that could break overflow of parent element


StoryBook: https://e197ae44--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=440))