### PR TITLE
feat(chip): add `xxs` size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Docs: update `Filter and sort` pattern doc page
+-   Docs: update `Filter and sort` pattern doc page
+-   `Avatar`: add `xxs` size (to add inside chips)
 
 ## [3.13.2][] - 2025-04-10
 

--- a/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.stories.tsx
@@ -13,7 +13,7 @@ import { withNestedProps } from '@lumx/react/stories/decorators/withNestedProps'
 import { iconArgType } from '@lumx/react/stories/controls/icons';
 import { Avatar } from './Avatar';
 
-const AVATAR_SIZES = [Size.xs, Size.s, Size.m, Size.l, Size.xl, Size.xxl];
+const AVATAR_SIZES = [Size.xxs, Size.xs, Size.s, Size.m, Size.l, Size.xl, Size.xxl];
 
 export default {
     title: 'LumX components/avatar/Avatar',

--- a/packages/lumx-react/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-react/src/components/avatar/Avatar.tsx
@@ -12,7 +12,7 @@ import { forwardRef } from '@lumx/react/utils/react/forwardRef';
 /**
  * Avatar sizes.
  */
-export type AvatarSize = Extract<Size, 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl'>;
+export type AvatarSize = Extract<Size, 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl'>;
 
 /**
  * Defines the props of the component.


### PR DESCRIPTION
# General summary

Add `xxs` size to avatar  
(ideal size to nest inside chips after/before)

