### PR TITLE
feat(vue): add Dialog component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `@lumx/vue`:
+    -   Create the `Dialog` component
+
 ### Changed
 
 -   `@lumx/core`:

--- a/packages/lumx-vue/src/components/dialog/Dialog.stories.tsx
+++ b/packages/lumx-vue/src/components/dialog/Dialog.stories.tsx
@@ -1,0 +1,356 @@
+/* eslint-disable vue/one-component-per-file */
+import { defineComponent, ref } from 'vue';
+import { mdiClose } from '@lumx/icons';
+import { Button, Checkbox, FlexBox, Heading, IconButton, TextField, Toolbar } from '@lumx/vue';
+import { withChromaticForceScreenSize } from '@lumx/vue/stories/decorators/withChromaticForceScreenSize';
+import { loremIpsum } from '@lumx/core/stories/utils/lorem';
+import { setup } from '@lumx/core/js/components/Dialog/Stories';
+
+import { Dialog } from '.';
+
+/**
+ * Story render component for Dialog.
+ *
+ * Defined as a standalone component so that:
+ * - The button ref is created inside a proper Vue setup context.
+ * - Storybook can pass args as reactive props (avoiding stale closure captures).
+ * - Header/footer/children args are mapped to Vue named slots.
+ */
+const DialogStory = defineComponent(
+    (_props: any, { attrs }: any) => {
+        const buttonRef = ref<HTMLElement>();
+        const isOpen = ref(true);
+
+        return () => {
+            const { children, header, footer, ...props } = attrs;
+            return (
+                <>
+                    <Button
+                        ref={buttonRef}
+                        onClick={() => {
+                            isOpen.value = true;
+                        }}
+                    >
+                        Open dialog
+                    </Button>
+                    <Dialog
+                        {...props}
+                        isOpen={isOpen.value}
+                        onClose={() => {
+                            isOpen.value = false;
+                        }}
+                        parentElement={(buttonRef.value as any)?.$el}
+                    >
+                        {{
+                            ...(header ? { header: () => header } : {}),
+                            default: () => children,
+                            ...(footer ? { footer: () => footer } : {}),
+                        }}
+                    </Dialog>
+                </>
+            );
+        };
+    },
+    { name: 'LumxDialogStory', inheritAttrs: false },
+);
+
+const { meta, ...stories } = setup({
+    component: Dialog,
+    decorators: { withChromaticForceScreenSize },
+    render: (args: any) => () => <DialogStory {...args} />,
+});
+
+export default {
+    title: 'LumX components/dialog/Dialog',
+    ...meta,
+};
+
+export const Default = { ...stories.Default };
+export const Loading = { ...stories.Loading };
+export const WithHeaderFooter = { ...stories.WithHeaderFooter };
+export const ForceDivider = { ...stories.ForceDivider };
+export const LongContent = { ...stories.LongContent };
+export const PreventAutoClose = { ...stories.PreventAutoClose };
+export const PreventCloseOnEscape = { ...stories.PreventCloseOnEscape };
+export const PreventCloseOnClick = { ...stories.PreventCloseOnClick };
+
+/**
+ * More complex header/footer using Vue named slots
+ */
+export const WithHeaderFooterChildren = {
+    render: () => {
+        const WithHeaderFooterChildrenStory = defineComponent(
+            () => {
+                const buttonRef = ref<HTMLElement>();
+                const isOpen = ref(true);
+
+                return () => (
+                    <>
+                        <Button
+                            ref={buttonRef}
+                            onClick={() => {
+                                isOpen.value = true;
+                            }}
+                        >
+                            Open dialog
+                        </Button>
+                        <Dialog
+                            isOpen={isOpen.value}
+                            onClose={() => {
+                                isOpen.value = false;
+                            }}
+                            parentElement={(buttonRef.value as any)?.$el}
+                        >
+                            {{
+                                header: () => (
+                                    <Toolbar>
+                                        {{
+                                            default: () => <Heading typography="title">Dialog heading</Heading>,
+                                            after: () => <IconButton label="Close" emphasis="low" icon={mdiClose} />,
+                                        }}
+                                    </Toolbar>
+                                ),
+                                default: () => <div class="lumx-spacing-padding-huge">{loremIpsum('short')}</div>,
+                                footer: () => <Toolbar>{{ after: () => <Button>Close</Button> }}</Toolbar>,
+                            }}
+                        </Dialog>
+                    </>
+                );
+            },
+            { name: 'LumxDialogWithHeaderFooterChildrenStory' },
+        );
+
+        return <WithHeaderFooterChildrenStory />;
+    },
+};
+
+/**
+ * Dialog needing a confirmation before close using a nested Dialog
+ */
+export const WithConfirmClose = {
+    render: () => {
+        const WithConfirmCloseStory = defineComponent(
+            () => {
+                const buttonRef = ref<HTMLElement>();
+                const closeButtonRef = ref<HTMLElement>();
+                const isOpen = ref(true);
+                const isConfirmOpen = ref(false);
+
+                const openConfirm = () => {
+                    isConfirmOpen.value = true;
+                };
+                const closeConfirm = () => {
+                    isConfirmOpen.value = false;
+                };
+                const closeAll = () => {
+                    isOpen.value = false;
+                    isConfirmOpen.value = false;
+                };
+
+                return () => (
+                    <>
+                        <Button
+                            ref={buttonRef}
+                            onClick={() => {
+                                isOpen.value = true;
+                            }}
+                        >
+                            Open dialog
+                        </Button>
+                        <Dialog
+                            isOpen={isOpen.value}
+                            onClose={openConfirm}
+                            parentElement={(buttonRef.value as any)?.$el}
+                        >
+                            <FlexBox orientation="vertical" verticalAlign="center" class="lumx-spacing-padding-huge">
+                                {loremIpsum('tiny')}
+                                <Button ref={closeButtonRef} onClick={openConfirm}>
+                                    Close
+                                </Button>
+                            </FlexBox>
+                        </Dialog>
+                        <Dialog
+                            isOpen={isConfirmOpen.value}
+                            onClose={closeConfirm}
+                            parentElement={(closeButtonRef.value as any)?.$el}
+                            size="tiny"
+                        >
+                            {{
+                                header: () => <Toolbar>{{ default: () => 'Confirm close' }}</Toolbar>,
+                                default: () => loremIpsum('tiny'),
+                                footer: () => (
+                                    <Toolbar>
+                                        {{
+                                            after: () => (
+                                                <>
+                                                    <Button emphasis="medium" onClick={closeConfirm}>
+                                                        Cancel
+                                                    </Button>
+                                                    <Button class="lumx-spacing-margin-left-regular" onClick={closeAll}>
+                                                        Confirm
+                                                    </Button>
+                                                </>
+                                            ),
+                                        }}
+                                    </Toolbar>
+                                ),
+                            }}
+                        </Dialog>
+                    </>
+                );
+            },
+            { name: 'DialogWithConfirmCloseStory' },
+        );
+
+        return <WithConfirmCloseStory />;
+    },
+};
+
+/**
+ * Test dialog focus trap (focus is contained inside the dialog) with all kinds of focusable and non-focusable items
+ */
+export const FocusTrap = {
+    tags: ['!snapshot'],
+    render: () => {
+        const FocusTrapStory = defineComponent(
+            () => {
+                const buttonRef = ref<HTMLElement>();
+                const inputRef = ref<HTMLInputElement | HTMLTextAreaElement | null>(null);
+                const inputRefCallback = (el: HTMLInputElement | HTMLTextAreaElement | null) => {
+                    inputRef.value = el;
+                };
+                const isOpen = ref(true);
+                const textValue = ref('value');
+                const checkboxValue = ref(false);
+
+                const nestedDialogButtonRef = ref<HTMLElement>();
+                const isNestedOpen = ref(false);
+
+                return () => (
+                    <>
+                        <Button
+                            ref={buttonRef}
+                            onClick={() => {
+                                isOpen.value = true;
+                            }}
+                        >
+                            Open dialog
+                        </Button>
+                        <Dialog
+                            isOpen={isOpen.value}
+                            onClose={() => {
+                                isOpen.value = false;
+                            }}
+                            parentElement={(buttonRef.value as any)?.$el}
+                            focusElement={inputRef.value ?? undefined}
+                        >
+                            {{
+                                header: () => (
+                                    <Toolbar>
+                                        {{
+                                            default: () => <span class="lumx-typography-title">Dialog header</span>,
+                                            after: () => (
+                                                <IconButton
+                                                    label="Close"
+                                                    icon={mdiClose}
+                                                    emphasis="low"
+                                                    onClick={() => {
+                                                        isOpen.value = false;
+                                                    }}
+                                                />
+                                            ),
+                                        }}
+                                    </Toolbar>
+                                ),
+                                default: () => (
+                                    <div class="lumx-spacing-padding-horizontal-huge lumx-spacing-padding-bottom-huge">
+                                        <div class="lumx-spacing-margin-bottom-huge">
+                                            The text field should capture the focus on open and a focus trap should be
+                                            in place.
+                                        </div>
+
+                                        <TextField
+                                            class="lumx-spacing-margin-bottom-huge"
+                                            inputRef={inputRefCallback}
+                                            value={textValue.value}
+                                            label="Text input"
+                                            maxLength={10}
+                                            onChange={(v: string) => {
+                                                textValue.value = v;
+                                            }}
+                                        />
+
+                                        <Checkbox
+                                            class="lumx-spacing-margin-bottom-huge"
+                                            isChecked={checkboxValue.value}
+                                            label="Checkbox input"
+                                            onChange={(v: boolean) => {
+                                                checkboxValue.value = v;
+                                            }}
+                                        />
+
+                                        <FlexBox orientation="horizontal" horizontalAlign="bottom" gap="regular">
+                                            <Button
+                                                ref={nestedDialogButtonRef}
+                                                onClick={() => {
+                                                    isNestedOpen.value = true;
+                                                }}
+                                            >
+                                                Open nested dialog
+                                            </Button>
+                                            <Dialog
+                                                isOpen={isNestedOpen.value}
+                                                parentElement={(nestedDialogButtonRef.value as any)?.$el}
+                                                onClose={() => {
+                                                    isNestedOpen.value = false;
+                                                }}
+                                            >
+                                                {{
+                                                    header: () => (
+                                                        <Toolbar>
+                                                            {{
+                                                                default: () => (
+                                                                    <span class="lumx-typography-title">
+                                                                        Nested dialog
+                                                                    </span>
+                                                                ),
+                                                                after: () => (
+                                                                    <IconButton
+                                                                        label="Close"
+                                                                        icon={mdiClose}
+                                                                        emphasis="low"
+                                                                        onClick={() => {
+                                                                            isNestedOpen.value = false;
+                                                                        }}
+                                                                    />
+                                                                ),
+                                                            }}
+                                                        </Toolbar>
+                                                    ),
+                                                    default: () => (
+                                                        <div class="lumx-spacing-padding">{loremIpsum('short')}</div>
+                                                    ),
+                                                }}
+                                            </Dialog>
+
+                                            <Button isDisabled>Disabled button (focus ignored)</Button>
+                                        </FlexBox>
+
+                                        <div tabindex={0}>Focus div</div>
+
+                                        <Button isDisabled={false}>
+                                            Button explicitly not disabled (should focus)
+                                        </Button>
+                                    </div>
+                                ),
+                            }}
+                        </Dialog>
+                    </>
+                );
+            },
+            { name: 'LumxDialogFocusTrapStory' },
+        );
+
+        return <FocusTrapStory />;
+    },
+};

--- a/packages/lumx-vue/src/components/dialog/Dialog.test.ts
+++ b/packages/lumx-vue/src/components/dialog/Dialog.test.ts
@@ -1,0 +1,126 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { nextTick } from 'vue';
+import { vi } from 'vitest';
+import BaseDialogTests, { setup } from '@lumx/core/js/components/Dialog/Tests';
+import { CLASSNAME } from '@lumx/core/js/components/Dialog';
+import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
+import { commonTestsSuiteVTL, type SetupRenderOptions } from '@lumx/vue/testing';
+import { queryByClassName } from '@lumx/core/testing/queries';
+
+import { Dialog } from '.';
+
+// Clean up teleported dialog elements between tests
+afterEach(() => {
+    cleanup();
+    document.querySelectorAll(`.${CLASSNAME}`).forEach((el) => el.remove());
+});
+
+describe('<Dialog />', () => {
+    const renderDialog = ({ children, header, footer, ...props }: any, options?: SetupRenderOptions<any>) =>
+        render(Dialog, {
+            ...options,
+            props: {
+                isOpen: true,
+                disableBodyScroll: false,
+                ...props,
+            },
+            slots: {
+                ...(children ? { default: () => children } : {}),
+                ...(header ? { header: () => header } : {}),
+                ...(footer ? { footer: () => footer } : {}),
+            },
+        });
+
+    // Core shared tests
+    BaseDialogTests({ render: renderDialog, screen });
+
+    const setupDialog = (props: any = {}, options: SetupRenderOptions<any> = {}) =>
+        setup(props, { ...options, render: renderDialog, screen });
+
+    describe('Vue', () => {
+        describe('Events', () => {
+            it('should emit close on Escape key press', async () => {
+                const { emitted } = render(Dialog, { props: { isOpen: true, disableBodyScroll: false } });
+                await userEvent.keyboard('[Escape]');
+                expect(emitted('close')).toBeTruthy();
+            });
+
+            it('should not emit close on Escape when preventAutoClose is true', async () => {
+                const { emitted } = render(Dialog, {
+                    props: { isOpen: true, disableBodyScroll: false, preventAutoClose: true },
+                });
+                await userEvent.keyboard('[Escape]');
+                expect(emitted('close')).toBeFalsy();
+            });
+
+            it('should not emit close on Escape when preventCloseOnEscape is true', async () => {
+                const { emitted } = render(Dialog, {
+                    props: { isOpen: true, disableBodyScroll: false, preventCloseOnEscape: true },
+                });
+                await userEvent.keyboard('[Escape]');
+                expect(emitted('close')).toBeFalsy();
+            });
+
+            it('should emit close when clicking outside (overlay)', () => {
+                const { emitted } = render(Dialog, { props: { isOpen: true, disableBodyScroll: false } });
+                const overlay = document.querySelector(`.${CLASSNAME}__overlay`);
+                fireEvent.mouseDown(overlay!);
+                fireEvent.click(overlay!);
+                expect(emitted('close')).toBeTruthy();
+            });
+
+            it('should not emit close when clicking inside the dialog', () => {
+                const { emitted } = render(Dialog, {
+                    props: { isOpen: true, disableBodyScroll: false },
+                });
+                const content = document.querySelector(`.${CLASSNAME}__content`);
+                fireEvent.mouseDown(content!);
+                fireEvent.click(content!);
+                expect(emitted('close')).toBeFalsy();
+            });
+        });
+
+        describe('closeMode', () => {
+            it('should unmount dialog when closed (default)', async () => {
+                vi.useFakeTimers();
+                const { rerender } = render(Dialog, { props: { isOpen: true, disableBodyScroll: false } });
+                expect(queryByClassName(document.body, CLASSNAME)).toBeInTheDocument();
+
+                await rerender({ isOpen: false, disableBodyScroll: false });
+                // Still mounted during close transition
+                expect(queryByClassName(document.body, CLASSNAME)).toBeInTheDocument();
+
+                vi.advanceTimersByTime(DIALOG_TRANSITION_DURATION);
+                await nextTick();
+                expect(queryByClassName(document.body, CLASSNAME)).not.toBeInTheDocument();
+                vi.useRealTimers();
+            });
+
+            it('should keep dialog mounted with closeMode="hide"', async () => {
+                const { rerender } = render(Dialog, {
+                    props: { isOpen: true, disableBodyScroll: false, closeMode: 'hide' },
+                });
+                await rerender({ isOpen: false, disableBodyScroll: false, closeMode: 'hide' });
+                expect(queryByClassName(document.body, CLASSNAME)).toBeInTheDocument();
+            });
+
+            it('should add is-hidden class when closed with closeMode="hide"', async () => {
+                const { rerender } = render(Dialog, {
+                    props: { isOpen: true, disableBodyScroll: false, closeMode: 'hide' },
+                });
+                expect(queryByClassName(document.body, CLASSNAME)).not.toHaveClass(`${CLASSNAME}--is-hidden`);
+
+                await rerender({ isOpen: false, disableBodyScroll: false, closeMode: 'hide' });
+                expect(queryByClassName(document.body, CLASSNAME)).toHaveClass(`${CLASSNAME}--is-hidden`);
+            });
+        });
+    });
+
+    commonTestsSuiteVTL(setupDialog, {
+        baseClassName: CLASSNAME,
+        forwardAttributes: 'dialog',
+        forwardRef: 'dialog',
+        forwardClassName: 'dialog',
+    });
+});

--- a/packages/lumx-vue/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-vue/src/components/dialog/Dialog.tsx
@@ -1,0 +1,202 @@
+import { computed, defineComponent, ref, type Ref } from 'vue';
+import { useIntersectionObserver } from '@vueuse/core';
+
+import { Dialog as UI, type BaseDialogProps, type DialogSizes, DEFAULT_PROPS } from '@lumx/core/js/components/Dialog';
+import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
+import type { GenericProps, HasCloseMode, JSXElement } from '@lumx/core/js/types';
+
+import { Portal } from '../../utils/Portal/Portal';
+import { ClickAwayProvider } from '../../utils/ClickAway/ClickAwayProvider';
+import { ThemeProvider } from '../../utils/theme/ThemeProvider';
+import HeadingLevelProvider from '../heading/HeadingLevelProvider';
+import ProgressCircular from '../progress/ProgressCircular';
+
+import { useCallbackOnEscape } from '../../composables/useCallbackOnEscape';
+import { useClassName } from '../../composables/useClassName';
+import { useFocusTrap } from '../../composables/useFocusTrap';
+import { useRestoreFocusOnClose } from '../../composables/useRestoreFocusOnClose';
+import { useTransitionVisibility } from '../../composables/useTransitionVisibility';
+import { useDisableBodyScroll } from '../../composables/useDisableBodyScroll';
+import { keysOf } from '../../utils/VueToJSX';
+
+export type DialogProps = Pick<BaseDialogProps, 'forceFooterDivider' | 'forceHeaderDivider' | 'isLoading'> &
+    HasCloseMode & {
+        /** Additional class name. */
+        class?: string;
+        /** Whether the dialog is open. */
+        isOpen?: boolean;
+        /** Size variant. */
+        size?: DialogSizes;
+        /** Z-axis position. */
+        zIndex?: number;
+        /** Additional props for the dialog container element. */
+        dialogProps?: GenericProps;
+        /** Reference to the parent element that triggered modal opening (gets focus back on close). */
+        parentElement?: HTMLElement;
+        /** Element that should receive focus when the dialog opens. By default the first focusable child. */
+        focusElement?: HTMLElement;
+        /** Reference to the dialog content element. */
+        contentRef?: Ref<HTMLDivElement>;
+        /** Whether to keep the dialog open on clickaway or escape press. */
+        preventAutoClose?: boolean;
+        /** Whether to keep the dialog open on escape press. */
+        preventCloseOnEscape?: boolean;
+        /** Whether to keep the dialog open on clickaway. */
+        preventCloseOnClick?: boolean;
+        /** Whether to disable body scroll when the dialog is open. */
+        disableBodyScroll?: boolean;
+    };
+
+export const emitSchema = {
+    close: () => true,
+    visibilityChange: (isVisible: boolean) => typeof isVisible === 'boolean',
+};
+
+const Dialog = defineComponent(
+    (props: DialogProps, { emit, slots, attrs }) => {
+        const className = useClassName(() => props.class);
+
+        const rootRef = ref<HTMLDivElement | null>(null);
+        const wrapperRef = ref<HTMLDivElement | null>(null);
+        const localContentRef = ref<HTMLDivElement | null>(null);
+
+        // Sentinel refs for scroll divider detection — passed as callback refs to core JSX
+        const sentinelTopRef = ref<HTMLElement | null>(null);
+        const sentinelBottomRef = ref<HTMLElement | null>(null);
+        const setSentinelTop = (el: HTMLElement | null) => {
+            sentinelTopRef.value = el;
+        };
+        const setSentinelBottom = (el: HTMLElement | null) => {
+            sentinelBottomRef.value = el;
+        };
+
+        // Intersection observer for scroll-triggered header/footer dividers
+        const hasTopIntersection = ref<boolean | null>(null);
+        const hasBottomIntersection = ref<boolean | null>(null);
+        useIntersectionObserver(sentinelTopRef, (entries) => {
+            const entry = entries[0];
+            hasTopIntersection.value = entry ? !entry.isIntersecting : null;
+        });
+        useIntersectionObserver(sentinelBottomRef, (entries) => {
+            const entry = entries[0];
+            hasBottomIntersection.value = entry ? !entry.isIntersecting : null;
+        });
+
+        // Escape key
+        const shouldPreventCloseOnEscape = computed(() => props.preventAutoClose || props.preventCloseOnEscape);
+        const handleClose = () => emit('close');
+        useCallbackOnEscape(
+            handleClose,
+            computed(() => Boolean(props.isOpen && !shouldPreventCloseOnEscape.value)),
+        );
+
+        // Focus trap inside the dialog wrapper
+        const focusZoneElement = computed(() => {
+            if (!props.isOpen) return false as const;
+            return wrapperRef.value || false;
+        });
+        useFocusTrap(
+            focusZoneElement,
+            computed(() => props.focusElement),
+        );
+
+        // Restore focus to parentElement when dialog closes
+        useRestoreFocusOnClose(
+            computed(() => true),
+            computed(() => undefined) as Ref<HTMLElement | undefined>,
+            computed(() => props.parentElement) as Ref<HTMLElement | undefined>,
+            wrapperRef as Ref<HTMLElement | undefined>,
+            computed(() => Boolean(props.isOpen)),
+        );
+
+        // Disable body scroll when dialog is open
+        useDisableBodyScroll(computed(() => props.disableBodyScroll !== false && Boolean(props.isOpen)));
+
+        // Track animation state: keeps dialog mounted during close animation
+        const isVisible = useTransitionVisibility(
+            computed(() => Boolean(props.isOpen)),
+            DIALOG_TRANSITION_DURATION,
+            computed(() => (v: boolean) => emit('visibilityChange', v)),
+        );
+
+        // Mount guard: keep mounted during open, animation, or hide mode
+        const isMounted = computed(() => props.isOpen || isVisible.value || props.closeMode === 'hide');
+
+        // Click-away: only the wrapper section is allowed to be clicked inside
+        const clickAwayRefs = computed(() => [wrapperRef]) as Ref<Array<Ref<HTMLElement | undefined>>>;
+        const shouldPreventCloseOnClickAway = computed(() => props.preventAutoClose || props.preventCloseOnClick);
+
+        // Merge external contentRef with internal one via callback ref
+        const contentRefCallback = (el: HTMLDivElement | null) => {
+            localContentRef.value = el;
+            if (props.contentRef) {
+                (props.contentRef as Ref<HTMLDivElement | null>).value = el;
+            }
+        };
+
+        return () => {
+            if (!isMounted.value) return null;
+
+            return UI({
+                ...attrs,
+                ClickAwayProvider,
+                HeadingLevelProvider,
+                Portal,
+                ThemeProvider,
+                ProgressCircular,
+                className: className.value,
+                clickAwayRefs,
+                content: slots.default?.() as JSXElement,
+                contentRef: contentRefCallback,
+                dialogProps: props.dialogProps,
+                footer: undefined,
+                footerChildContent: slots.footer?.() as JSXElement | undefined,
+                footerChildProps: undefined,
+                forceFooterDivider: props.forceFooterDivider,
+                forceHeaderDivider: props.forceHeaderDivider,
+                handleClose,
+                hasBottomIntersection: hasBottomIntersection.value,
+                hasTopIntersection: hasTopIntersection.value,
+                header: undefined,
+                headerChildContent: slots.header?.() as JSXElement | undefined,
+                headerChildProps: undefined,
+                isLoading: props.isLoading,
+                isOpen: props.isOpen,
+                isVisible: isVisible.value,
+                ref: rootRef,
+                rootRef: rootRef as Ref<HTMLElement | undefined>,
+                setSentinelBottom,
+                setSentinelTop,
+                shouldPreventCloseOnClickAway: shouldPreventCloseOnClickAway.value,
+                size: props.size ?? DEFAULT_PROPS.size,
+                wrapperRef: wrapperRef as Ref<HTMLElement | undefined>,
+                zIndex: props.zIndex,
+            });
+        };
+    },
+    {
+        name: 'LumxDialog',
+        inheritAttrs: false,
+        props: keysOf<DialogProps>()(
+            'class',
+            'closeMode',
+            'contentRef',
+            'dialogProps',
+            'disableBodyScroll',
+            'focusElement',
+            'forceFooterDivider',
+            'forceHeaderDivider',
+            'isLoading',
+            'isOpen',
+            'parentElement',
+            'preventAutoClose',
+            'preventCloseOnClick',
+            'preventCloseOnEscape',
+            'size',
+            'zIndex',
+        ),
+        emits: emitSchema,
+    },
+);
+
+export default Dialog;

--- a/packages/lumx-vue/src/components/dialog/index.ts
+++ b/packages/lumx-vue/src/components/dialog/index.ts
@@ -1,0 +1,2 @@
+export { default as Dialog, type DialogProps } from './Dialog';
+export type { DialogSizes } from '@lumx/core/js/components/Dialog';

--- a/packages/lumx-vue/src/composables/useDisableBodyScroll.ts
+++ b/packages/lumx-vue/src/composables/useDisableBodyScroll.ts
@@ -1,0 +1,15 @@
+import { watch, type Ref } from 'vue';
+import { useScrollLock } from '@vueuse/core';
+
+/**
+ * Disables body scroll when the dialog is open.
+ * Uses @vueuse/core's useScrollLock which sets overflow:hidden on document.body.
+ *
+ * @param isActive Whether body scroll should be disabled.
+ */
+export function useDisableBodyScroll(isActive: Ref<boolean>): void {
+    const isLocked = useScrollLock(typeof document !== 'undefined' ? document.body : null);
+    watch(isActive, (active) => {
+        isLocked.value = active;
+    });
+}

--- a/packages/lumx-vue/src/composables/useTransitionVisibility.ts
+++ b/packages/lumx-vue/src/composables/useTransitionVisibility.ts
@@ -1,0 +1,57 @@
+import { computed, onBeforeUnmount, ref, watch, type ComputedRef, type Ref } from 'vue';
+
+/**
+ * Returns true if the component is visible, tracking the opacity transition.
+ * Keeps the component mounted during the close animation, then unmounts after the timeout.
+ *
+ * @param isOpen               Whether the component intends to be visible or not.
+ * @param timeout              Duration of the close animation in ms.
+ * @param onVisibilityChange   Callback called when the visibility changes.
+ * @return ComputedRef<boolean> true if the component should be rendered (open or animating closed)
+ */
+export function useTransitionVisibility(
+    isOpen: Ref<boolean>,
+    timeout: number,
+    onVisibilityChange?: Ref<((isVisible: boolean) => void) | undefined>,
+): ComputedRef<boolean> {
+    const isStillVisible = ref(isOpen.value);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    watch(
+        isOpen,
+        (open) => {
+            if (open) {
+                clearTimeout(timer);
+                isStillVisible.value = true;
+            } else {
+                const isReducedMotion =
+                    typeof window.matchMedia === 'function' &&
+                    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                const hasTransition = typeof window !== 'undefined' && window.TransitionEvent && !isReducedMotion;
+
+                if (!hasTransition) {
+                    isStillVisible.value = false;
+                } else {
+                    timer = setTimeout(() => {
+                        isStillVisible.value = false;
+                    }, timeout);
+                }
+            }
+        },
+        { immediate: false },
+    );
+
+    let previousIsVisible = isStillVisible.value;
+    watch(isStillVisible, (val) => {
+        if (val !== previousIsVisible) {
+            previousIsVisible = val;
+            onVisibilityChange?.value?.(val);
+        }
+    });
+
+    onBeforeUnmount(() => {
+        clearTimeout(timer);
+    });
+
+    return computed(() => isOpen.value || isStillVisible.value);
+}

--- a/packages/lumx-vue/src/index.ts
+++ b/packages/lumx-vue/src/index.ts
@@ -7,6 +7,7 @@ export * from './components/badge';
 export * from './components/button';
 export * from './components/checkbox';
 export * from './components/chip';
+export * from './components/dialog';
 export * from './components/divider';
 export * from './components/drag-handle';
 export * from './components/expansion-panel';

--- a/packages/site-demo/content/product/components/dialog/index.mdx
+++ b/packages/site-demo/content/product/components/dialog/index.mdx
@@ -1,20 +1,24 @@
 ---
-frameworks: ['react']
+frameworks: ['react', 'vue']
 ---
 
-import * as DemoDefault from './react/default.tsx';
-import * as DemoConfirmDialog from './react/confirm-dialog.tsx';
-import * as DemoAlertDialog from './react/alert-dialog.tsx';
-import * as DemoSizes from './react/sizes.tsx';
-import * as DemoProcessingState from './react/processing-state.tsx';
+import * as ReactDemoDefault from './react/default.tsx';
+import * as ReactDemoConfirmDialog from './react/confirm-dialog.tsx';
+import * as ReactDemoAlertDialog from './react/alert-dialog.tsx';
+import * as ReactDemoSizes from './react/sizes.tsx';
+import * as ReactDemoProcessingState from './react/processing-state.tsx';
+import * as VueDemoDefault from './vue/default.vue';
+import * as VueDemoSizes from './vue/sizes.vue';
+import * as VueDemoProcessingState from './vue/processing-state.vue';
 import ReactDialog from 'lumx-docs:@lumx/react/components/dialog/Dialog';
 import ReactAlertDialog from 'lumx-docs:@lumx/react/components/alert-dialog/AlertDialog';
+import VueDialog from 'lumx-docs:@lumx/vue/components/dialog/Dialog';
 
 # Dialog
 
 **Inform users about a task and can contain critical information, require decisions, or involve multiple tasks.**
 
-<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: DemoDefault }} />
+<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: ReactDemoDefault, vue: VueDemoDefault }} />
 
 ## Anatomy
 
@@ -27,29 +31,29 @@ On user scroll, the header stays fixed on top and the footer at the bottom of th
 
 Confirmation dialogs cannot be dismissed until users confirm a choice.
 
-<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: DemoConfirmDialog }} />
+<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: ReactDemoConfirmDialog }} />
 
 ### Alert dialog
 
 Use alert dialogs to interrupt users with urgent information, details, or action requests.
 
-<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: DemoAlertDialog }} />
+<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: ReactDemoAlertDialog }} />
 
 ## Sizes
 
 Dialogs come in four sizes: `tiny` (400dp), `regular` (600dp), `big` (800dp), and `huge` (full screen).
 
-<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: DemoSizes }} />
+<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: ReactDemoSizes, vue: VueDemoSizes }} />
 
 ## Processing state
 
 Use processing state when dialogs contain a form which submission takes an extended amount of time to process.
 
-<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: DemoProcessingState }} />
+<DemoBlock orientation="horizontal" vAlign="center" demo={{ react: ReactDemoProcessingState, vue: VueDemoProcessingState }} />
 
 ### Properties
 
-<PropTable docs={{ react: ReactDialog }} />
+<PropTable docs={{ react: ReactDialog, vue: VueDialog }} />
 
 ### Alert Dialog Properties
 

--- a/packages/site-demo/content/product/components/dialog/vue/default.vue
+++ b/packages/site-demo/content/product/components/dialog/vue/default.vue
@@ -1,0 +1,42 @@
+<template>
+    <Button :left-icon="mdiPlay" ref="buttonRef" @click="toggle" :theme="theme">Try dialog</Button>
+
+    <Dialog :is-open="isOpen" :parent-element="buttonRef?.$el" @close="close">
+        <template #header>
+            <Toolbar>
+                <Text as="span" typography="title">Default dialog</Text>
+            </Toolbar>
+        </template>
+
+        <p class="lumx-spacing-padding-horizontal-huge">
+            Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros Afros. Magna
+            pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum dapibus. Praeterea iter est
+            quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea commodi consequat. Inmensae subtilitatis,
+            obscuris et malesuada fames. Me non paenitet nullum festiviorem excogitasse ad hoc. Cum ceteris in
+            veneratione tui montes, nascetur mus. Etiam habebis sem dicantur magna mollis euismod. Quis aute iure
+            reprehenderit in voluptate velit esse. Phasellus laoreet lorem vel dolor tempus vehicula.
+        </p>
+
+        <template #footer>
+            <Toolbar>
+                <template #after>
+                    <Button emphasis="medium" @click="close">Cancel</Button>
+                    <Button class="lumx-spacing-margin-left-regular" @click="close">Save</Button>
+                </template>
+            </Toolbar>
+        </template>
+    </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { mdiPlay } from '@lumx/icons';
+import { Button, Dialog, Text, Toolbar, type Theme } from '@lumx/vue';
+
+defineProps<{ theme?: Theme }>();
+
+const buttonRef = ref<InstanceType<typeof Button>>();
+const isOpen = ref(false);
+const close = () => { isOpen.value = false; };
+const toggle = () => { isOpen.value = !isOpen.value; };
+</script>

--- a/packages/site-demo/content/product/components/dialog/vue/processing-state.vue
+++ b/packages/site-demo/content/product/components/dialog/vue/processing-state.vue
@@ -1,0 +1,42 @@
+<template>
+    <Button :left-icon="mdiPlay" ref="buttonRef" @click="toggle" :theme="theme">Open processing dialog</Button>
+
+    <Dialog :is-open="isOpen" :is-loading="true" :parent-element="buttonRef?.$el" @close="close">
+        <template #header>
+            <Toolbar>
+                <Text as="span" typography="title">Default dialog</Text>
+            </Toolbar>
+        </template>
+
+        <p class="lumx-spacing-padding-horizontal-huge">
+            Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros Afros. Magna
+            pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum dapibus. Praeterea iter est
+            quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea commodi consequat. Inmensae subtilitatis,
+            obscuris et malesuada fames. Me non paenitet nullum festiviorem excogitasse ad hoc. Cum ceteris in
+            veneratione tui montes, nascetur mus. Etiam habebis sem dicantur magna mollis euismod. Quis aute iure
+            reprehenderit in voluptate velit esse. Phasellus laoreet lorem vel dolor tempus vehicula.
+        </p>
+
+        <template #footer>
+            <Toolbar>
+                <template #after>
+                    <Button emphasis="medium" @click="close">Cancel</Button>
+                    <Button class="lumx-spacing-margin-left-regular" @click="close">Save</Button>
+                </template>
+            </Toolbar>
+        </template>
+    </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { mdiPlay } from '@lumx/icons';
+import { Button, Dialog, Text, Toolbar, type Theme } from '@lumx/vue';
+
+defineProps<{ theme?: Theme }>();
+
+const buttonRef = ref<InstanceType<typeof Button>>();
+const isOpen = ref(false);
+const close = () => { isOpen.value = false; };
+const toggle = () => { isOpen.value = !isOpen.value; };
+</script>

--- a/packages/site-demo/content/product/components/dialog/vue/sizes.vue
+++ b/packages/site-demo/content/product/components/dialog/vue/sizes.vue
@@ -1,0 +1,50 @@
+<template>
+    <Button class="lumx-spacing-margin-horizontal-tiny" :left-icon="mdiPlay" @click="onClickSize('tiny', $event)" :theme="theme">Tiny</Button>
+    <Button class="lumx-spacing-margin-horizontal-tiny" :left-icon="mdiPlay" @click="onClickSize('regular', $event)" :theme="theme">Regular</Button>
+    <Button class="lumx-spacing-margin-horizontal-tiny" :left-icon="mdiPlay" @click="onClickSize('big', $event)" :theme="theme">Big</Button>
+    <Button class="lumx-spacing-margin-horizontal-tiny" :left-icon="mdiPlay" @click="onClickSize('huge', $event)" :theme="theme">Huge</Button>
+
+    <Dialog :is-open="isOpen" :parent-element="parentElement ?? undefined" :size="size" @close="close">
+        <template #header>
+            <Toolbar>
+                <Text as="span" typography="title">Dialog</Text>
+            </Toolbar>
+        </template>
+
+        <p class="lumx-spacing-padding-horizontal-huge">
+            Nihil hic munitissimus habendi senatus locus, nihil horum? At nos hinc posthac, sitientis piros Afros. Magna
+            pars studiorum, prodita quaerimus. Integer legentibus erat a ante historiarum dapibus. Praeterea iter est
+            quasdam res quas ex communi. Ullamco laboris nisi ut aliquid ex ea commodi consequat. Inmensae subtilitatis,
+            obscuris et malesuada fames. Me non paenitet nullum festiviorem excogitasse ad hoc. Cum ceteris in
+            veneratione tui montes, nascetur mus. Etiam habebis sem dicantur magna mollis euismod. Quis aute iure
+            reprehenderit in voluptate velit esse. Phasellus laoreet lorem vel dolor tempus vehicula.
+        </p>
+
+        <template #footer>
+            <Toolbar>
+                <template #after>
+                    <Button emphasis="medium" @click="close">Cancel</Button>
+                    <Button class="lumx-spacing-margin-left-regular" @click="close">Save</Button>
+                </template>
+            </Toolbar>
+        </template>
+    </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { mdiPlay } from '@lumx/icons';
+import { Button, Dialog, Text, Toolbar, type DialogSizes, type Theme } from '@lumx/vue';
+
+defineProps<{ theme?: Theme }>();
+
+const parentElement = ref<HTMLElement | null>(null);
+const isOpen = ref(false);
+const size = ref<DialogSizes>();
+const close = () => { isOpen.value = false; };
+const onClickSize = (newSize: DialogSizes, event: MouseEvent) => {
+    parentElement.value = event.currentTarget as HTMLElement;
+    size.value = newSize;
+    isOpen.value = true;
+};
+</script>


### PR DESCRIPTION
# General summary

- Add `Dialog` Vue component wrapping the existing core UI — with focus trap, escape/click-away close, scroll-triggered header/footer dividers, body scroll lock, and open/close transition visibility
- Add two new Vue composables: `useTransitionVisibility` (keeps dialog mounted during close animation) and `useDisableBodyScroll` (locks body scroll via `@vueuse/core` `useScrollLock`)
- Vue `Dialog` uses named slots (`default`, `header`, `footer`) instead of React's child extraction pattern
- Add Vue stories matching all React stories including `WithHeaderFooterChildren`, `WithConfirmClose`, and `FocusTrap`
- Add Vue unit tests and docs (3 Vue demo files + updated MDX page with `frameworks: ['react', 'vue']`)

StoryBook lumx-vue: https://2322eccc7--697a023f84e832e23544fb3c.chromatic.com/