### PR TITLE
feat(combobox): replace autoFilter with filter/openOnFocus props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/core`:
     -   Moved `Dialog` from `@lumx/react`
     -   `setupRovingTabIndex`: add MutationObserver-based tabindex normalization (mount, removal recovery, insertion, disabled-state, selection)
+    -   `Combobox`: replace `autoFilter` boolean with `filter` prop (`'auto'` | `'manual'` | `'off'`) and add `openOnFocus` prop
 -  `@lumx/react`:
     -  `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
+    -   `Combobox.Input`: replace `autoFilter` with `filter` and `openOnFocus` props
 -  `@lumx/vue`:
     -  `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
+    -   `Combobox.Input`: replace `autoFilter` with `filter` and `openOnFocus` props
 
 ## [4.10.0][] - 2026-04-03
 

--- a/packages/lumx-core/src/js/components/Combobox/ComboboxInput.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/ComboboxInput.tsx
@@ -20,6 +20,11 @@ export interface ComboboxInputProps extends HasClassName, HasTheme {
     toggleButtonProps?: Record<string, any>;
     /** Toggle callback for the chevron button. */
     handleToggle?(): void;
+    /**
+     * Controls how the combobox filters options as the user types.
+     * When `'off'`, the input is rendered as `readOnly`.
+     */
+    filter?: 'auto' | 'manual' | 'off';
 }
 
 /**
@@ -62,6 +67,7 @@ export const ComboboxInput = (props: ComboboxInputProps, { TextField, IconButton
         textFieldRef,
         toggleButtonProps,
         handleToggle,
+        filter,
         theme,
         ...forwardedProps
     } = props;
@@ -73,6 +79,7 @@ export const ComboboxInput = (props: ComboboxInputProps, { TextField, IconButton
     return (
         <TextField
             autoComplete="off"
+            readOnly={filter === 'off' || undefined}
             {...forwardedProps}
             ref={ref}
             role="combobox"

--- a/packages/lumx-core/src/js/components/Combobox/Stories.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Stories.tsx
@@ -317,6 +317,7 @@ export function setup({
                     value={value}
                     onChange={onChange}
                     placeholder="Pick a fruit…"
+                    openOnFocus
                     toggleButtonProps={{ label: 'Fruits' }}
                 />
                 <Combobox.Popover>
@@ -339,7 +340,12 @@ export function setup({
     const ComboboxWithErrorState = {
         render: () => (
             <Combobox.Provider>
-                <Combobox.Input value="" placeholder="Pick a fruit…" toggleButtonProps={{ label: 'Fruits' }} />
+                <Combobox.Input
+                    value=""
+                    placeholder="Pick a fruit…"
+                    openOnFocus
+                    toggleButtonProps={{ label: 'Fruits' }}
+                />
                 <Combobox.Popover>
                     <Combobox.List aria-label="Fruits" />
                     <Combobox.State errorMessage="Service unavailable" errorTryReloadMessage="Please try again later" />
@@ -356,7 +362,12 @@ export function setup({
     const ComboboxWithLoading = {
         render: () => (
             <Combobox.Provider>
-                <Combobox.Input value="" placeholder="Pick a fruit…" toggleButtonProps={{ label: 'Fruits' }} />
+                <Combobox.Input
+                    value=""
+                    placeholder="Pick a fruit…"
+                    openOnFocus
+                    toggleButtonProps={{ label: 'Fruits' }}
+                />
                 <Combobox.Popover>
                     <Combobox.List aria-label="Fruits">
                         <Combobox.OptionSkeleton count={3} />

--- a/packages/lumx-core/src/js/components/Combobox/TestStories.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/TestStories.tsx
@@ -163,6 +163,81 @@ export function setup({
         },
     };
 
+    // ─── Browser-only filter templates ─────────────────────────
+
+    const filterOffStory = {
+        args: { value: '' },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange, onSelect }: any) => (
+            <Combobox.Provider>
+                <Combobox.Input
+                    value={value}
+                    onChange={onChange}
+                    onSelect={onSelect}
+                    filter="off"
+                    placeholder="Pick a fruit…"
+                    toggleButtonProps={{ label: 'Fruits' }}
+                />
+                <Combobox.Popover>
+                    <Combobox.List aria-label="Fruits">
+                        {[
+                            'Apple',
+                            'Apricot',
+                            'Banana',
+                            'Blueberry',
+                            'Cherry',
+                            'Grape',
+                            'Lemon',
+                            'Orange',
+                            'Peach',
+                            'Strawberry',
+                        ].map((fruit) => (
+                            <Combobox.Option key={fruit} value={fruit}>
+                                {fruit}
+                            </Combobox.Option>
+                        ))}
+                    </Combobox.List>
+                </Combobox.Popover>
+            </Combobox.Provider>
+        ),
+    };
+
+    /**
+     * Verifies that filter="off" makes the input readOnly, opens on focus,
+     * and allows selecting via keyboard navigation.
+     */
+    const FilterOffOpenOnFocus = {
+        ...filterOffStory,
+        play: async ({ canvasElement }: any) => {
+            const input = getInput(canvasElement);
+
+            // Input should be readOnly
+            expect(input.readOnly).toBe(true);
+
+            // Should open on focus
+            input.focus();
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            // All 10 options visible (no filtering)
+            const visibleOptions = getVisibleOptions();
+            expect(visibleOptions).toHaveLength(10);
+
+            // Navigate and select
+            await userEvent.keyboard('{ArrowDown}');
+            await waitFor(() => {
+                expect(getActiveOption()!.textContent).toBe('Apple');
+            });
+
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => {
+                expect(input.value).toBe('Apple');
+                expect(input).toHaveAttribute('aria-expanded', 'false');
+            });
+        },
+    };
+
     const MouseHoverDoesNotActivateOption = {
         ...comboboxInputStory,
         play: async ({ canvasElement }: any) => {
@@ -379,6 +454,7 @@ export function setup({
     return {
         meta,
         AutoFilterOptions,
+        FilterOffOpenOnFocus,
         SelectOptionUpdatesInput,
         MouseHoverDoesNotActivateOption,
         ClickAwayClosesPopup,

--- a/packages/lumx-core/src/js/components/Combobox/Tests.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Tests.tsx
@@ -147,6 +147,130 @@ export function createTemplates(Combobox: ComboboxNamespace, IconButton: any) {
         </Combobox.Provider>
     );
 
+    /** Combobox with filter="manual" — no auto-filtering, consumer handles it. */
+    const manualFilterTemplate = ({
+        value,
+        onChange,
+        onSelect,
+    }: {
+        value: string;
+        onChange: (v: string) => void;
+        onSelect?: (option: { value: string }) => void;
+    }) => (
+        <Combobox.Provider>
+            <Combobox.Input
+                value={value}
+                onChange={onChange}
+                onSelect={onSelect}
+                filter="manual"
+                placeholder="Pick a fruit…"
+                toggleButtonProps={{ label: 'Fruits' }}
+            />
+            <Combobox.Popover>
+                <Combobox.List aria-label="Fruits">
+                    {FRUITS.map((fruit) => (
+                        <Combobox.Option key={fruit} value={fruit}>
+                            {fruit}
+                        </Combobox.Option>
+                    ))}
+                </Combobox.List>
+            </Combobox.Popover>
+        </Combobox.Provider>
+    );
+
+    /** Combobox with filter="off" — read-only input, opens on focus. */
+    const filterOffTemplate = ({
+        value,
+        onChange,
+        onSelect,
+    }: {
+        value: string;
+        onChange: (v: string) => void;
+        onSelect?: (option: { value: string }) => void;
+    }) => (
+        <Combobox.Provider>
+            <Combobox.Input
+                value={value}
+                onChange={onChange}
+                onSelect={onSelect}
+                filter="off"
+                placeholder="Pick a fruit…"
+                toggleButtonProps={{ label: 'Fruits' }}
+            />
+            <Combobox.Popover>
+                <Combobox.List aria-label="Fruits">
+                    {FRUITS.map((fruit) => (
+                        <Combobox.Option key={fruit} value={fruit}>
+                            {fruit}
+                        </Combobox.Option>
+                    ))}
+                </Combobox.List>
+            </Combobox.Popover>
+        </Combobox.Provider>
+    );
+
+    /** Combobox with explicit openOnFocus={true}. */
+    const openOnFocusTemplate = ({
+        value,
+        onChange,
+        onSelect,
+    }: {
+        value: string;
+        onChange: (v: string) => void;
+        onSelect?: (option: { value: string }) => void;
+    }) => (
+        <Combobox.Provider>
+            <Combobox.Input
+                value={value}
+                onChange={onChange}
+                onSelect={onSelect}
+                openOnFocus
+                placeholder="Pick a fruit…"
+                toggleButtonProps={{ label: 'Fruits' }}
+            />
+            <Combobox.Popover>
+                <Combobox.List aria-label="Fruits">
+                    {FRUITS.map((fruit) => (
+                        <Combobox.Option key={fruit} value={fruit}>
+                            {fruit}
+                        </Combobox.Option>
+                    ))}
+                </Combobox.List>
+            </Combobox.Popover>
+        </Combobox.Provider>
+    );
+
+    /** Combobox with explicit openOnFocus={false} (default behavior). */
+    const noOpenOnFocusTemplate = ({
+        value,
+        onChange,
+        onSelect,
+    }: {
+        value: string;
+        onChange: (v: string) => void;
+        onSelect?: (option: { value: string }) => void;
+    }) => (
+        <Combobox.Provider>
+            <Combobox.Input
+                value={value}
+                onChange={onChange}
+                onSelect={onSelect}
+                openOnFocus={false}
+                placeholder="Pick a fruit…"
+                toggleButtonProps={{ label: 'Fruits' }}
+            />
+            <Combobox.Popover>
+                <Combobox.List aria-label="Fruits">
+                    {FRUITS.map((fruit) => (
+                        <Combobox.Option key={fruit} value={fruit}>
+                            {fruit}
+                        </Combobox.Option>
+                    ))}
+                </Combobox.List>
+            </Combobox.Popover>
+        </Combobox.Provider>
+    );
+
     /** Select-only combobox with button trigger and 10 fruit options. */
     const buttonTemplate = ({ value, onSelect }: { value: string; onSelect: (option: { value: string }) => void }) => (
         <Combobox.Provider>
@@ -537,6 +661,10 @@ export function createTemplates(Combobox: ComboboxNamespace, IconButton: any) {
 
     return {
         inputTemplate,
+        manualFilterTemplate,
+        filterOffTemplate,
+        openOnFocusTemplate,
+        noOpenOnFocusTemplate,
         buttonTemplate,
         showLabelButtonTemplate,
         showTooltipButtonTemplate,
@@ -1645,6 +1773,171 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             expect(button.textContent).toBe('');
             expect(button).toHaveAttribute('role', 'combobox');
             expect(button).toHaveAttribute('aria-haspopup', 'listbox');
+        });
+    });
+
+    // ───────────────────────────────────────────────────────────────
+    // Filter Prop
+    // ───────────────────────────────────────────────────────────────
+
+    describe('filter="manual"', () => {
+        it('should not auto-filter options when typing', async () => {
+            renderWithState(t.manualFilterTemplate);
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            expect(getVisibleOptions().length).toBe(FRUITS.length);
+
+            await userEvent.type(input, 'bl');
+
+            // All options should remain visible — no auto-filter
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(FRUITS.length);
+            });
+        });
+
+        it('should still allow selecting options', async () => {
+            const onSelect = vi.fn();
+            renderWithState(t.manualFilterTemplate, { value: '', onSelect });
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            await userEvent.keyboard('{ArrowDown}');
+            await waitFor(() => {
+                expect(getActiveOption()!.textContent).toBe('Apple');
+            });
+
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => {
+                expect(input.value).toBe('Apple');
+            });
+
+            expect(onSelect).toHaveBeenCalled();
+        });
+
+        it('should not have readOnly on the input', async () => {
+            renderWithState(t.manualFilterTemplate);
+            const input = getInput();
+            expect(input.readOnly).toBe(false);
+        });
+    });
+
+    describe('filter="off"', () => {
+        it('should set input to readOnly', async () => {
+            renderWithState(t.filterOffTemplate);
+            const input = getInput();
+
+            await waitFor(() => {
+                expect(input.readOnly).toBe(true);
+            });
+        });
+
+        it('should open on focus (openOnFocus defaults to true)', async () => {
+            renderWithState(t.filterOffTemplate);
+            const input = getInput();
+
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+
+            fireEvent.focus(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+        });
+
+        it('should still allow selecting options', async () => {
+            const onSelect = vi.fn();
+            renderWithState(t.filterOffTemplate, { value: '', onSelect });
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            await userEvent.keyboard('{ArrowDown}');
+            await waitFor(() => {
+                expect(getActiveOption()!.textContent).toBe('Apple');
+            });
+
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => {
+                expect(input.value).toBe('Apple');
+            });
+
+            expect(onSelect).toHaveBeenCalled();
+        });
+
+        it('should show all options (no filtering)', async () => {
+            renderWithState(t.filterOffTemplate);
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            expect(getVisibleOptions().length).toBe(FRUITS.length);
+        });
+    });
+
+    describe('openOnFocus', () => {
+        it('should open on focus when openOnFocus is true', async () => {
+            renderWithState(t.openOnFocusTemplate);
+            const input = getInput();
+
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+
+            fireEvent.focus(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+        });
+
+        it('should not open on focus when openOnFocus is false', async () => {
+            renderWithState(t.noOpenOnFocusTemplate);
+            const input = getInput();
+
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+
+            fireEvent.focus(input);
+
+            // Should remain closed — only opens on click or typing
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+        });
+
+        it('should open on click even when openOnFocus is false', async () => {
+            renderWithState(t.noOpenOnFocusTemplate);
+            const input = getInput();
+
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+        });
+
+        it('should default to not opening on focus (filter="auto")', async () => {
+            renderWithState(t.inputTemplate);
+            const input = getInput();
+
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+
+            fireEvent.focus(input);
+
+            // Default filter="auto" should not open on focus
+            expect(input).toHaveAttribute('aria-expanded', 'false');
         });
     });
 

--- a/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
@@ -4,14 +4,22 @@ import { setupCombobox } from './setupCombobox';
 /** Options for configuring the input-mode combobox controller. */
 export interface SetupComboboxInputOptions extends ComboboxCallbacks {
     /**
-     * When true (default), the combobox automatically filters options as the user types.
-     * Each registered `Combobox.Option` receives filter state updates and hides itself
-     * when it does not match the current input value.
+     * Controls how the combobox filters options as the user types.
      *
-     * Set to false when you want to handle filtering yourself (e.g. async search,
-     * consumer-side pre-filtering). Options will not be registered for auto-filtering.
+     * - `'auto'` (default) — Options are automatically filtered client-side.
+     * - `'manual'` — Filtering is the consumer's responsibility.
+     * - `'off'` — Like `'manual'`, and `openOnFocus` defaults to `true`.
+     *   The core template renders the input as `readOnly`.
      */
-    autoFilter?: boolean;
+    filter?: 'auto' | 'manual' | 'off';
+    /**
+     * When true, the combobox opens automatically when the input receives focus.
+     * When false (default, unless `filter` is `'off'`), the combobox only opens
+     * on click, typing, or keyboard navigation.
+     *
+     * @default false (true when filter is 'off')
+     */
+    openOnFocus?: boolean;
 }
 
 /**
@@ -29,7 +37,9 @@ export interface SetupComboboxInputOptions extends ComboboxCallbacks {
  * @returns A ComboboxHandle for interacting with the combobox.
  */
 export function setupComboboxInput(input: HTMLInputElement, options: SetupComboboxInputOptions): ComboboxHandle {
-    const { autoFilter = true, onSelect: optionOnSelect } = options;
+    const { filter = 'auto', onSelect: optionOnSelect } = options;
+    const openOnFocus = options.openOnFocus ?? filter === 'off';
+    const autoFilter = filter === 'auto';
 
     /** Check if the input is disabled (native `disabled` attribute or `aria-disabled="true"`). */
     const isDisabled = () => input.disabled || input.getAttribute('aria-disabled') === 'true';
@@ -83,13 +93,15 @@ export function setupComboboxInput(input: HTMLInputElement, options: SetupCombob
             { signal },
         );
 
-        // Open on focus.
+        // Open on focus (only when openOnFocus is enabled).
         input.addEventListener(
             'focus',
             () => {
                 if (isDisabled()) return;
                 combobox.focusNav?.clear();
-                combobox.setIsOpen(true);
+                if (openOnFocus) {
+                    combobox.setIsOpen(true);
+                }
             },
             { signal },
         );

--- a/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
@@ -32,6 +32,7 @@ export function setupListbox(
     const trigger = handle.trigger!;
     const listbox = handle.listbox!;
     const isGrid = listbox.getAttribute('role') === 'grid';
+    const itemSelector = '[role="option"]';
 
     // ── Focus navigation ──────────────────────────────────────
 
@@ -39,10 +40,25 @@ export function setupListbox(
         onActivate: (item: HTMLElement) => {
             item.setAttribute('data-focus-visible-added', 'true');
             trigger.setAttribute('aria-activedescendant', item.id);
-            // Scroll to the element in listbox or else the item
-            const toScrollTo = item.closest('[role=listbox] > *') || item;
-            toScrollTo.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
             notify('activeDescendantChange', item.id);
+
+            requestAnimationFrame(() => {
+                // Last item in listbox
+                const lastItem =
+                    !isGrid &&
+                    // Last item: find last element containing itemSelector and not followed by elements containing itemSelector and then get the itemSelector inside
+                    listbox.querySelector(
+                        `:scope > :has(${itemSelector}):not(:has(~ * ${itemSelector})) ${itemSelector}`,
+                    );
+                if (item === lastItem) {
+                    // Scroll to the end of the listbox (shouldsnap to the end of the scroll container thanks to CSS scroll snap)
+                    listbox.lastElementChild?.scrollIntoView({ block: 'nearest' });
+                } else {
+                    // Scroll to the element in listbox or else the item
+                    const toScrollTo = item.closest('[role=listbox] > *') || item;
+                    toScrollTo.scrollIntoView({ block: 'nearest' });
+                }
+            });
         },
         onDeactivate: (item: HTMLElement) => {
             item.removeAttribute('data-focus-visible-added');
@@ -73,9 +89,7 @@ export function setupListbox(
             {
                 type: 'list',
                 container: listbox,
-                // Filtered options don't render [role="option"] at all (they render only a
-                // hidden placeholder), so no :not([data-filtered]) filter is needed here.
-                itemSelector: '[role="option"]',
+                itemSelector,
                 getActiveItem: () => {
                     const id = trigger.getAttribute('aria-activedescendant');
                     return id ? (document.getElementById(id) as HTMLElement | null) : null;

--- a/packages/lumx-core/src/scss/components/combobox/_index.scss
+++ b/packages/lumx-core/src/scss/components/combobox/_index.scss
@@ -18,6 +18,21 @@
 
     &__scroll {
         overflow-y: auto;
+        scroll-snap-type: y proximity;
+        @media (prefers-reduced-motion: no-preference) {
+            scroll-behavior: smooth;
+        }
+
+        &::before {
+          content: '';
+          display: block;
+          scroll-snap-align: start;
+        }
+        &::after {
+          content: '';
+          display: block;
+          scroll-snap-align: end;
+        }
     }
 }
 

--- a/packages/lumx-react/src/components/combobox/Combobox.test.stories.tsx
+++ b/packages/lumx-react/src/components/combobox/Combobox.test.stories.tsx
@@ -29,6 +29,9 @@ export default {
 // Browser-only: auto-filter test
 export const AutoFilterOptions = { ...testStories.AutoFilterOptions };
 
+// Browser-only: filter="off" test (readOnly input, opens on focus)
+export const FilterOffOpenOnFocus = { ...testStories.FilterOffOpenOnFocus };
+
 // Browser-only: select updates input (withValueOnChange decorator integration)
 export const SelectOptionUpdatesInput = { ...testStories.SelectOptionUpdatesInput };
 

--- a/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
@@ -25,13 +25,22 @@ export interface ComboboxInputProps extends TextFieldProps {
     /** Called when an option is selected. */
     onSelect?: (option: { value: string }) => void;
     /**
-     * When true (default), the combobox automatically filters options as the user types.
-     * Each `Combobox.Option` registers itself and hides when it doesn't match the input value.
+     * Controls how the combobox filters options as the user types.
      *
-     * Set to false when you handle filtering yourself (e.g. async search, consumer-side
-     * pre-filtering). Options will not be auto-filtered.
+     * - `'auto'` (default) — Options are automatically filtered client-side.
+     * - `'manual'` — Filtering is the consumer's responsibility.
+     * - `'off'` — Like `'manual'`, but the input is rendered as `readOnly`
+     *   and `openOnFocus` defaults to `true`.
      */
-    autoFilter?: boolean;
+    filter?: 'auto' | 'manual' | 'off';
+    /**
+     * When true, the combobox opens automatically when the input receives focus.
+     * When false (default, unless `filter` is `'off'`), the combobox only opens
+     * on click, typing, or keyboard navigation.
+     *
+     * @default false (true when filter is 'off')
+     */
+    openOnFocus?: boolean;
 }
 
 /**
@@ -45,7 +54,7 @@ export interface ComboboxInputProps extends TextFieldProps {
 export const ComboboxInput = forwardRef<ComboboxInputProps, HTMLDivElement>((props, ref) => {
     const { listboxId, anchorRef, setHandle } = useComboboxContext();
     const [isOpen, setIsOpen] = useComboboxOpen();
-    const { inputRef: externalInputRef, toggleButtonProps, onSelect, autoFilter, ...otherProps } = props;
+    const { inputRef: externalInputRef, toggleButtonProps, onSelect, filter, openOnFocus, ...otherProps } = props;
     const internalInputRef = useRef<HTMLInputElement>(null);
     const mergedInputRef = useMergeRefs(externalInputRef, internalInputRef);
 
@@ -65,14 +74,15 @@ export const ComboboxInput = forwardRef<ComboboxInputProps, HTMLDivElement>((pro
                 onChangeRef.current?.(option.value);
                 onSelectRef.current?.(option);
             },
-            autoFilter,
+            filter,
+            openOnFocus,
         });
         setHandle(handle);
         return () => {
             handle.destroy();
             setHandle(null);
         };
-    }, [autoFilter, setHandle]);
+    }, [filter, openOnFocus, setHandle]);
 
     const handleToggle = useCallback(() => {
         setIsOpen(!isOpen);
@@ -85,6 +95,7 @@ export const ComboboxInput = forwardRef<ComboboxInputProps, HTMLDivElement>((pro
             ref,
             listboxId,
             isOpen,
+            filter,
             inputRef: mergedInputRef,
             textFieldRef: anchorRef as Ref<HTMLDivElement>,
             toggleButtonProps,

--- a/packages/lumx-react/src/components/combobox/ComboboxOption.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxOption.tsx
@@ -48,7 +48,7 @@ export interface ComboboxOptionProps extends GenericProps, ReactToJSX<UIProps, C
 /**
  * Combobox.Option component - wraps ListItem with option role and data-value.
  *
- * When autoFilter is enabled on the parent Combobox.Input, each option registers itself
+ * When filter="auto" is enabled on the parent Combobox.Input, each option registers itself
  * with the combobox handle (via an internal ref to its root <li>). When the filter changes,
  * the handle calls back with the new match state. When filtered out, the core template renders
  * a bare `<li hidden>` — no ARIA roles, no CSS classes — keeping the element in the DOM so

--- a/packages/lumx-react/src/components/combobox/ComboboxSection.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxSection.tsx
@@ -28,7 +28,7 @@ export interface ComboboxSectionProps extends GenericProps, ReactToJSX<UIProps, 
  *
  * Returns null when children is empty so the section header is not rendered as an orphan.
  *
- * When autoFilter is active, the section registers itself with the combobox handle.
+ * When filter="auto" is active, the section registers itself with the combobox handle.
  * The handle monitors registered options within this section and notifies when all
  * are filtered out. When hidden, the core template renders a bare `<li hidden>` wrapper
  * so children (options) stay mounted and registered.

--- a/packages/lumx-vue/src/components/combobox/Combobox.test.stories.tsx
+++ b/packages/lumx-vue/src/components/combobox/Combobox.test.stories.tsx
@@ -26,6 +26,12 @@ export default {
     ...meta,
 };
 
+// Browser-only: auto-filter test
+export const AutoFilterOptions = { ...testStories.AutoFilterOptions };
+
+// Browser-only: filter="off" test (readOnly input, opens on focus)
+export const FilterOffOpenOnFocus = { ...testStories.FilterOffOpenOnFocus };
+
 // Browser-only: select updates input (withValueOnChange decorator integration)
 export const SelectOptionUpdatesInput = { ...testStories.SelectOptionUpdatesInput };
 

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -26,10 +26,22 @@ export type ComboboxInputProps = VueToJSXProps<TextFieldProps, 'inputRef' | 'tex
     /** Called when an option is selected. */
     onSelect?: (option: { value: string }) => void;
     /**
-     * When true (default), the combobox automatically filters options as the user types.
-     * Set to false when you handle filtering yourself (e.g. async search).
+     * Controls how the combobox filters options as the user types.
+     *
+     * - `'auto'` (default) — Options are automatically filtered client-side.
+     * - `'manual'` — Filtering is the consumer's responsibility.
+     * - `'off'` — Like `'manual'`, but the input is rendered as `readOnly`
+     *   and `openOnFocus` defaults to `true`.
      */
-    autoFilter?: boolean;
+    filter?: 'auto' | 'manual' | 'off';
+    /**
+     * When true, the combobox opens automatically when the input receives focus.
+     * When false (default, unless `filter` is `'off'`), the combobox only opens
+     * on click, typing, or keyboard navigation.
+     *
+     * @default false (true when filter is 'off')
+     */
+    openOnFocus?: boolean;
 };
 
 /**
@@ -69,7 +81,8 @@ const ComboboxInput = defineComponent(
                         props.onSelect?.(option);
                         emit('select', option);
                     },
-                    autoFilter: props.autoFilter,
+                    filter: props.filter,
+                    openOnFocus: props.openOnFocus,
                 }),
             );
         });
@@ -85,7 +98,14 @@ const ComboboxInput = defineComponent(
         };
 
         return () => {
-            const { toggleButtonProps, onSelect: _onSelect, autoFilter: _af, class: _class, ...forwardedProps } = props;
+            const {
+                toggleButtonProps,
+                onSelect: _onSelect,
+                filter,
+                openOnFocus: _oof,
+                class: _class,
+                ...forwardedProps
+            } = props;
 
             // Event handlers are framework-specific and forwarded through the core template's
             // spread to the TextField adapter. They are not in the core ComboboxInputProps type.
@@ -97,13 +117,19 @@ const ComboboxInput = defineComponent(
                 onClear: (event?: MouseEvent) => emit('clear', event),
             };
 
+            // Vue normalizes 'aria-disabled' prop to camelCase 'ariaDisabled'.
+            // Re-map it to kebab-case for the core template which expects 'aria-disabled'.
+            const { ariaDisabled: fwdAriaDisabled, ...restForwardedProps } = forwardedProps as any;
+
             return UI(
                 {
                     ...attrs,
-                    ...forwardedProps,
+                    ...restForwardedProps,
+                    'aria-disabled': fwdAriaDisabled ?? (attrs as any).ariaDisabled,
                     ...eventHandlers,
                     listboxId,
                     isOpen: isOpen.value,
+                    filter,
                     textFieldRef: (el: HTMLElement | null) => {
                         textFieldEl.value = el;
                     },
@@ -148,7 +174,8 @@ const ComboboxInput = defineComponent(
             'minimumRows',
             'toggleButtonProps',
             'onSelect',
-            'autoFilter',
+            'filter',
+            'openOnFocus',
         ),
         emits: {
             select: (option: { value: string }) => !!option,

--- a/packages/lumx-vue/src/components/text-field/TextField.tsx
+++ b/packages/lumx-vue/src/components/text-field/TextField.tsx
@@ -148,7 +148,7 @@ const TextField = defineComponent(
                 'aria-invalid': props.hasError || undefined,
                 'aria-describedby': describedById,
                 ...disabledStateProps.value,
-                readOnly: !!disabledStateProps.value['aria-disabled'],
+                readOnly: !!(inputAttrs as any).readOnly || !!disabledStateProps.value['aria-disabled'],
                 onChange: handleChange,
                 onInput: handleInput,
                 onFocus: handleFocus,


### PR DESCRIPTION
# General summary

Improve filter API 
- `filter=auto`: previously `autoFilter`
- `filter=manual`: previously `autoFilter=false`
- `filter=off`: make input `readOnly` but keeps the focus, click to open, key nav, selection etc.

Add `openOnFocus` flag defaulting to `false` most of the time but `true` when `filter=off`



StoryBook lumx-vue: https://bdf191940--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://bdf191940--5fbfb1d508c0520021560f10.chromatic.com/