### PR TITLE
feat(link): add focus outline for better a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `InputLabel`: add `typography` prop
+-   `Link`: add focus outline for better a11y
 
 ### Fixed
 
--   `Button`: fix icon color inside a theme context.
+-   `Button`: fix icon color inside a theme context
 
 ## [3.12.0][] - 2025-03-19
 

--- a/packages/lumx-core/src/scss/components/link/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/link/_mixins.scss
@@ -10,8 +10,15 @@
     outline: none;
 
     &:hover,
+    &[data-lumx-hover],
     &[data-focus-visible-added] {
         text-decoration: underline;
+    }
+
+    &[data-focus-visible-added],
+    &:focus-visible {
+        outline: 1px auto currentColor;
+        outline-offset: 2px;
     }
 }
 

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -1,4 +1,12 @@
-import { ColorPalette, ColorVariant, Link, Typography, TypographyInterface, TypographyTitleCustom } from '@lumx/react';
+import {
+    ColorPalette,
+    ColorVariant,
+    FlexBox,
+    Link,
+    Typography,
+    TypographyInterface,
+    TypographyTitleCustom,
+} from '@lumx/react';
 import React from 'react';
 import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
 import { colorArgType, colorVariantArgType } from '@lumx/react/stories/controls/color';
@@ -6,6 +14,9 @@ import { iconArgType } from '@lumx/react/stories/controls/icons';
 import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
 import { withUndefined } from '@lumx/react/stories/controls/withUndefined';
 import { CustomLink } from '@lumx/react/stories/utils/CustomLink';
+import { withWrapper } from '@lumx/react/stories/decorators/withWrapper';
+import { withThemedBackground } from '@lumx/react/stories/decorators/withThemedBackground';
+import { mdiFoodApple, mdiPencil } from '@lumx/icons/override/generated';
 
 const linkTypographies = { ...TypographyInterface, ...TypographyTitleCustom };
 
@@ -27,28 +38,6 @@ export default {
  */
 export const Default = {
     args: { href: 'https://example.com', target: '_blank' },
-};
-
-/**
- * Disabled
- */
-export const Disabled = {
-    args: { ...Default.args, children: 'Link (disabled)', isDisabled: true },
-};
-
-/**
- * Using onClick transforms the link into a <button> in DOM
- */
-export const ButtonLink = {
-    argTypes: { onClick: { action: true } },
-    args: { children: 'Button link' },
-};
-
-/**
- * Button link disabled
- */
-export const ButtonLinkDisabled = {
-    args: { ...ButtonLink.args, children: 'Button link (disabled)', isDisabled: true },
 };
 
 /**
@@ -76,6 +65,40 @@ export const WithCustomizableTypography = {
         </>
     ),
 };
+
+/**
+ * Show state combinations
+ */
+export const AllStates = {
+    argTypes: {
+        isDisabled: { control: false },
+    },
+    decorators: [
+        withThemedBackground(),
+        withCombinations({
+            combinations: {
+                sections: {
+                    Default: {},
+                    'with icons': { rightIcon: mdiPencil, leftIcon: mdiFoodApple },
+                },
+                cols: {
+                    Default: {},
+                    Disabled: { isDisabled: true },
+                    Focused: { 'data-focus-visible-added': true },
+                    Hovered: { 'data-lumx-hover': true },
+                },
+                rows: {
+                    Default: {},
+                    'color=red': { color: 'red' },
+                    'theme=dark': { theme: 'dark' },
+                    'theme=dark & color=red': { theme: 'dark', color: 'red' },
+                },
+            },
+        }),
+        withWrapper({ orientation: 'horizontal', vAlign: 'space-evenly', wrap: true, gap: 'huge' }, FlexBox),
+    ],
+};
+
 /**
  * Show all typographies
  */


### PR DESCRIPTION
# General summary

Add focus outline on links

![image](https://github.com/user-attachments/assets/06d1a06b-e92e-46c9-89f1-e331f4339932)




StoryBook: https://a9be2f8d--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=446)) **⚠️ Outdated commit**