### PR TITLE
chore(vue): migrate AlertDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `@lumx/vue`:
+    -   Create the `AlertDialog` component
     -   Create the `Dialog` component
     -   Create the `InfiniteScroll` utility component (available from `@lumx/vue/utils`)
 
 ### Changed
 
 -   `@lumx/core`:
+    -   Moved `AlertDialog` stories and tests from `@lumx/react`
     -   Moved `Dialog` from `@lumx/react`
     -   `setupRovingTabIndex`: add MutationObserver-based tabindex normalization (mount, removal recovery, insertion, disabled-state, selection)
     -   `Combobox`: replace `autoFilter` boolean with `filter` prop (`'auto'` | `'manual'` | `'off'`) and add `openOnFocus` prop

--- a/packages/lumx-core/src/js/components/AlertDialog/Stories.tsx
+++ b/packages/lumx-core/src/js/components/AlertDialog/Stories.tsx
@@ -1,0 +1,115 @@
+import type { SetupStoriesOptions } from '@lumx/core/stories/types';
+import { getSelectArgType } from '@lumx/core/stories/controls/selectArgType';
+import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
+import { loremIpsum } from '@lumx/core/stories/utils/lorem';
+import { Kind, Size } from '../../constants';
+import { DEFAULT_PROPS } from '.';
+
+const dialogSizes = [Size.tiny, Size.regular, Size.big, Size.huge];
+
+/**
+ * Setup AlertDialog stories for a specific framework (React or Vue).
+ * Framework-specific components and render function are injected via `components` and `render`.
+ */
+export function setup({
+    component: AlertDialog,
+    render,
+    components: { Link },
+    decorators: { withChromaticForceScreenSize, withNestedProps },
+}: SetupStoriesOptions<{
+    components: { Link: any };
+    decorators: 'withChromaticForceScreenSize' | 'withNestedProps';
+}>) {
+    const meta = {
+        component: AlertDialog,
+        render,
+        args: {
+            ...DEFAULT_PROPS,
+            'confirmProps.label': 'Ok',
+        },
+        argTypes: {
+            size: getSelectArgType(dialogSizes),
+            kind: getSelectArgType(Kind),
+            'confirmProps.onClick': { action: true },
+        },
+        parameters: {
+            chromatic: {
+                pauseAnimationAtEnd: true,
+                delay: DIALOG_TRANSITION_DURATION,
+            },
+        },
+        decorators: [withChromaticForceScreenSize(), withNestedProps()],
+    };
+
+    /** Alert dialog with default kind */
+    const DefaultKind = {
+        args: {
+            title: 'Default (info)',
+            children: loremIpsum('tiny'),
+        },
+    };
+
+    /** Alert dialog as warning */
+    const Warning = {
+        args: {
+            ...DefaultKind.args,
+            kind: Kind.warning,
+            title: 'Warning',
+        },
+    };
+
+    /** Alert dialog as success */
+    const Success = {
+        args: {
+            ...DefaultKind.args,
+            kind: Kind.success,
+            title: 'Success',
+        },
+    };
+
+    /** Alert dialog as error */
+    const Error = {
+        args: {
+            ...DefaultKind.args,
+            kind: Kind.error,
+            title: 'Error',
+        },
+    };
+
+    /** Alert dialog with cancel button */
+    const WithCancel = {
+        argTypes: {
+            'cancelProps.onClick': { action: true },
+        },
+        args: {
+            ...DefaultKind.args,
+            title: 'With Cancel',
+            'cancelProps.label': 'Cancel',
+        },
+    };
+
+    /** Alert dialog with rich description */
+    const RichDescription = {
+        argTypes: { children: { control: false } },
+        args: {
+            ...DefaultKind.args,
+            title: 'With Rich Description',
+        },
+        render: ({ children, ...args }: any) =>
+            render({
+                ...args,
+                children: (
+                    <>
+                        Amet ut elit dolore irure mollit <strong>sunt culpa esse</strong>.<br />
+                        Ea ut Lorem.
+                        <br />
+                        <Link href="https://example.com" target="_blank">
+                            Link
+                        </Link>
+                    </>
+                ),
+            }),
+    };
+
+    return { meta, DefaultKind, Warning, Success, Error, WithCancel, RichDescription };
+}

--- a/packages/lumx-core/src/js/components/AlertDialog/Tests.ts
+++ b/packages/lumx-core/src/js/components/AlertDialog/Tests.ts
@@ -1,0 +1,74 @@
+import { queryByClassName } from '../../../testing/queries';
+import { SetupOptions } from '../../../testing';
+import { Kind } from '../../constants';
+
+const CLASSNAME = 'lumx-alert-dialog';
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ */
+export const setup = (propsOverride: any = {}, { render, ...options }: SetupOptions<any>) => {
+    const props = {
+        isOpen: true,
+        title: 'Alert',
+        confirmProps: { onClick: () => {}, label: 'OK' },
+        id: 'test-id',
+        ...propsOverride,
+    };
+    const wrapper = render(props, options);
+
+    const alertDialog = queryByClassName(document.body, CLASSNAME);
+    return { props, alertDialog, wrapper };
+};
+
+export default (renderOptions: SetupOptions<any>) => {
+    const { screen } = renderOptions;
+
+    describe('AlertDialog core tests', () => {
+        describe('Accessibility', () => {
+            it('has the correct role and aria attributes', () => {
+                setup({ children: 'Content' }, renderOptions);
+                const dialog = screen.getByRole('alertdialog');
+                expect(dialog).toBeInTheDocument();
+                expect(dialog.getAttribute('aria-labelledby')).toBe('test-id-title');
+                expect(dialog.getAttribute('aria-describedby')).toBe('test-id-description');
+                expect(document.getElementById('test-id-title')?.textContent).toBe('Alert');
+                expect(document.getElementById('test-id-description')?.textContent).toBe('Content');
+            });
+        });
+
+        describe('Content Rendering', () => {
+            it('renders the title', () => {
+                setup({ title: 'Custom Title' }, renderOptions);
+                expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Custom Title');
+            });
+
+            it('renders children as a paragraph when string', () => {
+                setup({ children: 'String content' }, renderOptions);
+                const content = screen.getByText('String content');
+                expect(content.tagName).toBe('P');
+            });
+        });
+
+        describe('Buttons', () => {
+            it('does not render cancel button when props not provided', () => {
+                setup({ cancelProps: undefined }, renderOptions);
+                expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+            });
+        });
+
+        describe('Variants', () => {
+            it('applies correct color to confirm button based on kind (error)', () => {
+                setup({ kind: Kind.error }, renderOptions);
+                const btn = screen.getByRole('button', { name: 'OK' });
+                expect(btn.className).toContain('lumx-button--color-red');
+            });
+
+            it('applies correct color to confirm button based on kind (success)', () => {
+                setup({ kind: Kind.success }, renderOptions);
+                const btn = screen.getByRole('button', { name: 'OK' });
+                expect(btn.className).toContain('lumx-button--color-green');
+            });
+        });
+    });
+};

--- a/packages/lumx-core/src/js/components/AlertDialog/index.tsx
+++ b/packages/lumx-core/src/js/components/AlertDialog/index.tsx
@@ -1,0 +1,193 @@
+import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons';
+import { ColorPalette, Emphasis, Kind, Size } from '../../constants';
+import type { LumxClassName, JSXElement, HasClassName, CommonRef } from '../../types';
+import { classNames } from '../../utils';
+import { DialogProps } from '../Dialog';
+
+export interface BaseAlertDialogProps {
+    /** Message variant. */
+    kind?: Kind;
+    /** Dialog title. */
+    title?: string;
+    /**
+     * Children
+     */
+    children?: JSXElement;
+}
+
+export interface AlertDialogProps extends HasClassName, BaseAlertDialogProps, Pick<DialogProps, 'size'> {
+    /** Props forwarded to the confirm button */
+    confirmProps: any;
+    /**
+     * Props forwarded to the cancel button.
+     * Will not render a cancel button if undefined.
+     */
+    cancelProps?: any;
+    /** Props forwarded to the dialog wrapper element. */
+    dialogProps?: any;
+    /** Ref forwarded to the dialog root element. */
+    ref?: CommonRef;
+    /** Ref forwarded to the cancel button element. */
+    cancelButtonRef?: CommonRef;
+    /** Ref forwarded to the confirm button element. */
+    confirmationButtonRef?: CommonRef;
+    /** Element used to wrap the description (children). */
+    DescriptionElement: any;
+    /** Dialog component injected by the framework wrapper. */
+    Dialog: any;
+    /** Toolbar component injected by the framework wrapper. */
+    Toolbar: any;
+    /** Button component injected by the framework wrapper. */
+    Button: any;
+    /** Icon component injected by the framework wrapper. */
+    Icon: any;
+    /** Unique identifier for the dialog (used for aria-labelledby / aria-describedby). */
+    id: string;
+    /**
+     * Pre-computed focus element.
+     * Allows framework wrappers to pass the actual DOM element directly when ref-on-component
+     * does not yield a DOM node (e.g. Vue). Falls back to cancelButtonRef / confirmationButtonRef.
+     */
+    focusElement?: any;
+}
+
+/**
+ * Associative map from message kind to color and icon.
+ */
+export const CONFIG = {
+    [Kind.error]: { color: ColorPalette.red, icon: mdiAlert },
+    [Kind.info]: { color: ColorPalette.blue, icon: mdiInformation },
+    [Kind.success]: { color: ColorPalette.green, icon: mdiCheckCircle },
+    [Kind.warning]: { color: ColorPalette.yellow, icon: mdiAlertCircle },
+};
+
+/**
+ * Component display name.
+ */
+export const COMPONENT_NAME = 'AlertDialog';
+
+/**
+ * Component default class name and class prefix.
+ */
+export const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-alert-dialog';
+const { block } = classNames.bem(CLASSNAME);
+
+/**
+ * Component default props.
+ */
+export const DEFAULT_PROPS: Partial<AlertDialogProps> = {
+    size: Size.tiny,
+    kind: Kind.info,
+};
+
+/**
+ * AlertDialog component.
+ *
+ * An alert dialog is a modal dialog that interrupts the user's workflow to
+ * communicate an important message and acquire a response.
+ *
+ * It should not have a complex content.
+ * Children of this component should only be strings, paragraphs or links.
+ */
+export const AlertDialog = (props: AlertDialogProps) => {
+    const {
+        id,
+        title,
+        className,
+        cancelProps,
+        confirmProps,
+        ref,
+        kind = DEFAULT_PROPS.kind,
+        size = DEFAULT_PROPS.size,
+        dialogProps,
+        children,
+        DescriptionElement,
+        cancelButtonRef,
+        confirmationButtonRef,
+        focusElement,
+        Dialog,
+        Toolbar,
+        Button,
+        Icon,
+        ...forwardedProps
+    } = props;
+    const { color, icon } = CONFIG[kind as Kind] || {};
+
+    const titleId = `${id}-title`;
+    const descriptionId = `${id}-description`;
+
+    const { label: confirmLabel, onClick: confirmOnClick, ...forwardedConfirmProps } = confirmProps;
+    const { label: cancelLabel, onClick: cancelOnClick, ...forwardedCancelProps } = cancelProps || {};
+
+    return (
+        <Dialog
+            ref={ref}
+            focusElement={focusElement ?? (cancelProps ? cancelButtonRef : confirmationButtonRef)}
+            size={size}
+            dialogProps={{
+                id,
+                role: 'alertdialog',
+                'aria-labelledby': titleId,
+                'aria-describedby': descriptionId,
+                ...dialogProps,
+            }}
+            className={classNames.join(
+                className,
+                block({
+                    [`kind-${kind}`]: Boolean(kind),
+                }),
+            )}
+            {...forwardedProps}
+        >
+            <header>
+                <Toolbar
+                    className="lumx-spacing-margin-horizontal"
+                    before={<Icon icon={icon} size={Size.s} color={color} />}
+                    label={
+                        <h2 id={titleId} className="lumx-typography-title">
+                            {title}
+                        </h2>
+                    }
+                />
+            </header>
+
+            {children && (
+                <DescriptionElement
+                    id={descriptionId}
+                    className="lumx-typography-body2 lumx-spacing-padding-vertical-big lumx-spacing-padding-horizontal-huge"
+                >
+                    {children}
+                </DescriptionElement>
+            )}
+
+            <footer>
+                <Toolbar
+                    className="lumx-spacing-margin-horizontal"
+                    after={
+                        <>
+                            {cancelProps && (
+                                <Button
+                                    {...forwardedCancelProps}
+                                    ref={cancelButtonRef}
+                                    emphasis={Emphasis.medium}
+                                    onClick={cancelOnClick}
+                                >
+                                    {cancelLabel}
+                                </Button>
+                            )}
+                            <Button
+                                {...forwardedConfirmProps}
+                                ref={confirmationButtonRef}
+                                color={color}
+                                className="lumx-spacing-margin-left-regular"
+                                onClick={confirmOnClick}
+                            >
+                                {confirmLabel}
+                            </Button>
+                        </>
+                    }
+                />
+            </footer>
+        </Dialog>
+    );
+};

--- a/packages/lumx-react/src/components/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/lumx-react/src/components/alert-dialog/AlertDialog.stories.tsx
@@ -1,39 +1,16 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { RefObject, useRef } from 'react';
-import { Button, Link, Kind } from '@lumx/react';
-import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
+import { Button, Link } from '@lumx/react';
 import { useBooleanState } from '@lumx/react/hooks/useBooleanState';
 import { withNestedProps } from '@lumx/react/stories/decorators/withNestedProps';
-import { loremIpsum } from '@lumx/core/stories/utils/lorem';
-import { getSelectArgType } from '@lumx/core/stories/controls/selectArgType';
+import { setup } from '@lumx/core/js/components/AlertDialog/Stories';
 import { withChromaticForceScreenSize } from '../../stories/decorators/withChromaticForceScreenSize';
 import { AlertDialog } from './AlertDialog';
-import DialogStories from '../dialog/Dialog.stories';
 
-export default {
-    title: 'LumX components/alert-dialog/AlertDialog',
+const { meta, ...stories } = setup({
     component: AlertDialog,
-    args: {
-        ...AlertDialog.defaultProps,
-        'confirmProps.label': 'Ok',
-    },
-    argTypes: {
-        size: DialogStories.argTypes.size,
-        kind: getSelectArgType(Kind),
-        'confirmProps.onClick': { action: true },
-    },
-    parameters: {
-        // Delay Chromatic snapshot to wait for dialog to open.
-        chromatic: {
-            pauseAnimationAtEnd: true,
-            delay: DIALOG_TRANSITION_DURATION,
-        },
-    },
-    decorators: [
-        // Force minimum chromatic screen size to make sure the dialog appears in view.
-        withChromaticForceScreenSize(),
-        withNestedProps(),
-    ],
+    components: { Link },
+    decorators: { withChromaticForceScreenSize, withNestedProps },
     render(props: any) {
         const buttonRef = useRef() as RefObject<HTMLButtonElement>;
         const [isOpen, close, open] = useBooleanState(true);
@@ -46,82 +23,16 @@ export default {
             </>
         );
     },
+});
+
+export default {
+    title: 'LumX components/alert-dialog/AlertDialog',
+    ...meta,
 };
 
-/**
- * Alert dialog with default kind
- */
-export const DefaultKind = {
-    args: {
-        title: 'Default (info)',
-        children: loremIpsum('tiny'),
-    },
-};
-
-/**
- * Alert dialog as warning
- */
-export const Warning = {
-    args: {
-        ...DefaultKind.args,
-        kind: Kind.warning,
-        title: 'Warning',
-    },
-};
-
-/**
- * Alert dialog as success
- */
-export const Success = {
-    args: {
-        ...DefaultKind.args,
-        kind: Kind.success,
-        title: 'Success',
-    },
-};
-
-/**
- * Alert dialog as error
- */
-export const Error = {
-    args: {
-        ...DefaultKind.args,
-        kind: Kind.error,
-        title: 'Error',
-    },
-};
-
-/**
- * Alert dialog with cancel button
- */
-export const WithCancel = {
-    argTypes: {
-        'cancelProps.onClick': { action: true },
-    },
-    args: {
-        ...DefaultKind.args,
-        title: 'With Cancel',
-        'cancelProps.label': 'Cancel',
-    },
-};
-
-/**
- * Alert dialog with rich description
- */
-export const RichDescription = {
-    argTypes: { children: { control: false } },
-    args: {
-        ...DefaultKind.args,
-        title: 'With Rich Description',
-        children: (
-            <>
-                Amet ut elit dolore irure mollit <strong>sunt culpa esse</strong>.<br />
-                Ea ut Lorem.
-                <br />
-                <Link href="https://example.com" target="_blank">
-                    Link
-                </Link>
-            </>
-        ),
-    },
-};
+export const DefaultKind = { ...stories.DefaultKind };
+export const Warning = { ...stories.Warning };
+export const Success = { ...stories.Success };
+export const Error = { ...stories.Error };
+export const WithCancel = { ...stories.WithCancel };
+export const RichDescription = { ...stories.RichDescription };

--- a/packages/lumx-react/src/components/alert-dialog/AlertDialog.test.tsx
+++ b/packages/lumx-react/src/components/alert-dialog/AlertDialog.test.tsx
@@ -2,7 +2,7 @@ import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import { queryByClassName } from '@lumx/react/testing/utils/queries';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
-import { Kind } from '@lumx/react';
+import BaseAlertDialogTests from '@lumx/core/js/components/AlertDialog/Tests';
 import { AlertDialog, AlertDialogProps } from './AlertDialog';
 
 vi.mock('@lumx/react/hooks/useId', () => ({ useId: () => ':r1:' }));
@@ -26,50 +26,20 @@ const setup = (propsOverride: Partial<AlertDialogProps> = {}) => {
 };
 
 describe(`<${AlertDialog.displayName}>`, () => {
-    // Common tests suite.
-    commonTestsSuiteRTL(setup, {
-        baseClassName: CLASSNAME,
-        forwardClassName: 'alertDialog',
-        forwardAttributes: 'alertDialog',
+    // Run core tests
+    BaseAlertDialogTests({
+        render: (props: any) => render(<AlertDialog {...props} />),
+        screen,
     });
 
-    describe('Accessibility', () => {
-        it('has the correct role and aria attributes', () => {
-            setup({ children: 'Content' });
-            const dialog = screen.getByRole('alertdialog');
-            expect(dialog).toBeInTheDocument();
-
-            const titleId = dialog.getAttribute('aria-labelledby');
-            const descId = dialog.getAttribute('aria-describedby');
-
-            expect(titleId).toBe(':r1:-title');
-            expect(descId).toBe(':r1:-description');
-
-            expect(document.getElementById(titleId!)?.textContent).toBe('Alert');
-            expect(document.getElementById(descId!)?.textContent).toBe('Content');
-        });
-    });
-
-    describe('Content Rendering', () => {
-        it('renders the title', () => {
-            setup({ title: 'Custom Title' });
-            expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Custom Title');
-        });
-
-        it('renders children as a paragraph when string', () => {
-            setup({ children: 'String content' });
-            const content = screen.getByText('String content');
-            expect(content.tagName).toBe('P');
-        });
-
+    // React-specific tests
+    describe('React', () => {
         it('renders children as a div when node', () => {
             setup({ children: <span>Node content</span> });
             const content = screen.getByText('Node content');
             expect(content.parentElement?.tagName).toBe('DIV');
         });
-    });
 
-    describe('Buttons', () => {
         it('renders confirm button and handles click', () => {
             const onClick = vi.fn();
             setup({ confirmProps: { label: 'Confirm Me', onClick } });
@@ -87,24 +57,12 @@ describe(`<${AlertDialog.displayName}>`, () => {
             fireEvent.click(btn);
             expect(onClick).toHaveBeenCalled();
         });
-
-        it('does not render cancel button when props not provided', () => {
-            setup({ cancelProps: undefined });
-            expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
-        });
     });
 
-    describe('Variants', () => {
-        it('applies correct color to confirm button based on kind (error)', () => {
-            setup({ kind: Kind.error, confirmProps: { label: 'Confirm', onClick: vi.fn() } });
-            const btn = screen.getByRole('button', { name: 'Confirm' });
-            expect(btn.className).toContain('lumx-button--color-red');
-        });
-
-        it('applies correct color to confirm button based on kind (success)', () => {
-            setup({ kind: Kind.success, confirmProps: { label: 'Confirm', onClick: vi.fn() } });
-            const btn = screen.getByRole('button', { name: 'Confirm' });
-            expect(btn.className).toContain('lumx-button--color-green');
-        });
+    // Common tests suite.
+    commonTestsSuiteRTL(setup, {
+        baseClassName: CLASSNAME,
+        forwardClassName: 'alertDialog',
+        forwardAttributes: 'alertDialog',
     });
 });

--- a/packages/lumx-react/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/lumx-react/src/components/alert-dialog/AlertDialog.tsx
@@ -1,28 +1,17 @@
 import React from 'react';
 
-import {
-    DialogProps,
-    Dialog,
-    Button,
-    Emphasis,
-    ColorPalette,
-    Icon,
-    Size,
-    Kind,
-    Toolbar,
-    ButtonProps,
-} from '@lumx/react';
-import { mdiAlert, mdiAlertCircle, mdiCheckCircle, mdiInformation } from '@lumx/icons';
+import { DialogProps, Dialog, Button, Icon, Toolbar, ButtonProps } from '@lumx/react';
 import { useId } from '@lumx/react/hooks/useId';
 import { forwardRef } from '@lumx/react/utils/react/forwardRef';
-import type { LumxClassName } from '@lumx/react/utils/type';
-import { classNames } from '@lumx/core/js/utils';
+import {
+    AlertDialog as UI,
+    BaseAlertDialogProps as UIProps,
+    CLASSNAME,
+    COMPONENT_NAME,
+    DEFAULT_PROPS,
+} from '@lumx/core/js/components/AlertDialog';
 
-export interface AlertDialogProps extends Omit<DialogProps, 'header' | 'footer'> {
-    /** Message variant. */
-    kind?: Kind;
-    /** Dialog title. */
-    title?: string;
+export interface AlertDialogProps extends Omit<DialogProps, 'header' | 'footer'>, UIProps {
     /** Props forwarded to the confirm button */
     confirmProps: ButtonProps & {
         label: string;
@@ -34,40 +23,7 @@ export interface AlertDialogProps extends Omit<DialogProps, 'header' | 'footer'>
     cancelProps?: ButtonProps & {
         label: string;
     };
-    /**
-     * Children
-     */
-    children?: React.ReactNode;
 }
-
-/**
- * Associative map from message kind to color and icon.
- */
-const CONFIG = {
-    [Kind.error]: { color: ColorPalette.red, icon: mdiAlert },
-    [Kind.info]: { color: ColorPalette.blue, icon: mdiInformation },
-    [Kind.success]: { color: ColorPalette.green, icon: mdiCheckCircle },
-    [Kind.warning]: { color: ColorPalette.yellow, icon: mdiAlertCircle },
-};
-
-/**
- * Component display name.
- */
-const COMPONENT_NAME = 'AlertDialog';
-
-/**
- * Component default class name and class prefix.
- */
-const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-alert-dialog';
-const { block } = classNames.bem(CLASSNAME);
-
-/**
- * Component default props.
- */
-const DEFAULT_PROPS: Partial<DialogProps> = {
-    size: Size.tiny,
-    kind: Kind.info,
-};
 
 /**
  * AlertDialog component.
@@ -79,106 +35,39 @@ const DEFAULT_PROPS: Partial<DialogProps> = {
  * Children of this component should only be strings, paragraphs or links.
  */
 export const AlertDialog = forwardRef<AlertDialogProps, HTMLDivElement>((props, ref) => {
-    const {
-        id,
-        title,
-        className,
-        cancelProps,
-        confirmProps,
-        kind = DEFAULT_PROPS.kind,
-        size = DEFAULT_PROPS.size,
-        dialogProps,
-        children,
-        ...forwardedProps
-    } = props;
+    const { id, title, className, cancelProps, confirmProps, kind, size, dialogProps, children, ...forwardedProps } =
+        props;
 
     const cancelButtonRef = React.useRef(null);
     const confirmationButtonRef = React.useRef(null);
-    const { color, icon } = CONFIG[kind as Kind] || {};
 
     // Define a unique ID to target title and description for aria attributes.
     const generatedId = useId();
     const uniqueId = id || generatedId;
-    const titleId = `${uniqueId}-title`;
-    const descriptionId = `${uniqueId}-description`;
 
     // If content is a string, set in a paragraph.
     const DescriptionElement = typeof children === 'string' ? 'p' : 'div';
 
-    const { label: confirmLabel, onClick: confirmOnClick, ...forwardedConfirmProps } = confirmProps;
-    const { label: cancelLabel, onClick: cancelOnClick, ...forwardedCancelProps } = cancelProps || {};
-
-    return (
-        <Dialog
-            ref={ref}
-            focusElement={cancelProps ? cancelButtonRef : confirmationButtonRef}
-            size={size}
-            dialogProps={{
-                id: uniqueId,
-                role: 'alertdialog',
-                'aria-labelledby': titleId,
-                'aria-describedby': descriptionId,
-                ...dialogProps,
-            }}
-            className={classNames.join(
-                className,
-                block({
-                    [`kind-${kind}`]: Boolean(kind),
-                }),
-            )}
-            {...forwardedProps}
-        >
-            <header>
-                <Toolbar
-                    className="lumx-spacing-margin-horizontal"
-                    before={<Icon icon={icon} size={Size.s} color={color} />}
-                    label={
-                        <h2 id={titleId} className="lumx-typography-title">
-                            {title}
-                        </h2>
-                    }
-                />
-            </header>
-
-            {children && (
-                <DescriptionElement
-                    id={descriptionId}
-                    className="lumx-typography-body2 lumx-spacing-padding-vertical-big lumx-spacing-padding-horizontal-huge"
-                >
-                    {children}
-                </DescriptionElement>
-            )}
-
-            <footer>
-                <Toolbar
-                    className="lumx-spacing-margin-horizontal"
-                    after={
-                        <>
-                            {cancelProps && (
-                                <Button
-                                    {...forwardedCancelProps}
-                                    ref={cancelButtonRef}
-                                    emphasis={Emphasis.medium}
-                                    onClick={cancelOnClick}
-                                >
-                                    {cancelLabel}
-                                </Button>
-                            )}
-                            <Button
-                                {...forwardedConfirmProps}
-                                ref={confirmationButtonRef}
-                                color={color}
-                                className="lumx-spacing-margin-left-regular"
-                                onClick={confirmOnClick}
-                            >
-                                {confirmLabel}
-                            </Button>
-                        </>
-                    }
-                />
-            </footer>
-        </Dialog>
-    );
+    return UI({
+        Button,
+        confirmProps,
+        DescriptionElement,
+        Dialog,
+        Icon,
+        id: uniqueId,
+        Toolbar,
+        cancelButtonRef,
+        cancelProps,
+        children,
+        className,
+        confirmationButtonRef,
+        dialogProps,
+        kind,
+        ref,
+        size,
+        title,
+        ...forwardedProps,
+    });
 });
 
 AlertDialog.displayName = COMPONENT_NAME;

--- a/packages/lumx-vue/src/components/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/lumx-vue/src/components/alert-dialog/AlertDialog.stories.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable vue/one-component-per-file */
+import { defineComponent, ref } from 'vue';
+import { Button, Link } from '@lumx/vue';
+import { withChromaticForceScreenSize } from '@lumx/vue/stories/decorators/withChromaticForceScreenSize';
+import { withNestedProps } from '@lumx/vue/stories/decorators/withNestedProps';
+import { setup } from '@lumx/core/js/components/AlertDialog/Stories';
+
+import { AlertDialog } from '.';
+
+/**
+ * Story render component for AlertDialog.
+ *
+ * Defined as a standalone component so that:
+ * - The button ref is created inside a proper Vue setup context.
+ * - Storybook can pass args as reactive props (avoiding stale closure captures).
+ * - Children are passed as the default slot.
+ */
+const AlertDialogStory = defineComponent(
+    (_props: any, { attrs }: any) => {
+        const buttonRef = ref<HTMLElement>();
+        const isOpen = ref(true);
+
+        return () => {
+            const { children, ...props } = attrs;
+            return (
+                <>
+                    <Button
+                        ref={buttonRef}
+                        onClick={() => {
+                            isOpen.value = true;
+                        }}
+                    >
+                        Open dialog
+                    </Button>
+                    <AlertDialog
+                        {...props}
+                        isOpen={isOpen.value}
+                        parentElement={(buttonRef.value as any)?.$el}
+                        onClose={() => {
+                            isOpen.value = false;
+                        }}
+                    >
+                        {children}
+                    </AlertDialog>
+                </>
+            );
+        };
+    },
+    { name: 'LumxAlertDialogStory', inheritAttrs: false },
+);
+
+const { meta, ...stories } = setup({
+    component: AlertDialog,
+    components: { Link },
+    decorators: { withChromaticForceScreenSize, withNestedProps },
+    render: (args: any) => () => <AlertDialogStory {...args} />,
+});
+
+export default {
+    title: 'LumX components/alert-dialog/AlertDialog',
+    ...meta,
+};
+
+export const DefaultKind = { ...stories.DefaultKind };
+export const Warning = { ...stories.Warning };
+export const Success = { ...stories.Success };
+export const Error = { ...stories.Error };
+export const WithCancel = { ...stories.WithCancel };
+export const RichDescription = { ...stories.RichDescription };

--- a/packages/lumx-vue/src/components/alert-dialog/AlertDialog.test.ts
+++ b/packages/lumx-vue/src/components/alert-dialog/AlertDialog.test.ts
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/vue';
+import { vi } from 'vitest';
+import BaseAlertDialogTests, { setup } from '@lumx/core/js/components/AlertDialog/Tests';
+import { CLASSNAME } from '@lumx/core/js/components/AlertDialog';
+import { commonTestsSuiteVTL, type SetupRenderOptions } from '@lumx/vue/testing';
+
+import { AlertDialog } from '.';
+
+// Clean up teleported dialog elements between tests
+afterEach(() => {
+    cleanup();
+    document.querySelectorAll(`.${CLASSNAME}`).forEach((el) => el.remove());
+});
+
+describe('<AlertDialog />', () => {
+    const renderAlertDialog = ({ children, ...props }: any, options?: SetupRenderOptions<any>) =>
+        render(AlertDialog, {
+            ...options,
+            props: {
+                isOpen: true,
+                confirmProps: { label: 'OK', onClick: () => {} },
+                ...props,
+            },
+            slots: children ? { default: () => children } : {},
+        });
+
+    // Run core tests
+    BaseAlertDialogTests({ render: renderAlertDialog, screen });
+
+    const setupAlertDialog = (props: any = {}, options: SetupRenderOptions<any> = {}) =>
+        setup(props, { ...options, render: renderAlertDialog, screen });
+
+    // Vue-specific tests
+    describe('Vue', () => {
+        it('emits close when the dialog requests close', () => {
+            const { emitted } = render(AlertDialog, {
+                props: { isOpen: true, confirmProps: { label: 'OK', onClick: vi.fn() } },
+            });
+            const overlay = document.querySelector('.lumx-dialog__overlay');
+            fireEvent.mouseDown(overlay!);
+            fireEvent.click(overlay!);
+            expect(emitted('close')).toBeTruthy();
+        });
+    });
+
+    commonTestsSuiteVTL(setupAlertDialog, {
+        baseClassName: CLASSNAME,
+        forwardClassName: 'alertDialog',
+        forwardAttributes: 'alertDialog',
+    });
+});

--- a/packages/lumx-vue/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/lumx-vue/src/components/alert-dialog/AlertDialog.tsx
@@ -1,0 +1,138 @@
+import { Text as TextVNode, computed, defineComponent, shallowRef, useAttrs } from 'vue';
+import { AlertDialog as UI, COMPONENT_NAME, type BaseAlertDialogProps } from '@lumx/core/js/components/AlertDialog';
+import type { DialogSizes } from '@lumx/core/js/components/Dialog';
+import type { GenericProps, JSXElement } from '@lumx/core/js/types';
+
+import { useId } from '../../composables/useId';
+import { useClassName } from '../../composables/useClassName';
+import { keysOf } from '../../utils/VueToJSX';
+
+import Dialog from '../dialog/Dialog';
+import Button from '../button/Button';
+import Icon from '../icon/Icon';
+import Toolbar from '../toolbar/Toolbar';
+
+type ButtonActionProps = {
+    label: string;
+    onClick?: () => void;
+    [key: string]: any;
+};
+
+export interface AlertDialogProps extends Pick<BaseAlertDialogProps, 'kind' | 'title'> {
+    /** Additional class name. */
+    class?: string;
+    /** Size variant. */
+    size?: DialogSizes;
+    /** Whether the dialog is open. */
+    isOpen?: boolean;
+    /** Reference to the parent element that triggered modal opening. */
+    parentElement?: HTMLElement;
+    /** Additional props for the dialog container element. */
+    dialogProps?: GenericProps;
+    /** Props forwarded to the confirm button. */
+    confirmProps: ButtonActionProps;
+    /** Props forwarded to the cancel button. Will not render a cancel button if undefined. */
+    cancelProps?: ButtonActionProps;
+    /** Unique identifier for the dialog. Generated automatically if not provided. */
+    id?: string;
+}
+
+export const emitSchema = {
+    close: () => true,
+};
+
+/**
+ * AlertDialog component.
+ *
+ * An alert dialog is a modal dialog that interrupts the user's workflow to
+ * communicate an important message and acquire a response.
+ *
+ * It should not have a complex content.
+ * Children of this component should only be strings, paragraphs or links.
+ */
+const AlertDialog = defineComponent(
+    (props: AlertDialogProps, { emit, slots }) => {
+        const attrs = useAttrs();
+        const className = useClassName(() => props.class);
+        const generatedId = useId();
+        const uniqueId = computed(() => props.id || generatedId);
+
+        const cancelButtonEl = shallowRef<HTMLElement | undefined>(undefined);
+        const confirmButtonEl = shallowRef<HTMLElement | undefined>(undefined);
+
+        return () => {
+            const children = slots.default?.();
+            const isStringContent = children?.length === 1 && children[0].type === TextVNode;
+            const DescriptionElement = isStringContent ? 'p' : 'div';
+
+            // isOpen, parentElement and onClose are not in core's AlertDialogProps but flow
+            // through to Dialog via ...forwardedProps — spread to avoid excess property checking.
+            const dialogPassthrough = {
+                isOpen: props.isOpen,
+                parentElement: props.parentElement,
+                onClose: () => emit('close'),
+            };
+
+            // Inject vnode lifecycle hooks into button props to capture DOM elements for focus
+            // management. We intentionally omit cancelButtonRef/confirmationButtonRef from the
+            // UI() call so core's focusElement fallback stays undefined (not a callback function).
+            const confirmProps = {
+                ...props.confirmProps,
+                onVnodeMounted: (vnode: any) => {
+                    confirmButtonEl.value = vnode.el;
+                },
+                onVnodeUnmounted: () => {
+                    confirmButtonEl.value = undefined;
+                },
+            };
+            const cancelProps = props.cancelProps && {
+                ...props.cancelProps,
+                onVnodeMounted: (vnode: any) => {
+                    cancelButtonEl.value = vnode.el;
+                },
+                onVnodeUnmounted: () => {
+                    cancelButtonEl.value = undefined;
+                },
+            };
+
+            return UI({
+                ...attrs,
+                ...dialogPassthrough,
+                Button,
+                Dialog,
+                Icon,
+                Toolbar,
+                DescriptionElement,
+                focusElement: props.cancelProps ? cancelButtonEl.value : confirmButtonEl.value,
+                className: className.value,
+                id: uniqueId.value,
+                kind: props.kind,
+                size: props.size,
+                title: props.title,
+                dialogProps: props.dialogProps,
+                confirmProps,
+                cancelProps,
+                children: children as JSXElement,
+            });
+        };
+    },
+    {
+        name: COMPONENT_NAME,
+        inheritAttrs: false,
+        props: keysOf<AlertDialogProps>()(
+            'class',
+            'kind',
+            'title',
+            'size',
+            'isOpen',
+            'parentElement',
+            'dialogProps',
+            'confirmProps',
+            'cancelProps',
+            'id',
+        ),
+        emits: emitSchema,
+    },
+);
+
+export default AlertDialog;

--- a/packages/lumx-vue/src/components/alert-dialog/index.ts
+++ b/packages/lumx-vue/src/components/alert-dialog/index.ts
@@ -1,0 +1,1 @@
+export { default as AlertDialog, type AlertDialogProps } from './AlertDialog';

--- a/packages/lumx-vue/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-vue/src/components/dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref, type Ref } from 'vue';
+import { Comment, computed, defineComponent, ref, type Ref } from 'vue';
 import { useIntersectionObserver } from '@vueuse/core';
 
 import { Dialog as UI, type BaseDialogProps, type DialogSizes, DEFAULT_PROPS } from '@lumx/core/js/components/Dialog';
@@ -137,6 +137,16 @@ const Dialog = defineComponent(
         return () => {
             if (!isMounted.value) return null;
 
+            // Support React-style children where <header> and <footer> are passed inline
+            // (used by core component JSX). Falls back to named slots for regular Dialog usage.
+            const defaultChildren = slots.default?.() ?? [];
+            const headerVnode = defaultChildren.find((c: any) => c.type === 'header');
+            const footerVnode = defaultChildren.find((c: any) => c.type === 'footer');
+            const hasPartitioned = Boolean(headerVnode || footerVnode);
+            const bodyChildren = hasPartitioned
+                ? defaultChildren.filter((c: any) => c.type !== 'header' && c.type !== 'footer' && c.type !== Comment)
+                : defaultChildren;
+
             return UI({
                 ...attrs,
                 ClickAwayProvider,
@@ -146,11 +156,11 @@ const Dialog = defineComponent(
                 ProgressCircular,
                 className: className.value,
                 clickAwayRefs,
-                content: slots.default?.() as JSXElement,
+                content: (bodyChildren.length ? bodyChildren : undefined) as JSXElement,
                 contentRef: contentRefCallback,
                 dialogProps: props.dialogProps,
                 footer: undefined,
-                footerChildContent: slots.footer?.() as JSXElement | undefined,
+                footerChildContent: (slots.footer?.() ?? (footerVnode as any)?.children) as JSXElement | undefined,
                 footerChildProps: undefined,
                 forceFooterDivider: props.forceFooterDivider,
                 forceHeaderDivider: props.forceHeaderDivider,
@@ -158,7 +168,7 @@ const Dialog = defineComponent(
                 hasBottomIntersection: hasBottomIntersection.value,
                 hasTopIntersection: hasTopIntersection.value,
                 header: undefined,
-                headerChildContent: slots.header?.() as JSXElement | undefined,
+                headerChildContent: (slots.header?.() ?? (headerVnode as any)?.children) as JSXElement | undefined,
                 headerChildProps: undefined,
                 isLoading: props.isLoading,
                 isOpen: props.isOpen,

--- a/packages/lumx-vue/src/components/toolbar/Toolbar.tsx
+++ b/packages/lumx-vue/src/components/toolbar/Toolbar.tsx
@@ -20,14 +20,16 @@ const Toolbar = defineComponent(
         const className = useClassName(() => props.class);
 
         return () => {
+            // Fall back to attrs for before/label/after to support core JSX calling
+            // Toolbar with props (React-style) instead of named slots (Vue-style).
             return (
                 <ToolbarUI
                     {...props}
                     {...attrs}
                     className={className.value}
-                    label={slots.default?.() as JSXElement}
-                    before={slots.before?.() as JSXElement}
-                    after={slots.after?.() as JSXElement}
+                    label={(slots.default?.() ?? (attrs as any).label) as JSXElement}
+                    before={(slots.before?.() ?? (attrs as any).before) as JSXElement}
+                    after={(slots.after?.() ?? (attrs as any).after) as JSXElement}
                 />
             );
         };

--- a/packages/lumx-vue/src/index.ts
+++ b/packages/lumx-vue/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@lumx/core/js/constants';
 export * from '@lumx/core/js/types';
 
+export * from './components/alert-dialog';
 export * from './components/avatar';
 export * from './components/combobox';
 export * from './components/badge';


### PR DESCRIPTION
# General summary

- Move `AlertDialog` stories and tests from `@lumx/react` to `@lumx/core` (shared `Stories.tsx` + `Tests.ts`)
- React stories updated to thin wrappers calling core `setup()`; `RichDescription` JSX children moved from `args` to a `render` function
- New `AlertDialog` Vue component using Vue Dialog with named slots (header/default/footer), with string-slot detection for `<p>` vs `<div>` description wrapper
- Vue stories and tests added, all 1498 unit tests pass

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

StoryBook lumx-vue: https://b71478521--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://b71478521--5fbfb1d508c0520021560f10.chromatic.com/