### PR TITLE
fix(link): fix parent typo not correctly inherited on button-like links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `Button`: fix icon color inside a theme context
+-   `Link`: fix parent typography not correctly inherited on button-like links
 
 ### Changed
 

--- a/packages/lumx-core/src/scss/components/link/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/link/_mixins.scss
@@ -8,6 +8,15 @@
     border: none;
     outline: none;
 
+    // Inherit parent typography
+    &:not(#{&}--has-typography) {
+        font-family: inherit;
+        font-size: inherit;
+        font-style: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+    }
+
     &:hover,
     &[data-lumx-hover],
     &[data-focus-visible-added] {

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -2,7 +2,9 @@ import {
     ColorPalette,
     ColorVariant,
     FlexBox,
+    Heading,
     Icon,
+    Text,
     Link,
     Typography,
     TypographyInterface,
@@ -18,6 +20,7 @@ import { CustomLink } from '@lumx/react/stories/utils/CustomLink';
 import { withWrapper } from '@lumx/react/stories/decorators/withWrapper';
 import { withThemedBackground } from '@lumx/react/stories/decorators/withThemedBackground';
 import { mdiEarth, mdiFoodApple, mdiPencil } from '@lumx/icons/override/generated';
+import { withNestedProps } from '@lumx/react/stories/decorators/withNestedProps';
 
 const linkTypographies = { ...TypographyInterface, ...TypographyTitleCustom };
 
@@ -138,5 +141,35 @@ export const AllColors = {
                 cols: { key: 'colorVariant', options: withUndefined(ColorVariant) },
             },
         }),
+    ],
+};
+
+/**
+ * Check how link inherit the parent typography & color
+ */
+export const ParentTypographyAndColor = {
+    args: {
+        children: ['Link', <Icon key="icon" icon={mdiEarth} />, 'with icon'],
+        'parent.typography': undefined,
+        'parent.color': undefined,
+    },
+    render: ({ parent: { typography, color }, ...args }: any) => (
+        <Text as="p" color={color} typography={typography}>
+            <Link {...args} />
+        </Text>
+    ),
+    decorators: [
+        withNestedProps(),
+        withCombinations({
+            combinations: {
+                sections: { Button: {}, Link: { href: '#' } },
+                rows: {
+                    Default: {},
+                    'Parent typography=title': { 'parent.typography': 'title' },
+                    'Parent color=red': { 'parent.color': 'red' },
+                },
+            },
+        }),
+        withWrapper({ orientation: 'horizontal', vAlign: 'space-evenly', wrap: true, gap: 'huge' }, FlexBox),
     ],
 };

--- a/packages/lumx-react/src/components/link/Link.tsx
+++ b/packages/lumx-react/src/components/link/Link.tsx
@@ -94,7 +94,7 @@ export const Link = forwardRef<LinkProps, HTMLAnchorElement | HTMLButtonElement>
             {...baseProps}
             className={classNames(
                 className,
-                handleBasicClasses({ prefix: CLASSNAME, color, colorVariant }),
+                handleBasicClasses({ prefix: CLASSNAME, color, colorVariant, hasTypography: !!typography }),
                 typography && getTypographyClassName(typography),
             )}
         >


### PR DESCRIPTION
# General summary

fix parent typography not correctly inherited on button-like links
