### PR TITLE
fix(link): fix focus outline warping around nested icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `Link`: fix focus outline warping around nested icons
+
 ## [3.13.1][] - 2025-04-02
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/link/_index.scss
+++ b/packages/lumx-core/src/scss/components/link/_index.scss
@@ -14,6 +14,7 @@
     & .#{$lumx-base-prefix}-icon {
         &, & svg {
             display: inline;
+            line-height: initial;
         }
     }
 }


### PR DESCRIPTION
# General summary

Fix weird warping of the link focus outline around nested icons

| Before | After |
| --- | --- |
| <img width="284" alt="before" src="https://github.com/user-attachments/assets/7e4b85a6-a137-4aec-9b74-0f353d35f4f7" /> | <img width="284" alt="after" src="https://github.com/user-attachments/assets/35ac5f8b-cd6f-4c92-8618-5ea84b866950" /> |


