### PR TITLE
fix(cd): override Chromatic commit detection on release deploys

### DIFF
--- a/.github/workflows/workflow-deploy-storybook.yml
+++ b/.github/workflows/workflow-deploy-storybook.yml
@@ -74,6 +74,15 @@ jobs:
                       core.setOutput('run_html_url', run_html_url);
                       core.setOutput('package_path', package_path);
 
+                      // When a custom ref is checked out (e.g. release deploys), we end up
+                      // in detached HEAD and Chromatic can't auto-detect the commit/branch.
+                      // Export the full SHA so we can set CHROMATIC_SHA to override detection.
+                      if ('${{ inputs.ref }}') {
+                          const exec = require('util').promisify(require('child_process').exec);
+                          const fullSHA = (await exec('git rev-parse HEAD')).stdout.trim();
+                          core.setOutput('chromatic_sha', fullSHA);
+                      }
+
             - name: 'Update PR body: Deploying state'
               id: update-pr-deploying
               if: inputs.pr_number != ''
@@ -101,6 +110,11 @@ jobs:
               id: deploy
               env:
                   CHROMATIC_PROJECT_TOKEN: ${{ secrets[inputs.token_secret] }}
+                  # When a custom ref is checked out (e.g. release deploys), override
+                  # Chromatic's GitHub PR commit detection which would fall back to the
+                  # merge commit (GITHUB_SHA) instead of the checked-out commit.
+                  CHROMATIC_SHA: ${{ steps.vars.outputs.chromatic_sha || '' }}
+                  CHROMATIC_BRANCH: ${{ steps.vars.outputs.chromatic_sha && 'master' || '' }}
               run: yarn dlx chromatic --exit-once-uploaded
               working-directory: ${{ steps.vars.outputs.package_path }}
 


### PR DESCRIPTION
## Summary

- Fix broken Chromatic Storybook permalink URLs on release deploys (v4.10.0, v4.11.0 were affected)
- Set `CHROMATIC_SHA` and `CHROMATIC_BRANCH` env vars when deploying at a custom ref to override Chromatic's GitHub PR commit detection

## Problem

PR #1618 changed the release storybook deploy to check out the PR head commit (`github.event.pull_request.head.sha`) instead of the default merge commit. However, Chromatic's CLI has [special GitHub PR detection logic](https://github.com/chromaui/chromatic-cli/blob/main/node-src/git/getCommitAndBranch.ts) that, in detached HEAD state, falls back to `GITHUB_SHA` (the merge commit) for indexing the build. This caused a mismatch: our constructed permalink URL used the PR head commit SHA, but Chromatic indexed the build under the merge commit SHA → **404 on all commit-based permalinks**.

## Fix

When the `ref` input is provided (release deploys), export `CHROMATIC_SHA` and `CHROMATIC_BRANCH` environment variables to force Chromatic to record the build under the checked-out commit. These env vars are empty (no-op) for normal PR deploys.

Also manually fixed the release notes for v4.10.0 and v4.11.0 with the correct URLs.