### PR TITLE
feat(react): create select text field component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/vue`:
     -   Create the `Lightbox` component
+-   `@lumx/react`:
+    -   Create the `SelectTextField` component
 
 ### Changed
 

--- a/packages/lumx-core/src/js/components/Combobox/ComboboxState.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/ComboboxState.tsx
@@ -24,6 +24,14 @@ export interface ComboboxStateProps {
      */
     emptyMessage?: string | ((inputValue: string) => string);
     /**
+     * Message callback to display the number of available options.
+     * Called with the current visible option count and should return a human-readable string
+     * (e.g. `(n) => \`${n} result(s) available\``).
+     * Displayed when the combobox is open, not empty, not loading, and not in error.
+     * When omitted, no option count message is shown.
+     */
+    nbOptionMessage?: (optionsLength: number) => string;
+    /**
      * Error state title message.
      * When provided, the error state is active (takes priority over the empty state).
      * When omitted, the error state is not shown.
@@ -44,10 +52,10 @@ export interface ComboboxStateProps {
      */
     state?: {
         /**
-         * Whether the list currently has no visible options.
-         * Driven by the framework wrapper via the combobox handle's `emptyChange` event.
+         * The number of currently visible options.
+         * Driven by the framework wrapper via the combobox handle's `optionsChange` event.
          */
-        isEmpty?: boolean;
+        optionsLength?: number;
         /**
          * The current value of the combobox input.
          * Passed to `emptyMessage` when it is a function.
@@ -83,29 +91,35 @@ export interface ComboboxStateComponents {
 
 /**
  * ComboboxState core template.
- * Renders empty/error state messages inside the combobox popover.
+ * Renders empty/error/option-count state messages inside the combobox popover.
  * The block itself acts as a screen reader live region (`role="status" aria-live="polite"`).
  *
  * Activation rules:
  * - Error state: active when `errorMessage` is provided (presence-based).
- * - Empty state: active when `isEmpty` is true and `emptyMessage` is provided, and there is no error.
+ * - Empty state: active when `optionsLength` is 0 and `emptyMessage` is provided, and there is no error.
+ * - Option count: active when `nbOptionMessage` is provided, the list is not empty, not loading, and not in error.
  *
  * @param props Component props.
  * @param components Injected framework-specific components.
  * @return JSX element or null when no state is active.
  */
 export const ComboboxState = (props: ComboboxStateProps, { GenericBlock, Text }: ComboboxStateComponents) => {
-    const { emptyMessage, errorMessage, errorTryReloadMessage, loadingMessage, state } = props;
+    const { emptyMessage, nbOptionMessage, errorMessage, errorTryReloadMessage, loadingMessage, state } = props;
     const isOpen = state?.isOpen ?? true;
+    const optionsLength = state?.optionsLength ?? 0;
+    const isEmpty = optionsLength === 0;
     const showError = !!errorMessage;
     const resolvedEmptyMessage =
         typeof emptyMessage === 'function' ? emptyMessage(state?.inputValue || '') : emptyMessage;
     // Suppress empty while loading (immediate flag prevents false "no results" before data arrives)
-    const showEmpty = state?.isEmpty && !showError && !state?.isLoading && !!resolvedEmptyMessage;
+    const showEmpty = isEmpty && !showError && !state?.isLoading && !!resolvedEmptyMessage;
     // Show loading message when provided and not in error state.
     // The framework wrapper gates `loadingMessage` via the debounced `loadingAnnouncement` event,
     // passing `undefined` until the 500ms threshold is reached.
     const showLoading = !showError && !!loadingMessage;
+    // Show option count message when the list is open, not empty, not loading, and not in error.
+    const resolvedNbOptionMessage =
+        !isEmpty && !showError && !state?.isLoading && nbOptionMessage ? nbOptionMessage(optionsLength) : undefined;
     const show = showEmpty || showError;
     const alignProps = { hAlign: 'center', vAlign: 'center' };
 
@@ -132,6 +146,11 @@ export const ComboboxState = (props: ComboboxStateProps, { GenericBlock, Text }:
             {renderContent && showLoading && (
                 <Text as="p" typography="body1" color="dark-L2">
                     {loadingMessage}
+                </Text>
+            )}
+            {renderContent && !!resolvedNbOptionMessage && (
+                <Text as="p" typography="body1" color="dark-L2">
+                    {resolvedNbOptionMessage}
                 </Text>
             )}
             {renderContent && !!errorMessage && (

--- a/packages/lumx-core/src/js/components/Combobox/Stories.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Stories.tsx
@@ -304,13 +304,19 @@ export function setup({
     };
 
     /**
-     * Combobox with empty state — shown when no options match the current input.
-     * Try typing something that matches no fruit (e.g. "xyz") to see the empty state.
-     * Uses `Combobox.State` with an `emptyMessage` callback that includes the input value.
+     * Combobox with empty state and option count message.
+     * Uses `Combobox.State` with both `emptyMessage` and `nbOptionMessage`.
+     * - When options are visible, shows the option count (e.g. "10 result(s) available").
+     * - When all options are filtered out (e.g. type "xyz"), shows the empty message.
+     * Try typing to filter and see the count update, or type a non-matching query to see the empty state.
      */
     const ComboboxWithEmptyState = {
         args: { value: '' },
         decorators: [withValueOnChange()],
+        async play({ canvas }: any) {
+            await userEvent.click(await canvas.findByRole('combobox'));
+            await userEvent.keyboard('Lime');
+        },
         render: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
             <Combobox.Provider>
                 <Combobox.Input
@@ -321,11 +327,18 @@ export function setup({
                     toggleButtonProps={{ label: 'Fruits' }}
                 />
                 <Combobox.Popover>
-                    <Combobox.List aria-label="Fruits" />
+                    <Combobox.List aria-label="Fruits">
+                        {FRUITS.map((fruit) => (
+                            <Combobox.Option key={fruit} value={fruit}>
+                                {fruit}
+                            </Combobox.Option>
+                        ))}
+                    </Combobox.List>
                     <Combobox.State
                         emptyMessage={(inputValue: string) =>
                             inputValue ? `No results for "${inputValue}"` : 'No results'
                         }
+                        nbOptionMessage={(n: number) => `${n} result(s) available`}
                     />
                 </Combobox.Popover>
             </Combobox.Provider>

--- a/packages/lumx-core/src/js/components/Combobox/Tests.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Tests.tsx
@@ -571,6 +571,28 @@ export function createTemplates(Combobox: ComboboxNamespace, IconButton: any) {
         </Combobox.Provider>
     );
 
+    /** Combobox with nbOptionMessage — shows option count when list is not empty. */
+    const nbOptionMessageTemplate = ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+        <Combobox.Provider>
+            <Combobox.Input
+                value={value}
+                onChange={onChange}
+                placeholder="Pick a fruit…"
+                toggleButtonProps={{ label: 'Fruits' }}
+            />
+            <Combobox.Popover>
+                <Combobox.List aria-label="Fruits">
+                    {FRUITS.map((fruit) => (
+                        <Combobox.Option key={fruit} value={fruit}>
+                            {fruit}
+                        </Combobox.Option>
+                    ))}
+                </Combobox.List>
+                <Combobox.State emptyMessage="No results" nbOptionMessage={(n: number) => `${n} result(s) available`} />
+            </Combobox.Popover>
+        </Combobox.Provider>
+    );
+
     /** Combobox with skeleton loading — no options yet, skeletons shown. */
     const loadingTemplate = ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
         <Combobox.Provider>
@@ -675,6 +697,7 @@ export function createTemplates(Combobox: ComboboxNamespace, IconButton: any) {
         gridInputTemplate,
         gridButtonTemplate,
         emptyStateTemplate,
+        nbOptionMessageTemplate,
         errorStateTemplate,
         loadingTemplate,
         loadMoreTemplate,
@@ -2613,6 +2636,67 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.type(input, 'z');
             await waitFor(() => {
                 expect(getStateContainer()).toHaveTextContent('No results for "zz"');
+            });
+        });
+    });
+
+    describe('Combobox.State - Option count message', () => {
+        it('should show option count message when list has options', async () => {
+            renderWithState(t.nbOptionMessageTemplate);
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            await waitFor(() => {
+                const stateEl = getStateContainer();
+                expect(stateEl).toBeInTheDocument();
+                expect(stateEl).toHaveTextContent('10 result(s) available');
+            });
+        });
+
+        it('should update option count when filtering reduces visible options', async () => {
+            renderWithState(t.nbOptionMessageTemplate);
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            await userEvent.type(input, 'bl');
+
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(1);
+            });
+
+            await waitFor(() => {
+                const stateEl = getStateContainer();
+                expect(stateEl).toHaveTextContent('1 result(s) available');
+            });
+        });
+
+        it('should show empty message instead of option count when all options are filtered out', async () => {
+            renderWithState(t.nbOptionMessageTemplate);
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            await userEvent.type(input, 'z');
+
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(0);
+            });
+
+            await waitFor(() => {
+                const stateEl = getStateContainer();
+                expect(stateEl).toHaveTextContent('No results');
+                expect(stateEl).not.toHaveTextContent('result(s) available');
             });
         });
     });

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -63,17 +63,17 @@ export function setupCombobox(
     /** AbortController for all structural event listeners. */
     let abortController: AbortController | null = null;
 
-    /** Last notified isEmpty state, to avoid redundant `emptyChange` notifications. */
-    let lastIsEmpty = true;
+    /** Last notified visible option count, to avoid redundant `optionsChange` notifications. */
+    let lastOptionsLength = 0;
 
-    /** Last notified input value, to re-fire `emptyChange` when the user keeps typing while empty. */
+    /** Last notified input value, to re-fire `optionsChange` when the user keeps typing while empty. */
     let lastInputValue = '';
 
     /** Event subscribers managed by the handle. */
     const subscribers: { [K in keyof ComboboxEventMap]: Set<(value: ComboboxEventMap[K]) => void> } = {
         open: new Set(),
         activeDescendantChange: new Set(),
-        emptyChange: new Set(),
+        optionsChange: new Set(),
         loadingChange: new Set(),
         loadingAnnouncement: new Set(),
     };
@@ -84,7 +84,7 @@ export function setupCombobox(
     }
 
     /**
-     * Notify all registered sections and fire `emptyChange` if the visible option count changed
+     * Notify all registered sections and fire `optionsChange` if the visible option count changed
      * or if the input value changed while the list is empty (so `emptyMessage` callbacks get
      * the updated query string).
      * Called whenever the set of visible options may have changed (option register/unregister, filter change).
@@ -98,12 +98,12 @@ export function setupCombobox(
         for (const reg of optionRegistrations.values()) {
             if (!reg.lastFiltered) visibleCount += 1;
         }
-        const isEmpty = visibleCount === 0;
         const inputValue = trigger?.value ?? '';
-        if (isEmpty !== lastIsEmpty || (isEmpty && inputValue !== lastInputValue)) {
-            lastIsEmpty = isEmpty;
+        const isEmpty = visibleCount === 0;
+        if (visibleCount !== lastOptionsLength || (isEmpty && inputValue !== lastInputValue)) {
+            lastOptionsLength = visibleCount;
             lastInputValue = inputValue;
-            notify('emptyChange', { isEmpty, inputValue });
+            notify('optionsChange', { optionsLength: visibleCount, inputValue });
         }
     }
 
@@ -365,14 +365,14 @@ export function setupCombobox(
             trigger?.setAttribute('aria-expanded', String(isOpen));
             notify('open', isOpen);
 
-            // When opening, always notify the current empty state so that
+            // When opening, always notify the current options state so that
             // subscribers (ComboboxState) get the correct initial value.
-            // Without this, a list that starts empty never fires `emptyChange`
-            // because `lastIsEmpty` is initialized to `true` and `notifyVisibilityChange`
+            // Without this, a list that starts empty never fires `optionsChange`
+            // because `lastOptionsLength` is initialized to `0` and `notifyVisibilityChange`
             // only fires on *changes*.
             if (isOpen) {
                 const inputValue = trigger?.value ?? '';
-                notify('emptyChange', { isEmpty: lastIsEmpty, inputValue });
+                notify('optionsChange', { optionsLength: lastOptionsLength, inputValue });
             }
         },
 
@@ -496,7 +496,7 @@ export function setupCombobox(
             trigger = null;
             listbox = null;
             filterValue = '';
-            lastIsEmpty = true;
+            lastOptionsLength = 0;
             lastInputValue = '';
             optionRegistrations.clear();
             sectionRegistrations.clear();

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -409,6 +409,19 @@ export function setupCombobox(
             notifyVisibilityChange();
         },
 
+        refilterOption(element: HTMLElement) {
+            const reg = optionRegistrations.get(element);
+            if (!reg) return;
+            const filterLower = filterValue.toLowerCase();
+            const text = getOptionValue(element).toLowerCase();
+            const isFiltered = filterLower.length > 0 && !text.includes(filterLower);
+            if (isFiltered !== reg.lastFiltered) {
+                reg.lastFiltered = isFiltered;
+                reg.callback(isFiltered);
+                notifyVisibilityChange();
+            }
+        },
+
         registerSection(
             element: HTMLElement,
             callback: (state: { hidden: boolean; 'aria-hidden': boolean }) => void,

--- a/packages/lumx-core/src/js/components/Combobox/types.ts
+++ b/packages/lumx-core/src/js/components/Combobox/types.ts
@@ -92,6 +92,13 @@ export interface ComboboxHandle {
      */
     setFilter(filterValue: string): void;
     /**
+     * Re-evaluate the filter state of a single registered option.
+     * Call this after the option's `data-value` or textContent has been updated
+     * (e.g. after a framework re-render) to ensure its filtered/visible state
+     * is consistent with the current filter value.
+     */
+    refilterOption(element: HTMLElement): void;
+    /**
      * Register a section DOM element for state notifications.
      * The callback is invoked immediately with the current state, and again whenever
      * the state changes after a filter update or option un/registration.

--- a/packages/lumx-core/src/js/components/Combobox/types.ts
+++ b/packages/lumx-core/src/js/components/Combobox/types.ts
@@ -25,10 +25,10 @@ export interface ComboboxEventMap {
     /** Fired when the active descendant changes (visual focus). Payload: the option id or null. */
     activeDescendantChange: string | null;
     /**
-     * Fired when the visible option count transitions between empty and non-empty.
-     * Payload: whether the list is empty plus the current input value.
+     * Fired when the visible option count changes.
+     * Payload: the number of visible options plus the current input value.
      */
-    emptyChange: { isEmpty?: boolean; inputValue?: string } | undefined;
+    optionsChange: { optionsLength: number; inputValue?: string } | undefined;
     /**
      * Fired immediately when the aggregate loading state changes (skeleton count transitions
      * between 0 and >0). Used for empty suppression in ComboboxState and for aria-busy on the listbox.

--- a/packages/lumx-core/src/js/components/SelectTextField/Stories.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/Stories.tsx
@@ -1,0 +1,536 @@
+import { userEvent } from 'storybook/test';
+import {
+    mdiFoodApple,
+    mdiFruitCherries,
+    mdiFruitCitrus,
+    mdiFruitGrapes,
+    mdiFruitWatermelon,
+    mdiMagnify,
+    mdiSprout,
+} from '@lumx/icons';
+import type { SetupStoriesOptions } from '@lumx/core/stories/types';
+import { TRANSLATIONS, MULTI_TRANSLATIONS } from './Tests';
+
+export const FRUITS = [
+    {
+        id: 'apple',
+        name: 'Apple',
+        icon: mdiFoodApple,
+        category: 'Pome',
+        categoryIcon: mdiFoodApple,
+        description: 'A sweet red fruit',
+    },
+    {
+        id: 'apricot',
+        name: 'Apricot',
+        icon: mdiFruitCherries,
+        category: 'Stone',
+        categoryIcon: mdiFruitCherries,
+        description: 'A soft orange fruit',
+    },
+    {
+        id: 'banana',
+        name: 'Banana',
+        icon: mdiSprout,
+        category: 'Tropical',
+        categoryIcon: mdiSprout,
+        description: 'A long yellow fruit',
+    },
+    {
+        id: 'blueberry',
+        name: 'Blueberry',
+        icon: mdiFruitGrapes,
+        category: 'Berry',
+        categoryIcon: mdiFruitGrapes,
+        description: 'A small blue fruit',
+    },
+    {
+        id: 'cherry',
+        name: 'Cherry',
+        icon: mdiFruitCherries,
+        category: 'Stone',
+        categoryIcon: mdiFruitCherries,
+        description: 'A small red fruit',
+    },
+    {
+        id: 'grape',
+        name: 'Grape',
+        icon: mdiFruitGrapes,
+        category: 'Berry',
+        categoryIcon: mdiFruitGrapes,
+        description: 'A small purple fruit',
+    },
+    {
+        id: 'lemon',
+        name: 'Lemon',
+        icon: mdiFruitCitrus,
+        category: 'Citrus',
+        categoryIcon: mdiFruitCitrus,
+        description: 'A sour yellow fruit',
+    },
+    {
+        id: 'orange',
+        name: 'Orange',
+        icon: mdiFruitCitrus,
+        category: 'Citrus',
+        categoryIcon: mdiFruitCitrus,
+        description: 'A citrus fruit',
+    },
+    {
+        id: 'peach',
+        name: 'Peach',
+        icon: mdiFruitCherries,
+        category: 'Stone',
+        categoryIcon: mdiFruitCherries,
+        description: 'A soft fuzzy fruit',
+    },
+    {
+        id: 'strawberry',
+        name: 'Strawberry',
+        icon: mdiFruitWatermelon,
+        category: 'Berry',
+        categoryIcon: mdiFruitGrapes,
+        description: 'A sweet red berry',
+    },
+];
+
+export type Fruit = (typeof FRUITS)[number];
+
+/**
+ * Setup SelectTextField stories for a specific framework (React or Vue).
+ */
+export function setup({
+    components: { SelectTextField },
+    decorators: { withValueOnChange },
+}: SetupStoriesOptions<{
+    components: {
+        SelectTextField: any;
+    };
+    decorators: 'withValueOnChange';
+}>) {
+    const meta = {
+        component: SelectTextField,
+        async play({ canvas }: any) {
+            const combobox = await canvas.findByRole('combobox');
+            await userEvent.click(combobox);
+        },
+    };
+
+    /** Simple SelectTextField with basic options */
+    const Default = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField with pre-selected value */
+    const WithSelectedValue = {
+        args: { value: FRUITS[3] },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField with clear button disabled */
+    const NoClearButton = {
+        args: { value: FRUITS[0] },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                hasClearButton={false}
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField with option descriptions */
+    const WithDescriptions = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                getOptionDescription="description"
+                value={value}
+                onChange={onChange}
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField with options grouped into labelled sections */
+    const WithSections = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                getSectionId="category"
+                value={value}
+                onChange={onChange}
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField with a leading icon */
+    const WithIcon = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                icon={mdiMagnify}
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField in disabled state */
+    const Disabled = {
+        args: { value: FRUITS[0] },
+        decorators: [withValueOnChange()],
+        play: undefined as any,
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                isDisabled
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField with error state */
+    const WithError = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                hasError
+                error="Please select a fruit"
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** SelectTextField with helper text */
+    const WithHelper = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                helper="Choose your favorite fruit"
+                translations={TRANSLATIONS}
+            />
+        ),
+    };
+
+    // ─── Multiple selection ──────────────────────────────────────
+
+    /** Multiple selection — basic usage with chips */
+    const MultipleSelection = {
+        args: { value: [] },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="multiple"
+                label="Select fruits"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={(v: any) => onChange(v ?? [])}
+                translations={MULTI_TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** Multiple selection with pre-selected values */
+    const MultipleWithPreselected = {
+        args: { value: [FRUITS[0], FRUITS[2], FRUITS[4]] },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="multiple"
+                label="Select fruits"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={(v: any) => onChange(v ?? [])}
+                translations={MULTI_TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** Multiple selection with many chips, including long labels that overflow */
+    const MultipleWithManyChips = {
+        args: {
+            value: [
+                FRUITS[0],
+                FRUITS[1],
+                FRUITS[2],
+                FRUITS[3],
+                FRUITS[4],
+                FRUITS[5],
+                {
+                    id: 'dragon-fruit',
+                    name: 'Dragon Fruit from the Exotic Tropical Rainforests of Southeast Asia',
+                    category: 'Tropical',
+                },
+                FRUITS[6],
+                FRUITS[7],
+                {
+                    id: 'passion-fruit',
+                    name: 'Extremely Rare Golden Passion Fruit Grown in the High Altitude Volcanic Soils of South America',
+                    category: 'Tropical',
+                },
+                FRUITS[8],
+                FRUITS[9],
+            ],
+        },
+        decorators: [withValueOnChange()],
+        play: undefined as any,
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="multiple"
+                label="Select fruits"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={(v: any) => onChange(v ?? [])}
+                translations={MULTI_TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** Multiple selection — disabled state with chips */
+    const MultipleDisabled = {
+        args: { value: [FRUITS[0], FRUITS[2]] },
+        decorators: [withValueOnChange()],
+        play: undefined as any,
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="multiple"
+                label="Select fruits"
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={(v: any) => onChange(v ?? [])}
+                isDisabled
+                translations={MULTI_TRANSLATIONS}
+            />
+        ),
+    };
+
+    // ─── Option count message ────────────────────────────────────
+
+    const NB_OPTION_TRANSLATIONS = {
+        ...TRANSLATIONS,
+        emptyMessage: 'No results found',
+        nbOptionMessage: (n: number) => `${n} result(s) available`,
+    };
+
+    /** SelectTextField with option count message — shows how many results are available */
+    const WithNbOptionMessage = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={FRUITS}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                translations={NB_OPTION_TRANSLATIONS}
+            />
+        ),
+    };
+
+    // ─── Loading and error states ───────────────────────────────
+
+    const LOADING_TRANSLATIONS = {
+        ...TRANSLATIONS,
+        loadingMessage: 'Loading fruits…',
+    };
+
+    const ERROR_TRANSLATIONS = {
+        ...TRANSLATIONS,
+        errorMessage: 'Failed to load',
+        errorTryReloadMessage: 'Please try again later',
+    };
+
+    /** Full loading state — shows skeleton placeholders instead of options */
+    const Loading = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={[]}
+                filter="manual"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                listStatus="loading"
+                translations={LOADING_TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** Loading more state — appends skeleton after existing options */
+    const LoadingMore = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={FRUITS.slice(0, 3)}
+                filter="manual"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                listStatus="loadingMore"
+                translations={LOADING_TRANSLATIONS}
+            />
+        ),
+    };
+
+    /** Error state — shows error message in the dropdown */
+    const ErrorState = {
+        args: { value: undefined },
+        decorators: [withValueOnChange()],
+        render: ({ value, onChange }: any) => (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={[]}
+                filter="manual"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={onChange}
+                listStatus="error"
+                translations={ERROR_TRANSLATIONS}
+            />
+        ),
+    };
+
+    return {
+        meta,
+        Default,
+        WithSelectedValue,
+        NoClearButton,
+        WithDescriptions,
+        WithSections,
+        WithIcon,
+        Disabled,
+        WithError,
+        WithHelper,
+        MultipleSelection,
+        MultipleWithPreselected,
+        MultipleWithManyChips,
+        MultipleDisabled,
+        WithNbOptionMessage,
+        Loading,
+        LoadingMore,
+        ErrorState,
+    };
+}

--- a/packages/lumx-core/src/js/components/SelectTextField/TestStories.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/TestStories.tsx
@@ -1,0 +1,205 @@
+/**
+ * Browser-only test stories for SelectTextField.
+ *
+ * These tests require a real browser environment (Playwright via Vitest browser mode)
+ * because they rely on blur/focus interactions with outside elements and click-away
+ * detection that do not work reliably in jsdom.
+ *
+ * The majority of SelectTextField tests have been migrated to jsdom in Tests.tsx.
+ */
+import { expect, screen, userEvent, within, waitFor } from 'storybook/test';
+import type { SetupStoriesOptions } from '@lumx/core/stories/types';
+import { createTemplates, MULTI_TRANSLATIONS } from './Tests';
+
+// Test fruits — local to test stories (include descriptions for blur-reset tests).
+const FRUITS = [
+    { id: 'apple', name: 'Apple', category: 'Pome', description: 'A sweet red fruit' },
+    { id: 'apricot', name: 'Apricot', category: 'Stone', description: 'A soft orange fruit' },
+    { id: 'banana', name: 'Banana', category: 'Tropical', description: 'A long yellow fruit' },
+    { id: 'blueberry', name: 'Blueberry', category: 'Berry', description: 'A small blue fruit' },
+    { id: 'cherry', name: 'Cherry', category: 'Stone', description: 'A small red fruit' },
+    { id: 'grape', name: 'Grape', category: 'Berry', description: 'A small purple fruit' },
+    { id: 'lemon', name: 'Lemon', category: 'Citrus', description: 'A sour yellow fruit' },
+    { id: 'orange', name: 'Orange', category: 'Citrus', description: 'A citrus fruit' },
+    { id: 'peach', name: 'Peach', category: 'Stone', description: 'A soft fuzzy fruit' },
+    { id: 'strawberry', name: 'Strawberry', category: 'Berry', description: 'A sweet red berry' },
+];
+
+/**
+ * Setup test stories
+ */
+export function setup({
+    components: { SelectTextField },
+}: SetupStoriesOptions<{
+    components: { SelectTextField: any; Combobox?: any };
+}>) {
+    const { defaultTemplate, multiTemplate } = createTemplates(SelectTextField);
+
+    const meta = {
+        component: SelectTextField as any,
+        tags: ['!snapshot'],
+        parameters: { chromatic: { disable: true } },
+    };
+
+    /** Test click-away */
+    const ClickOutsideCloses = {
+        render: (args: any) => (
+            <div>
+                {defaultTemplate(args)}
+                <button type="button" data-testid="outside-button">
+                    Outside
+                </button>
+            </div>
+        ),
+        async play({ canvas }: any) {
+            const input = canvas.getByRole('combobox') as HTMLInputElement;
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            const outsideButton = canvas.getByTestId('outside-button');
+            await userEvent.click(outsideButton);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'false');
+            });
+        },
+    };
+
+    /** Test blur reset to selected value */
+    const BlurResetsToSelectedValue = {
+        render: (args: any) => (
+            <div>
+                {defaultTemplate({ value: FRUITS[0], ...args })}
+                <button type="button" data-testid="outside-button">
+                    Outside
+                </button>
+            </div>
+        ),
+        async play({ canvas }: any) {
+            const input = canvas.getByRole('combobox') as HTMLInputElement;
+
+            await expect(input).toHaveValue('Apple');
+
+            await userEvent.clear(input);
+            await userEvent.type(input, 'xyz');
+            await expect(input).toHaveValue('xyz');
+
+            const outsideButton = canvas.getByTestId('outside-button');
+            await userEvent.click(outsideButton);
+
+            await waitFor(() => {
+                expect(input).toHaveValue('Apple');
+            });
+        },
+    };
+
+    /** Test blur reset to empty */
+    const BlurResetsToEmpty = {
+        render: (args: any) => (
+            <div>
+                {defaultTemplate(args)}
+                <button type="button" data-testid="outside-button">
+                    Outside
+                </button>
+            </div>
+        ),
+        async play({ canvas }: any) {
+            const input = canvas.getByRole('combobox') as HTMLInputElement;
+
+            await userEvent.type(input, 'xyz');
+            await expect(input).toHaveValue('xyz');
+
+            const outsideButton = canvas.getByTestId('outside-button');
+            await userEvent.click(outsideButton);
+
+            await waitFor(() => {
+                expect(input).toHaveValue('');
+            });
+        },
+    };
+
+    /** Test blur reset to empty (multi select) */
+    const MultiBlurResetsSearch = {
+        render: (args: any) => (
+            <div>
+                {multiTemplate({ value: [FRUITS[0]], translations: MULTI_TRANSLATIONS, ...args })}
+                <button type="button" data-testid="outside-button">
+                    Outside
+                </button>
+            </div>
+        ),
+        async play({ canvas }: any) {
+            const input = canvas.getByRole('combobox') as HTMLInputElement;
+
+            await userEvent.type(input, 'xyz');
+            await expect(input).toHaveValue('xyz');
+
+            const outsideButton = canvas.getByTestId('outside-button');
+            await userEvent.click(outsideButton);
+
+            await waitFor(() => {
+                expect(input).toHaveValue('');
+            });
+
+            const chipGroup = canvas.getByRole('listbox', { name: 'Selected fruits' });
+            const chipButtons = within(chipGroup).getAllByRole('option');
+            expect(chipButtons).toHaveLength(1);
+        },
+    };
+
+    /**
+     * Test story for WithInfiniteScroll.
+     * Opens the dropdown and verifies that the infinite scroll sentinel triggers
+     * loading additional options.
+     *
+     * The render function is framework-specific (React hooks / Vue SFC),
+     * so each framework consumer overrides `render` and keeps this `play`.
+     */
+    const WithInfiniteScroll = {
+        async play({ canvas }: any) {
+            const input = canvas.getByRole('combobox') as HTMLInputElement;
+
+            // Open the dropdown
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            // Verify the listbox is rendered (portal content, use screen)
+            const listbox = await screen.findByRole('listbox', { name: 'Select a fruit' });
+
+            // Capture the initial number of options once render settles.
+            // The render is expected to provide enough items to overflow the popover
+            // so the IntersectionObserver sentinel does not fire before scroll.
+            let initialCount = 0;
+            await waitFor(() => {
+                const options = within(listbox).getAllByRole('option');
+                expect(options.length).toBeGreaterThan(0);
+                initialCount = options.length;
+            });
+
+            // Scroll the popover to the bottom to trigger the IntersectionObserver sentinel
+            const scrollContainer = listbox.closest('.lumx-combobox-popover__scroll')!;
+            expect(scrollContainer).toBeTruthy();
+            scrollContainer.scrollTop = scrollContainer.scrollHeight;
+
+            // Wait for more options to be loaded after scroll
+            await waitFor(() => {
+                const options = within(listbox).getAllByRole('option');
+                expect(options.length).toBeGreaterThan(initialCount);
+            });
+        },
+    };
+
+    return {
+        meta,
+        ClickOutsideCloses,
+        BlurResetsToSelectedValue,
+        BlurResetsToEmpty,
+        MultiBlurResetsSearch,
+        WithInfiniteScroll,
+    };
+}

--- a/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
@@ -1,0 +1,1416 @@
+/* eslint-disable no-await-in-loop */
+import userEvent from '@testing-library/user-event';
+import { getByRole, getConfig, waitFor } from '@testing-library/dom';
+
+// ─── Fixtures ────────────────────────────────────────────────────
+
+interface Fruit {
+    id: string;
+    name: string;
+    category: string;
+    description?: string;
+}
+
+const FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple', category: 'Pome', description: 'A sweet red fruit' },
+    { id: 'apricot', name: 'Apricot', category: 'Stone', description: 'A soft orange fruit' },
+    { id: 'banana', name: 'Banana', category: 'Tropical', description: 'A long yellow fruit' },
+    { id: 'blueberry', name: 'Blueberry', category: 'Berry', description: 'A small blue fruit' },
+    { id: 'cherry', name: 'Cherry', category: 'Stone', description: 'A small red fruit' },
+    { id: 'grape', name: 'Grape', category: 'Berry', description: 'A small purple fruit' },
+    { id: 'lemon', name: 'Lemon', category: 'Citrus', description: 'A sour yellow fruit' },
+    { id: 'orange', name: 'Orange', category: 'Citrus', description: 'A citrus fruit' },
+    { id: 'peach', name: 'Peach', category: 'Stone', description: 'A soft fuzzy fruit' },
+    { id: 'strawberry', name: 'Strawberry', category: 'Berry', description: 'A sweet red berry' },
+];
+
+export const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+export const MULTI_TRANSLATIONS = {
+    ...TRANSLATIONS,
+    chipGroupLabel: 'Selected fruits',
+    chipRemoveLabel: 'Remove',
+};
+
+// ─── Types ───────────────────────────────────────────────────────
+
+type RenderResult = { unmount: () => void; container: HTMLElement };
+
+/**
+ * Options to set up the SelectTextField test suite.
+ * Injected by the framework-specific test file (React or Vue).
+ */
+export interface SelectTextFieldTestSetup {
+    components: {
+        SelectTextField: any;
+        Combobox: any;
+    };
+    /**
+     * Render a SelectTextField template with controlled state management.
+     *
+     * @param template    JSX render function receiving `{ value, onChange, ... }`.
+     * @param initialArgs Initial props (value, spies, etc.).
+     */
+    renderWithState: (template: (props: any) => any, initialArgs?: Record<string, any>) => RenderResult;
+}
+
+// ─── DOM Helpers ─────────────────────────────────────────────────
+// Options and listbox are rendered in a portal (document.body).
+// All option/listbox queries target document.body.
+// NB: Queries for the dropdown listbox and options are scoped to `.lumx-combobox-list`
+// to avoid matching the SelectionChipGroup's [role="listbox"] and [role="option"] elements.
+
+function getInput(): HTMLInputElement {
+    return document.body.querySelector<HTMLInputElement>('[role="combobox"]')!;
+}
+
+function getListbox(): HTMLElement | null {
+    return document.body.querySelector<HTMLElement>('.lumx-combobox-list[role="listbox"]');
+}
+
+function getVisibleOptions(): HTMLElement[] {
+    return Array.from(
+        document.body.querySelectorAll<HTMLElement>('.lumx-combobox-list [role="option"]:not([data-filtered])'),
+    );
+}
+
+function getAllOptions(): HTMLElement[] {
+    return Array.from(document.body.querySelectorAll<HTMLElement>('.lumx-combobox-list [role="option"]'));
+}
+
+/** Get chip elements inside the selection chip group. Chips render as [role="option"] inside a listbox. */
+function getChips(): HTMLElement[] {
+    return Array.from(
+        document.body.querySelectorAll<HTMLElement>('[role="listbox"][aria-label="Selected fruits"] [role="option"]'),
+    );
+}
+
+// ─── Template factory ─────────────────────────────────────────────
+
+export function createTemplates(SelectTextField: any) {
+    /** Default single-select template (filter="auto") */
+    const defaultTemplate = (props: any) => (
+        <SelectTextField
+            selectionType="single"
+            label="Select a fruit"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            getOptionId="id"
+            getOptionName="name"
+            filter="auto"
+            translations={TRANSLATIONS}
+            {...props}
+        />
+    );
+
+    /** Single-select with consumer-controlled search (filter="manual" by default) */
+    const searchTemplate = (props: any) => {
+        const { onSearch, options: filteredOptions, ...rest } = props;
+        return (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Type to search..."
+                options={filteredOptions ?? FRUITS}
+                getOptionId="id"
+                getOptionName="name"
+                filter="manual"
+                translations={TRANSLATIONS}
+                onSearch={onSearch}
+                {...rest}
+            />
+        );
+    };
+
+    /** Default multi-select template (filter="auto") */
+    const multiTemplate = (props: any) => (
+        <SelectTextField
+            selectionType="multiple"
+            label="Select fruits"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            getOptionId="id"
+            getOptionName="name"
+            filter="auto"
+            translations={MULTI_TRANSLATIONS}
+            {...props}
+        />
+    );
+
+    return { defaultTemplate, searchTemplate, multiTemplate };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Main test suite
+// ═══════════════════════════════════════════════════════════════════
+
+const LOADING_TRANSLATIONS = {
+    ...TRANSLATIONS,
+    loadingMessage: 'Loading fruits…',
+};
+
+const ERROR_TRANSLATIONS = {
+    ...TRANSLATIONS,
+    errorMessage: 'Failed to load',
+    errorTryReloadMessage: 'Please try again later',
+};
+
+function getSkeletons(): HTMLElement[] {
+    return Array.from(document.body.querySelectorAll<HTMLElement>('.lumx-combobox-option-skeleton'));
+}
+
+export default function selectTextFieldTests({ components, renderWithState }: SelectTextFieldTestSetup) {
+    const { SelectTextField, Combobox } = components;
+    const { defaultTemplate, searchTemplate, multiTemplate } = createTemplates(SelectTextField);
+
+    // ─── Static rendering ────────────────────────────────────────
+
+    describe('Static rendering', () => {
+        it('should render the input with label', () => {
+            renderWithState(defaultTemplate);
+            // Use testing-library getByRole to find by accessible name (label element, not aria-label on input)
+            const input = getByRole(document.body, 'combobox', { name: 'Select a fruit' });
+            expect(input).toBeTruthy();
+        });
+
+        it('should render placeholder when no value is selected', () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+            expect(input.getAttribute('placeholder')).toBe('Search fruits...');
+            expect(input.value).toBe('');
+        });
+
+        it('should display selected value name in the input', () => {
+            renderWithState(defaultTemplate, { value: FRUITS[2] }); // FRUITS[2] = Banana
+            const input = getInput();
+            expect(input.value).toBe('Banana');
+        });
+
+        it('should render the toggle button', () => {
+            renderWithState(defaultTemplate);
+            const toggleButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Show suggestions"]');
+            expect(toggleButton).toBeTruthy();
+        });
+
+        it('should not render the toggle button when showSuggestionsLabel is omitted', () => {
+            const { showSuggestionsLabel: _, ...translationsWithoutToggle } = TRANSLATIONS;
+            renderWithState(defaultTemplate, { translations: translationsWithoutToggle });
+            // No button with aria-expanded should exist besides the combobox input itself
+            const toggleButtons = document.body.querySelectorAll<HTMLButtonElement>('button[aria-expanded]');
+            expect(toggleButtons).toHaveLength(0);
+        });
+
+        it('should render the clear button when value is set', () => {
+            renderWithState(defaultTemplate, { value: FRUITS[0] });
+            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            expect(clearButton).toBeTruthy();
+        });
+
+        it('should not render clear button when hasClearButton is false', () => {
+            renderWithState(defaultTemplate, { value: FRUITS[0], hasClearButton: false });
+            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            expect(clearButton).toBeNull();
+        });
+
+        it('should not render clear button when no value is selected', () => {
+            renderWithState(defaultTemplate);
+            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            expect(clearButton).toBeNull();
+        });
+
+        it('should render options in the listbox', () => {
+            renderWithState(defaultTemplate);
+            const options = getAllOptions();
+            expect(options).toHaveLength(FRUITS.length);
+            expect(options[0].textContent).toBe('Apple');
+            expect(options[1].textContent).toBe('Apricot');
+            expect(options[2].textContent).toBe('Banana');
+        });
+
+        it('should render option descriptions when getOptionDescription is provided', () => {
+            renderWithState(defaultTemplate, { getOptionDescription: 'description' });
+            const options = getAllOptions();
+            const describedBy = options[0].getAttribute('aria-describedby');
+            expect(describedBy).toBeTruthy();
+            const descriptionId = describedBy!.split(' ')[0];
+            const description = document.getElementById(descriptionId);
+            expect(description?.textContent).toBe('A sweet red fruit');
+        });
+
+        it('should mark selected option with aria-selected', () => {
+            renderWithState(defaultTemplate, { value: FRUITS[1] }); // Apricot
+            const options = getAllOptions();
+            expect(options[0].getAttribute('aria-selected')).toBe('false');
+            expect(options[1].getAttribute('aria-selected')).toBe('true');
+            expect(options[2].getAttribute('aria-selected')).toBe('false');
+        });
+
+        it('should render in disabled state', () => {
+            renderWithState(defaultTemplate, { isDisabled: true, value: FRUITS[0] });
+            const input = getInput();
+            expect((input as HTMLInputElement).disabled).toBe(true);
+            expect(input.value).toBe('Apple');
+        });
+
+        it('should render sections when getSectionId is provided', () => {
+            renderWithState(defaultTemplate, {
+                getSectionId: 'category',
+            });
+            const groups = document.body.querySelectorAll('[role="group"]');
+            expect(groups.length).toBeGreaterThan(0);
+        });
+
+        it('should render beforeOptions content', () => {
+            renderWithState(defaultTemplate, {
+                beforeOptions: <div data-testid="before-content">Before</div>,
+            });
+            const beforeContent = document.body.querySelector('[data-testid="before-content"]');
+            expect(beforeContent).toBeTruthy();
+            expect(beforeContent?.textContent).toBe('Before');
+        });
+
+        it('should have proper ARIA attributes on the combobox', () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+            expect(input.getAttribute('aria-autocomplete')).toBe('list');
+            expect(input.getAttribute('aria-controls')).toBeTruthy();
+            expect(input.getAttribute('aria-expanded')).toBeTruthy();
+        });
+
+        it('should render the listbox with aria-label', () => {
+            renderWithState(defaultTemplate);
+            const listbox = getListbox();
+            expect(listbox?.getAttribute('aria-label')).toBe('Select a fruit');
+        });
+    });
+
+    // ─── Open and select ─────────────────────────────────────────
+
+    describe('Open and select', () => {
+        it('should open on click and close after selecting an option', async () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            expect(getListbox()).toBeTruthy();
+
+            const options = getVisibleOptions();
+            await userEvent.click(options[2]); // Banana
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+                expect(input.value).toBe('Banana');
+            });
+        });
+
+        it('should show selected value in input when pre-selected', async () => {
+            renderWithState(defaultTemplate, { value: FRUITS[3] }); // Blueberry
+            expect(getInput().value).toBe('Blueberry');
+        });
+
+        it('should call onOpen with true when opening and false when closing', async () => {
+            const onOpen = vi.fn();
+            renderWithState(defaultTemplate, { onOpen });
+            const input = getInput();
+
+            // Open on click
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+            expect(onOpen).toHaveBeenCalledWith(true);
+
+            // Close by selecting an option
+            const options = getVisibleOptions();
+            await userEvent.click(options[0]); // Apple
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+            });
+            expect(onOpen).toHaveBeenCalledWith(false);
+        });
+    });
+
+    // ─── Clear button ────────────────────────────────────────────
+
+    describe('Clear button', () => {
+        it('should clear the selection when clicking the clear button', async () => {
+            renderWithState(defaultTemplate, { value: FRUITS[0] });
+            const input = getInput();
+
+            expect(input.value).toBe('Apple');
+
+            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]')!;
+            await userEvent.click(clearButton);
+
+            await waitFor(() => {
+                expect(input.value).toBe('');
+            });
+        });
+
+        it('should not show clear button when hasClearButton is false', async () => {
+            renderWithState(defaultTemplate, { value: FRUITS[0], hasClearButton: false });
+            expect(getInput().value).toBe('Apple');
+            expect(document.body.querySelector('[aria-label="Clear"]')).toBeNull();
+        });
+    });
+
+    // ─── Input clear ─────────────────────────────────────────────
+
+    describe('Input clear', () => {
+        it('should clear the selection when the user empties the input', async () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, { value: FRUITS[0], onChange });
+            const input = getInput();
+
+            // Input shows the selected value name
+            expect(input.value).toBe('Apple');
+
+            // User focuses the field and clears the text
+            await userEvent.click(input);
+            await userEvent.clear(input);
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalledWith(undefined);
+            });
+        });
+
+        it('should not clear the selection while the user is still typing (non-empty input)', async () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, { value: FRUITS[0], onChange });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await userEvent.type(input, 'App');
+
+            // onChange must not have been called with undefined during partial typing
+            expect(onChange).not.toHaveBeenCalledWith(undefined);
+        });
+    });
+
+    // ─── Search / filter ─────────────────────────────────────────
+
+    describe('Search / filter', () => {
+        it('should call onSearch when typing', async () => {
+            const onSearch = vi.fn();
+            renderWithState(searchTemplate, { onSearch, options: FRUITS });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.type(input, 'ban');
+            expect(onSearch).toHaveBeenCalled();
+        });
+
+        it('should use filter="auto" when no onSearch is provided', async () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                expect(getVisibleOptions()).toHaveLength(FRUITS.length);
+            });
+
+            await userEvent.type(input, 'Ap');
+
+            await waitFor(() => {
+                // Apple, Apricot, and Grape contain "ap" (case-insensitive substring match)
+                expect(getVisibleOptions().length).toBe(3);
+            });
+        });
+
+        it('should reset filter after selecting an option', async () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.type(input, 'Ap');
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(3);
+            });
+
+            const filteredOptions = getVisibleOptions();
+            await userEvent.click(filteredOptions[0]);
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+                expect(input.value).toBe('Apple');
+            });
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                expect(getVisibleOptions()).toHaveLength(FRUITS.length);
+            });
+        });
+
+        it('should reset filter after clearing the selection', async () => {
+            renderWithState(defaultTemplate, { value: FRUITS[0] });
+            const input = getInput();
+
+            expect(input.value).toBe('Apple');
+
+            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]')!;
+            await userEvent.click(clearButton);
+            await waitFor(() => {
+                expect(input.value).toBe('');
+            });
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                expect(getVisibleOptions()).toHaveLength(FRUITS.length);
+            });
+        });
+
+        it('should filter with substring matching (not just prefix)', async () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // "ana" is a substring of "Banana" but not a prefix
+            await userEvent.type(input, 'ana');
+
+            await waitFor(() => {
+                const visible = getVisibleOptions();
+                expect(visible.length).toBe(1);
+                expect(visible[0].textContent).toBe('Banana');
+            });
+        });
+
+        it('should not filter when filter is "manual"', async () => {
+            renderWithState(defaultTemplate, { filter: 'manual' });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                expect(getVisibleOptions()).toHaveLength(FRUITS.length);
+            });
+
+            await userEvent.type(input, 'xyz');
+
+            // All options should still be visible
+            await waitFor(() => {
+                expect(getVisibleOptions()).toHaveLength(FRUITS.length);
+            });
+        });
+
+        it('should show consumer-filtered options with filter="manual" (single select)', async () => {
+            // Simulate consumer-controlled search: pass a pre-filtered subset of options
+            const filteredFruits = FRUITS.filter((f) => f.name.toLowerCase().includes('ap'));
+            renderWithState(searchTemplate, { options: filteredFruits });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // Only the pre-filtered options should be rendered
+            await waitFor(() => {
+                const options = getVisibleOptions();
+                expect(options).toHaveLength(filteredFruits.length);
+            });
+
+            // Selecting a filtered option should work
+            const options = getVisibleOptions();
+            await userEvent.click(options[0]);
+            await waitFor(() => {
+                expect(input.value).toBe(filteredFruits[0].name);
+            });
+        });
+
+        it('should show consumer-filtered options with filter="manual" (multiple select)', async () => {
+            // Simulate consumer-controlled search: pass a pre-filtered subset of options
+            const filteredFruits = FRUITS.filter((f) => f.name.toLowerCase().includes('ber'));
+            renderWithState(searchTemplate, {
+                options: filteredFruits,
+                selectionType: 'multiple',
+                translations: MULTI_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // Only the pre-filtered options should be rendered
+            await waitFor(() => {
+                const options = getVisibleOptions();
+                expect(options).toHaveLength(filteredFruits.length);
+            });
+
+            // Selecting options in multi mode should add chips
+            const options = getVisibleOptions();
+            await userEvent.click(options[0]);
+            await waitFor(() => {
+                expect(getChips()).toHaveLength(1);
+            });
+
+            // Dropdown stays open after selection in multi mode
+            expect(input.getAttribute('aria-expanded')).toBe('true');
+        });
+
+        it('should support filter="auto" with onSearch together', async () => {
+            const onSearch = vi.fn();
+            renderWithState(searchTemplate, { filter: 'auto', onSearch, options: FRUITS });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.type(input, 'Ap');
+
+            // Client-side filtering should hide non-matching options
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(3); // Apple, Apricot, Grape
+            });
+
+            // onSearch should also have been called
+            expect(onSearch).toHaveBeenCalled();
+        });
+    });
+
+    // ─── Sections ────────────────────────────────────────────────
+
+    describe('Sections', () => {
+        it('should render sections as ARIA groups and allow selecting options', async () => {
+            renderWithState(defaultTemplate, {
+                getSectionId: 'category',
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            const groups = document.body.querySelectorAll('[role="group"]');
+            expect(groups.length).toBeGreaterThan(0);
+
+            const options = getVisibleOptions();
+            expect(options).toHaveLength(FRUITS.length);
+
+            const blueberry = Array.from(options).find((o) => o.textContent === 'Blueberry')!;
+            await userEvent.click(blueberry);
+
+            await waitFor(() => {
+                expect(input.value).toBe('Blueberry');
+            });
+        });
+    });
+
+    // ─── Custom option render ────────────────────────────────────
+
+    describe('Custom option render', () => {
+        it('should render custom option content and show descriptions', async () => {
+            renderWithState(defaultTemplate, {
+                getOptionDescription: 'description',
+                renderOption: (fruit: Fruit) => (
+                    <Combobox.Option value={fruit.id}>
+                        <strong>{fruit.name}</strong>
+                    </Combobox.Option>
+                ),
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(getListbox()).toBeTruthy();
+            });
+
+            const options = getVisibleOptions();
+            const firstOption = options[0];
+            expect(firstOption.textContent).toContain('Apple');
+
+            const describedBy = firstOption.getAttribute('aria-describedby') as string;
+            const descriptionId = describedBy.split(' ')[0];
+            const description = document.getElementById(descriptionId);
+            expect(description?.textContent).toBe('A sweet red fruit');
+        });
+    });
+
+    // ─── Keyboard navigation ─────────────────────────────────────
+
+    describe('Keyboard navigation', () => {
+        it('should navigate with ArrowDown and select with Enter', async () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.keyboard('{ArrowDown}');
+            const firstOption = getAllOptions()[0];
+            await waitFor(() => {
+                expect(input.getAttribute('aria-activedescendant')).toBe(firstOption?.id ?? '');
+            });
+
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+                expect(input.value).toBe('Apple');
+            });
+        });
+
+        it('should focus selected option when pressing ArrowDown with a pre-selected value', async () => {
+            renderWithState(defaultTemplate, { value: FRUITS[4] }); // Cherry (index 4)
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.keyboard('{ArrowDown}');
+            const allOptions = getAllOptions();
+            const cherryOption = allOptions[4];
+            await waitFor(() => {
+                expect(input.getAttribute('aria-activedescendant')).toBe(cherryOption?.id ?? '');
+                expect(cherryOption.getAttribute('aria-selected')).toBe('true');
+            });
+        });
+
+        it('should focus selected option when pressing ArrowUp with a pre-selected value', async () => {
+            renderWithState(defaultTemplate, { value: FRUITS[2] }); // Banana (index 2)
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // Close first, then ArrowUp to reopen
+            await userEvent.keyboard('{Escape}');
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+            });
+
+            await userEvent.keyboard('{ArrowUp}');
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            const allOptions = getAllOptions();
+            const bananaOption = allOptions[2];
+            await waitFor(() => {
+                expect(input.getAttribute('aria-activedescendant')).toBe(bananaOption?.id ?? '');
+                expect(bananaOption.getAttribute('aria-selected')).toBe('true');
+            });
+        });
+
+        it('should close dropdown on Escape', async () => {
+            renderWithState(defaultTemplate);
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.keyboard('{Escape}');
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+            });
+        });
+    });
+
+    // ─── Disabled state (isDisabled) ────────────────────────────
+
+    describe('Disabled state (isDisabled)', () => {
+        it('should set the native disabled attribute on the input', () => {
+            renderWithState(defaultTemplate, { isDisabled: true, value: FRUITS[0] });
+            const input = getInput();
+
+            expect(input.value).toBe('Apple');
+            expect(input.disabled).toBe(true);
+        });
+
+        it('should not open dropdown on click when disabled', async () => {
+            renderWithState(defaultTemplate, { isDisabled: true });
+            const input = getInput();
+
+            await userEvent.click(input);
+
+            // Dropdown should remain closed (browser blocks events on disabled inputs)
+            expect(input.getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it('should not show clear button when disabled', () => {
+            renderWithState(defaultTemplate, { isDisabled: true, value: FRUITS[0] });
+            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            expect(clearButton).toBeNull();
+        });
+
+        it('should not be focusable when disabled', () => {
+            renderWithState(defaultTemplate, { isDisabled: true });
+            const input = getInput();
+
+            input.focus();
+
+            // A natively disabled input should not receive focus
+            expect(document.activeElement).not.toBe(input);
+        });
+    });
+
+    // ─── Aria-disabled state ─────────────────────────────────────
+
+    describe('Aria-disabled state', () => {
+        it('should NOT set the native disabled attribute on the input', () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true, value: FRUITS[0] });
+            const input = getInput();
+
+            expect(input.value).toBe('Apple');
+            expect(input.disabled).toBe(false);
+        });
+
+        it('should set aria-disabled on the input', () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true });
+            const input = getInput();
+
+            expect(input.getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('should still be focusable when aria-disabled', () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true });
+            const input = getInput();
+
+            // Wrap in eventWrapper to flush framework state updates triggered by focus.
+            getConfig().eventWrapper(() => {
+                input.focus();
+            });
+
+            expect(document.activeElement).toBe(input);
+        });
+
+        it('should not open dropdown on focus when aria-disabled', async () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true });
+            const input = getInput();
+
+            // Wrap in eventWrapper to flush framework state updates triggered by focus.
+            getConfig().eventWrapper(() => {
+                input.focus();
+            });
+
+            // Give time for any async handlers to fire
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+            });
+        });
+
+        it('should not open dropdown on click when aria-disabled', async () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true });
+            const input = getInput();
+
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('false');
+            });
+        });
+
+        it('should make the input read-only when aria-disabled', () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true });
+            const input = getInput();
+
+            expect(input.readOnly).toBe(true);
+        });
+
+        it('should not show clear button when aria-disabled', () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true, value: FRUITS[0] });
+            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            expect(clearButton).toBeNull();
+        });
+
+        it('should apply disabled styling (lumx-text-field--is-disabled class)', () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true });
+            const textField = document.body.querySelector('.lumx-text-field');
+            expect(textField?.classList.contains('lumx-text-field--is-disabled')).toBe(true);
+        });
+
+        it('should disable the toggle button when aria-disabled', () => {
+            renderWithState(defaultTemplate, { 'aria-disabled': true });
+            const toggleButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Show suggestions"]');
+            expect(toggleButton?.disabled).toBe(true);
+        });
+    });
+
+    // ─── Multiple selection ──────────────────────────────────────
+
+    describe('Multiple selection', () => {
+        it('should add chips when selecting options and keep dropdown open', async () => {
+            renderWithState(multiTemplate, { value: [] });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            const options = getVisibleOptions();
+            await userEvent.click(options[0]); // Apple
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // Select second option
+            const optionsAfter = getVisibleOptions();
+            await userEvent.click(optionsAfter[1]); // Apricot
+
+            await waitFor(() => {
+                // Chips render as [role="option"] elements inside a [role="listbox"]
+                expect(getChips().length).toBe(2);
+            });
+
+            expect(input.value).toBe('');
+        });
+
+        it('should deselect an option when clicking it again', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[2]] }); // Apple, Banana
+            const input = getInput();
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(2);
+            });
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            const options = getVisibleOptions();
+            await userEvent.click(options[0]); // Deselect Apple
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(1);
+            });
+        });
+
+        it('should remove a chip by clicking it', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[2]] }); // Apple, Banana
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(2);
+            });
+
+            const firstChip = getChips()[0]!;
+            await userEvent.click(firstChip);
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(1);
+            });
+        });
+
+        it('should render pre-selected values as chips', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[3], FRUITS[7]] }); // Apple, Blueberry, Orange
+            const input = getInput();
+
+            expect(input.value).toBe('');
+            expect(getChips().length).toBe(3);
+        });
+
+        it('should display option name in each chip', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[2]] }); // Apple, Banana
+
+            const chips = getChips();
+            expect(chips).toHaveLength(2);
+
+            // Each chip should contain the option name as visible text
+            expect(chips[0].textContent).toContain('Apple');
+            expect(chips[1].textContent).toContain('Banana');
+        });
+
+        it('should keep dropdown open after each selection', async () => {
+            renderWithState(multiTemplate, { value: [] });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            const options = getVisibleOptions();
+            await userEvent.click(options[0]);
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            const optionsAfter = getVisibleOptions();
+            await userEvent.click(optionsAfter[2]);
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+        });
+
+        it('should select via keyboard and keep dropdown open with preserved visual focus', async () => {
+            renderWithState(multiTemplate, { value: [] });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.keyboard('{ArrowDown}');
+            const firstOption = getAllOptions()[0];
+            await waitFor(() => {
+                expect(input.getAttribute('aria-activedescendant')).toBe(firstOption?.id ?? '');
+            });
+
+            await userEvent.keyboard('{Enter}');
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-activedescendant')).toBe(firstOption?.id ?? '');
+            });
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(1);
+            });
+        });
+
+        it('should focus first selected option when pressing ArrowDown in multi mode', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[2], FRUITS[5]] }); // Banana, Grape
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.keyboard('{ArrowDown}');
+            const allOptions = getAllOptions();
+            const bananaOption = allOptions[2];
+            await waitFor(() => {
+                expect(input.getAttribute('aria-activedescendant')).toBe(bananaOption?.id ?? '');
+                expect(bananaOption.getAttribute('aria-selected')).toBe('true');
+            });
+        });
+
+        it('should mark selected options with aria-selected in multi mode', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[2]] }); // Apple, Banana
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            const options = getAllOptions();
+            await waitFor(() => {
+                expect(options[0].getAttribute('aria-selected')).toBe('true');
+                expect(options[1].getAttribute('aria-selected')).toBe('false');
+                expect(options[2].getAttribute('aria-selected')).toBe('true');
+                expect(options[3].getAttribute('aria-selected')).toBe('false');
+            });
+        });
+
+        it('should set aria-multiselectable on the listbox in multi mode', async () => {
+            renderWithState(multiTemplate, { value: [] });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                const listbox = getListbox();
+                expect(listbox?.getAttribute('aria-multiselectable')).toBe('true');
+            });
+        });
+
+        it('should not show a clear button in multi mode', () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0]] });
+            expect(document.body.querySelector('[aria-label="Clear"]')).toBeNull();
+        });
+
+        it('should call onSearch when typing in multi mode', async () => {
+            const onSearch = vi.fn();
+            renderWithState(searchTemplate, {
+                onSearch,
+                options: FRUITS,
+                selectionType: 'multiple',
+                translations: MULTI_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.type(input, 'ber');
+            expect(onSearch).toHaveBeenCalled();
+        });
+
+        it('should reset filter after selecting in multi mode', async () => {
+            renderWithState(multiTemplate, { value: [] });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                expect(getVisibleOptions()).toHaveLength(FRUITS.length);
+            });
+
+            await userEvent.type(input, 'Ap');
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(3); // Apple, Apricot, Grape
+            });
+
+            const filteredOptions = getVisibleOptions();
+            await userEvent.click(filteredOptions[0]);
+
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+                expect(getVisibleOptions()).toHaveLength(FRUITS.length);
+            });
+        });
+    });
+
+    // ─── Empty and option count messages ────────────────────────
+
+    describe('Empty and option count messages', () => {
+        const EMPTY_TRANSLATIONS = {
+            ...TRANSLATIONS,
+            emptyMessage: 'No results found',
+        };
+
+        const NB_OPTION_TRANSLATIONS = {
+            ...TRANSLATIONS,
+            emptyMessage: 'No results found',
+            nbOptionMessage: (n: number) => `${n} result(s) available`,
+        };
+
+        it('should show empty message when all options are filtered out', async () => {
+            renderWithState(defaultTemplate, {
+                translations: EMPTY_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.type(input, 'zzz');
+
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(0);
+            });
+
+            await waitFor(() => {
+                const stateElement = document.body.querySelector('.lumx-combobox-state');
+                expect(stateElement).toBeTruthy();
+                expect(stateElement?.textContent).toContain('No results found');
+            });
+        });
+
+        it('should show option count message when list has options', async () => {
+            renderWithState(defaultTemplate, {
+                translations: NB_OPTION_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                const stateElement = document.body.querySelector('.lumx-combobox-state');
+                expect(stateElement).toBeTruthy();
+                expect(stateElement?.textContent).toContain('10 result(s) available');
+            });
+        });
+
+        it('should update option count when filtering', async () => {
+            renderWithState(defaultTemplate, {
+                translations: NB_OPTION_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.type(input, 'bl');
+
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(1);
+            });
+
+            await waitFor(() => {
+                const stateElement = document.body.querySelector('.lumx-combobox-state');
+                expect(stateElement?.textContent).toContain('1 result(s) available');
+            });
+        });
+
+        it('should show empty message instead of option count when all filtered out', async () => {
+            renderWithState(defaultTemplate, {
+                translations: NB_OPTION_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await userEvent.type(input, 'zzz');
+
+            await waitFor(() => {
+                expect(getVisibleOptions().length).toBe(0);
+            });
+
+            await waitFor(() => {
+                const stateElement = document.body.querySelector('.lumx-combobox-state');
+                expect(stateElement?.textContent).toContain('No results found');
+                expect(stateElement?.textContent).not.toContain('result(s) available');
+            });
+        });
+    });
+
+    // ─── Loading and error states ────────────────────────────────
+
+    describe('Loading state', () => {
+        it('should render skeleton placeholders when status is loading', async () => {
+            renderWithState(defaultTemplate, {
+                listStatus: 'loading',
+                options: [],
+                translations: LOADING_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                expect(getSkeletons()).toHaveLength(3);
+            });
+        });
+
+        it('should hide options when status is loading', async () => {
+            renderWithState(defaultTemplate, {
+                listStatus: 'loading',
+                options: FRUITS,
+                translations: LOADING_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                // Options are replaced by skeletons
+                expect(getAllOptions()).toHaveLength(0);
+                expect(getSkeletons()).toHaveLength(3);
+            });
+        });
+
+        it('should render skeletons after options when status is loadingMore', async () => {
+            renderWithState(defaultTemplate, {
+                listStatus: 'loadingMore',
+                options: FRUITS.slice(0, 3),
+                translations: LOADING_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                // Options remain visible
+                expect(getVisibleOptions()).toHaveLength(3);
+                // One skeleton appended
+                expect(getSkeletons()).toHaveLength(1);
+            });
+        });
+
+        it('should keep options visible when status is loadingMore', async () => {
+            renderWithState(defaultTemplate, {
+                listStatus: 'loadingMore',
+                options: FRUITS.slice(0, 5),
+                translations: LOADING_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                const options = getVisibleOptions();
+                expect(options).toHaveLength(5);
+                expect(options[0].textContent).toBe('Apple');
+                expect(options[4].textContent).toBe('Cherry');
+            });
+        });
+
+        it('should not render skeletons when status is idle', () => {
+            renderWithState(defaultTemplate, {
+                listStatus: 'idle',
+                translations: LOADING_TRANSLATIONS,
+            });
+
+            expect(getSkeletons()).toHaveLength(0);
+        });
+
+        it('should guard onLoadMore when status is loading', async () => {
+            const onLoadMore = vi.fn();
+            renderWithState(defaultTemplate, {
+                listStatus: 'loading',
+                options: [],
+                onLoadMore,
+                translations: LOADING_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // Wait a tick to let InfiniteScroll potentially fire
+            await waitFor(() => {
+                expect(onLoadMore).not.toHaveBeenCalled();
+            });
+        });
+
+        it('should guard onLoadMore when status is loadingMore', async () => {
+            const onLoadMore = vi.fn();
+            renderWithState(defaultTemplate, {
+                listStatus: 'loadingMore',
+                options: FRUITS.slice(0, 3),
+                onLoadMore,
+                translations: LOADING_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // Wait a tick to let InfiniteScroll potentially fire
+            await waitFor(() => {
+                expect(onLoadMore).not.toHaveBeenCalled();
+            });
+        });
+
+        it('should guard onLoadMore when status is error', async () => {
+            const onLoadMore = vi.fn();
+            renderWithState(defaultTemplate, {
+                listStatus: 'error',
+                options: [],
+                onLoadMore,
+                translations: ERROR_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            // Wait a tick to let InfiniteScroll potentially fire
+            await waitFor(() => {
+                expect(onLoadMore).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('Error state', () => {
+        it('should render error message when status is error', async () => {
+            renderWithState(defaultTemplate, {
+                listStatus: 'error',
+                options: [],
+                translations: ERROR_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            await waitFor(() => {
+                const stateElement = document.body.querySelector('.lumx-combobox-state');
+                expect(stateElement).toBeTruthy();
+                expect(stateElement?.textContent).toContain('Failed to load');
+                expect(stateElement?.textContent).toContain('Please try again later');
+            });
+        });
+
+        it('should not render skeletons when status is error', async () => {
+            renderWithState(defaultTemplate, {
+                listStatus: 'error',
+                options: [],
+                translations: ERROR_TRANSLATIONS,
+            });
+            const input = getInput();
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input.getAttribute('aria-expanded')).toBe('true');
+            });
+
+            expect(getSkeletons()).toHaveLength(0);
+        });
+    });
+}

--- a/packages/lumx-core/src/js/components/SelectTextField/index.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/index.tsx
@@ -1,0 +1,198 @@
+import type { JSXElement, LumxClassName } from '../../types';
+import { renderSelectOptions } from '../../utils/select/renderSelectOptions';
+import { BaseSelectComponents, BaseSelectProps, SelectTextFieldStatus } from '../../utils/select/types';
+
+/**
+ * Defines the props for the core SelectTextField template.
+ */
+export interface SelectTextFieldProps<O = any> extends BaseSelectProps<O> {
+    /** Selected option (single) or options (multiple) — for marking options as selected. */
+    selected?: O | O[];
+
+    /** Field label (required). Also used as aria-label for the listbox. */
+    label: string;
+
+    /** Whether the listbox supports multiple selection. */
+    isMultiselectable?: boolean;
+
+    /** Props forwarded to Combobox.Input. */
+    inputProps?: Record<string, any>;
+
+    /** Props forwarded to Combobox.Popover. */
+    popoverProps?: Record<string, any>;
+
+    /** Props forwarded to Combobox.List (e.g. ref). */
+    listProps?: Record<string, any>;
+
+    /**
+     * Status of the dropdown list.
+     * - `'idle'` — Default state, no loading indicators.
+     * - `'loading'` — Full loading: shows skeleton placeholders, hides real options.
+     * - `'loadingMore'` — Paginated loading: appends a skeleton after existing options.
+     * - `'error'` — Error state: shows an error message in the dropdown.
+     * @default 'idle'
+     */
+    listStatus?: SelectTextFieldStatus;
+
+    /** Screen reader loading announcement (e.g. "Loading…"). */
+    loadingMessage?: string;
+
+    /**
+     * Message to display when the list has no visible options.
+     * Can be a plain string or a function receiving the current input value (for dynamic messages).
+     * When omitted, the empty state is not shown.
+     */
+    emptyMessage?: string | ((inputValue: string) => string);
+
+    /**
+     * Message callback to display the number of available options.
+     * Called with the current visible option count and should return a human-readable string.
+     * Displayed when the combobox is open, not empty, not loading, and not in error.
+     * When omitted, no option count message is shown.
+     */
+    nbOptionMessage?: (optionsLength: number) => string;
+
+    /** Error title displayed in the dropdown (e.g. "Failed to load"). */
+    errorMessage?: string;
+
+    /** Secondary error message (e.g. "Please try again"). */
+    errorTryReloadMessage?: string;
+
+    /** Callback fired when the dropdown open state changes. */
+    onOpen?: (isOpen: boolean) => void;
+
+    /** Chips element rendered inside the input (multiple selection). */
+    chips?: JSXElement;
+
+    /** Content to render before the options list. */
+    beforeOptions?: JSXElement;
+
+    /** Content to render after options. */
+    afterOptions?: JSXElement;
+
+    /**
+     * Callback fired to load more items (infinite scroll).
+     * When provided together with an injected `InfiniteScroll` component, an invisible
+     * sentinel element is rendered after the options to trigger loading via IntersectionObserver.
+     */
+    onLoadMore?: () => void;
+
+    /** IntersectionObserver options forwarded to the InfiniteScroll sentinel. */
+    infiniteScrollOptions?: IntersectionObserverInit;
+}
+
+/**
+ * Component display name.
+ */
+export const COMPONENT_NAME = 'SelectTextField';
+
+/**
+ * Component default class name.
+ */
+export const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-select-text-field';
+
+/**
+ * SelectTextField core template.
+ * Renders a Combobox with a text input trigger and a dropdown list of options.
+ * Supports search/filter, single selection, and multiple selection with chips.
+ *
+ * Framework-specific components are passed as a second argument by the React/Vue wrappers.
+ *
+ * @param props      Component props.
+ * @param components Injected framework-specific components.
+ * @return JSX element.
+ */
+export const SelectTextField = (props: SelectTextFieldProps, { Combobox, InfiniteScroll }: BaseSelectComponents) => {
+    const {
+        options,
+        getOptionId,
+        getOptionName,
+        getOptionDescription,
+        renderOption,
+        getSectionId,
+        renderSectionTitle,
+        selected,
+        label,
+        isMultiselectable,
+        inputProps,
+        popoverProps,
+        listProps,
+        listStatus = 'idle',
+        loadingMessage,
+        emptyMessage,
+        nbOptionMessage,
+        errorMessage,
+        errorTryReloadMessage,
+        onOpen,
+        chips,
+        beforeOptions,
+        afterOptions,
+        onLoadMore,
+        infiniteScrollOptions,
+    } = props;
+
+    const isFullLoading = listStatus === 'loading';
+    const isLoadingMore = listStatus === 'loadingMore';
+    const isError = listStatus === 'error';
+
+    return (
+        <Combobox.Provider onOpen={onOpen}>
+            <Combobox.Input label={label} {...inputProps} chips={chips} />
+
+            <Combobox.Popover
+                fitToAnchorWidth="minWidth"
+                fitWithinViewportHeight
+                placement="bottom-start"
+                {...popoverProps}
+            >
+                <Combobox.List {...listProps} aria-label={label} aria-multiselectable={isMultiselectable || undefined}>
+                    {beforeOptions}
+
+                    {isFullLoading ? (
+                        <Combobox.OptionSkeleton count={3} />
+                    ) : (
+                        renderSelectOptions(
+                            {
+                                options,
+                                getOptionId,
+                                getOptionName,
+                                getOptionDescription,
+                                renderOption,
+                                getSectionId,
+                                renderSectionTitle,
+                                selected,
+                            },
+                            { Combobox },
+                        )
+                    )}
+
+                    {afterOptions}
+
+                    {onLoadMore && InfiniteScroll && (
+                        <InfiniteScroll
+                            callback={() => {
+                                // Guard: prevent firing during loading or error states to avoid duplicate fetches.
+                                if (listStatus && listStatus !== 'idle') return;
+                                onLoadMore();
+                            }}
+                            options={infiniteScrollOptions}
+                        />
+                    )}
+
+                    {isLoadingMore && <Combobox.OptionSkeleton count={1} />}
+                </Combobox.List>
+
+                <Combobox.State
+                    loadingMessage={loadingMessage}
+                    emptyMessage={emptyMessage}
+                    nbOptionMessage={nbOptionMessage}
+                    errorMessage={isError ? errorMessage : undefined}
+                    errorTryReloadMessage={isError ? errorTryReloadMessage : undefined}
+                />
+            </Combobox.Popover>
+        </Combobox.Provider>
+    );
+};
+
+SelectTextField.displayName = COMPONENT_NAME;
+SelectTextField.className = CLASSNAME;

--- a/packages/lumx-core/src/js/utils/select/getOptionDisplayName.test.ts
+++ b/packages/lumx-core/src/js/utils/select/getOptionDisplayName.test.ts
@@ -1,0 +1,58 @@
+import { getOptionDisplayName } from './getOptionDisplayName';
+
+interface Fruit {
+    id: number;
+    name: string;
+}
+
+const apple: Fruit = { id: 1, name: 'Apple' };
+const getOptionName = (fruit: Fruit) => fruit.name;
+const getOptionId = (fruit: Fruit) => String(fruit.id);
+
+describe(getOptionDisplayName, () => {
+    it('should return empty string for undefined value', () => {
+        expect(getOptionDisplayName(undefined, getOptionName, getOptionId)).toBe('');
+    });
+
+    it('should return empty string for null value', () => {
+        // The function handles null at runtime even though the type only declares `undefined`.
+        expect(getOptionDisplayName(null as unknown as undefined, getOptionName, getOptionId)).toBe('');
+    });
+
+    it('should use getOptionName when it returns a non-null value', () => {
+        expect(getOptionDisplayName(apple, getOptionName, getOptionId)).toBe('Apple');
+    });
+
+    it('should fall back to getOptionId when getOptionName returns null', () => {
+        const nullName = () => null;
+        expect(getOptionDisplayName(apple, nullName, getOptionId)).toBe('1');
+    });
+
+    it('should fall back to getOptionId when getOptionName returns undefined', () => {
+        const undefinedName = () => undefined;
+        expect(getOptionDisplayName(apple, undefinedName, getOptionId)).toBe('1');
+    });
+
+    it('should use getOptionId when getOptionName is not provided', () => {
+        expect(getOptionDisplayName(apple, undefined, getOptionId)).toBe('1');
+    });
+
+    it('should return empty string when neither selector is provided', () => {
+        expect(getOptionDisplayName(apple)).toBe('');
+    });
+
+    it('should convert non-string getOptionId result to string', () => {
+        // getOptionId accepts Selector<O> (defaults to string), but String() is called at runtime.
+        const numericId = (fruit: Fruit) => fruit.id as any;
+        expect(getOptionDisplayName(apple, undefined, numericId)).toBe('1');
+    });
+
+    it('should convert non-string getOptionName result to string', () => {
+        const numericName = (fruit: Fruit) => fruit.id as any;
+        expect(getOptionDisplayName(apple, numericName)).toBe('1');
+    });
+
+    it('should work with string selectors', () => {
+        expect(getOptionDisplayName(apple, 'name' as any, 'id' as any)).toBe('Apple');
+    });
+});

--- a/packages/lumx-core/src/js/utils/select/getOptionDisplayName.ts
+++ b/packages/lumx-core/src/js/utils/select/getOptionDisplayName.ts
@@ -1,0 +1,24 @@
+import type { Selector } from '../../types';
+import { getWithSelector } from '../selectors';
+
+/**
+ * Get the display name for a single option value.
+ *
+ * Resolves the option's display name by trying `getOptionName` first,
+ * then falling back to `getOptionId`, returning `''` for nullish values.
+ */
+export function getOptionDisplayName<O>(
+    value: O | undefined,
+    getOptionName?: Selector<O, string | undefined | null>,
+    getOptionId?: Selector<O>,
+): string {
+    if (value === undefined || value === null) return '';
+    if (getOptionName) {
+        const name = getWithSelector(getOptionName, value);
+        if (name != null) return String(name);
+    }
+    if (getOptionId) {
+        return String(getWithSelector(getOptionId, value));
+    }
+    return '';
+}

--- a/packages/lumx-core/src/js/utils/select/renderSelectOptions.tsx
+++ b/packages/lumx-core/src/js/utils/select/renderSelectOptions.tsx
@@ -1,0 +1,76 @@
+import { getWithSelector, groupBySelector } from '../selectors';
+import type { JSXElement } from '../../types';
+import type { BaseSelectComponents, RenderSelectOptionsProps } from './types';
+
+/**
+ * Render options as ComboboxOption elements.
+ * Framework-specific components are passed as a second argument.
+ */
+export function renderSelectOptions<O>(
+    props: RenderSelectOptionsProps<O>,
+    components: BaseSelectComponents,
+): JSXElement {
+    const {
+        options,
+        getOptionId,
+        getOptionName,
+        getOptionDescription,
+        renderOption,
+        selected,
+        getSectionId,
+        renderSectionTitle,
+    } = props;
+    const { Combobox } = components;
+
+    // Render sections when getSectionId is provided.
+    if (getSectionId && options) {
+        const sections = groupBySelector(options, (option) => getWithSelector(getSectionId, option));
+
+        return Array.from(sections.entries()).map(([sectionId, sectionOptions]) => {
+            // When renderSectionTitle is provided, use the custom JSX as the label; otherwise fall back to sectionId.
+            const sectionLabel = renderSectionTitle ? renderSectionTitle(sectionId, sectionOptions) : sectionId;
+
+            return (
+                <Combobox.Section key={sectionId} label={sectionLabel}>
+                    {renderSelectOptions(
+                        {
+                            options: sectionOptions,
+                            getOptionId,
+                            getOptionName,
+                            getOptionDescription,
+                            renderOption,
+                            selected,
+                            // getSectionId intentionally omitted to render flat options inside.
+                        },
+                        components,
+                    )}
+                </Combobox.Section>
+            );
+        }) as any;
+    }
+
+    // Build a Set of selected IDs (works for both single value and arrays).
+    const selectedIds: Set<any> | undefined = selected
+        ? new Set((Array.isArray(selected) ? selected : [selected]).map((s) => getWithSelector(getOptionId, s)))
+        : undefined;
+
+    return options?.map((item, index) => {
+        const id = getWithSelector(getOptionId || getOptionName, item);
+        const name = getWithSelector(getOptionName || getOptionId, item);
+        const description = getOptionDescription && getWithSelector(getOptionDescription, item);
+        const isSelected = selectedIds?.has(id) ?? false;
+
+        // Delegate to the consumer's render function when provided.
+        // The consumer receives core-computed context and is responsible for rendering
+        // a <Combobox.Option> with those values forwarded.
+        if (renderOption) {
+            return renderOption(item, { index, value: id, isSelected, description }) as any;
+        }
+
+        return (
+            <Combobox.Option key={id} value={id} description={description} isSelected={isSelected}>
+                {name}
+            </Combobox.Option>
+        );
+    }) as any;
+}

--- a/packages/lumx-core/src/js/utils/select/types.ts
+++ b/packages/lumx-core/src/js/utils/select/types.ts
@@ -1,0 +1,211 @@
+import type { HasAriaDisabled } from '../../types/HasAriaDisabled';
+import type { HasClassName } from '../../types/HasClassName';
+import type { HasTheme } from '../../types/HasTheme';
+import type { JSXElement, Selector } from '../../types';
+
+/**
+ * Status of the SelectTextField dropdown list.
+ *
+ * - `'idle'` — Default state, no loading indicators.
+ * - `'loading'` — Full loading: shows skeleton placeholders, hides real options.
+ * - `'loadingMore'` — Paginated loading: appends a skeleton after existing options.
+ * - `'error'` — Error state: shows an error message in the dropdown.
+ */
+export type SelectTextFieldStatus = 'idle' | 'loading' | 'loadingMore' | 'error';
+
+/**
+ * Context passed to the `renderOption` callback alongside the option object.
+ * Contains core-computed values that the consumer should forward to `<Combobox.Option>`.
+ */
+export interface RenderOptionContext {
+    /** Index of the option in the current (possibly section-filtered) list. */
+    index: number;
+    /** Resolved option id (from `getOptionId`). Should be passed as `value` to `<Combobox.Option>`. */
+    value: any;
+    /** Whether this option is currently selected. Should be forwarded as `isSelected`. */
+    isSelected: boolean;
+    /** Resolved description string (from `getOptionDescription`), if any. Should be forwarded as `description`. */
+    description?: string | null;
+}
+
+export interface BaseSelectProps<O> {
+    /** List of option objects. */
+    options?: Array<O>;
+    /** Option object id selector. */
+    getOptionId: Selector<O>;
+    /** Option object name selector (falls back to id if not defined). */
+    getOptionName?: Selector<O, string | undefined | null>;
+    /** Option object description selector. */
+    getOptionDescription?: Selector<O, string | undefined | null>;
+    /**
+     * Custom option render function (core/Vue contract).
+     * Receives the option object and a `RenderOptionContext` with core-computed props (`value`,
+     * `isSelected`, `description`, `index`). The callee must render a `<Combobox.Option>` and
+     * forward those context values, including a unique `key`.
+     *
+     * @example (Vue / core level)
+     * renderOption={(fruit, { value, isSelected, description }) => (
+     *     <Combobox.Option key={value} value={value} isSelected={isSelected} description={description}>
+     *         <strong>{fruit.name}</strong>
+     *     </Combobox.Option>
+     * )}
+     */
+    renderOption?: (option: O, context: RenderOptionContext) => JSXElement;
+    /**
+     * Selector returning a section id string for each option. Options with the same
+     * section id are grouped together. The id is also used as the default displayed
+     * label unless `renderSectionTitle` is provided.
+     */
+    getSectionId?: Selector<O, string>;
+    /**
+     * Custom section title render function. Receives the section id and the options
+     * in that section. Returns custom JSX to display as the section header.
+     * When not provided, the section id is used as a plain text label.
+     */
+    renderSectionTitle?: (sectionId: string, options: O[]) => JSXElement;
+}
+
+export interface BaseSelectComponents {
+    /** Combobox compound component. */
+    Combobox: {
+        Provider: any;
+        Button: any;
+        Input: any;
+        Popover: any;
+        List: any;
+        Section: any;
+        Option: any;
+        State: any;
+        OptionSkeleton: any;
+    };
+    /** Framework-specific InfiniteScroll component (handles IntersectionObserver lifecycle). */
+    InfiniteScroll?: any;
+}
+
+/**
+ * Props for rendering select options.
+ */
+export interface RenderSelectOptionsProps<O> extends BaseSelectProps<O> {
+    /** Selected option (single) or options (multiple). */
+    selected?: O | O[];
+}
+
+/**
+ * Shared translation labels for SelectTextField wrappers (React and Vue).
+ */
+export interface SelectTextFieldTranslations {
+    /** Accessible label for the clear button. */
+    clearLabel?: string;
+    /** Accessible label for the show-suggestions toggle button. When omitted, the toggle button is not rendered. */
+    showSuggestionsLabel?: string;
+    /** Accessible label for the chip group. */
+    chipGroupLabel?: string;
+    /** Accessible label for the remove action on chips (used in visually hidden text). */
+    chipRemoveLabel?: string;
+    /** Screen reader loading announcement (e.g. "Loading…"). */
+    loadingMessage?: string;
+    /**
+     * Message to display when the list has no visible options.
+     * Can be a plain string or a function receiving the current input value (for dynamic messages).
+     * When omitted, the empty state is not shown.
+     */
+    emptyMessage?: string | ((inputValue: string) => string);
+    /**
+     * Message callback to display the number of available options.
+     * Called with the current visible option count and should return a human-readable string
+     * (e.g. `(n) => \`${n} result(s) available\``).
+     * Displayed when the combobox is open, not empty, not loading, and not in error.
+     * When omitted, no option count message is shown.
+     */
+    nbOptionMessage?: (optionsLength: number) => string;
+    /** Error title displayed in the dropdown (e.g. "Failed to load"). */
+    errorMessage?: string;
+    /** Secondary error message (e.g. "Please try again"). */
+    errorTryReloadMessage?: string;
+}
+
+/**
+ * Wrapper-level props shared between React and Vue SelectTextField implementations.
+ * These are framework-specific concerns (not part of the core template) that both
+ * wrappers need — extracted here to avoid duplication.
+ */
+export interface BaseSelectTextFieldWrapperProps<O>
+    extends Pick<
+            BaseSelectProps<O>,
+            'options' | 'getOptionId' | 'getOptionName' | 'getOptionDescription' | 'getSectionId'
+        >,
+        HasAriaDisabled,
+        HasClassName,
+        HasTheme {
+    /** Selection type: 'single' or 'multiple'. */
+    selectionType: 'single' | 'multiple';
+    /**
+     * Status of the dropdown list.
+     * @default 'idle'
+     */
+    listStatus?: SelectTextFieldStatus;
+    /**
+     * Controls how the combobox filters options as the user types.
+     *
+     * - `'auto'` — Options that do not match the input value are hidden client-side.
+     * - `'manual'` — All options remain visible; filtering is the consumer's
+     *   responsibility (e.g. by updating the `options` prop in response to `onSearch`).
+     * - `'off'` — Like `'manual'`, but the input is also set to `readOnly` and
+     *   `openOnFocus` defaults to `true` (useful for static dropdowns / pure pickers).
+     *
+     * This prop is independent of `onSearch`: you can use both together (e.g. client-side
+     * filtering + tracking search text for a "create" action), or use `filter: 'manual'`
+     * without `onSearch` for static dropdowns.
+     */
+    filter: 'auto' | 'manual' | 'off';
+    /**
+     * Controlled search input value.
+     * When provided, this value seeds (and resets) the visible search text in the input.
+     * Setting it to `''` (empty string) resets the input.
+     */
+    searchInputValue?: string;
+    /**
+     * Whether to show a clear button when a value is selected.
+     * @default true
+     */
+    hasClearButton?: boolean;
+    /**
+     * When true, the dropdown opens automatically when the input receives focus.
+     * When false (default), the dropdown only opens on click, typing, or keyboard navigation.
+     *
+     * @default false
+     */
+    openOnFocus?: boolean;
+    /** Field label (required). Also used as aria-label for the listbox. */
+    label: string;
+    /** Input placeholder text. */
+    placeholder?: string;
+    /** Leading icon (SVG path). */
+    icon?: string;
+    /** Disabled state. */
+    isDisabled?: boolean;
+    /** Required field indicator. */
+    isRequired?: boolean;
+    /** Error state flag. */
+    hasError?: boolean;
+    /** Error message text. */
+    error?: string;
+    /** Helper text below the field. */
+    helper?: string;
+    /** Native input id attribute. */
+    id?: string;
+    /** Native input name attribute. */
+    name?: string;
+    /** Whether displayed with valid style. */
+    isValid?: boolean;
+    /** Maximum string length (shows character counter). */
+    maxLength?: number;
+    /** Accessible label for the input element (overrides the visual label for screen readers). */
+    ariaLabel?: string;
+    /** Additional props forwarded to the Combobox.Input (and ultimately to TextField). */
+    inputProps?: Record<string, any>;
+    /** Props forwarded to the Combobox.Popover. */
+    popoverProps?: Record<string, any>;
+    /** Labels for the clear button, toggle button, and chip group. */
+    translations: SelectTextFieldTranslations;
+}

--- a/packages/lumx-core/src/scss/components/text-field/_mixins.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_mixins.scss
@@ -140,4 +140,5 @@
     align-items: center;
     margin: calc((var(--lumx-text-field-input-min-height) - var(--lumx-size-s) - 6px) / 2 + $lumx-chip-group-spacing) 0;
     gap: $lumx-chip-group-spacing * 2;
+    min-width: 0;
 }

--- a/packages/lumx-react/src/components/chip/Chip.tsx
+++ b/packages/lumx-react/src/components/chip/Chip.tsx
@@ -2,9 +2,8 @@ import { ReactNode } from 'react';
 
 import isFunction from 'lodash/isFunction';
 
-import { Theme } from '@lumx/react';
+import { Theme } from '@lumx/core/js/constants';
 import { useStopPropagation } from '@lumx/react/hooks/useStopPropagation';
-
 import { GenericProps } from '@lumx/react/utils/type';
 import { forwardRef } from '@lumx/react/utils/react/forwardRef';
 import { useTheme } from '@lumx/react/utils/theme/ThemeContext';

--- a/packages/lumx-react/src/components/combobox/ComboboxOption.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxOption.tsx
@@ -91,6 +91,13 @@ export const ComboboxOption = forwardRef<ComboboxOptionProps, HTMLLIElement>((pr
         return handle.registerOption(element, setIsFiltered);
     }, [handle]);
 
+    // Re-evaluate filter state when the option value changes.
+    useEffect(() => {
+        const element = internalRef.current;
+        if (!element || !handle) return;
+        handle.refilterOption(element);
+    }, [handle, value]);
+
     // Wrap `after` content in an option context so sub-components (e.g. OptionMoreInfo)
     // can access the parent option's ID for keyboard highlight detection.
     const optionContextValue = useMemo(() => ({ optionId }), [optionId]);

--- a/packages/lumx-react/src/components/combobox/ComboboxProvider.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo, useRef, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ComboboxHandle } from '@lumx/core/js/components/Combobox/types';
 import { useId } from '@lumx/react/hooks/useId';
@@ -11,6 +11,8 @@ import { ComboboxContext } from './context/ComboboxContext';
 export interface ComboboxProviderProps {
     /** Combobox content. */
     children?: ReactNode;
+    /** Callback fired when the combobox open state changes. */
+    onOpen?: (isOpen: boolean) => void;
 }
 
 /**
@@ -23,11 +25,21 @@ export interface ComboboxProviderProps {
  * @return React element.
  */
 export function ComboboxProvider(props: ComboboxProviderProps) {
-    const { children } = props;
+    const { children, onOpen } = props;
     const listboxId = useId();
     const anchorRef = useRef<HTMLElement>(null);
     const [handle, setHandle] = useState<ComboboxHandle | null>(null);
     const contextValue = useMemo(() => ({ handle, setHandle, listboxId, anchorRef }), [handle, listboxId]);
+
+    // Subscribe to the combobox open event and forward to the onOpen callback.
+    const onOpenRef = useRef(onOpen);
+    onOpenRef.current = onOpen;
+    useEffect(() => {
+        if (!handle) return undefined;
+        return handle.subscribe('open', (isOpen) => {
+            onOpenRef.current?.(isOpen);
+        });
+    }, [handle]);
 
     return <ComboboxContext.Provider value={contextValue}>{children}</ComboboxContext.Provider>;
 }

--- a/packages/lumx-react/src/components/combobox/ComboboxState.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxState.tsx
@@ -44,13 +44,15 @@ export interface ComboboxStateProps extends ReactToJSX<UIProps, 'state'> {
  *   mounted for at least 500ms. Suppresses the empty state while loading.
  * - **Empty state**: active when `emptyMessage` is provided and the list has no visible options
  *   and is not loading.
+ * - **Option count**: active when `nbOptionMessage` is provided and the list is not empty,
+ *   not loading, and not in error.
  *
  * @param props Component props.
  * @return React element.
  */
 export const ComboboxState = (props: ComboboxStateProps) => {
     const { handle } = useComboboxContext();
-    const emptyState = useComboboxEvent('emptyChange', undefined);
+    const optionsState = useComboboxEvent('optionsChange', undefined);
 
     const [isLoading, setIsLoading] = useState(false);
     const [shouldAnnounce, setShouldAnnounce] = useState(false);
@@ -61,7 +63,7 @@ export const ComboboxState = (props: ComboboxStateProps) => {
         return subscribeComboboxState(handle, { setIsLoading, setShouldAnnounce, setIsOpen });
     }, [handle]);
 
-    const state = { ...emptyState, isLoading, isOpen };
+    const state = { ...optionsState, isLoading, isOpen };
 
     // Only pass loadingMessage to core after the 500ms debounce threshold
     const loadingMessage = shouldAnnounce ? props.loadingMessage : undefined;

--- a/packages/lumx-react/src/components/list/ListSection.tsx
+++ b/packages/lumx-react/src/components/list/ListSection.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
 
-import { Text } from '@lumx/react';
 import { GenericProps } from '@lumx/react/utils/type';
 import {
     CLASSNAME,
@@ -12,6 +11,8 @@ import {
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
 import { forwardRef } from '@lumx/react/utils/react/forwardRef';
 import { useId } from '@lumx/react/hooks/useId';
+
+import { Text } from '../text';
 
 /**
  * Defines the props of the component.

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.stories.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.stories.tsx
@@ -1,0 +1,115 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useState, useCallback } from 'react';
+import type { Meta } from '@storybook/react-vite';
+
+import { withValueOnChange } from '@lumx/react/stories/decorators/withValueOnChange';
+import { setup, FRUITS, type Fruit } from '@lumx/core/js/components/SelectTextField/Stories';
+import { MULTI_TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+
+import { SelectTextField } from '.';
+import { Chip } from '../chip';
+import { Icon } from '../icon';
+import { Combobox } from '../combobox';
+
+const { meta, ...stories } = setup({
+    components: { SelectTextField },
+    decorators: { withValueOnChange },
+});
+
+const defaultMeta: Meta<typeof SelectTextField> = {
+    title: 'LumX components/select-text-field/SelectTextField',
+    ...meta,
+};
+export default defaultMeta;
+
+export const Default = { ...stories.Default };
+export const WithSelectedValue = { ...stories.WithSelectedValue };
+export const NoClearButton = { ...stories.NoClearButton };
+export const WithDescriptions = { ...stories.WithDescriptions };
+export const WithSections = { ...stories.WithSections };
+export const WithIcon = { ...stories.WithIcon };
+export const Disabled = { ...stories.Disabled };
+export const WithError = { ...stories.WithError };
+export const WithHelper = { ...stories.WithHelper };
+export const MultipleSelection = { ...stories.MultipleSelection };
+export const MultipleWithPreselected = { ...stories.MultipleWithPreselected };
+export const MultipleWithManyChips = { ...stories.MultipleWithManyChips };
+export const MultipleDisabled = { ...stories.MultipleDisabled };
+export const Loading = { ...stories.Loading };
+export const LoadingMore = { ...stories.LoadingMore };
+export const ErrorState = { ...stories.ErrorState };
+
+// ── Framework-specific stories (use React hooks for complex state) ──
+
+/** SelectTextField with custom option, section title, and chip rendering */
+export const CustomRender = () => {
+    const [value, setValue] = useState<Fruit[]>([FRUITS[0], FRUITS[4]]);
+
+    return (
+        <SelectTextField<Fruit>
+            selectionType="multiple"
+            label="Select fruits"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            getSectionId="category"
+            value={value}
+            onChange={(v) => setValue(v ?? [])}
+            translations={MULTI_TRANSLATIONS}
+            renderOption={(fruit: Fruit) => (
+                <Combobox.Option value={fruit.id} before={<Icon icon={fruit.icon} size="xs" />}>
+                    {fruit.name}
+                </Combobox.Option>
+            )}
+            renderSectionTitle={(sectionId: string, options: Fruit[]) => (
+                <>
+                    <Icon icon={options[0].categoryIcon} size="xs" />
+                    {sectionId}
+                </>
+            )}
+            renderChip={(fruit: Fruit) => <Chip before={<Icon icon={fruit.icon} size="xs" />}>{fruit.name}</Chip>}
+        />
+    );
+};
+
+/** SelectTextField with a creatable option before the list, using `searchInputValue` to reset the input after creation */
+export const WithCreatableOptionsRender = () => {
+    const [value, setValue] = useState<string[]>([]);
+    const [search, setSearch] = useState('');
+    const [options, setOptions] = useState(['Apple', 'Banana', 'Cherry', 'Orange']);
+
+    const handleCreate = useCallback((name: string) => {
+        setOptions((prev) => (prev.includes(name) ? prev : [...prev, name]));
+        setValue((prev) => [...prev, name]);
+        setSearch(''); // reset the search input after creation
+    }, []);
+
+    const canCreate = search && !options.some((o) => o.toLowerCase() === search.toLowerCase());
+
+    return (
+        <SelectTextField<string>
+            selectionType="multiple"
+            label="Select or create a fruit"
+            placeholder="Type to search or create..."
+            options={options}
+            filter="auto"
+            getOptionId={String}
+            value={value}
+            onChange={(v) => setValue(v ?? [])}
+            onSearch={setSearch}
+            searchInputValue={search}
+            beforeOptions={
+                canCreate ? (
+                    <SelectTextField.Section>
+                        <SelectTextField.Option value={`__create__${search}`} onClick={() => handleCreate(search)}>
+                            {`Create "${search}"`}
+                        </SelectTextField.Option>
+                    </SelectTextField.Section>
+                ) : undefined
+            }
+            translations={MULTI_TRANSLATIONS}
+        />
+    );
+};

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.test.stories.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.test.stories.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useState, useCallback } from 'react';
+import { setup } from '@lumx/core/js/components/SelectTextField/TestStories';
+import { FRUITS, type Fruit } from '@lumx/core/js/components/SelectTextField/Stories';
+import { TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { SelectTextField } from '.';
+import { Combobox } from '../combobox';
+
+const { meta, ...testStories } = setup({
+    components: { SelectTextField, Combobox },
+});
+
+export default { ...meta, title: 'LumX components/select-text-field/SelectTextField/Tests' };
+
+export const ClickOutsideCloses = { ...testStories.ClickOutsideCloses };
+export const BlurResetsToSelectedValue = { ...testStories.BlurResetsToSelectedValue };
+export const BlurResetsToEmpty = { ...testStories.BlurResetsToEmpty };
+export const MultiBlurResetsSearch = { ...testStories.MultiBlurResetsSearch };
+
+// React-specific test stories (use React hooks for stateful rendering)
+
+/** Test infinite scroll loads more options when scrolling to the bottom */
+export const WithInfiniteScroll = {
+    ...testStories.WithInfiniteScroll,
+    render: () => {
+        // Start with 3 pages of items so the popover overflows and the
+        // IntersectionObserver sentinel doesn't fire until the user scrolls.
+        const initialItems = Array.from({ length: 3 }).flatMap((_, page) =>
+            FRUITS.map((f, i) => ({ ...f, id: `${f.id}-${page * FRUITS.length + i}` })),
+        );
+        const [items, setItems] = useState(initialItems);
+        const [value, setValue] = useState<Fruit | undefined>();
+
+        const onLoadMore = useCallback(() => {
+            setItems((prev) => {
+                if (prev.length >= 200) return prev;
+                const offset = prev.length;
+                return prev.concat(FRUITS.map((f, i) => ({ ...f, id: `${f.id}-${offset + i}` })));
+            });
+        }, []);
+
+        return (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={items}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={setValue}
+                onLoadMore={onLoadMore}
+                translations={TRANSLATIONS}
+            />
+        );
+    },
+};

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.test.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import selectTextFieldTests from '@lumx/core/js/components/SelectTextField/Tests';
+import { SelectTextField } from '.';
+import { Combobox } from '../combobox';
+
+/**
+ * Render a SelectTextField template with controlled state management.
+ * Manages a `value` state and wires it through the `onChange` prop.
+ *
+ * @param template    JSX render function receiving `{ value, onChange, ... }`.
+ * @param initialArgs Initial props (value, spies, etc.).
+ */
+function renderWithState(template: (props: any) => React.JSX.Element, initialArgs: Record<string, any> = {}) {
+    const Wrapper = () => {
+        const [value, setValue] = React.useState(initialArgs.value ?? undefined);
+        const props = {
+            ...initialArgs,
+            value,
+            onChange: (v: any) => {
+                setValue(v);
+                initialArgs.onChange?.(v);
+            },
+        };
+        return template(props);
+    };
+    return render(<Wrapper />);
+}
+
+describe('<SelectTextField>', () => {
+    selectTextFieldTests({
+        components: { SelectTextField, Combobox },
+        renderWithState,
+    });
+});

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
@@ -1,0 +1,358 @@
+import React, { SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
+
+import type { ChipProps } from '@lumx/core/js/components/Chip';
+import { getWithSelector } from '@lumx/core/js/utils/selectors';
+import { type RenderOptionContext, type BaseSelectTextFieldWrapperProps } from '@lumx/core/js/utils/select/types';
+import { getOptionDisplayName } from '@lumx/core/js/utils/select/getOptionDisplayName';
+import { SelectTextField as UI } from '@lumx/core/js/components/SelectTextField';
+import { isComponentType } from '@lumx/react/utils/type';
+import { Combobox, type ComboboxPopoverProps } from '../combobox';
+import { InfiniteScroll } from '../../utils/InfiniteScroll';
+import { useMergeRefs } from '../../utils/react/mergeRefs';
+import { SelectionChipGroup } from '../chip/SelectionChipGroup';
+
+interface BaseSelectTextFieldProps<O = any> extends BaseSelectTextFieldWrapperProps<O> {
+    /**
+     * Custom option render function. Must return a `<Combobox.Option>` element with custom
+     * children/props. Core-computed props (`value`, `isSelected`, `description`, `key`) are
+     * merged in automatically — the consumer does not need to forward them.
+     */
+    renderOption?: (option: O, index: number) => React.ReactNode;
+    /**
+     * Custom section title render function. Receives the section id and the options
+     * in that section. Returns custom JSX to display as the section header.
+     * When not provided, the section id is used as a plain text label.
+     */
+    renderSectionTitle?: (sectionId: string, options: O[]) => React.ReactNode;
+    /**
+     * Callback fired when the search input text changes.
+     * Independent of `filter`: both can be used together (e.g. client-side
+     * filtering + tracking search text for a "create" action).
+     */
+    onSearch?: (searchText: string) => void;
+    /** Ref to the underlying input element. */
+    inputRef?: React.Ref<HTMLInputElement>;
+    /** Callback to load more items (infinite scroll). */
+    onLoadMore?: () => void;
+    /** Content to render before the options list. */
+    beforeOptions?: React.ReactNode;
+    /** Props forwarded to the Combobox.List popover. */
+    popoverProps?: ComboboxPopoverProps;
+    /** On blur callback. */
+    onBlur?: (event: React.FocusEvent) => void;
+    /** On focus callback. */
+    onFocus?: (event: React.FocusEvent) => void;
+    /** On key down callback. */
+    onKeyDown?: (event: React.KeyboardEvent) => void;
+    /** On clear callback (fired when the clear button is clicked). */
+    onClear?: (event?: SyntheticEvent) => void;
+    /** Callback fired when the dropdown open state changes. */
+    onOpen?: (isOpen: boolean) => void;
+}
+
+/** Single selection props **/
+export interface SingleSelectTextFieldProps<O = any> extends BaseSelectTextFieldProps<O> {
+    /** Selection type. */
+    selectionType: 'single';
+    /** Selected option object. */
+    value?: O;
+    /** Callback on option selected (or cleared). */
+    onChange?: (newValue?: O) => void;
+    /** Not available in single selection. */
+    renderChip?: never;
+}
+
+/** Multiple selection props **/
+export interface MultipleSelectTextFieldProps<O = any> extends BaseSelectTextFieldProps<O> {
+    /** Selection type. */
+    selectionType: 'multiple';
+    /** Selected option objects. */
+    value?: O[];
+    /** Callback on option array changed. */
+    onChange?: (newValue?: O[]) => void;
+    /** Custom chip render function. */
+    renderChip?: (option: O) => React.ReactNode;
+    /** Customize chip props per selected option. */
+    getChipProps?: (option: O) => Partial<ChipProps>;
+}
+
+/**
+ * SelectTextField props — supports both single and multiple selection.
+ */
+export type SelectTextFieldProps<O = any> = SingleSelectTextFieldProps<O> | MultipleSelectTextFieldProps<O>;
+
+/**
+ * A text field with a select dropdown to choose between a list of options.
+ * Supports search/filter, single selection, and multiple selection with chips.
+ */
+export const SelectTextField = <O,>(props: SelectTextFieldProps<O>) => {
+    const {
+        // Options
+        options,
+        getOptionId,
+        getOptionName,
+        getOptionDescription,
+        renderOption,
+        getSectionId,
+        renderSectionTitle,
+        // Selection
+        selectionType,
+        value,
+        onChange,
+        // Search / filter
+        filter,
+        openOnFocus,
+        onSearch,
+        searchInputValue: externalSearchValue,
+        // Clear
+        hasClearButton = true,
+        // Status
+        listStatus = 'idle',
+        // Text field
+        className,
+        label,
+        placeholder,
+        icon,
+        isDisabled,
+        'aria-disabled': ariaDisabled,
+        isRequired,
+        hasError,
+        error,
+        helper,
+        id,
+        name,
+        isValid,
+        maxLength,
+        ariaLabel,
+        inputRef: externalInputRef,
+        // Event callbacks
+        onBlur: externalOnBlur,
+        onFocus,
+        onKeyDown,
+        onClear: externalOnClear,
+        onOpen,
+        // Forwarding
+        inputProps: consumerInputProps,
+        // Load more
+        onLoadMore,
+        beforeOptions,
+        // Popover
+        popoverProps,
+        // Theme
+        theme,
+        // Translations
+        translations,
+    } = props;
+
+    const isAnyDisabled = !!isDisabled || ariaDisabled === true || ariaDisabled === 'true';
+    const isMultiple = selectionType === 'multiple';
+    const renderChip = isMultiple ? (props as MultipleSelectTextFieldProps<O>).renderChip : undefined;
+    const getChipProps = isMultiple ? (props as MultipleSelectTextFieldProps<O>).getChipProps : undefined;
+
+    /* Wrap the consumer's renderOption to inject core-computed props.
+     * The consumer returns a <Combobox.Option> with custom children/props.
+     * This wrapper validates the element type, extracts the consumer's props, and
+     * re-renders a <Combobox.Option> merging them with core-computed value/isSelected/description/key. */
+    const wrappedRenderOption = renderOption
+        ? (option: O, { index, value: optionValue, isSelected, description }: RenderOptionContext) => {
+              const node = renderOption(option, index);
+              if (!isComponentType(Combobox.Option)(node)) return null;
+              const { children, ...customProps } = (node as React.ReactElement).props;
+              return (
+                  <Combobox.Option
+                      key={optionValue}
+                      {...customProps}
+                      value={optionValue}
+                      isSelected={isSelected}
+                      description={description}
+                  >
+                      {children}
+                  </Combobox.Option>
+              );
+          }
+        : undefined;
+
+    const [listElement, setListElement] = useState<HTMLElement | null>(null);
+    const localInputRef = useRef<HTMLInputElement>(null);
+    const mergedInputRef = useMergeRefs(localInputRef, externalInputRef);
+
+    // Track whether the user is actively typing a search.
+    const [isSearching, setIsSearching] = useState(() => Boolean(externalSearchValue));
+    const [searchText, setSearchText] = useState(() => externalSearchValue ?? '');
+
+    /* Sync external controlled search value into internal state when it changes.
+     * This allows the parent to seed or reset the visible search text
+     * (e.g., setting searchInputValue='' after creating an entry from beforeOptions). */
+    useEffect(() => {
+        if (externalSearchValue !== undefined) {
+            setSearchText(externalSearchValue);
+            setIsSearching(Boolean(externalSearchValue));
+        }
+    }, [externalSearchValue]);
+
+    // The displayed value shown in the input
+    let displayValue;
+    if (isMultiple || isSearching) {
+        displayValue = searchText;
+    } else if (!isMultiple) {
+        displayValue = getOptionDisplayName(value as O | undefined, getOptionName, getOptionId);
+    }
+
+    // Map option id selection to option object selection.
+    const handleSelect = useCallback(
+        (selectedOption: { value: string }) => {
+            const selectedValue = selectedOption.value;
+            const newOption =
+                selectedValue && options?.find((option) => getWithSelector(getOptionId, option) === selectedValue);
+
+            if (!isMultiple) {
+                onChange?.(newOption as any);
+            } else {
+                const currentValue = (value as any[]) || [];
+                const existingIndex = currentValue.findIndex(
+                    (item) => getWithSelector(getOptionId, item) === selectedValue,
+                );
+
+                if (existingIndex === -1) {
+                    // Skip if no matching option found (e.g. beforeOptions custom actions).
+                    if (newOption) {
+                        onChange?.([...currentValue, newOption] as any);
+                    }
+                } else {
+                    // Remove option (toggle off)
+                    const updated = [...currentValue];
+                    updated.splice(existingIndex, 1);
+                    onChange?.(updated as any);
+                }
+            }
+
+            // Reset search state after selection.
+            setIsSearching(false);
+            setSearchText('');
+            onSearch?.('');
+        },
+        [getOptionId, isMultiple, onChange, onSearch, options, value],
+    );
+
+    // Handle text input changes (search).
+    const handleInputChange = useCallback(
+        (inputValue: string) => {
+            setIsSearching(true);
+            setSearchText(inputValue);
+            onSearch?.(inputValue);
+
+            // When the user clears the input (single mode only), clear the selection too.
+            if (!isMultiple && inputValue === '' && value !== undefined && value !== null) {
+                (onChange as ((newValue?: O) => void) | undefined)?.(undefined);
+            }
+        },
+        [isMultiple, onChange, onSearch, value],
+    );
+
+    // Handle clear button click (single mode only).
+    const handleClear = useCallback(
+        (event?: SyntheticEvent) => {
+            // Prevent the clear event from being handled as a regular input change.
+            event?.stopPropagation();
+            (onChange as ((newValue?: O) => void) | undefined)?.(undefined);
+            setIsSearching(false);
+            setSearchText('');
+            onSearch?.('');
+            externalOnClear?.(event);
+        },
+        [onChange, onSearch, externalOnClear],
+    );
+
+    // Handle blur: reset input to selected value name, then call consumer's onBlur.
+    const handleBlur = useCallback(
+        (event?: React.FocusEvent) => {
+            setIsSearching(false);
+            setSearchText('');
+            onSearch?.('');
+            externalOnBlur?.(event as React.FocusEvent);
+        },
+        [externalOnBlur, onSearch],
+    );
+
+    const showClear = !isMultiple && !isAnyDisabled && hasClearButton && value !== undefined && value !== null;
+
+    const chips = isMultiple ? (
+        <SelectionChipGroup
+            value={value as O[] | undefined}
+            theme={theme}
+            getOptionId={getOptionId}
+            getOptionName={getOptionName}
+            onChange={onChange as ((newValue?: O[]) => void) | undefined}
+            inputRef={localInputRef as React.RefObject<HTMLInputElement>}
+            isDisabled={isAnyDisabled}
+            label={translations.chipGroupLabel ?? label}
+            chipRemoveLabel={translations.chipRemoveLabel}
+            renderChip={renderChip}
+            getChipProps={getChipProps}
+        />
+    ) : undefined;
+
+    // The core template is not generic, so we cast selectors when forwarding to UI().
+    return UI(
+        {
+            options,
+            getOptionId: getOptionId as any,
+            getOptionName: getOptionName as any,
+            getOptionDescription: getOptionDescription as any,
+            renderOption: wrappedRenderOption,
+            getSectionId: getSectionId as any,
+            renderSectionTitle: renderSectionTitle as any,
+            selected: value,
+            label,
+            isMultiselectable: isMultiple,
+            listStatus,
+            onOpen,
+            loadingMessage: translations.loadingMessage,
+            emptyMessage: translations.emptyMessage,
+            nbOptionMessage: translations.nbOptionMessage,
+            errorMessage: translations.errorMessage,
+            errorTryReloadMessage: translations.errorTryReloadMessage,
+            inputProps: {
+                ...consumerInputProps,
+                placeholder,
+                icon,
+                value: displayValue,
+                onChange: handleInputChange,
+                onSelect: handleSelect,
+                onBlur: handleBlur,
+                onFocus,
+                onKeyDown,
+                inputRef: mergedInputRef,
+                isDisabled,
+                'aria-disabled': ariaDisabled,
+                isRequired,
+                hasError,
+                error,
+                helper,
+                id,
+                name,
+                isValid,
+                maxLength,
+                'aria-label': ariaLabel,
+                clearButtonProps: showClear ? { label: translations.clearLabel } : undefined,
+                onClear: handleClear,
+                toggleButtonProps: translations.showSuggestionsLabel
+                    ? { label: translations.showSuggestionsLabel }
+                    : undefined,
+                filter,
+                openOnFocus,
+                className,
+                theme,
+            },
+            popoverProps,
+            listProps: { ref: setListElement },
+            chips,
+            beforeOptions,
+            onLoadMore,
+            infiniteScrollOptions: { root: listElement, rootMargin: '100px' },
+        },
+        { Combobox, InfiniteScroll },
+    );
+};
+
+SelectTextField.displayName = 'SelectTextField';

--- a/packages/lumx-react/src/components/select-text-field/index.ts
+++ b/packages/lumx-react/src/components/select-text-field/index.ts
@@ -1,0 +1,29 @@
+import { ComboboxOption } from '../combobox/ComboboxOption';
+import { ComboboxSection } from '../combobox/ComboboxSection';
+import { ComboboxOptionMoreInfo } from '../combobox/ComboboxOptionMoreInfo';
+import { ComboboxOptionSkeleton } from '../combobox/ComboboxOptionSkeleton';
+import { ListDivider } from '../list/ListDivider';
+import { SelectTextField as _SelectTextField } from './SelectTextField';
+
+export {
+    type SelectTextFieldProps,
+    type SingleSelectTextFieldProps,
+    type MultipleSelectTextFieldProps,
+} from './SelectTextField';
+export type { SelectTextFieldStatus, SelectTextFieldTranslations } from '@lumx/core/js/utils/select/types';
+
+/**
+ * SelectTextField compound component.
+ */
+export const SelectTextField = Object.assign(_SelectTextField, {
+    /** Selectable option within the dropdown list. */
+    Option: ComboboxOption,
+    /** Labelled group of options. */
+    Section: ComboboxSection,
+    /** Info icon on an option that reveals a popover with additional details. */
+    OptionMoreInfo: ComboboxOptionMoreInfo,
+    /** Skeleton loading placeholder for options being fetched. */
+    OptionSkeleton: ComboboxOptionSkeleton,
+    /** Visual separator between option groups (alias for ListDivider). Purely decorative — invisible to screen readers. */
+    Divider: ListDivider,
+});

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -1,6 +1,6 @@
 import { Ref, RefObject, SyntheticEvent, useRef, useState } from 'react';
 
-import { IconButton, IconButtonProps, InputLabelProps, Theme } from '@lumx/react';
+import { Theme } from '@lumx/core/js/constants';
 import { GenericProps } from '@lumx/react/utils/type';
 import { mergeRefs } from '@lumx/react/utils/react/mergeRefs';
 import { useId } from '@lumx/react/hooks/useId';
@@ -17,6 +17,8 @@ import {
     generateAccessibilityIds,
 } from '@lumx/core/js/components/TextField/TextField';
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
+import { type InputLabelProps } from '../input-label';
+import { IconButton, type IconButtonProps } from '../button';
 import { RawInputText } from './RawInputText';
 import { RawInputTextarea } from './RawInputTextarea';
 

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -47,6 +47,7 @@ export * from './components/progress';
 export * from './components/progress-tracker';
 export * from './components/radio-button';
 export * from './components/select';
+export * from './components/select-text-field';
 export * from './components/side-navigation';
 export * from './components/skeleton';
 export * from './components/slider';

--- a/packages/lumx-react/src/utils/react/wrapChildrenIconWithSpaces.tsx
+++ b/packages/lumx-react/src/utils/react/wrapChildrenIconWithSpaces.tsx
@@ -1,6 +1,6 @@
 import React, { Children } from 'react';
 import { isComponentType } from '@lumx/react/utils/type';
-import { Icon } from '@lumx/react';
+import { Icon } from '@lumx/react/components/icon';
 
 /** Force wrap spaces around icons to make sure they are never stuck against text. */
 export function wrapChildrenIconWithSpaces(children: React.ReactNode): React.ReactNode {

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -10,6 +10,7 @@ import { TextField } from '../text-field';
 import { IconButton } from '../button';
 import type { IconButtonProps } from '../button/IconButton';
 import { useComboboxContext } from './context/ComboboxContext';
+import { useComboboxEvent } from './context/useComboboxEvent';
 import { useComboboxOpen } from './context/useComboboxOpen';
 
 /**
@@ -92,7 +93,11 @@ const ComboboxInput = defineComponent(
             setHandle(null);
         });
 
+        // Track whether the option list is empty to disable the toggle button.
+        const optionsState = useComboboxEvent('optionsChange', undefined);
+
         const handleToggle = () => {
+            if (optionsState.value?.optionsLength === 0) return;
             setIsOpen(!isOpen.value);
             inputEl.value?.focus();
         };

--- a/packages/lumx-vue/src/components/combobox/ComboboxOption.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxOption.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref, useAttrs } from 'vue';
+import { defineComponent, ref, useAttrs, watch, toRef } from 'vue';
 
 import {
     ComboboxOption as UI,
@@ -60,6 +60,19 @@ const ComboboxOption = defineComponent(
                 });
             }
         });
+
+        // Re-evaluate filter state when the option value changes.
+        watch(
+            toRef(props, 'value'),
+            () => {
+                const handleValue = handle.value;
+                const element = optionRef.value;
+                if (!handleValue || !element) return;
+                handleValue.refilterOption(element);
+            },
+            // ensuring data-value is committed before re-evaluating the filter.
+            { flush: 'post' },
+        );
 
         // Update optionRef when the option element is mounted/unmounted
         const setOptionRef = (el: Element | null) => {

--- a/packages/lumx-vue/src/components/combobox/ComboboxProvider.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxProvider.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref, shallowRef } from 'vue';
+import { defineComponent, onWatcherCleanup, ref, shallowRef, useAttrs, watch } from 'vue';
 
 import type { ComboboxHandle } from '@lumx/core/js/components/Combobox/types';
 
@@ -20,7 +20,8 @@ export interface ComboboxProviderProps {}
  * @return Vue element.
  */
 const ComboboxProvider = defineComponent(
-    (_props: ComboboxProviderProps, { slots }) => {
+    (_props: ComboboxProviderProps, { slots, emit }) => {
+        const attrs = useAttrs();
         const listboxId = useId();
         const anchorRef = ref<HTMLElement | null>(null);
         const handle = shallowRef<ComboboxHandle | null>(null);
@@ -30,12 +31,26 @@ const ComboboxProvider = defineComponent(
 
         provideComboboxContext({ handle, setHandle, listboxId, anchorRef });
 
+        // Subscribe to the combobox open event and forward to the onOpen callback.
+        watch(handle, (handleValue) => {
+            if (!handleValue) return;
+            const unsubscribe = handleValue.subscribe('open', (isOpen) => {
+                (attrs.onOpen as any)?.(isOpen);
+                emit('open', isOpen);
+            });
+            onWatcherCleanup(unsubscribe);
+        });
+
         return () => slots.default?.();
     },
     {
         name: 'LumxComboboxProvider',
         inheritAttrs: false,
         props: {},
+        emits: {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            open: (isOpen: boolean) => true,
+        },
     },
 );
 

--- a/packages/lumx-vue/src/components/combobox/ComboboxState.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxState.tsx
@@ -26,7 +26,7 @@ export type ComboboxStateProps = VueToJSXProps<UIProps, 'state'>;
 const ComboboxState = defineComponent(
     (props: ComboboxStateProps) => {
         const { handle } = useComboboxContext();
-        const emptyState = useComboboxEvent('emptyChange', undefined);
+        const optionsState = useComboboxEvent('optionsChange', undefined);
         const isLoading = ref(false);
         const shouldAnnounce = ref(false);
         const isOpen = ref(false);
@@ -48,13 +48,14 @@ const ComboboxState = defineComponent(
         });
 
         return () => {
-            const state = { ...emptyState.value, isLoading: isLoading.value, isOpen: isOpen.value };
+            const state = { ...optionsState.value, isLoading: isLoading.value, isOpen: isOpen.value };
             // Only pass loadingMessage to core after the 500ms debounce threshold
             const loadingMessage = shouldAnnounce.value ? props.loadingMessage : undefined;
 
             return UI(
                 {
                     emptyMessage: props.emptyMessage,
+                    nbOptionMessage: props.nbOptionMessage,
                     errorMessage: props.errorMessage,
                     errorTryReloadMessage: props.errorTryReloadMessage,
                     loadingMessage,
@@ -69,6 +70,7 @@ const ComboboxState = defineComponent(
         inheritAttrs: false,
         props: keysOf<ComboboxStateProps>()(
             'emptyMessage',
+            'nbOptionMessage',
             'errorMessage',
             'errorTryReloadMessage',
             'loadingMessage',

--- a/packages/site-demo/content/product/components/select-text-field/index.mdx
+++ b/packages/site-demo/content/product/components/select-text-field/index.mdx
@@ -1,0 +1,118 @@
+---
+frameworks: ['react']
+---
+
+import * as ReactDemoSingleSelection from './react/single-selection.tsx';
+import * as ReactDemoMultipleSelection from './react/multiple-selection.tsx';
+import * as ReactDemoWithSections from './react/with-sections.tsx';
+import * as ReactDemoCustomRender from './react/custom-render.tsx';
+import * as ReactDemoLoading from './react/loading.tsx';
+import * as ReactDemoLoadingMore from './react/loading-more.tsx';
+import * as ReactDemoEmpty from './react/empty.tsx';
+import * as ReactDemoListError from './react/list-error.tsx';
+import ReactSelectTextField from 'lumx-docs:@lumx/react/components/select-text-field/SelectTextField';
+
+# Select text field
+
+**Select text fields let users choose from a list of options with built-in search and filtering.**\
+Use them when users need to select one or more items from a searchable dropdown list.
+
+## Single selection
+
+Set `selectionType="single"` for single selection mode. Users can type to filter options and select one.
+
+<DemoBlock demo={{ react: ReactDemoSingleSelection }} />
+
+## Multiple selection
+
+Set `selectionType="multiple"` to allow selecting multiple options. Selected values are displayed as chips below the input.
+
+<DemoBlock demo={{ react: ReactDemoMultipleSelection  }} />
+
+## Options
+
+Each option is an object. Use selector props to tell the component how to read each option:
+
+- `getOptionId` **(required)** — resolves a unique identifier for each option (used internally for selection tracking and as the combobox `value`).
+- `getOptionName` — resolves the display label shown in the dropdown and in the input when selected. Falls back to the id when not provided.
+- `getOptionDescription` — resolves an optional secondary line of text displayed below the option name.
+
+### Sections
+
+Options can be grouped in sections via `getSectionId`.
+
+<DemoBlock demo={{ react: ReactDemoWithSections }} />
+
+### Custom rendering
+
+Beyond simple text customization, options, section title and chips (multiple selection only) can be customized.
+
+Extra options can also be injected at the top of the dropdown list — for example, a "Create" option that lets users add new entries on the fly.
+
+<DemoBlock demo={{ react: ReactDemoCustomRender  }} />
+
+## Input options
+
+The select text field input shares the same options as the [TextField](/product/components/text-field):
+
+- `isDisabled`/`aria-disabled` — prevents interaction with the field.
+- `hasError` and `error` — displays an error state with a message.
+- `isValid` — displays a success state (green border and check icon).
+- `isRequired` — marks the field as required (asterisk indicator).
+
+## List states
+
+The select text field dropdown list have alternative states to handle server-backed listing and search.
+
+### Loading
+
+Set `listStatus="loading"` to display skeleton placeholders while options are being fetched. Real options are hidden until loading completes.
+
+<DemoBlock demo={{ react: ReactDemoLoading  }} />
+
+### Loading more
+
+Set `listStatus="loadingMore"` to append a skeleton placeholder at the bottom of the existing options, indicating that more items are being loaded (e.g. during infinite scroll pagination).
+
+<DemoBlock demo={{ react: ReactDemoLoadingMore  }} />
+
+### Empty
+
+Provide `translations.emptyMessage` to display a message when no options are available. The message can be a static string or a function receiving the current input value for dynamic messages.
+
+<DemoBlock demo={{ react: ReactDemoEmpty  }} />
+
+### Error
+
+Set `listStatus="error"` to display an error state inside the dropdown. Use `translations.errorMessage` for the error title and optionally `translations.errorTryReloadMessage` for a secondary message.
+
+<DemoBlock demo={{ react: ReactDemoListError  }} />
+
+## Filter types
+
+The `filter` prop controls how option filtering behaves:
+
+- **`"auto"`** — Options that do not match the input value are automatically hidden client-side. Best for small, static option lists.
+- **`"manual"`** — All options remain visible; filtering is the consumer's responsibility. Use this when options are fetched from a server in response to the `onSearch` callback.
+- **`"off"`** — The input is set to read-only (no typing). The dropdown opens on focus, acting as a pure picker. Useful for static dropdowns where search is not needed.
+
+## Accessibility concerns
+
+`SelectTextField` is built on the combobox pattern and uses the WAI-ARIA combobox role internally.
+
+- Always provide a `label` prop so the field is properly announced by screen readers.
+- The `translations` prop is required and must include an accessible label for the clear button (`clearLabel`). Optionally provide `showSuggestionsLabel` for the toggle button; when omitted, the toggle button is not rendered.
+- In multiple selection mode, also provide `chipGroupLabel` (accessible label for the chip group) and `chipRemoveLabel` (appended to each chip's aria-label to indicate it can be removed, e.g. "Apple - Remove").
+- Provide `loadingMessage` so screen readers announce when options are being loaded (announced via a live region after a short debounce).
+- Provide `nbOptionMessage` to announce the number of available options when the list updates.
+
+Select text fields can be disabled in two ways:
+
+- `isDisabled` which completely disables the select text field. It's not focusable and pointer events (hover, click, etc.) are
+  all disabled too. You'll have to find another way to indicate to users that the field is here and why it is disabled.
+- `aria-disabled` only disable editing the select text field (read only) so it's still focusable and accessible. You'll have
+  to setup either a `helper`, a tooltip or an aria description to explain to the user why this field is disabled.
+
+## Properties
+
+<PropTable docs={{ react: ReactSelectTextField  }} />

--- a/packages/site-demo/content/product/components/select-text-field/react/custom-render.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/custom-render.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useState } from 'react';
+import { Chip, Combobox, Icon, SelectTextField } from '@lumx/react';
+import {
+    mdiFoodApple,
+    mdiFoodForkDrink,
+    mdiFruitCitrus,
+    mdiFruitGrapes,
+    mdiFruitPineapple,
+    mdiSprout,
+} from '@lumx/icons';
+
+interface Fruit {
+    id: string;
+    name: string;
+    icon: string;
+    category: string;
+    categoryIcon: string;
+}
+
+const INITIAL_FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple', icon: mdiFoodApple, category: 'Pome', categoryIcon: mdiFoodApple },
+    { id: 'banana', name: 'Banana', icon: mdiSprout, category: 'Tropical', categoryIcon: mdiFruitPineapple },
+    {
+        id: 'pineapple',
+        name: 'Pineapple',
+        icon: mdiFruitPineapple,
+        category: 'Tropical',
+        categoryIcon: mdiFruitPineapple,
+    },
+    { id: 'grape', name: 'Grape', icon: mdiFruitGrapes, category: 'Berry', categoryIcon: mdiFruitGrapes },
+    { id: 'lemon', name: 'Lemon', icon: mdiFruitCitrus, category: 'Citrus', categoryIcon: mdiFruitCitrus },
+    { id: 'orange', name: 'Orange', icon: mdiFruitCitrus, category: 'Citrus', categoryIcon: mdiFruitCitrus },
+];
+
+const TRANSLATIONS = {
+    showSuggestionsLabel: 'Show suggestions',
+    chipGroupLabel: 'Selected fruits',
+    chipRemoveLabel: 'Remove',
+};
+
+export default () => {
+    const [value, onChange] = useState<Fruit[]>([INITIAL_FRUITS[1], INITIAL_FRUITS[3]]);
+    const [search, setSearch] = useState('');
+    const [fruits, setFruits] = useState(INITIAL_FRUITS);
+
+    const handleCreate = useCallback(() => {
+        const newFruit: Fruit = {
+            id: search.toLowerCase(),
+            name: search,
+            icon: mdiFoodForkDrink,
+            category: 'Custom',
+            categoryIcon: mdiFoodForkDrink,
+        };
+        setFruits((prev) => [...prev, newFruit]);
+        onChange((prev) => [...prev, newFruit]);
+        setSearch('');
+    }, [search]);
+
+    const canCreate = search && !fruits.some((f) => f.name.toLowerCase() === search.toLowerCase());
+
+    return (
+        <SelectTextField<Fruit>
+            selectionType="multiple"
+            label="Select fruits"
+            placeholder="Search fruits..."
+            options={fruits}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            getSectionId="category"
+            value={value}
+            onChange={(v) => onChange(v ?? [])}
+            onSearch={setSearch}
+            searchInputValue={search}
+            translations={TRANSLATIONS}
+            renderChip={(fruit) => <Chip before={<Icon icon={fruit.icon} size="xs" />}>{fruit.name}</Chip>}
+            beforeOptions={
+                canCreate ? (
+                    <SelectTextField.Section>
+                        <SelectTextField.Option value={`__create__${search}`} onClick={handleCreate}>
+                            {`Create "${search}"`}
+                        </SelectTextField.Option>
+                    </SelectTextField.Section>
+                ) : undefined
+            }
+            renderOption={(fruit) => (
+                <Combobox.Option before={<Icon icon={fruit.icon} size="xs" />}>{fruit.name}</Combobox.Option>
+            )}
+            renderSectionTitle={(sectionId, options) => (
+                <>
+                    <Icon icon={options[0].categoryIcon} size="xs" />
+                    {sectionId}
+                </>
+            )}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/select-text-field/react/empty.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/empty.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { SelectTextField } from '@lumx/react';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    emptyMessage: 'No options available',
+};
+
+export default () => {
+    const [value, onChange] = useState<{ id: string; name: string } | undefined>();
+    return (
+        <SelectTextField
+            selectionType="single"
+            label="Select a fruit"
+            placeholder="Search fruits..."
+            options={[]}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            value={value}
+            onChange={onChange}
+            translations={TRANSLATIONS}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/select-text-field/react/list-error.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/list-error.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { SelectTextField } from '@lumx/react';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    errorMessage: 'Failed to load options',
+    errorTryReloadMessage: 'Please try again later',
+};
+
+export default () => {
+    const [value, onChange] = useState<{ id: string; name: string } | undefined>();
+    return (
+        <SelectTextField
+            selectionType="single"
+            label="Select a fruit"
+            placeholder="Search fruits..."
+            options={[]}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            value={value}
+            onChange={onChange}
+            listStatus="error"
+            translations={TRANSLATIONS}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/select-text-field/react/loading-more.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/loading-more.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { SelectTextField } from '@lumx/react';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    loadingMessage: 'Loading more options...',
+};
+
+export default () => {
+    const [value, onChange] = useState<(typeof FRUITS)[number] | undefined>();
+    return (
+        <SelectTextField
+            selectionType="single"
+            label="Select a fruit"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            value={value}
+            onChange={onChange}
+            listStatus="loadingMore"
+            translations={TRANSLATIONS}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/select-text-field/react/loading.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/loading.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { SelectTextField } from '@lumx/react';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    loadingMessage: 'Loading options...',
+};
+
+export default () => {
+    const [value, onChange] = useState<(typeof FRUITS)[number] | undefined>();
+    return (
+        <SelectTextField
+            selectionType="single"
+            label="Select a fruit"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            value={value}
+            onChange={onChange}
+            listStatus="loading"
+            translations={TRANSLATIONS}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/select-text-field/react/multiple-selection.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/multiple-selection.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { SelectTextField } from '@lumx/react';
+
+interface Fruit {
+    id: string;
+    name: string;
+}
+
+const FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+    { id: 'grape', name: 'Grape' },
+    { id: 'orange', name: 'Orange' },
+    { id: 'peach', name: 'Peach' },
+    { id: 'strawberry', name: 'Strawberry' },
+];
+
+const TRANSLATIONS = {
+    showSuggestionsLabel: 'Show suggestions',
+    chipGroupLabel: 'Selected fruits',
+    chipRemoveLabel: 'Remove',
+};
+
+export default () => {
+    const [value, onChange] = useState<Fruit[] | undefined>([FRUITS[0], FRUITS[2]]);
+
+    return (
+        <SelectTextField<Fruit>
+            selectionType="multiple"
+            label="Select fruits"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            value={value}
+            onChange={onChange}
+            translations={TRANSLATIONS}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/select-text-field/react/single-selection.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/single-selection.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { SelectTextField } from '@lumx/react';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+    { id: 'grape', name: 'Grape' },
+    { id: 'orange', name: 'Orange' },
+    { id: 'peach', name: 'Peach' },
+    { id: 'strawberry', name: 'Strawberry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+export default () => {
+    const [value, onChange] = useState<(typeof FRUITS)[number] | undefined>();
+    return (
+        <SelectTextField
+            selectionType="single"
+            label="Select a fruit"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            value={value}
+            onChange={onChange}
+            translations={TRANSLATIONS}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/select-text-field/react/with-sections.tsx
+++ b/packages/site-demo/content/product/components/select-text-field/react/with-sections.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { SelectTextField } from '@lumx/react';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple', category: 'Pome' },
+    { id: 'banana', name: 'Banana', category: 'Tropical' },
+    { id: 'blueberry', name: 'Blueberry', category: 'Berry' },
+    { id: 'cherry', name: 'Cherry', category: 'Stone' },
+    { id: 'grape', name: 'Grape', category: 'Berry' },
+    { id: 'lemon', name: 'Lemon', category: 'Citrus' },
+    { id: 'orange', name: 'Orange', category: 'Citrus' },
+    { id: 'peach', name: 'Peach', category: 'Stone' },
+    { id: 'strawberry', name: 'Strawberry', category: 'Berry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+export default () => {
+    const [value, onChange] = useState<(typeof FRUITS)[number] | undefined>();
+
+    return (
+        <SelectTextField
+            selectionType="single"
+            label="Select a fruit"
+            placeholder="Search fruits..."
+            options={FRUITS}
+            filter="auto"
+            getOptionId="id"
+            getOptionName="name"
+            getSectionId="category"
+            value={value}
+            onChange={onChange}
+            translations={TRANSLATIONS}
+        />
+    );
+};


### PR DESCRIPTION
# General summary

Create a new `SelectTextField` component that provides a text field with a searchable dropdown to choose between a list of options. Supports single and multiple selection, search/filter, sections, custom rendering, infinite scroll, and various list states (loading, error, empty).

## Changes

### New: `SelectTextField` component
- **Core** (`@lumx/core`): Framework-agnostic JSX template with props for options, selection, list status, search, chips, infinite scroll, and accessibility messages.
- **React** (`@lumx/react`): Full wrapper with discriminated union props (`SingleSelectTextFieldProps` / `MultipleSelectTextFieldProps`), controlled value/onChange, search state management, clear button, and `SelectionChipGroup` integration for multi-select chips.
- **Shared types** (`@lumx/core/js/utils/select/`): New `BaseSelectTextFieldWrapperProps`, `SelectTextFieldTranslations`, `RenderOptionContext`, `BaseSelectComponents`, and `renderSelectOptions` utility for rendering options with section grouping.
- **Docs** (`site-demo`): Full MDX documentation page with 11 React demos covering single/multiple selection, sections, custom rendering, loading/loading-more, empty, error, and disabled states.
- **Tests**: Unit tests (`SelectTextField.test.tsx`) and Storybook stories with test stories (`SelectTextField.stories.tsx`, `SelectTextField.test.stories.tsx`). Core-level shared test suite (`SelectTextField/Tests.tsx`) with comprehensive coverage.

### Enhancement: Combobox `nbOptionMessage` a11y announcement
- `Combobox.State` now accepts a `nbOptionMessage` callback that announces the number of visible options (e.g. "10 result(s) available") via a live region.
- Internal `emptyChange` event renamed to `optionsChange`, now carries `optionsLength` (count) instead of a boolean `isEmpty` — enables the option count feature with no extra DOM observation.
- New Combobox unit tests for option count display and filtering behavior.

### Fix: Combobox filtering option changing value
- Added `refilterOption()` to the Combobox handle, allowing framework wrappers to re-evaluate a single option's filter state when its `data-value` or text content changes after initial render.
- Fixes edge cases where dynamically updated option values could get stuck in a stale filtered/visible state.


StoryBook lumx-vue: https://0baf0a873--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://0baf0a873--5fbfb1d508c0520021560f10.chromatic.com/