### PR TITLE
feat(expansion-panel): add closeMode so children are unmounted/hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `ExpansionPanel`: added `closeMode` to `"unmount"` or `"hide"` children when the item is closed.
+
 ## [3.17.2][] - 2025-10-01
 
 ### Fixed

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.stories.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.stories.tsx
@@ -18,7 +18,11 @@ export default {
     component: ExpansionPanel,
     args: {
         'toggleButtonProps.label': 'Toggle',
-        children: 'Content',
+        children: (
+            <Text as="p" typography="body1" color="dark-L2" className="lumx-spacing-padding-big">
+                content
+            </Text>
+        ),
         label: 'Label',
     },
     decorators: [withNestedProps()],
@@ -75,5 +79,13 @@ export const Nested = {
                 </ExpansionPanel>
             </ExpansionPanel>
         );
+    },
+};
+
+/** Hide component instead of unmounting it */
+export const HideChildren = {
+    args: {
+        hasBackground: true,
+        closeMode: 'hide',
     },
 };

--- a/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
+++ b/packages/lumx-react/src/components/expansion-panel/ExpansionPanel.test.tsx
@@ -134,11 +134,11 @@ describe(`<${ExpansionPanel.displayName}>`, () => {
             expect(onToggleOpen).toHaveBeenCalledWith(false, expect.anything());
         });
 
-        it('should hide children after toggling the expansion panel', async () => {
+        it('should unmount children after toggling the expansion panel', async () => {
             const user = userEvent.setup();
             const { query } = setup({}, { controlled: true });
 
-            // Content is not visible by default
+            // Content is not mounted by default
             expect(query.content()).not.toBeInTheDocument();
 
             await user.click(query.header() as any);
@@ -148,6 +148,25 @@ describe(`<${ExpansionPanel.displayName}>`, () => {
             await user.click(query.header() as any);
 
             expect(query.content()).not.toBeInTheDocument();
+        });
+
+        it('should hide children after toggling the expansion panel', async () => {
+            const user = userEvent.setup();
+            const { element, query } = setup({ closeMode: 'hide' }, { controlled: true });
+
+            // Content is hidden (but mounted) by default
+            expect(query.content()).toBeInTheDocument();
+            expect(element).toHaveClass(`${CLASSNAME}--is-close`);
+
+            await user.click(query.header() as any);
+
+            expect(query.content()).toBeInTheDocument();
+            expect(element).toHaveClass(`${CLASSNAME}--is-open`);
+
+            await user.click(query.header() as any);
+
+            expect(query.content()).toBeInTheDocument();
+            expect(element).toHaveClass(`${CLASSNAME}--is-close`);
         });
     });
 


### PR DESCRIPTION
# General summary

As discussed a few weeks ago with @gcornut, I updated the `ExpansionPanel` component to add a new prop `closeMode?: 'hide' | 'unmount'`

This prop should condition whether the children components of the panel should just be hidden or unmounted when the panel gets closed. It defaults to `unmount` for the sake of compatibility with prior versions.

NB: This prop also exists in the `Tooltip` and `SideNavigation` components.

# Screenshots

N/A

# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [x] (if has code) Add `need: review-frontend` label
-   [x] (if has react) Check through the [react dev check list]
-   [x] (if fix or feature) Add `need: test` label
-   [x] (if you need a storybook and/or visual diff) Add `need: deploy-chromatic` label
    Chromatic builds are available here: https://www.chromatic.com/builds?appId=5fbfb1d508c0520021560f10

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook: https://c0b3e7ca--5fbfb1d508c0520021560f10.chromatic.com/ ([Chromatic build](https://www.chromatic.com/build?appId=5fbfb1d508c0520021560f10&number=482))