### PR TITLE
feat(link): make any nested icon adapt to the link typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `InputLabel`: add `typography` prop
+-   `Link`: add focus outline for better a11y
 
 ### Fixed
 
--   `Button`: fix icon color inside a theme context.
+-   `Button`: fix icon color inside a theme context
 
 ## [3.12.0][] - 2025-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `InputLabel`: add `typography` prop
 -   `Link`: add focus outline for better a11y
+-   `Link`: make any nested icon adapt to the link typography
 
 ### Fixed
 
 -   `Button`: fix icon color inside a theme context
+
+### Changed
+
+-   `Link`: deprecated `rightIcon`/`leftIcon` props (use nested icons instead)
 
 ## [3.12.0][] - 2025-03-19
 

--- a/packages/lumx-core/src/scss/components/link/_index.scss
+++ b/packages/lumx-core/src/scss/components/link/_index.scss
@@ -5,17 +5,16 @@
 .#{$lumx-base-prefix}-link {
     @include lumx-link;
 
-    &__left-icon {
-        margin-right: $lumx-spacing-unit-tiny;
-    }
-
-    &__right-icon {
-        margin-left: $lumx-spacing-unit-tiny;
-    }
-
     &:disabled,
     &[aria-disabled="true"] {
         @include lumx-state-disabled-input;
+    }
+
+    // Fix icon alignment
+    & .#{$lumx-base-prefix}-icon {
+        &, & svg {
+            display: inline;
+        }
     }
 }
 

--- a/packages/lumx-core/src/scss/components/link/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/link/_mixins.scss
@@ -10,8 +10,15 @@
     outline: none;
 
     &:hover,
+    &[data-lumx-hover],
     &[data-focus-visible-added] {
         text-decoration: underline;
+    }
+
+    &[data-focus-visible-added],
+    &:focus-visible {
+        outline: 1px auto currentColor;
+        outline-offset: 2px;
     }
 }
 

--- a/packages/lumx-core/src/scss/components/link/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/link/_mixins.scss
@@ -1,6 +1,5 @@
 @mixin lumx-link-base() {
-    display: inline-flex;
-    align-items: center;
+    display: inline;
     padding: 0;
     text-align: inherit;
     text-decoration: none;

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -2,6 +2,7 @@ import {
     ColorPalette,
     ColorVariant,
     FlexBox,
+    Icon,
     Link,
     Typography,
     TypographyInterface,
@@ -16,7 +17,7 @@ import { withUndefined } from '@lumx/react/stories/controls/withUndefined';
 import { CustomLink } from '@lumx/react/stories/utils/CustomLink';
 import { withWrapper } from '@lumx/react/stories/decorators/withWrapper';
 import { withThemedBackground } from '@lumx/react/stories/decorators/withThemedBackground';
-import { mdiFoodApple, mdiPencil } from '@lumx/icons/override/generated';
+import { mdiEarth, mdiFoodApple, mdiPencil } from '@lumx/icons/override/generated';
 
 const linkTypographies = { ...TypographyInterface, ...TypographyTitleCustom };
 
@@ -79,7 +80,9 @@ export const AllStates = {
             combinations: {
                 sections: {
                     Default: {},
-                    'with icons': { rightIcon: mdiPencil, leftIcon: mdiFoodApple },
+                    'with icon': {
+                        children: ['Link', <Icon key="icon" icon={mdiEarth} />, 'with icon'],
+                    },
                 },
                 cols: {
                     Default: {},
@@ -103,6 +106,11 @@ export const AllStates = {
  * Show all typographies
  */
 export const AllTypography = {
+    args: {
+        children: ['Link', <Icon key="icon" icon={mdiEarth} />, 'with icon'],
+        rightIcon: mdiPencil,
+        leftIcon: mdiFoodApple,
+    },
     argTypes: {
         typography: { control: false },
     },

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -1,4 +1,12 @@
-import { ColorPalette, ColorVariant, Link, Typography, TypographyInterface, TypographyTitleCustom } from '@lumx/react';
+import {
+    ColorPalette,
+    ColorVariant,
+    FlexBox,
+    Link,
+    Typography,
+    TypographyInterface,
+    TypographyTitleCustom,
+} from '@lumx/react';
 import React from 'react';
 import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
 import { colorArgType, colorVariantArgType } from '@lumx/react/stories/controls/color';
@@ -6,6 +14,9 @@ import { iconArgType } from '@lumx/react/stories/controls/icons';
 import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
 import { withUndefined } from '@lumx/react/stories/controls/withUndefined';
 import { CustomLink } from '@lumx/react/stories/utils/CustomLink';
+import { withWrapper } from '@lumx/react/stories/decorators/withWrapper';
+import { withThemedBackground } from '@lumx/react/stories/decorators/withThemedBackground';
+import { mdiFoodApple, mdiPencil } from '@lumx/icons/override/generated';
 
 const linkTypographies = { ...TypographyInterface, ...TypographyTitleCustom };
 
@@ -27,28 +38,6 @@ export default {
  */
 export const Default = {
     args: { href: 'https://example.com', target: '_blank' },
-};
-
-/**
- * Disabled
- */
-export const Disabled = {
-    args: { ...Default.args, children: 'Link (disabled)', isDisabled: true },
-};
-
-/**
- * Using onClick transforms the link into a <button> in DOM
- */
-export const ButtonLink = {
-    argTypes: { onClick: { action: true } },
-    args: { children: 'Button link' },
-};
-
-/**
- * Button link disabled
- */
-export const ButtonLinkDisabled = {
-    args: { ...ButtonLink.args, children: 'Button link (disabled)', isDisabled: true },
 };
 
 /**
@@ -76,6 +65,40 @@ export const WithCustomizableTypography = {
         </>
     ),
 };
+
+/**
+ * Show state combinations
+ */
+export const AllStates = {
+    argTypes: {
+        isDisabled: { control: false },
+    },
+    decorators: [
+        withThemedBackground(),
+        withCombinations({
+            combinations: {
+                sections: {
+                    Default: {},
+                    'with icons': { rightIcon: mdiPencil, leftIcon: mdiFoodApple },
+                },
+                cols: {
+                    Default: {},
+                    Disabled: { isDisabled: true },
+                    Focused: { 'data-focus-visible-added': true },
+                    Hovered: { 'data-lumx-hover': true },
+                },
+                rows: {
+                    Default: {},
+                    'color=red': { color: 'red' },
+                    'theme=dark': { theme: 'dark' },
+                    'theme=dark & color=red': { theme: 'dark', color: 'red' },
+                },
+            },
+        }),
+        withWrapper({ orientation: 'horizontal', vAlign: 'space-evenly', wrap: true, gap: 'huge' }, FlexBox),
+    ],
+};
+
 /**
  * Show all typographies
  */

--- a/packages/lumx-react/src/components/link/Link.test.tsx
+++ b/packages/lumx-react/src/components/link/Link.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { ColorPalette, ColorVariant, Typography } from '@lumx/react';
+import { ColorPalette, ColorVariant, Icon, Typography } from '@lumx/react';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
-import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
+import { getByClassName, queryAllByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
 import { render, screen } from '@testing-library/react';
 import { mdiCheck, mdiPlus } from '@lumx/icons';
 import { Link, LinkProps } from './Link';
@@ -15,11 +15,9 @@ const CLASSNAME = Link.className as string;
 const setup = (props: LinkProps = {}) => {
     render(<Link {...props} />);
     const link = getByClassName(document.body, CLASSNAME);
-    const content = queryByClassName(link, `${CLASSNAME}__content`);
     const rightIcon = queryByClassName(link, `${CLASSNAME}__right-icon`);
     const leftIcon = queryByClassName(link, `${CLASSNAME}__left-icon`);
-
-    return { props, link, content, rightIcon, leftIcon };
+    return { props, link, rightIcon, leftIcon };
 };
 
 describe(`<${Link.displayName}>`, () => {
@@ -42,14 +40,12 @@ describe(`<${Link.displayName}>`, () => {
                 color: ColorPalette.primary,
                 colorVariant: ColorVariant.D1,
             });
-            expect(link.className).toMatchInlineSnapshot(
-                '"lumx-link lumx-link--color-primary lumx-link--color-variant-D1"',
-            );
+            expect(link.className).toBe('lumx-link lumx-link--color-primary lumx-link--color-variant-D1');
         });
 
         it('should render typography', () => {
-            const { content } = setup({ href: 'https://google.com', typography: Typography.title });
-            expect(content?.className).toMatchInlineSnapshot('undefined');
+            const { link } = setup({ href: 'https://google.com', typography: Typography.title });
+            expect(link.className).toBe('lumx-link lumx-typography-title');
         });
 
         it('should render a button', () => {
@@ -59,10 +55,26 @@ describe(`<${Link.displayName}>`, () => {
             expect(link).toBe(screen.queryByRole('button', { name }));
         });
 
+        it('should render disabled link as button', () => {
+            const name = 'Link';
+            const { link } = setup({ href: 'https://google.com', isDisabled: true, children: name });
+            expect(link).toBe(screen.queryByRole('button', { name }));
+        });
+
         it('should render with icons', () => {
-            const { rightIcon, leftIcon } = setup({ rightIcon: mdiPlus, leftIcon: mdiCheck });
-            expect(rightIcon).toBeInTheDocument();
-            expect(leftIcon).toBeInTheDocument();
+            const { link } = setup({
+                leftIcon: mdiCheck,
+                children: ['Link', <Icon key="icon" icon={mdiCheck} />, 'with icons'],
+                rightIcon: mdiPlus,
+            });
+            const icons = queryAllByClassName(link, Icon.className as string);
+            expect(icons).toHaveLength(3);
+
+            // Icons are all wrapped with spaces
+            for (const icon of icons) {
+                expect((icon.previousSibling as any).textContent).toEqual(' ');
+                expect((icon.nextSibling as any).textContent).toEqual(' ');
+            }
         });
     });
 

--- a/packages/lumx-react/src/components/text/Text.test.tsx
+++ b/packages/lumx-react/src/components/text/Text.test.tsx
@@ -4,7 +4,7 @@ import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import { mdiEarth } from '@lumx/icons';
 import { Icon } from '@lumx/react';
 import { render } from '@testing-library/react';
-import { getByClassName } from '@lumx/react/testing/utils/queries';
+import { getByClassName, queryAllByClassName } from '@lumx/react/testing/utils/queries';
 import { Text, TextProps } from '.';
 
 const setup = (props: Partial<TextProps> = {}) => {
@@ -69,34 +69,14 @@ describe(`<${Text.displayName}>`, () => {
 
         it('should wrap icons with spaces', () => {
             const { element } = setup({ children: ['Some text', <Icon key="icon" icon={mdiEarth} />, 'with icon'] });
-            // Spaces have been inserted around the icon.
-            expect(element).toMatchInlineSnapshot(`
-                <span
-                  class="lumx-text"
-                >
-                  Some text
-                   
-                  <i
-                    class="lumx-icon lumx-icon--no-shape lumx-icon--path"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      height="1em"
-                      preserveAspectRatio="xMidYMid meet"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 24 24"
-                      width="1em"
-                    >
-                      <path
-                        d="M17.9 17.39A2 2 0 0 0 16 16h-1v-3a1 1 0 0 0-1-1H8v-2h2a1 1 0 0 0 1-1V7h2a2 2 0 0 0 2-2v-.41a7.98 7.98 0 0 1 2.9 12.8M11 19.93a8 8 0 0 1-6.79-9.72L9 15v1a2 2 0 0 0 2 2m1-16A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </i>
-                   
-                  with icon
-                </span>
-            `);
+            const icons = queryAllByClassName(element, Icon.className as string);
+            expect(icons).toHaveLength(1);
+
+            // Icons are all wrapped with spaces
+            for (const icon of icons) {
+                expect((icon.previousSibling as any).textContent).toEqual(' ');
+                expect((icon.nextSibling as any).textContent).toEqual(' ');
+            }
         });
 
         it('should render dangerouslySetInnerHTML', () => {

--- a/packages/lumx-react/src/components/text/Text.tsx
+++ b/packages/lumx-react/src/components/text/Text.tsx
@@ -1,9 +1,9 @@
-import React, { Children, Fragment } from 'react';
+import React from 'react';
 
 import classNames from 'classnames';
 
-import { Icon, ColorPalette, ColorVariant, Typography, WhiteSpace } from '@lumx/react';
-import { GenericProps, TextElement, isComponent } from '@lumx/react/utils/type';
+import { ColorPalette, ColorVariant, Typography, WhiteSpace } from '@lumx/react';
+import { GenericProps, TextElement } from '@lumx/react/utils/type';
 import {
     getFontColorClassName,
     getRootClassName,
@@ -13,6 +13,7 @@ import {
 import { useOverflowTooltipLabel } from '@lumx/react/hooks/useOverflowTooltipLabel';
 import { useMergeRefs } from '@lumx/react/utils/react/mergeRefs';
 import { forwardRef } from '@lumx/react/utils/react/forwardRef';
+import { wrapChildrenIconWithSpaces } from '@lumx/react/utils/react/wrapChildrenIconWithSpaces';
 
 /**
  * Defines the props of the component.
@@ -132,14 +133,7 @@ export const Text = forwardRef<TextProps>((props, ref) => {
             style={{ ...truncateLinesStyle, ...whiteSpaceStyle, ...style }}
             {...forwardedProps}
         >
-            {children &&
-                Children.toArray(children).map((child, index) => {
-                    // Force wrap spaces around icons to make sure they are never stuck against text.
-                    if (isComponent(Icon)(child)) {
-                        return <Fragment key={child.key || index}> {child} </Fragment>;
-                    }
-                    return child;
-                })}
+            {wrapChildrenIconWithSpaces(children)}
         </Component>
     );
 });

--- a/packages/lumx-react/src/stories/controls/icons.ts
+++ b/packages/lumx-react/src/stories/controls/icons.ts
@@ -63,6 +63,7 @@ import {
 export const iconArgType = {
     control: { type: 'select' },
     options: {
+        undefined,
         mdiAbTesting,
         mdiAbjadArabic,
         mdiAccount,

--- a/packages/lumx-react/src/utils/react/wrapChildrenIconWithSpaces.test.tsx
+++ b/packages/lumx-react/src/utils/react/wrapChildrenIconWithSpaces.test.tsx
@@ -1,0 +1,37 @@
+import React, { Fragment } from 'react';
+
+import { Icon } from '@lumx/react';
+import { mdiEarth, mdiFoodApple, mdiPencil } from '@lumx/icons';
+import { wrapChildrenIconWithSpaces } from './wrapChildrenIconWithSpaces';
+
+describe(wrapChildrenIconWithSpaces, () => {
+    it('should ignore null or undefined children', () => {
+        expect(wrapChildrenIconWithSpaces(undefined)).toBeUndefined();
+        expect(wrapChildrenIconWithSpaces(null)).toBeUndefined();
+    });
+
+    it('should wrap icons with spaces', () => {
+        expect(
+            wrapChildrenIconWithSpaces(
+                <>
+                    <Icon icon={mdiEarth} />a string
+                    <>
+                        some more string with
+                        <Icon icon={mdiFoodApple} />
+                    </>
+                    {['array with', <Icon key="custom-key" icon={mdiPencil} />]}
+                </>,
+            ),
+        ).toEqual([
+            // prettier-ignore
+            <Fragment key=".0">
+                {' '}
+                <Icon key=".0" icon={mdiEarth} />{' '}a string
+                <Fragment key=".2">
+                    some more string with{' '}<Icon key=".1" icon={mdiFoodApple} />{' '}
+                </Fragment>
+                array with{' '}<Icon key=".3:$custom-key" icon={mdiPencil} />{' '}
+            </Fragment>,
+        ]);
+    });
+});

--- a/packages/lumx-react/src/utils/react/wrapChildrenIconWithSpaces.tsx
+++ b/packages/lumx-react/src/utils/react/wrapChildrenIconWithSpaces.tsx
@@ -1,0 +1,22 @@
+import React, { Children } from 'react';
+import { isComponentType } from '@lumx/react/utils/type';
+import { Icon } from '@lumx/react';
+
+/** Force wrap spaces around icons to make sure they are never stuck against text. */
+export function wrapChildrenIconWithSpaces(children: React.ReactNode): React.ReactNode {
+    if (children === null || children === undefined) return undefined;
+    return Children.toArray(children).flatMap((child) => {
+        if (isComponentType(Icon)(child)) {
+            return [' ', child, ' '];
+        }
+        if (
+            React.isValidElement(child) &&
+            child.props &&
+            typeof child.props === 'object' &&
+            'children' in child.props
+        ) {
+            return React.cloneElement(child, undefined, wrapChildrenIconWithSpaces(child.props.children));
+        }
+        return child;
+    });
+}

--- a/packages/site-demo/content/product/components/link/index.mdx
+++ b/packages/site-demo/content/product/components/link/index.mdx
@@ -3,19 +3,19 @@
 **Display simple hyperlinks**.
 By default, links are in primary color. They can have an optional icon.
 
-<DemoBlock orientation="vertical" demo="default" withThemeSwitcher />
+<DemoBlock orientation="vertical" demo="default" />
 
 ## Styles and sizes
 
 Use text styles and icon sizes so that the icon height doesn’t exceed the text line height.
 
-<DemoBlock orientation="vertical" demo="sizes" withThemeSwitcher />
+<DemoBlock orientation="vertical" demo="sizes" />
 
 ## Implicit
 
 Links can also be more subtle and appear as normal text (ex: articles titles, user name in [user-block](../user-block))
 
-<DemoBlock orientation="vertical" demo="implicit" withThemeSwitcher />
+<DemoBlock orientation="vertical" demo="implicit" />
 
 ### Accessibility concerns
 

--- a/packages/site-demo/content/product/components/link/react/default.tsx
+++ b/packages/site-demo/content/product/components/link/react/default.tsx
@@ -1,17 +1,15 @@
-import { mdiPencil } from '@lumx/icons';
-import { ColorPalette, Link, Theme } from '@lumx/react';
-import React from 'react';
-
 /* eslint-disable jsx-a11y/anchor-is-valid */
-export const App = ({ theme = Theme.light }: any) => {
-    const color = theme === Theme.light ? ColorPalette.primary : ColorPalette.light;
-    return (
-        <>
-            <Link color={color}>Default link</Link>
+import React from 'react';
+import { mdiPencil } from '@lumx/icons';
+import { Icon, Link } from '@lumx/react';
 
-            <Link leftIcon={mdiPencil} color={color}>
-                Link with an icon
-            </Link>
-        </>
-    );
-};
+export const App = () => (
+    <>
+        <Link href="#">Default link</Link>
+
+        <Link href="#">
+            <Icon icon={mdiPencil} />
+            Link with an icon
+        </Link>
+    </>
+);

--- a/packages/site-demo/content/product/components/link/react/implicit.tsx
+++ b/packages/site-demo/content/product/components/link/react/implicit.tsx
@@ -1,21 +1,19 @@
-import { mdiPencil } from '@lumx/icons';
-import { ColorPalette, Link, Theme, Typography } from '@lumx/react';
-import React from 'react';
-
 /* eslint-disable jsx-a11y/anchor-is-valid */
-export const App = ({ theme = Theme.light }: any) => {
-    const color = theme === Theme.light ? ColorPalette.dark : ColorPalette.light;
-    return (
-        <>
-            <Link color={color}>Default link</Link>
+import React from 'react';
+import { mdiPencil } from '@lumx/icons';
+import { Icon, Link } from '@lumx/react';
 
-            <Link leftIcon={mdiPencil} color={color}>
-                Link with an icon
-            </Link>
+export const App = () => (
+    <>
+        <Link href="#">Default link</Link>
 
-            <Link color={color} typography={Typography.title}>
-                Link with Title typography
-            </Link>
-        </>
-    );
-};
+        <Link href="#">
+            <Icon icon={mdiPencil} />
+            Link with an icon
+        </Link>
+
+        <Link href="#" typography="title">
+            Link with Title typography
+        </Link>
+    </>
+);

--- a/packages/site-demo/content/product/components/link/react/sizes.tsx
+++ b/packages/site-demo/content/product/components/link/react/sizes.tsx
@@ -1,27 +1,28 @@
-import { mdiPencil } from '@lumx/icons';
-import { ColorPalette, Link, Theme, Typography } from '@lumx/react';
-import React from 'react';
-
 /* eslint-disable jsx-a11y/anchor-is-valid */
-export const App = ({ theme = Theme.light }: any) => {
-    const color = theme === Theme.light ? ColorPalette.primary : ColorPalette.light;
-    return (
-        <>
-            <Link leftIcon={mdiPencil} typography={Typography.title} color={color}>
-                Link with Title typography
-            </Link>
+import React from 'react';
+import { mdiPencil } from '@lumx/icons';
+import { Icon, Link } from '@lumx/react';
 
-            <Link leftIcon={mdiPencil} typography={Typography.subtitle2} color={color}>
-                Link with Subtitle 2 typography
-            </Link>
+export const App = () => (
+    <>
+        <Link href="#" typography="title">
+            <Icon icon={mdiPencil} />
+            Link with Title typography
+        </Link>
 
-            <Link leftIcon={mdiPencil} typography={Typography.body1} color={color}>
-                Link with Body 1 typography
-            </Link>
+        <Link href="#" typography="subtitle2">
+            <Icon icon={mdiPencil} />
+            Link with Subtitle 2 typography
+        </Link>
 
-            <Link leftIcon={mdiPencil} typography={Typography.caption} color={color}>
-                Link with Caption typography
-            </Link>
-        </>
-    );
-};
+        <Link href="#" typography="body1">
+            <Icon icon={mdiPencil} />
+            Link with Body 1 typography
+        </Link>
+
+        <Link href="#" typography="caption">
+            <Icon icon={mdiPencil} />
+            Link with Caption typography
+        </Link>
+    </>
+);

--- a/packages/site-demo/src/components/content/CodeBlock/renderJSXLinesWithCollapsedImports.tsx
+++ b/packages/site-demo/src/components/content/CodeBlock/renderJSXLinesWithCollapsedImports.tsx
@@ -1,47 +1,20 @@
-import filter from 'lodash/filter';
-import first from 'lodash/first';
-import last from 'lodash/last';
-import partition from 'lodash/partition';
 import React, { ReactElement } from 'react';
 import { renderLines } from '@lumx/demo/components/content/CodeBlock/renderLines';
-import { RenderLineParams, Token, TokenLines } from './types';
-
-const isToken = (token: Token | undefined, type: string, content: string) =>
-    token?.types?.includes(type) && token?.content === content;
+import { RenderLineParams, TokenLines } from './types';
 
 /** Split import lines from other lines */
 export function partitionImports(tokenLines: TokenLines): { imports: TokenLines; others: TokenLines } {
-    const state = {
-        finished: false,
-        inImport: false,
-        inImportList: false,
-    };
-
-    const [imports, others] = partition(tokenLines, (tokens) => {
-        if (state.finished) {
-            return false;
+    let lastImportLineIndex = 0;
+    for (let i = tokenLines.length - 1; i >= 0; i--) {
+        const line = tokenLines[i];
+        const token = line[1];
+        if (token.types.includes('keyword') && token.content === 'import') {
+            lastImportLineIndex = i;
+            break;
         }
-        const nonBlankTokens = filter(tokens, 'content');
-        if (nonBlankTokens.length === 0) {
-            return state.inImportList;
-        }
-
-        const firstToken = first(nonBlankTokens);
-        const lastToken = last(nonBlankTokens);
-        if (!state.inImport) {
-            if (!isToken(firstToken, 'keyword', 'import')) {
-                state.inImportList = false;
-                state.finished = true;
-                return false;
-            }
-            state.inImport = true;
-            state.inImportList = true;
-        }
-        if (isToken(lastToken, 'punctuation', ';')) {
-            state.inImport = false;
-        }
-        return true;
-    });
+    }
+    const others = [...tokenLines];
+    const imports = others.splice(0, lastImportLineIndex + 1);
     return { imports, others };
 }
 


### PR DESCRIPTION
# General summary

- **feat(link): make any nested icon adapt to the link typography**
- **chore(site-demo): update link demos**

|  | |
--- | --- 
![image](https://github.com/user-attachments/assets/6a793295-0f15-44bd-bf76-e3182f05b1e1) | ![image](https://github.com/user-attachments/assets/3808a1a7-b3b4-4961-987c-afe03f01c513)



StoryBook: https://ffa81de6--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=448)) **⚠️ Outdated commit**