### PR TITLE
feat(text-field): improve clear button naming linked to input label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/core`:
     -   Moved `Dialog` from `@lumx/react`
     -   `setupRovingTabIndex`: add MutationObserver-based tabindex normalization (mount, removal recovery, insertion, disabled-state, selection)
+-  `@lumx/react`:
+    -  `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
+-  `@lumx/vue`:
+    -  `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
 
 ## [4.10.0][] - 2026-04-03
 

--- a/packages/lumx-core/src/js/components/InputLabel/index.tsx
+++ b/packages/lumx-core/src/js/components/InputLabel/index.tsx
@@ -12,6 +12,8 @@ export interface InputLabelProps extends HasClassName, HasTheme {
     children: JSXElement;
     /** Native htmlFor property. */
     htmlFor: string;
+    /** Native id property. */
+    id?: string;
     /** Whether the component is required or not. */
     isRequired?: boolean;
     /** ref to the root element */

--- a/packages/lumx-core/src/js/components/TextField/Tests.ts
+++ b/packages/lumx-core/src/js/components/TextField/Tests.ts
@@ -1,6 +1,12 @@
 import partition from 'lodash/partition';
 
-import { getByClassName, getByTagName, queryAllByClassName, queryByTagName } from '../../../testing/queries';
+import {
+    getByClassName,
+    getByTagName,
+    queryAllByClassName,
+    queryByClassName,
+    queryByTagName,
+} from '../../../testing/queries';
 import { SetupOptions } from '../../../testing';
 
 const CLASSNAME = 'lumx-text-field';
@@ -207,6 +213,38 @@ export default (renderOptions: SetupOptions<any>) => {
             it('should not forward "labelProps" to the native input element', () => {
                 const { inputNative } = setup({ labelProps: { className: 'custom-label' } }, renderOptions);
                 expect(inputNative).not.toHaveAttribute('labelprops');
+            });
+
+            it('should link the clear button to the field label via aria-describedby', () => {
+                setup(
+                    {
+                        label: 'My label',
+                        value: 'some value',
+                        clearButtonProps: { label: 'Clear' },
+                    },
+                    renderOptions,
+                );
+
+                const clearButton = queryByClassName(document.body, 'lumx-text-field__input-clear') as HTMLElement;
+
+                expect(clearButton).toBeInTheDocument();
+                expect(clearButton).toHaveAccessibleName('Clear');
+                expect(clearButton).toHaveAccessibleDescription('My label');
+            });
+
+            it('should not set accessible description on clear button when there is no label', () => {
+                setup(
+                    {
+                        value: 'some value',
+                        clearButtonProps: { label: 'Clear' },
+                    },
+                    renderOptions,
+                );
+
+                const clearButton = queryByClassName(document.body, 'lumx-text-field__input-clear') as HTMLElement;
+
+                expect(clearButton).toBeInTheDocument();
+                expect(clearButton).not.toHaveAccessibleDescription();
             });
         });
 

--- a/packages/lumx-core/src/js/components/TextField/TextField.tsx
+++ b/packages/lumx-core/src/js/components/TextField/TextField.tsx
@@ -36,6 +36,8 @@ export interface TextFieldProps extends HasClassName, HasTheme, HasAriaDisabled,
     helperId?: string;
     /** Generated error id for accessibility attributes. */
     errorId?: string;
+    /** Generated label id for accessibility attributes (used to link the clear button to the field label). */
+    labelId?: string;
     /** Whether the component is required or not. */
     isRequired?: boolean;
     /** Whether the text field is displayed with valid style or not. */
@@ -74,6 +76,7 @@ export type TextFieldPropsToOverride =
     | 'clearButtonProps'
     | 'helperId'
     | 'errorId'
+    | 'labelId'
     | 'isAnyDisabled'
     | 'isFocus';
 
@@ -92,13 +95,15 @@ export function generateAccessibilityIds(
     error: TextFieldProps['error'],
     generatedId: string,
     existingAriaDescribedBy?: string,
-): { helperId?: string; errorId?: string; describedById?: string } {
+    label?: TextFieldProps['label'],
+): { helperId?: string; errorId?: string; describedById?: string; labelId?: string } {
     const helperId = helper ? `text-field-helper-${generatedId}` : undefined;
     const errorId = error ? `text-field-error-${generatedId}` : undefined;
+    const labelId = label ? `text-field-label-${generatedId}` : undefined;
     const describedByIds = [errorId, helperId, existingAriaDescribedBy].filter(Boolean);
     const describedById = describedByIds.length === 0 ? undefined : describedByIds.join(' ');
 
-    return { helperId, errorId, describedById };
+    return { helperId, errorId, describedById, labelId };
 }
 
 /**
@@ -130,6 +135,7 @@ export const TextField = (props: TextFieldProps) => {
         textFieldRef,
         helperId,
         errorId,
+        labelId,
         theme,
         value,
         afterElement,
@@ -169,6 +175,7 @@ export const TextField = (props: TextFieldProps) => {
                     {label &&
                         InputLabel({
                             ...labelProps,
+                            id: labelId,
                             htmlFor: textFieldId as string,
                             className: element('label'),
                             isRequired,
@@ -214,6 +221,7 @@ export const TextField = (props: TextFieldProps) => {
 
                 {clearButtonProps && isNotEmpty && !isAnyDisabled && (
                     <IconButton
+                        aria-describedby={labelId}
                         {...clearButtonProps}
                         className={element('input-clear')}
                         icon={mdiCloseCircle}

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -104,11 +104,12 @@ export const TextField = forwardRef<TextFieldProps, HTMLDivElement>((props, ref)
     /** Merge prop input ref and local input ref */
     const inputRef = mergeRefs(localInputRef, inputRefProps);
 
-    const { helperId, errorId, describedById } = generateAccessibilityIds(
+    const { helperId, errorId, describedById, labelId } = generateAccessibilityIds(
         helper,
         error,
         generatedTextFieldId,
         forwardedProps['aria-describedby'],
+        label,
     );
 
     const [isFocus, setFocus] = useState(false);
@@ -183,6 +184,7 @@ export const TextField = forwardRef<TextFieldProps, HTMLDivElement>((props, ref)
         afterElement,
         hasError,
         helperId,
+        labelId,
         multiline,
         maxLength,
         isRequired,

--- a/packages/lumx-vue/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-vue/src/components/input-label/InputLabel.tsx
@@ -35,7 +35,7 @@ const InputLabel = defineComponent(
         name: 'InputLabel',
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
-        props: keysOf<InputLabelProps>()('htmlFor', 'isRequired', 'typography', 'theme', 'class'),
+        props: keysOf<InputLabelProps>()('htmlFor', 'id', 'isRequired', 'typography', 'theme', 'class'),
     },
 );
 

--- a/packages/lumx-vue/src/components/text-field/TextField.tsx
+++ b/packages/lumx-vue/src/components/text-field/TextField.tsx
@@ -88,6 +88,7 @@ const TextField = defineComponent(
                 props.error,
                 generatedId,
                 (attrs['aria-describedby'] as string) || undefined,
+                props.label,
             ),
         );
 
@@ -117,7 +118,7 @@ const TextField = defineComponent(
 
         return () => {
             const theme = props.theme || defaultTheme.value;
-            const { helperId, errorId, describedById } = accessibilityIds.value;
+            const { helperId, errorId, describedById, labelId } = accessibilityIds.value;
 
             // Filter out attrs handled explicitly so that unknown attrs (e.g. data-*, aria-*)
             // are forwarded to the native input element.
@@ -184,6 +185,7 @@ const TextField = defineComponent(
                     id={textFieldId.value}
                     isAnyDisabled={isAnyDisabled.value}
                     helperId={helperId}
+                    labelId={labelId}
                     errorId={errorId}
                     isFocus={isFocus.value}
                     input={input}


### PR DESCRIPTION
# General summary

Link text field clear button to the input label via aria-describedby



StoryBook lumx-vue: https://823a5f5a3--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://823a5f5a3--5fbfb1d508c0520021560f10.chromatic.com/