### PR TITLE
fix(link): fix icon alignment with nested `hasShape` icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   `Link`: fix focus outline warping around nested icons
+-   `Link`: fix icon alignment with nested `hasShape` icons
 
 ## [3.13.1][] - 2025-04-02
 

--- a/packages/lumx-core/src/scss/components/link/_index.scss
+++ b/packages/lumx-core/src/scss/components/link/_index.scss
@@ -11,7 +11,9 @@
     }
 
     // Fix icon alignment
-    & .#{$lumx-base-prefix}-icon {
+    & > .#{$lumx-base-prefix}-icon,
+    &__content > .#{$lumx-base-prefix}-icon
+    {
         &, & svg {
             display: inline;
             line-height: initial;

--- a/packages/lumx-react/src/components/link/Link.stories.tsx
+++ b/packages/lumx-react/src/components/link/Link.stories.tsx
@@ -8,6 +8,7 @@ import {
     Typography,
     TypographyInterface,
     TypographyTitleCustom,
+    GenericBlock,
 } from '@lumx/react';
 import React from 'react';
 import { getSelectArgType } from '@lumx/react/stories/controls/selectArgType';
@@ -173,4 +174,20 @@ export const ParentTypographyAndColor = {
         }),
         withWrapper({ orientation: 'horizontal', vAlign: 'space-evenly', wrap: true, gap: 'huge' }, FlexBox),
     ],
+};
+
+/** Check wrapping a block with a Link */
+export const WrappingBlock = {
+    render() {
+        return (
+            // eslint-disable-next-line jsx-a11y/anchor-is-valid
+            <Link href="#" color="dark">
+                <GenericBlock figure={<Icon icon={mdiEarth} hasShape color="red" />} hAlign="center">
+                    <Text as="p" typography="subtitle1">
+                        Hello Earth
+                    </Text>
+                </GenericBlock>
+            </Link>
+        );
+    },
 };


### PR DESCRIPTION
DSW-401

Before | After
 --- | ---
![before](https://github.com/user-attachments/assets/10d459e6-4c41-4daa-95b2-0db031da51d0) | ![after](https://github.com/user-attachments/assets/ec538fa3-f04f-4364-8ba0-394a52c58925)




StoryBook: https://738a0e66--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=452))