### PR TITLE
fix(button): fix icon color inside a theme context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `InputLabel`: add `typography` prop
 
+### Fixed
+
+-   `Button`: fix icon color inside a theme context.
+
 ## [3.12.0][] - 2025-03-19
 
 ### Added

--- a/packages/lumx-react/src/components/button/Button.test.tsx
+++ b/packages/lumx-react/src/components/button/Button.test.tsx
@@ -72,10 +72,11 @@ describe(`<${Button.displayName}>`, () => {
         forwardAttributes: 'button',
         forwardRef: 'button',
         applyTheme: {
-            affects: [{ element: 'button' }],
+            affects: [{ element: 'button' }, { not: { element: 'icons' } }],
             viaProp: true,
             viaContext: true,
             defaultTheme: 'light',
+            defaultProps: { rightIcon: mdiPlus, leftIcon: mdiCheck },
         },
     });
 });

--- a/packages/lumx-react/src/components/button/Button.tsx
+++ b/packages/lumx-react/src/components/button/Button.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
 
-import { Emphasis, Icon, Size, Theme, Text } from '@lumx/react';
+import { Emphasis, Icon, Size, Theme, Text, ThemeProvider } from '@lumx/react';
 import { isComponent } from '@lumx/react/utils/type';
 import { getBasicClass, getRootClassName } from '@lumx/react/utils/className';
 import { useTheme } from '@lumx/react/utils/theme/ThemeContext';
@@ -73,9 +73,19 @@ export const Button = forwardRef<ButtonProps, HTMLButtonElement | HTMLAnchorElem
             className={buttonClassName}
             variant="button"
         >
-            {leftIcon && !isEmpty(leftIcon) && <Icon icon={leftIcon} />}
+            {leftIcon && !isEmpty(leftIcon) && (
+                // Theme is handled in the button scss
+                <ThemeProvider value={undefined}>
+                    <Icon icon={leftIcon} />
+                </ThemeProvider>
+            )}
             {children && (isComponent(Text)(children) ? children : <span>{children}</span>)}
-            {rightIcon && !isEmpty(rightIcon) && <Icon icon={rightIcon} />}
+            {rightIcon && !isEmpty(rightIcon) && (
+                // Theme is handled in the button scss
+                <ThemeProvider value={undefined}>
+                    <Icon icon={rightIcon} />
+                </ThemeProvider>
+            )}
         </ButtonRoot>
     );
 });

--- a/packages/lumx-react/src/testing/utils/commonTestsSuiteRTL.tsx
+++ b/packages/lumx-react/src/testing/utils/commonTestsSuiteRTL.tsx
@@ -30,6 +30,8 @@ interface Options<S extends CommonSetup> {
         viaContext: boolean;
         /** Apply a default theme if no prop or context was provided */
         defaultTheme?: Theme;
+        /** Default props to apply when testing theme */
+        defaultProps?: S['props'];
     };
 }
 
@@ -128,7 +130,7 @@ export function commonTestsSuiteRTL<S extends CommonSetup>(setup: SetupFunction<
                     it.each(testElements)(
                         `should $apply default theme (${defaultTheme}) to \`$element\``,
                         async (affectedElement) => {
-                            const wrappers = await setup();
+                            const wrappers = await setup(applyTheme.defaultProps);
                             expectTheme(wrappers, affectedElement, defaultTheme);
                         },
                     );
@@ -140,7 +142,7 @@ export function commonTestsSuiteRTL<S extends CommonSetup>(setup: SetupFunction<
                     it.each(affectedElements)(
                         `should not apply default theme (${defaultTheme}) to \`$element\``,
                         async (affectedElement) => {
-                            const wrappers = await setup();
+                            const wrappers = await setup(applyTheme.defaultProps);
                             expectTheme(wrappers, affectedElement, Theme.light, { shouldHaveModifier: false });
                             expectTheme(wrappers, affectedElement, Theme.dark, { shouldHaveModifier: false });
                         },
@@ -152,7 +154,7 @@ export function commonTestsSuiteRTL<S extends CommonSetup>(setup: SetupFunction<
                     it.each(testElements)(
                         `should $apply prop theme=${theme} to \`$element\``,
                         async (affectedElement) => {
-                            const wrappers = await setup({ theme });
+                            const wrappers = await setup({ ...applyTheme.defaultProps, theme });
                             expectTheme(wrappers, affectedElement, theme);
                         },
                     );


### PR DESCRIPTION
# General summary

fix button icons color inside a theme context


StoryBook: https://ed9f99c3--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=445))