### PR TITLE
chore(vue): migrate Lightbox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `@lumx/vue`:
+    -   Create the `Lightbox` component
+
+### Changed
+
+-   `@lumx/core`:
+    -   Moved `Lightbox` from `@lumx/react`
+
 ## [4.11.0][] - 2026-04-15
 
 ### Added
@@ -15,12 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Create the `AlertDialog` component
     -   Create the `Dialog` component
     -   Create the `InfiniteScroll` utility component (available from `@lumx/vue/utils`)
+    -   Create the `Lightbox` component
 
 ### Changed
 
 -   `@lumx/core`:
     -   Moved `AlertDialog` stories and tests from `@lumx/react`
     -   Moved `Dialog` from `@lumx/react`
+    -   Moved `Lightbox` from `@lumx/react`
     -   `setupRovingTabIndex`: add MutationObserver-based tabindex normalization (mount, removal recovery, insertion, disabled-state, selection)
     -   `Combobox`: replace `autoFilter` boolean with `filter` prop (`'auto'` | `'manual'` | `'off'`) and add `openOnFocus` prop
 -  `@lumx/react`:

--- a/packages/lumx-core/src/js/components/Lightbox/Stories.tsx
+++ b/packages/lumx-core/src/js/components/Lightbox/Stories.tsx
@@ -1,0 +1,59 @@
+import { userEvent } from 'storybook/test';
+
+import type { SetupStoriesOptions } from '@lumx/core/stories/types';
+import { LANDSCAPE_IMAGES, LANDSCAPE_IMAGES_ALT } from '@lumx/core/stories/controls/image';
+
+/**
+ * Core stories for the Lightbox component.
+ *
+ * Lightbox is interactive (open/close state, focus trap, etc.) and requires
+ * framework-specific rendering for refs and state management.
+ * A `render` function is provided per framework to handle this.
+ */
+export function setup({
+    component: Lightbox,
+    render,
+    components: { ImageBlock },
+}: SetupStoriesOptions<{
+    components: { ImageBlock: any };
+}>) {
+    const play = async ({ canvas }: any) => {
+        const button = canvas.getByRole('button', { name: 'Open lightbox' });
+
+        await userEvent.click(button);
+    };
+
+    const meta = {
+        component: Lightbox,
+        render,
+        play,
+        argTypes: {
+            children: { control: false },
+        },
+    };
+
+    /** Base Lightbox with image block */
+    const Image = {
+        render: ({ children, ...args }: any) =>
+            render({
+                ...args,
+                children: (
+                    <ImageBlock
+                        align="center"
+                        fillHeight
+                        image={LANDSCAPE_IMAGES.landscape1}
+                        alt={LANDSCAPE_IMAGES_ALT.landscape1}
+                    />
+                ),
+            }),
+        args: { 'aria-label': 'Fullscreen image' },
+    };
+
+    /** Lightbox with image block and close button */
+    const WithCloseButton = {
+        render: Image.render,
+        args: { ...Image.args, closeButtonProps: { label: 'Close' } },
+    };
+
+    return { meta, Image, WithCloseButton, play };
+}

--- a/packages/lumx-core/src/js/components/Lightbox/Tests.ts
+++ b/packages/lumx-core/src/js/components/Lightbox/Tests.ts
@@ -1,0 +1,44 @@
+import { queryByClassName } from '../../../testing/queries';
+import { SetupOptions } from '../../../testing';
+
+const CLASSNAME = 'lumx-lightbox';
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ */
+export const setup = (propsOverride: any = {}, { render, ...options }: SetupOptions<any>) => {
+    const parentElement = { current: document.createElement('div') };
+    const props = { isOpen: true, parentElement, ...propsOverride };
+    const wrapper = render(props, options);
+
+    const lightbox = queryByClassName(document.body, CLASSNAME);
+    return { props, lightbox, wrapper };
+};
+
+export default (renderOptions: SetupOptions<any>) => {
+    describe('Lightbox core tests', () => {
+        describe('Visibility', () => {
+            it('should render when open', () => {
+                const { lightbox } = setup({ isOpen: true }, renderOptions);
+                expect(lightbox).toBeInTheDocument();
+                expect(lightbox).toHaveClass('lumx-lightbox--is-shown');
+            });
+
+            it('should not render when closed', () => {
+                const { lightbox } = setup({ isOpen: false }, renderOptions);
+                expect(lightbox).not.toBeInTheDocument();
+            });
+        });
+
+        describe('Aria', () => {
+            it('should apply aria-label and aria-labelledby', () => {
+                const { lightbox } = setup(
+                    { 'aria-label': 'My Lightbox', 'aria-labelledby': 'header-id' },
+                    renderOptions,
+                );
+                expect(lightbox).toHaveAttribute('aria-label', 'My Lightbox');
+                expect(lightbox).toHaveAttribute('aria-labelledby', 'header-id');
+            });
+        });
+    });
+};

--- a/packages/lumx-core/src/js/components/Lightbox/index.tsx
+++ b/packages/lumx-core/src/js/components/Lightbox/index.tsx
@@ -1,0 +1,155 @@
+import { mdiClose } from '@lumx/icons';
+import type { AriaAttributes, CommonRef, HasClassName, LumxClassName, HasTheme, JSXElement } from '../../types';
+import { classNames } from '../../utils';
+
+export interface BaseLightboxProps
+    extends HasClassName,
+        HasTheme,
+        Pick<AriaAttributes, 'aria-label' | 'aria-labelledby'> {
+    /** Whether the component is open or not. */
+    isOpen?: boolean;
+    /** Whether to keep the dialog open on clickaway or escape press. */
+    preventAutoClose?: boolean;
+    /** Z-axis position. */
+    zIndex?: number;
+}
+
+/**
+ * Defines the props of the component.
+ */
+export interface LightboxProps extends BaseLightboxProps {
+    /**
+     * @deprecated Use `aria-label` instead.
+     */
+    ariaLabel?: string;
+    /**
+     * @deprecated Use `aria-labelledby` instead.
+     */
+    ariaLabelledBy?: string;
+    /** Props to pass to the close button (minus those already set by the Lightbox props). */
+    closeButtonProps?: any;
+    /** Whether the component is still visible (e.g. during the close transition). */
+    isVisible?: boolean;
+    /** Reference to the element that triggered modal opening to set focus on. */
+    parentElement?: CommonRef;
+    /** Reference to the element that should get the focus when the lightbox opens. By default, the close button or the lightbox itself will take focus. */
+    focusElement?: CommonRef;
+    /** On close callback. */
+    handleClose?(): void;
+    /** Children */
+    children?: JSXElement;
+    /** Reference to the lightbox root element. */
+    ref?: CommonRef;
+    /** Reference to the wrapper div containing the children. */
+    childrenRef?: CommonRef;
+    /** Refs used for click-away detection. */
+    clickAwayRefs?: any;
+    /** Reference to the close button element. */
+    closeButtonRef?: CommonRef;
+    /** Portal component for rendering the lightbox outside the DOM hierarchy. */
+    Portal: any;
+    /** HeadingLevelProvider component injected by the framework wrapper. */
+    HeadingLevelProvider: any;
+    /** ThemeProvider component injected by the framework wrapper. */
+    ThemeProvider: any;
+    /** ClickAwayProvider component injected by the framework wrapper. */
+    ClickAwayProvider: any;
+    /** IconButton component injected by the framework wrapper. */
+    IconButton: any;
+}
+
+/**
+ * Component display name.
+ */
+export const COMPONENT_NAME = 'Lightbox';
+
+/**
+ * Component default class name and class prefix.
+ */
+export const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-lightbox';
+const { block, element } = classNames.bem(CLASSNAME);
+
+/**
+ * Lightbox component.
+ *
+ * @param  props Component props.
+ * @param  ref   Component ref.
+ * @return React element.
+ */
+export const Lightbox = (props: LightboxProps) => {
+    const {
+        'aria-labelledby': propAriaLabelledBy,
+        ariaLabelledBy = propAriaLabelledBy,
+        'aria-label': propAriaLabel,
+        ariaLabel = propAriaLabel,
+        children,
+        className,
+        closeButtonProps,
+        isOpen,
+        handleClose,
+        parentElement,
+        focusElement,
+        preventAutoClose,
+        theme,
+        zIndex,
+        isVisible,
+        ref,
+        Portal,
+        HeadingLevelProvider,
+        ThemeProvider,
+        ClickAwayProvider,
+        childrenRef,
+        clickAwayRefs,
+        closeButtonRef,
+        IconButton,
+        ...forwardedProps
+    } = props;
+    if (!isOpen && !isVisible) return null;
+
+    return (
+        <Portal>
+            <div
+                ref={ref}
+                {...forwardedProps}
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledBy}
+                aria-modal="true"
+                role="dialog"
+                tabIndex={-1}
+                className={classNames.join(
+                    className,
+                    block({
+                        'is-hidden': !isOpen,
+                        'is-shown': isOpen || isVisible,
+                        [`theme-${theme}`]: Boolean(theme),
+                    }),
+                )}
+                style={{ zIndex }}
+            >
+                {closeButtonProps && (
+                    <div className={element('close')}>
+                        <IconButton
+                            {...closeButtonProps}
+                            ref={closeButtonRef}
+                            emphasis="low"
+                            hasBackground
+                            icon={mdiClose}
+                            theme="dark"
+                            type="button"
+                            onClick={handleClose}
+                        />
+                    </div>
+                )}
+                <HeadingLevelProvider level={2}>
+                    <ThemeProvider value={undefined}>
+                        <ClickAwayProvider callback={!preventAutoClose && handleClose} childrenRefs={clickAwayRefs}>
+                            <div ref={childrenRef} className={element('wrapper')} role="presentation">
+                                {children}
+                            </div>
+                        </ClickAwayProvider>
+                    </ThemeProvider>
+                </HeadingLevelProvider>
+            </div>
+        </Portal>
+    );
+};

--- a/packages/lumx-react/src/components/lightbox/Lightbox.stories.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.stories.tsx
@@ -1,19 +1,15 @@
 /* eslint-disable react-hooks/rules-of-hooks,react/display-name */
 import React from 'react';
-import { ImageBlock, Alignment, Lightbox, Button, Slideshow, SlideshowItem } from '@lumx/react';
+import { ImageBlock, Lightbox, Button, Slideshow, SlideshowItem } from '@lumx/react';
 import { useBooleanState } from '@lumx/react/hooks/useBooleanState';
 import { LANDSCAPE_IMAGES, LANDSCAPE_IMAGES_ALT } from '@lumx/core/stories/controls/image';
+import { setup } from '@lumx/core/js/components/Lightbox/Stories';
 
-export default {
-    title: 'LumX components/lightbox/Lightbox',
+const { meta, ...stories } = setup({
     component: Lightbox,
-    args: Lightbox.defaultProps,
-    argTypes: {
-        children: { control: false },
-    },
-    render: (props: any) => {
+    render(props: any) {
         const buttonRef = React.useRef<HTMLButtonElement>(null);
-        const [isOpen, close, open] = useBooleanState(true);
+        const [isOpen, close, open] = useBooleanState(false);
         return (
             <>
                 <Button ref={buttonRef} onClick={open}>
@@ -23,79 +19,75 @@ export default {
             </>
         );
     },
+    components: { ImageBlock },
+});
+
+export default {
+    title: 'LumX components/lightbox/Lightbox',
+    ...meta,
 };
 
-/**
- * Base LightBox with image block
- */
-export const Image = {
-    args: {
-        'aria-label': 'Fullscreen image',
-        children: (
-            <ImageBlock
-                align={Alignment.center}
-                fillHeight
-                image={LANDSCAPE_IMAGES.landscape1}
-                alt={LANDSCAPE_IMAGES_ALT.landscape1}
-            />
-        ),
-    },
-};
+export const Image = { ...stories.Image };
+export const WithCloseButton = { ...stories.WithCloseButton };
 
 /**
- * LightBox with image block and close button
- */
-export const WithCloseButton = {
-    args: {
-        ...Image.args,
-        closeButtonProps: { label: 'Close' },
-    },
-};
-
-/**
- * Demo a LightBox containing an image slideshow
+ * Demo a LightBox containing an image slideshow.
+ * Uses Slideshow/SlideshowItem which are React-only and not available in core.
  */
 export const ImageSlideshow = {
-    args: {
-        'aria-label': 'Fullscreen image slideshow',
-        closeButtonProps: { label: 'Close' },
-        children: (
-            <Slideshow
-                aria-label="Image slideshow"
-                theme="dark"
-                slideshowControlsProps={{
-                    nextButtonProps: { label: 'Next image' },
-                    previousButtonProps: { label: 'Previous image' },
-                }}
-                slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
-            >
-                <SlideshowItem>
-                    <ImageBlock
-                        align="center"
-                        fillHeight
-                        image={LANDSCAPE_IMAGES.landscape1}
-                        alt={LANDSCAPE_IMAGES_ALT.landscape1}
-                    />
-                </SlideshowItem>
+    render() {
+        const buttonRef = React.useRef<HTMLButtonElement>(null);
+        const [isOpen, close, open] = useBooleanState(true);
+        return (
+            <>
+                <Button ref={buttonRef} onClick={open}>
+                    Open lightbox
+                </Button>
+                <Lightbox
+                    aria-label="Fullscreen image slideshow"
+                    closeButtonProps={{ label: 'Close' }}
+                    parentElement={buttonRef}
+                    isOpen={isOpen}
+                    onClose={close}
+                >
+                    <Slideshow
+                        aria-label="Image slideshow"
+                        theme="dark"
+                        slideshowControlsProps={{
+                            nextButtonProps: { label: 'Next image' },
+                            previousButtonProps: { label: 'Previous image' },
+                        }}
+                        slideGroupLabel={(currentGroup, totalGroup) => `${currentGroup} of ${totalGroup}`}
+                    >
+                        <SlideshowItem>
+                            <ImageBlock
+                                align="center"
+                                fillHeight
+                                image={LANDSCAPE_IMAGES.landscape1}
+                                alt={LANDSCAPE_IMAGES_ALT.landscape1}
+                            />
+                        </SlideshowItem>
 
-                <SlideshowItem>
-                    <ImageBlock
-                        align="center"
-                        fillHeight
-                        image={LANDSCAPE_IMAGES.landscape2}
-                        alt={LANDSCAPE_IMAGES_ALT.landscape2}
-                    />
-                </SlideshowItem>
+                        <SlideshowItem>
+                            <ImageBlock
+                                align="center"
+                                fillHeight
+                                image={LANDSCAPE_IMAGES.landscape2}
+                                alt={LANDSCAPE_IMAGES_ALT.landscape2}
+                            />
+                        </SlideshowItem>
 
-                <SlideshowItem>
-                    <ImageBlock
-                        align="center"
-                        fillHeight
-                        image={LANDSCAPE_IMAGES.landscape3}
-                        alt={LANDSCAPE_IMAGES_ALT.landscape3}
-                    />
-                </SlideshowItem>
-            </Slideshow>
-        ),
+                        <SlideshowItem>
+                            <ImageBlock
+                                align="center"
+                                fillHeight
+                                image={LANDSCAPE_IMAGES.landscape3}
+                                alt={LANDSCAPE_IMAGES_ALT.landscape3}
+                            />
+                        </SlideshowItem>
+                    </Slideshow>
+                </Lightbox>
+            </>
+        );
     },
 };

--- a/packages/lumx-react/src/components/lightbox/Lightbox.test.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.test.tsx
@@ -5,6 +5,7 @@ import { ThemeSentinel } from '@lumx/react/testing/utils/ThemeSentinel';
 import { vi } from 'vitest';
 
 import { Heading, HeadingLevelProvider } from '@lumx/react';
+import BaseLightboxTests from '@lumx/core/js/components/Lightbox/Tests';
 import { Lightbox, LightboxProps } from './Lightbox';
 
 const CLASSNAME = Lightbox.className as string;
@@ -24,65 +25,48 @@ const setup = (props: Partial<LightboxProps> = {}, { wrapper }: SetupRenderOptio
 };
 
 describe(`<${Lightbox.displayName}>`, () => {
-    it('should have reset the heading level context', () => {
-        setup(
-            {
-                // Heading inside the lightbox
-                children: <Heading>Title</Heading>,
-            },
-            {
-                // This level context should not affect headings inside the lightbox
-                wrapper({ children }) {
-                    return <HeadingLevelProvider level={3}>{children}</HeadingLevelProvider>;
+    // Run core tests
+    BaseLightboxTests({
+        render: (props: any) => render(<Lightbox {...props} />),
+        screen,
+    });
+
+    describe('React', () => {
+        it('should have reset the heading level context', () => {
+            setup(
+                {
+                    // Heading inside the lightbox
+                    children: <Heading>Title</Heading>,
                 },
-            },
-        );
-        // Heading inside should use the lightbox heading level 2
-        expect(screen.queryByRole('heading', { name: 'Title', level: 2 })).toBeInTheDocument();
-    });
-
-    describe('Visibility', () => {
-        it('should render when open', () => {
-            const { lightbox } = setup({ isOpen: true });
-            expect(lightbox).toBeInTheDocument();
-            expect(lightbox).toHaveClass('lumx-lightbox--is-shown');
+                {
+                    // This level context should not affect headings inside the lightbox
+                    wrapper({ children }) {
+                        return <HeadingLevelProvider level={3}>{children}</HeadingLevelProvider>;
+                    },
+                },
+            );
+            // Heading inside should use the lightbox heading level 2
+            expect(screen.queryByRole('heading', { name: 'Title', level: 2 })).toBeInTheDocument();
         });
 
-        it('should not render when closed', () => {
-            const { lightbox } = setup({ isOpen: false });
-            expect(lightbox).not.toBeInTheDocument();
+        describe('Close Button', () => {
+            it('should render close button when props provided', () => {
+                const onClose = vi.fn();
+                setup({ closeButtonProps: { label: 'Close Lightbox' }, onClose });
+                const closeBtn = screen.getByRole('button', { name: 'Close Lightbox' });
+                expect(closeBtn).toBeInTheDocument();
+                fireEvent.click(closeBtn);
+                expect(onClose).toHaveBeenCalled();
+            });
         });
-    });
 
-    describe('Close Button', () => {
-        it('should render close button when props provided', () => {
-            const onClose = vi.fn();
-            setup({ closeButtonProps: { label: 'Close Lightbox' }, onClose });
-            const closeBtn = screen.getByRole('button', { name: 'Close Lightbox' });
-            expect(closeBtn).toBeInTheDocument();
-            fireEvent.click(closeBtn);
-            expect(onClose).toHaveBeenCalled();
-        });
-    });
-
-    describe('Interactions', () => {
-        it('should trigger onClose on click away', () => {
-            const onClose = vi.fn();
-            setup({ onClose });
-            // Lightbox root has custom click away detection or uses ClickAwayProvider
-            // The overlay is usually the root div or a child.
-            // In Lightbox.tsx, ClickAwayProvider wraps the wrapper.
-            // Clicks outside wrapper trigger callback.
-            fireEvent.mouseDown(document.body);
-            expect(onClose).toHaveBeenCalled();
-        });
-    });
-
-    describe('Aria', () => {
-        it('should apply aria-label and aria-labelledby', () => {
-            const { lightbox } = setup({ 'aria-label': 'My Lightbox', 'aria-labelledby': 'header-id' });
-            expect(lightbox).toHaveAttribute('aria-label', 'My Lightbox');
-            expect(lightbox).toHaveAttribute('aria-labelledby', 'header-id');
+        describe('Interactions', () => {
+            it('should trigger onClose on click away', () => {
+                const onClose = vi.fn();
+                setup({ onClose });
+                fireEvent.mouseDown(document.body);
+                expect(onClose).toHaveBeenCalled();
+            });
         });
     });
 

--- a/packages/lumx-react/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.tsx
@@ -1,11 +1,8 @@
-import { RefObject, useRef, useEffect, AriaAttributes } from 'react';
+import { RefObject, useRef, useEffect } from 'react';
 
-import { mdiClose } from '@lumx/icons';
 import { HeadingLevelProvider, IconButton, IconButtonProps } from '@lumx/react';
 import { DIALOG_TRANSITION_DURATION, DOCUMENT } from '@lumx/react/constants';
-import { GenericProps, HasTheme } from '@lumx/react/utils/type';
-import type { LumxClassName } from '@lumx/core/js/types';
-import { classNames } from '@lumx/core/js/utils';
+import { GenericProps } from '@lumx/react/utils/type';
 
 import { useFocusTrap } from '@lumx/react/hooks/useFocusTrap';
 import { useDisableBodyScroll } from '@lumx/react/hooks/useDisableBodyScroll';
@@ -18,39 +15,30 @@ import { forwardRef } from '@lumx/react/utils/react/forwardRef';
 
 import { Portal } from '@lumx/react/utils';
 
+import {
+    Lightbox as UI,
+    CLASSNAME,
+    COMPONENT_NAME,
+    BaseLightboxProps as UIProps,
+} from '@lumx/core/js/components/Lightbox';
+import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
+
 /**
  * Defines the props of the component.
  */
-export interface LightboxProps extends GenericProps, HasTheme, Pick<AriaAttributes, 'aria-label' | 'aria-labelledby'> {
+export interface LightboxProps extends GenericProps, ReactToJSX<UIProps> {
     /** Props to pass to the close button (minus those already set by the Lightbox props). */
     closeButtonProps?: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis' | 'color'>;
-    /** Whether the component is open or not. */
-    isOpen?: boolean;
     /** Reference to the element that triggered modal opening to set focus on. */
     parentElement: RefObject<any>;
     /** Reference to the element that should get the focus when the lightbox opens. By default, the close button or the lightbox itself will take focus. */
     focusElement?: RefObject<HTMLElement>;
-    /** Whether to keep the dialog open on clickaway or escape press. */
-    preventAutoClose?: boolean;
-    /** Z-axis position. */
-    zIndex?: number;
     /** On close callback. */
     onClose?(): void;
     /** Children */
     children?: React.ReactNode;
 }
-
-/**
- * Component display name.
- */
-const COMPONENT_NAME = 'Lightbox';
-
-/**
- * Component default class name and class prefix.
- */
-const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-lightbox';
-const { block, element } = classNames.bem(CLASSNAME);
 
 /**
  * Lightbox component.
@@ -61,10 +49,6 @@ const { block, element } = classNames.bem(CLASSNAME);
  */
 export const Lightbox = forwardRef<LightboxProps, HTMLDivElement>((props, ref) => {
     const {
-        'aria-labelledby': propAriaLabelledBy,
-        ariaLabelledBy = propAriaLabelledBy,
-        'aria-label': propAriaLabel,
-        ariaLabel = propAriaLabel,
         children,
         className,
         closeButtonProps,
@@ -128,52 +112,29 @@ export const Lightbox = forwardRef<LightboxProps, HTMLDivElement>((props, ref) =
 
     if (!isOpen && !isVisible) return null;
 
-    return (
-        <Portal>
-            <div
-                ref={mergeRefs(ref, wrapperRef)}
-                {...forwardedProps}
-                aria-label={ariaLabel}
-                aria-labelledby={ariaLabelledBy}
-                aria-modal="true"
-                role="dialog"
-                tabIndex={-1}
-                className={classNames.join(
-                    className,
-                    block({
-                        'is-hidden': !isOpen,
-                        'is-shown': isOpen || isVisible,
-                        [`theme-${theme}`]: Boolean(theme),
-                    }),
-                )}
-                style={{ zIndex }}
-            >
-                {closeButtonProps && (
-                    <div className={element('close')}>
-                        <IconButton
-                            {...closeButtonProps}
-                            ref={closeButtonRef}
-                            emphasis="low"
-                            hasBackground
-                            icon={mdiClose}
-                            theme="dark"
-                            type="button"
-                            onClick={onClose}
-                        />
-                    </div>
-                )}
-                <HeadingLevelProvider level={2}>
-                    <ThemeProvider value={undefined}>
-                        <ClickAwayProvider callback={!preventAutoClose && onClose} childrenRefs={clickAwayRefs}>
-                            <div ref={childrenRef} className={element('wrapper')} role="presentation">
-                                {children}
-                            </div>
-                        </ClickAwayProvider>
-                    </ThemeProvider>
-                </HeadingLevelProvider>
-            </div>
-        </Portal>
-    );
+    return UI({
+        ClickAwayProvider,
+        HeadingLevelProvider,
+        IconButton,
+        parentElement,
+        Portal,
+        ThemeProvider,
+        children,
+        childrenRef,
+        className,
+        clickAwayRefs,
+        closeButtonProps,
+        closeButtonRef,
+        focusElement,
+        isOpen,
+        isVisible,
+        ref: mergeRefs(ref, wrapperRef),
+        theme,
+        zIndex,
+        preventAutoClose,
+        handleClose: onClose,
+        ...forwardedProps,
+    });
 });
 Lightbox.displayName = COMPONENT_NAME;
 Lightbox.className = CLASSNAME;

--- a/packages/lumx-vue/src/components/lightbox/Lightbox.stories.tsx
+++ b/packages/lumx-vue/src/components/lightbox/Lightbox.stories.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable vue/one-component-per-file */
+import { defineComponent, ref } from 'vue';
+import { Button, ImageBlock, Lightbox } from '@lumx/vue';
+import { setup } from '@lumx/core/js/components/Lightbox/Stories';
+
+/**
+ * Story render component for Lightbox.
+ *
+ * Defined as a standalone component so that:
+ * - The button ref is created inside a proper Vue setup context.
+ * - Storybook can pass args as reactive props (avoiding stale closure captures).
+ * - Children (image content) passed by core story renders flow through attrs as the default slot.
+ */
+const LightboxStory = defineComponent(
+    (_props: any, { attrs }: any) => {
+        const buttonRef = ref<HTMLElement>();
+        const isOpen = ref(false);
+
+        return () => {
+            const { children, ...props } = attrs;
+            return (
+                <>
+                    <Button
+                        ref={buttonRef}
+                        onClick={() => {
+                            isOpen.value = true;
+                        }}
+                    >
+                        Open lightbox
+                    </Button>
+                    <Lightbox
+                        {...props}
+                        isOpen={isOpen.value}
+                        onClose={() => {
+                            isOpen.value = false;
+                        }}
+                        parentElement={(buttonRef.value as any)?.$el}
+                    >
+                        {children}
+                    </Lightbox>
+                </>
+            );
+        };
+    },
+    { name: 'LumxLightboxStory', inheritAttrs: false },
+);
+
+const { meta, ...stories } = setup({
+    component: Lightbox,
+    components: { ImageBlock },
+    render: (args: any) => () => <LightboxStory {...args} />,
+});
+
+export default {
+    title: 'LumX components/lightbox/Lightbox',
+    ...meta,
+};
+
+export const Image = { ...stories.Image };
+export const WithCloseButton = { ...stories.WithCloseButton };
+// ImageSlideshow is React-only (uses Slideshow/SlideshowItem which are not available in @lumx/vue)

--- a/packages/lumx-vue/src/components/lightbox/Lightbox.test.ts
+++ b/packages/lumx-vue/src/components/lightbox/Lightbox.test.ts
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+
+import BaseLightboxTests, { setup } from '@lumx/core/js/components/Lightbox/Tests';
+import { CLASSNAME } from '@lumx/core/js/components/Lightbox';
+import { commonTestsSuiteVTL, type SetupRenderOptions } from '@lumx/vue/testing';
+
+import { Lightbox } from '.';
+
+// Clean up teleported lightbox elements between tests
+afterEach(() => {
+    cleanup();
+    document.querySelectorAll(`.${CLASSNAME}`).forEach((el) => el.remove());
+});
+
+describe('<Lightbox />', () => {
+    const renderLightbox = ({ children, parentElement, ...props }: any, options?: SetupRenderOptions<any>) =>
+        render(Lightbox, {
+            ...options,
+            props: {
+                isOpen: true,
+                // Tests.ts passes parentElement as a React ref { current: HTMLElement }; Vue expects a plain HTMLElement
+                parentElement: parentElement?.current ?? parentElement ?? document.createElement('div'),
+                ...props,
+            },
+            slots: children ? { default: () => children } : undefined,
+        });
+
+    // Core shared tests
+    BaseLightboxTests({ render: renderLightbox, screen });
+
+    const setupLightbox = (props: any = {}, options: SetupRenderOptions<any> = {}) =>
+        setup(props, { ...options, render: renderLightbox, screen });
+
+    describe('Vue', () => {
+        describe('Events', () => {
+            it('should emit close on Escape key press', async () => {
+                const { emitted } = render(Lightbox, {
+                    props: { isOpen: true, parentElement: document.createElement('div') },
+                });
+                await userEvent.keyboard('[Escape]');
+                expect(emitted('close')).toBeTruthy();
+            });
+
+            it('should not emit close on Escape when preventAutoClose is true', async () => {
+                const { emitted } = render(Lightbox, {
+                    props: { isOpen: true, parentElement: document.createElement('div'), preventAutoClose: true },
+                });
+                await userEvent.keyboard('[Escape]');
+                expect(emitted('close')).toBeFalsy();
+            });
+
+            it('should emit close when clicking outside the lightbox', () => {
+                const { emitted } = render(Lightbox, {
+                    props: { isOpen: true, parentElement: document.createElement('div') },
+                });
+                fireEvent.mouseDown(document.body);
+                expect(emitted('close')).toBeTruthy();
+            });
+        });
+    });
+
+    commonTestsSuiteVTL(setupLightbox, {
+        baseClassName: CLASSNAME,
+        forwardClassName: 'lightbox',
+        forwardAttributes: 'lightbox',
+        forwardRef: 'lightbox',
+    });
+});

--- a/packages/lumx-vue/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-vue/src/components/lightbox/Lightbox.tsx
@@ -1,0 +1,131 @@
+import { computed, defineComponent, ref, type Ref } from 'vue';
+
+import { Lightbox as UI, type BaseLightboxProps } from '@lumx/core/js/components/Lightbox';
+import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
+import type { JSXElement } from '@lumx/core/js/types';
+
+import { Portal } from '../../utils/Portal/Portal';
+import { ClickAwayProvider } from '../../utils/ClickAway/ClickAwayProvider';
+import { ThemeProvider } from '../../utils/theme/ThemeProvider';
+import HeadingLevelProvider from '../heading/HeadingLevelProvider';
+import IconButton from '../button/IconButton';
+
+import { useCallbackOnEscape } from '../../composables/useCallbackOnEscape';
+import { useClassName } from '../../composables/useClassName';
+import { useFocusTrap } from '../../composables/useFocusTrap';
+import { useRestoreFocusOnClose } from '../../composables/useRestoreFocusOnClose';
+import { useTransitionVisibility } from '../../composables/useTransitionVisibility';
+import { useDisableBodyScroll } from '../../composables/useDisableBodyScroll';
+import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+
+export type LightboxProps = VueToJSXProps<BaseLightboxProps, 'theme' | 'aria-label' | 'aria-labelledby'> & {
+    /** Reference to the element that triggered lightbox opening (gets focus back on close). */
+    parentElement?: HTMLElement;
+    /** Element that should receive focus when the lightbox opens. By default the first focusable child. */
+    focusElement?: HTMLElement;
+    /** Props to pass to the close button. */
+    closeButtonProps?: any;
+};
+// theme, aria-label, aria-labelledby pass through via attrs
+
+export const emitSchema = {
+    close: () => true,
+};
+
+const Lightbox = defineComponent(
+    (props: LightboxProps, { emit, slots, attrs }) => {
+        const className = useClassName(() => props.class);
+
+        // Root div ref — used as focus zone and click-away zone
+        const wrapperRef = ref<HTMLDivElement | null>(null);
+        // Close button ref (passed to core; only mounted when closeButtonProps is provided)
+        const closeButtonRef = ref<HTMLButtonElement | null>(null);
+
+        const handleClose = () => emit('close');
+
+        // Escape key closes the lightbox
+        useCallbackOnEscape(
+            handleClose,
+            computed(() => Boolean(props.isOpen && !props.preventAutoClose)),
+        );
+
+        // Focus trap inside the lightbox root
+        const focusZoneElement = computed(() => {
+            if (!props.isOpen) return false as const;
+            return wrapperRef.value || false;
+        });
+
+        useFocusTrap(
+            focusZoneElement,
+            computed(() => {
+                // closeButtonRef holds a Vue component instance; unwrap to the underlying DOM element via $el
+                const closeButtonEl = (closeButtonRef.value as any)?.$el ?? closeButtonRef.value;
+                return props.focusElement || closeButtonEl || wrapperRef.value;
+            }),
+        );
+
+        // Restore focus to parentElement when lightbox closes
+        useRestoreFocusOnClose(
+            computed(() => true),
+            computed(() => undefined) as Ref<HTMLElement | undefined>,
+            computed(() => props.parentElement) as Ref<HTMLElement | undefined>,
+            wrapperRef as Ref<HTMLElement | undefined>,
+            computed(() => Boolean(props.isOpen)),
+        );
+
+        // Disable body scroll when lightbox is open
+        useDisableBodyScroll(computed(() => Boolean(props.isOpen)));
+
+        // Track animation state: keeps lightbox mounted during close animation
+        const isVisible = useTransitionVisibility(
+            computed(() => Boolean(props.isOpen)),
+            DIALOG_TRANSITION_DURATION,
+        );
+
+        // Mount guard: keep mounted while open or animating closed
+        const isMounted = computed(() => props.isOpen || isVisible.value);
+
+        // Click-away: treat the full root div as the "inside" zone
+        const clickAwayRefs = computed(() => [wrapperRef]) as Ref<Array<Ref<HTMLElement | undefined>>>;
+
+        return () => {
+            if (!isMounted.value) return null;
+
+            return UI({
+                ...attrs,
+                ClickAwayProvider,
+                HeadingLevelProvider,
+                IconButton,
+                Portal,
+                ThemeProvider,
+                className: className.value,
+                clickAwayRefs,
+                closeButtonProps: props.closeButtonProps,
+                closeButtonRef,
+                isOpen: props.isOpen,
+                isVisible: isVisible.value,
+                handleClose,
+                preventAutoClose: props.preventAutoClose,
+                ref: wrapperRef,
+                zIndex: props.zIndex,
+                children: slots.default?.() as JSXElement,
+            });
+        };
+    },
+    {
+        name: 'LumxLightbox',
+        inheritAttrs: false,
+        props: keysOf<LightboxProps>()(
+            'class',
+            'closeButtonProps',
+            'focusElement',
+            'isOpen',
+            'parentElement',
+            'preventAutoClose',
+            'zIndex',
+        ),
+        emits: emitSchema,
+    },
+);
+
+export default Lightbox;

--- a/packages/lumx-vue/src/components/lightbox/index.ts
+++ b/packages/lumx-vue/src/components/lightbox/index.ts
@@ -1,0 +1,1 @@
+export { default as Lightbox, type LightboxProps } from './Lightbox';

--- a/packages/lumx-vue/src/index.ts
+++ b/packages/lumx-vue/src/index.ts
@@ -9,6 +9,7 @@ export * from './components/button';
 export * from './components/checkbox';
 export * from './components/chip';
 export * from './components/dialog';
+export * from './components/lightbox';
 export * from './components/divider';
 export * from './components/drag-handle';
 export * from './components/expansion-panel';

--- a/packages/lumx-vue/src/shims-tsx.d.ts
+++ b/packages/lumx-vue/src/shims-tsx.d.ts
@@ -9,6 +9,7 @@ declare module 'vue' {
     interface HTMLAttributes {
         className?: string;
         htmlFor?: string;
+        tabIndex?: number;
     }
 
     interface LabelHTMLAttributes {

--- a/packages/site-demo/content/product/components/lightbox/index.mdx
+++ b/packages/site-demo/content/product/components/lightbox/index.mdx
@@ -1,14 +1,16 @@
 ---
-frameworks: ['react']
+frameworks: ['react', 'vue']
 ---
-import * as DemoDefault from './react/default.tsx';
+import * as ReactDemoDefault from './react/default.tsx';
+import * as VueDemoDefault from './vue/default.vue';
 import ReactLightbox from 'lumx-docs:@lumx/react/components/lightbox/Lightbox';
+import VueLightbox from 'lumx-docs:@lumx/vue/components/lightbox/Lightbox';
 
 # Lightbox
 
 **Reveals elements above the page and on a backdrop after clicking on a trigger.**
 
-<DemoBlock vAlign="center" demo={{ react: DemoDefault }} />
+<DemoBlock vAlign="center" demo={{ react: ReactDemoDefault, vue: VueDemoDefault }} />
 
 See the [ImageLightbox](/product/components/image-lightbox) component a fully featured image and image slideshow lightbox.
 
@@ -26,4 +28,4 @@ This component uses the `dialog` accessible pattern, a few specific behaviors ar
 
 ### Properties
 
-<PropTable docs={{ react: ReactLightbox }} />
+<PropTable docs={{ react: ReactLightbox, vue: VueLightbox }} />

--- a/packages/site-demo/content/product/components/lightbox/vue/default.vue
+++ b/packages/site-demo/content/product/components/lightbox/vue/default.vue
@@ -1,0 +1,21 @@
+<template>
+    <Button ref="triggerRef" @click="isOpen = true">Open LightBox</Button>
+    <Lightbox
+        :is-open="isOpen"
+        :parent-element="(triggerRef as any)?.$el"
+        :close-button-props="{ label: 'Close' }"
+        @close="isOpen = false"
+    >
+        <FlexBox vertical-align="center" horizontal-align="center" style="height: 100%">
+            <Thumbnail alt="Portrait image" image="https://picsum.photos/id/653/275/500" />
+        </FlexBox>
+    </Lightbox>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Button, FlexBox, Lightbox, Thumbnail } from '@lumx/vue';
+
+const isOpen = ref(false);
+const triggerRef = ref<any>(null);
+</script>


### PR DESCRIPTION
# General summary

- Migrated `Lightbox` to the shared core/React/Vue architecture
- Extracted `BaseLightboxProps` (public API) and `LightboxProps` (full, with injected providers) in `@lumx/core`
- Created Vue wrapper using `useCallbackOnEscape`, `useFocusTrap`, `useRestoreFocusOnClose`, `useDisableBodyScroll`, and `useTransitionVisibility` — mirroring the React hooks exactly
- Shared core stories (`Image`, `WithCloseButton`) and tests (visibility, aria); `ImageSlideshow` stays React-only (uses `Slideshow`/`SlideshowItem` not available in `@lumx/vue`)
- Added `tabIndex` to Vue JSX shims (`shims-tsx.d.ts`) to support the lightbox root div's `tabIndex={-1}`
- Added Vue demo and updated docs page to `frameworks: ['react', 'vue']`

# Screenshots

<!-- N/A — component is a fullscreen overlay; verify in Storybook -->

StoryBook lumx-vue: https://f337227f4--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://f337227f4--5fbfb1d508c0520021560f10.chromatic.com/