### PR TITLE
feat(button): add disabled behavior with aria-disabled only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `Button`: add disabled behavior with `aria-disabled` only
+
 ## [3.14.0][] - 2025-05-13
 
 ### Fixed

--- a/packages/lumx-core/src/scss/components/button/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/button/_mixins.scss
@@ -132,7 +132,7 @@
         }
     }
 
-    &:hover,
+    &:hover:not([aria-disabled="true"]),
     &[class*="--is-hovered"] {
         @if $color == "primary" and $emphasis == lumx-base-const("emphasis", "HIGH") {
             color: var(--lumx-button-#{$emphasis}-state-hover-#{$theme}-color);
@@ -158,7 +158,7 @@
         }
     }
 
-    &:active,
+    &:active:not([aria-disabled="true"]),
     &[class*="--is-active"] {
         @if $color == "primary" and $emphasis == lumx-base-const("emphasis", "HIGH") {
             color: var(--lumx-button-#{$emphasis}-state-active-#{$theme}-color);
@@ -192,6 +192,9 @@
     &:disabled,
     &[aria-disabled="true"] {
         @include lumx-state-disabled-input;
+        // Enabling pointer-events to display label tooltips on hover
+        // @TODO: should be moved in the mixin when all disabled states will be aligned
+        pointer-events: all;
     }
 }
 

--- a/packages/lumx-core/src/scss/core/state/_mixins.scss
+++ b/packages/lumx-core/src/scss/core/state/_mixins.scss
@@ -133,6 +133,7 @@
 @mixin lumx-state-disabled-input() {
     pointer-events: none;
     opacity: 0.5;
+    cursor: default;
 }
 
 @mixin lumx-state($state, $emphasis, $color, $theme: null) {

--- a/packages/lumx-react/src/components/button/Button.stories.tsx
+++ b/packages/lumx-react/src/components/button/Button.stories.tsx
@@ -178,6 +178,7 @@ export const StateVariations = {
                     Active: { isActive: true },
                     Focused: { isFocused: true },
                     Disabled: { isDisabled: true },
+                    AriaDisabled: { 'aria-disabled': true },
                 },
                 // Emphasis/Background
                 sections: {
@@ -212,6 +213,7 @@ export const Theming = {
                     Active: { isActive: true },
                     Focused: { isFocused: true },
                     Disabled: { isDisabled: true },
+                    AriaDisabled: { 'aria-disabled': true },
                 },
                 rows: {
                     Default: {},

--- a/packages/lumx-react/src/components/button/Button.test.tsx
+++ b/packages/lumx-react/src/components/button/Button.test.tsx
@@ -63,6 +63,12 @@ describe(`<${Button.displayName}>`, () => {
             expect(buttonWrapper).toBeInTheDocument();
             expect(button).toBe(within(buttonWrapper as any).queryByRole('button', { name: label }));
         });
+
+        it('should prevent click when aria-disabled', () => {
+            const onClick = jest.fn();
+            const { button } = setup({ children: 'Label', 'aria-disabled': true, onClick });
+            expect(button.onclick).toBeFalsy();
+        });
     });
 
     // Common tests suite.

--- a/packages/lumx-react/src/components/button/ButtonRoot.tsx
+++ b/packages/lumx-react/src/components/button/ButtonRoot.tsx
@@ -20,7 +20,7 @@ export type ButtonSize = Extract<Size, 's' | 'm'>;
 
 export interface BaseButtonProps
     extends GenericProps,
-        Pick<AriaAttributes, 'aria-expanded' | 'aria-haspopup' | 'aria-pressed' | 'aria-label'>,
+        Pick<AriaAttributes, 'aria-expanded' | 'aria-haspopup' | 'aria-pressed' | 'aria-label' | 'aria-disabled'>,
         HasTheme {
     /** Color variant. */
     color?: ColorPalette;
@@ -106,6 +106,7 @@ export const ButtonRoot = forwardRef<ButtonRootProps, HTMLButtonElement | HTMLAn
         hasBackground,
         href,
         isDisabled = disabled,
+        'aria-disabled': ariaDisabled = isDisabled,
         isSelected,
         isActive,
         isFocused,
@@ -172,8 +173,9 @@ export const ButtonRoot = forwardRef<ButtonRootProps, HTMLButtonElement | HTMLAn
     return (
         <button
             {...forwardedProps}
+            {...(ariaDisabled ? { onClick: undefined } : undefined)}
             disabled={isDisabled}
-            aria-disabled={isDisabled}
+            aria-disabled={ariaDisabled}
             aria-label={ariaLabel}
             ref={ref as RefObject<HTMLButtonElement>}
             className={buttonClassName}


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->
Make the button disableable with only the `aria-disabled` prop. 
If `aria-disabled` is set to `true`, the button will have all disabled behavior (prevent click, disabled styles, no hover or active styles) but displays the tooltip on hover correctly.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
