### PR TITLE
chore(react): fix export dialog size type warning

### DIFF
--- a/packages/lumx-react/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.tsx
@@ -22,9 +22,11 @@ import {
     Dialog as UI,
     CLASSNAME,
     COMPONENT_NAME,
-    DialogSizes,
+    type DialogSizes,
     BaseDialogProps as UIProps,
 } from '@lumx/core/js/components/Dialog';
+
+export type { DialogSizes } from '@lumx/core/js/components/Dialog';
 
 /**
  * Defines the props of the component.
@@ -69,8 +71,6 @@ const DEFAULT_PROPS: Partial<DialogProps> = {
     size: Size.big,
     disableBodyScroll: true,
 };
-
-export { type DialogSizes };
 
 /**
  * Dialog component.


### PR DESCRIPTION
# General summary

Fixing a warning we get in gatbsy (and maybe other bundler builds)



StoryBook lumx-react: https://2b5dbdc70--5fbfb1d508c0520021560f10.chromatic.com/