### PR TITLE
feat(vue): create select text field component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/vue`:
     -   Create the `Lightbox` component
+    -   Create the `SelectTextField` component
 -   `@lumx/react`:
     -   Create the `SelectTextField` component
 

--- a/packages/lumx-core/src/js/components/Combobox/ComboboxList.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/ComboboxList.tsx
@@ -14,7 +14,7 @@ export type ComboboxListType = 'listbox' | 'grid';
  */
 export interface ComboboxListProps extends HasClassName {
     /** Accessible label for the listbox (required for accessibility). */
-    'aria-label': string;
+    'aria-label'?: string;
     /**
      * Indicates that the listbox content is incomplete (loading).
      * Set to `true` when skeleton placeholders are present and no real options have loaded yet.

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -178,8 +178,6 @@ export function setupCombobox(
         onKeydown?: (event: KeyboardEvent) => boolean,
     ) {
         function handleKeydown(event: KeyboardEvent) {
-            if (event.ctrlKey || event.shiftKey) return;
-
             // Let the mode-specific handler run first.
             if (onKeydown?.(event)) {
                 event.stopPropagation();

--- a/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
@@ -1113,6 +1113,26 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
                 expect(getVisibleOptions()).toHaveLength(FRUITS.length);
             });
         });
+
+        it('should focus the last selected chip when pressing Backspace at the start of an empty input', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[2]] }); // Apple, Banana
+            const input = getInput();
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(2);
+            });
+
+            // Focus the empty input (cursor naturally at position 0).
+            await userEvent.click(input);
+            expect(document.activeElement).toBe(input);
+
+            await userEvent.keyboard('{Backspace}');
+
+            // The last selected chip should receive focus, not the input.
+            const chips = getChips();
+            const lastChip = chips[chips.length - 1];
+            expect(document.activeElement).toBe(lastChip);
+        });
     });
 
     // ─── Empty and option count messages ────────────────────────

--- a/packages/lumx-core/src/js/utils/select/types.ts
+++ b/packages/lumx-core/src/js/utils/select/types.ts
@@ -1,5 +1,4 @@
 import type { HasAriaDisabled } from '../../types/HasAriaDisabled';
-import type { HasClassName } from '../../types/HasClassName';
 import type { HasTheme } from '../../types/HasTheme';
 import type { JSXElement, Selector } from '../../types';
 
@@ -135,7 +134,6 @@ export interface BaseSelectTextFieldWrapperProps<O>
             'options' | 'getOptionId' | 'getOptionName' | 'getOptionDescription' | 'getSectionId'
         >,
         HasAriaDisabled,
-        HasClassName,
         HasTheme {
     /** Selection type: 'single' or 'multiple'. */
     selectionType: 'single' | 'multiple';

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
@@ -5,13 +5,13 @@ import { getWithSelector } from '@lumx/core/js/utils/selectors';
 import { type RenderOptionContext, type BaseSelectTextFieldWrapperProps } from '@lumx/core/js/utils/select/types';
 import { getOptionDisplayName } from '@lumx/core/js/utils/select/getOptionDisplayName';
 import { SelectTextField as UI } from '@lumx/core/js/components/SelectTextField';
-import { isComponentType } from '@lumx/react/utils/type';
+import { HasClassName, isComponentType } from '@lumx/react/utils/type';
 import { Combobox, type ComboboxPopoverProps } from '../combobox';
 import { InfiniteScroll } from '../../utils/InfiniteScroll';
 import { useMergeRefs } from '../../utils/react/mergeRefs';
 import { SelectionChipGroup } from '../chip/SelectionChipGroup';
 
-interface BaseSelectTextFieldProps<O = any> extends BaseSelectTextFieldWrapperProps<O> {
+interface BaseSelectTextFieldProps<O = any> extends BaseSelectTextFieldWrapperProps<O>, HasClassName {
     /**
      * Custom option render function. Must return a `<Combobox.Option>` element with custom
      * children/props. Core-computed props (`value`, `isSelected`, `description`, `key`) are

--- a/packages/lumx-vue/src/components/chip/SelectionChipGroup.tsx
+++ b/packages/lumx-vue/src/components/chip/SelectionChipGroup.tsx
@@ -1,4 +1,14 @@
-import { type ComponentPublicInstance, computed, defineComponent, ref, useAttrs, watchEffect } from 'vue';
+import {
+    type ComponentPublicInstance,
+    type EmitFn,
+    type EmitsToProps,
+    type PublicProps,
+    computed,
+    defineComponent,
+    ref,
+    useAttrs,
+    watchEffect,
+} from 'vue';
 
 import {
     SelectionChipGroup as UI,
@@ -23,15 +33,38 @@ import ChipGroup from './ChipGroup';
  * Props omit 'ref' (handled internally).
  * inputRef is added here for Vue (ref to an associated input element for backspace focus handling).
  */
-export type SelectionChipGroupProps = VueToJSXProps<UIProps<any>> & {
+export type SelectionChipGroupProps<O = any> = VueToJSXProps<UIProps<O>> & {
     /** Ref to the associated input element (for focus restoration on backspace) */
     inputRef?: HTMLInputElement | null;
 };
 
+/** SelectionChipGroup emit schema */
 export const emitSchema = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     change: (_newValue?: any[]) => true,
 };
+
+/**
+ * SelectionChipGroup emits adapted to the value generic type
+ */
+export type SelectionChipGroupEmits<O> = {
+    change: (newValue: O[] | undefined) => void;
+};
+
+/**
+ * SelectionChipGroup component constructor with generic type attached to props
+ *
+ * Vue's `defineComponent` setup-fn overload cannot carry an unbound generic from the setup
+ * signature to the resulting component constructor, so the generic is layered on via cast.
+ */
+export interface SelectionChipGroupConstructor {
+    new <O = any>(
+        props: SelectionChipGroupProps<O> & EmitsToProps<SelectionChipGroupEmits<O>> & PublicProps,
+    ): {
+        $props: SelectionChipGroupProps<O> & EmitsToProps<SelectionChipGroupEmits<O>>;
+        $emit: EmitFn<SelectionChipGroupEmits<O>>;
+    };
+}
 
 /**
  * SelectionChipGroup component.
@@ -40,7 +73,8 @@ export const emitSchema = {
  * @return Vue element.
  */
 const SelectionChipGroup = defineComponent(
-    (props: SelectionChipGroupProps, { emit, slots }) => {
+    // The component is internally typed against `any` — the generic is layered on at export time
+    (props: SelectionChipGroupProps<any>, { emit, slots }) => {
         const attrs = useAttrs();
         const className = useClassName(() => props.class);
         const defaultTheme = useTheme();
@@ -71,7 +105,7 @@ const SelectionChipGroup = defineComponent(
         return () => {
             // Merge getChipProps and chip slot: getChipProps provides base props, slot overrides them,
             // and the core JSX template props take final priority (applied in the core component).
-            const getChipProps = (option: any) => {
+            const getChipProps = (option: unknown) => {
                 const chipProps = props.getChipProps?.(option) || {};
                 let slotProps: Record<string, any> = {};
                 if (slots.chip) {
@@ -91,10 +125,19 @@ const SelectionChipGroup = defineComponent(
 
             const { class: _class, ...restProps } = props;
 
+            /*
+             * Selector<O> is not assignable to Selector<any>/Selector<unknown> due to function
+             * parameter contravariance. The core template is generic, so we let it infer `unknown`
+             * by casting the selectors.
+             */
             return UI(
                 {
                     ...attrs,
                     ...restProps,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    getOptionId: props.getOptionId as any,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    getOptionName: props.getOptionName as any,
                     className: className.value,
                     theme: props.theme || defaultTheme.value,
                     getChipProps,
@@ -123,4 +166,4 @@ const SelectionChipGroup = defineComponent(
     },
 );
 
-export default SelectionChipGroup;
+export default SelectionChipGroup as unknown as SelectionChipGroupConstructor & typeof SelectionChipGroup;

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, onMounted, onUnmounted, ref, watch } from 'vue';
+import { defineComponent, onMounted, onUnmounted, ref } from 'vue';
 
 import { ComboboxInput as UI, COMPONENT_NAME, CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxInput';
 import { setupComboboxInput } from '@lumx/core/js/components/Combobox/setupComboboxInput';
@@ -58,16 +58,6 @@ const ComboboxInput = defineComponent(
         const { isOpen, setIsOpen } = useComboboxOpen();
 
         const inputEl = ref<HTMLInputElement | null>(null);
-        const textFieldEl = ref<HTMLElement | null>(null);
-
-        // Sync the anchor ref when the text field element is set (via the adapter ref callback).
-        watch(
-            textFieldEl,
-            (el) => {
-                anchorRef.value = el;
-            },
-            { flush: 'sync' },
-        );
 
         // Get the input element from the TextField component after mount
         onMounted(() => {
@@ -136,10 +126,11 @@ const ComboboxInput = defineComponent(
                     isOpen: isOpen.value,
                     filter,
                     textFieldRef: (el: HTMLElement | null) => {
-                        textFieldEl.value = el;
+                        anchorRef.value = el;
                     },
                     inputRef: (el: HTMLInputElement | null) => {
                         inputEl.value = el;
+                        (attrs as any).inputRef?.(el);
                     },
                     toggleButtonProps,
                     handleToggle,

--- a/packages/lumx-vue/src/components/combobox/ComboboxList.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxList.tsx
@@ -34,19 +34,13 @@ const ComboboxList = defineComponent(
         provideComboboxListContext({ type: props.type || 'listbox' });
 
         // Register the list as the listbox when both handle and list element are available
-        useWatchDisposable([handle, listRef], ([h, list]) => {
-            if (h && list) {
-                return h.registerListbox(list);
-            }
+        useWatchDisposable([handle, listRef], ([handleValue, list]) => {
+            if (!handleValue || !list) return;
+            return handleValue.registerListbox(list);
         });
 
         // Track loading state for aria-busy
         const isLoading = useComboboxEvent('loadingChange', false);
-
-        // Update listRef when the list element is mounted/unmounted
-        const setListRef = (el: Element | null) => {
-            listRef.value = el as HTMLElement | null;
-        };
 
         return () => {
             const children = slots.default?.() as JSXElement;
@@ -59,7 +53,7 @@ const ComboboxList = defineComponent(
                 'aria-multiselectable': ariaMultiselectable || undefined,
                 'aria-busy': isLoading.value || undefined,
                 className: className.value,
-                ref: setListRef as any,
+                ref: listRef as any,
                 id: listboxId,
                 type: props.type || 'listbox',
                 children,

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.stories.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.stories.tsx
@@ -1,0 +1,70 @@
+import { withValueOnChange } from '@lumx/vue/stories/decorators/withValueOnChange';
+import { setup } from '@lumx/core/js/components/SelectTextField/Stories';
+
+import { SelectTextField } from '.';
+
+import StoryCustomRender from './Stories/CustomRender.vue';
+import StoryWithCreatableOptions from './Stories/WithCreatableOptions.vue';
+import StoryWithSearch from './Stories/WithSearch.vue';
+import StoryMultipleWithSearch from './Stories/MultipleWithSearch.vue';
+
+const { meta, ...stories } = setup({
+    components: { SelectTextField },
+    decorators: { withValueOnChange },
+});
+
+export default {
+    title: 'LumX components/select-text-field/SelectTextField',
+    ...meta,
+};
+
+export const Default = { ...stories.Default };
+export const WithSelectedValue = { ...stories.WithSelectedValue };
+export const NoClearButton = { ...stories.NoClearButton };
+export const WithDescriptions = { ...stories.WithDescriptions };
+export const WithSections = { ...stories.WithSections };
+export const WithIcon = { ...stories.WithIcon };
+export const Disabled = { ...stories.Disabled };
+export const WithError = { ...stories.WithError };
+export const WithHelper = { ...stories.WithHelper };
+export const MultipleSelection = { ...stories.MultipleSelection };
+export const MultipleWithPreselected = { ...stories.MultipleWithPreselected };
+export const MultipleWithManyChips = { ...stories.MultipleWithManyChips };
+export const MultipleDisabled = { ...stories.MultipleDisabled };
+export const Loading = { ...stories.Loading };
+export const LoadingMore = { ...stories.LoadingMore };
+export const ErrorState = { ...stories.ErrorState };
+
+// ── Vue-specific stories (scoped slots + stateful behavior) ──
+
+/** SelectTextField with custom option, section title, and chip rendering via scoped slots */
+export const CustomRender = {
+    render: () => ({
+        components: { StoryCustomRender },
+        template: '<StoryCustomRender />',
+    }),
+};
+
+/** SelectTextField with a creatable option before the list */
+export const WithCreatableOptions = {
+    render: () => ({
+        components: { StoryWithCreatableOptions },
+        template: '<StoryWithCreatableOptions />',
+    }),
+};
+
+/** Single-select with consumer-controlled search (`filter="manual"` + `@search` listener) */
+export const WithSearch = {
+    render: () => ({
+        components: { StoryWithSearch },
+        template: '<StoryWithSearch />',
+    }),
+};
+
+/** Multi-select with consumer-controlled search (`filter="manual"` + `@search` listener) */
+export const MultipleWithSearch = {
+    render: () => ({
+        components: { StoryMultipleWithSearch },
+        template: '<StoryMultipleWithSearch />',
+    }),
+};

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.test.stories.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.test.stories.tsx
@@ -1,0 +1,27 @@
+import { setup } from '@lumx/core/js/components/SelectTextField/TestStories';
+import { SelectTextField } from '.';
+import { Combobox } from '../combobox';
+
+import StoryWithInfiniteScroll from './Stories/WithInfiniteScroll.vue';
+
+const { meta, ...testStories } = setup({
+    components: { SelectTextField, Combobox },
+});
+
+export default { ...meta, title: 'LumX components/select-text-field/SelectTextField/Tests' };
+
+export const ClickOutsideCloses = { ...testStories.ClickOutsideCloses };
+export const BlurResetsToSelectedValue = { ...testStories.BlurResetsToSelectedValue };
+export const BlurResetsToEmpty = { ...testStories.BlurResetsToEmpty };
+export const MultiBlurResetsSearch = { ...testStories.MultiBlurResetsSearch };
+
+// Vue-specific test stories (use Vue SFCs for stateful rendering)
+
+/** Test infinite scroll loads more options when scrolling to the bottom */
+export const WithInfiniteScroll = {
+    ...testStories.WithInfiniteScroll,
+    render: () => ({
+        components: { StoryWithInfiniteScroll },
+        template: '<StoryWithInfiniteScroll />',
+    }),
+};

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.test.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.test.tsx
@@ -1,0 +1,580 @@
+import { defineComponent, ref, nextTick } from 'vue';
+import { fireEvent, render, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { expectTypeOf } from 'vitest';
+
+import selectTextFieldTests, { TRANSLATIONS, MULTI_TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { SelectTextField, type SingleSelectTextFieldProps, type MultipleSelectTextFieldProps } from '.';
+import { Combobox } from '../combobox';
+import { Chip } from '../chip';
+
+interface Fruit {
+    id: string;
+    name: string;
+    category?: string;
+}
+
+const FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple', category: 'Pome' },
+    { id: 'banana', name: 'Banana', category: 'Tropical' },
+    { id: 'cherry', name: 'Cherry', category: 'Stone' },
+];
+
+/**
+ * Render a SelectTextField template with controlled state management for Vue.
+ * Manages a `value` state and wires it through the `onChange` prop.
+ *
+ * The `template` function is a JSX function (from the core tests) that receives
+ * `{ value, onChange, ... }` and returns a VNode. We wrap it in a Vue component
+ * that manages the reactive state.
+ */
+function renderWithState(template: (props: any) => any, initialArgs: Record<string, any> = {}) {
+    const Wrapper = defineComponent({
+        setup() {
+            const value = ref(initialArgs.value ?? undefined);
+            return () => {
+                const props = {
+                    ...initialArgs,
+                    value: value.value,
+                    onChange: (v: any) => {
+                        value.value = v;
+                        initialArgs.onChange?.(v);
+                    },
+                };
+                return template(props);
+            };
+        },
+    });
+
+    const result = render(Wrapper);
+    return { ...result, container: result.container as unknown as HTMLElement };
+}
+
+/** Get the combobox input from the rendered output. */
+function getInput(): HTMLInputElement {
+    return document.body.querySelector<HTMLInputElement>('[role="combobox"]')!;
+}
+
+describe('<SelectTextField>', () => {
+    selectTextFieldTests({
+        components: { SelectTextField, Combobox },
+        renderWithState,
+    });
+
+    describe('Vue', () => {
+        // ─── Emits ──────────────────────────────────────────────
+
+        it('should emit "change" when an option is selected', async () => {
+            const { emitted } = render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            const option = await waitFor(() => {
+                const el = document.body.querySelector<HTMLElement>('[role="option"][data-value="banana"]');
+                if (!el) throw new Error('option not found');
+                return el;
+            });
+            await user.click(option);
+
+            const changes = emitted('change') as any[][];
+            expect(changes).toBeTruthy();
+            expect(changes.at(-1)![0]).toEqual(FRUITS[1]);
+        });
+
+        it('should emit "search" when typing in the input', async () => {
+            const { emitted } = render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'manual',
+                    translations: TRANSLATIONS,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await user.keyboard('app');
+
+            const events = emitted('search') as string[][];
+            expect(events).toBeTruthy();
+            // Final search emission should equal the typed string.
+            expect(events.at(-1)![0]).toBe('app');
+        });
+
+        it('should emit "clear" when clear button is clicked', async () => {
+            const { emitted } = render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    value: FRUITS[0],
+                    translations: TRANSLATIONS,
+                },
+            });
+            const clearButton = await waitFor(() => {
+                const el = document.body.querySelector<HTMLElement>(
+                    'button[aria-label="Clear"], .lumx-text-field__input-clear',
+                );
+                if (!el) throw new Error('clear button not found');
+                return el;
+            });
+            await fireEvent.click(clearButton);
+
+            expect(emitted('clear')).toBeTruthy();
+            const changes = emitted('change') as any[][];
+            expect(changes.at(-1)![0]).toBeUndefined();
+        });
+
+        it('should emit "open" when dropdown opens and closes', async () => {
+            const { emitted } = render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+
+            await waitFor(() => {
+                const opens = (emitted('open') as boolean[][]) || [];
+                expect(opens.length).toBeGreaterThan(0);
+                expect(opens.at(-1)![0]).toBe(true);
+            });
+        });
+
+        it('should emit "load-more" only when a listener is attached (infinite scroll sentinel)', async () => {
+            // No load-more listener: sentinel must not be rendered.
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[role="listbox"]')).toBeInTheDocument();
+            });
+            expect(document.body.querySelector('.lumx-infinite-scroll-anchor')).toBeNull();
+        });
+
+        it('should render the infinite scroll sentinel when a load-more listener is attached', async () => {
+            const onLoadMore = vi.fn();
+            // With a load-more listener: sentinel should be present.
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                    'onLoad-more': onLoadMore,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[role="listbox"]')).toBeInTheDocument();
+            });
+            expect(document.body.querySelector('.lumx-infinite-scroll-anchor')).toBeInTheDocument();
+        });
+
+        // ─── Controlled searchInputValue ─────────────────────────
+
+        it('should seed the input with searchInputValue on first render', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'manual',
+                    searchInputValue: 'app',
+                    translations: TRANSLATIONS,
+                },
+            });
+            expect(getInput().value).toBe('app');
+        });
+
+        it('should react to a parent changing searchInputValue', async () => {
+            const search = ref('');
+            const Wrapper = defineComponent({
+                setup: () => () => (
+                    <SelectTextField
+                        selectionType="single"
+                        label="Select a fruit"
+                        options={FRUITS}
+                        getOptionId="id"
+                        getOptionName="name"
+                        filter="manual"
+                        searchInputValue={search.value}
+                        translations={TRANSLATIONS}
+                    />
+                ),
+            });
+            render(Wrapper);
+            expect(getInput().value).toBe('');
+
+            search.value = 'cher';
+            await nextTick();
+            expect(getInput().value).toBe('cher');
+        });
+
+        // ─── Scoped slots ────────────────────────────────────────
+
+        it('should render the `option` scoped slot for each option', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+                slots: {
+                    // Slot must render a Combobox.Option to integrate with combobox handle.
+                    option: ({ option }: any) => (
+                        <Combobox.Option value={option.id} key={option.id}>
+                            Custom: {option.name}
+                        </Combobox.Option>
+                    ),
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[role="option"][data-value="apple"]')).toBeInTheDocument();
+            });
+            const optionEl = document.body.querySelector('[role="option"][data-value="apple"]');
+            expect(optionEl?.textContent).toContain('Custom: Apple');
+        });
+
+        it('should merge `option` slot props with core-computed Combobox.Option props', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+                slots: {
+                    // Slot returns a <Combobox.Option> with an extra `data-test` attr and isDisabled.
+                    option: ({ option }: any) => (
+                        <Combobox.Option value={option.id} key={option.id} isDisabled data-test={`opt-${option.id}`}>
+                            Custom: {option.name}
+                        </Combobox.Option>
+                    ),
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[role="option"][data-value="apple"]')).toBeInTheDocument();
+            });
+            // Custom content is rendered.
+            const appleOption = document.body.querySelector('[role="option"][data-value="apple"]');
+            expect(appleOption?.textContent).toContain('Custom: Apple');
+            // Slot-provided `isDisabled` is applied (aria-disabled="true").
+            expect(appleOption).toHaveAttribute('aria-disabled', 'true');
+            // Core-computed `data-value` and `role` are still present (not clobbered).
+            expect(appleOption).toHaveAttribute('data-value', 'apple');
+            expect(appleOption).toHaveAttribute('role', 'option');
+        });
+
+        it('should pass before/after slots from the `option` slot to the rendered Combobox.Option', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+                slots: {
+                    option: ({ option }: any) => (
+                        <Combobox.Option value={option.id} key={option.id}>
+                            {{
+                                default: () => `Custom: ${option.name}`,
+                                before: () => <span data-test={`before-${option.id}`}>★</span>,
+                            }}
+                        </Combobox.Option>
+                    ),
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[role="option"][data-value="apple"]')).toBeInTheDocument();
+            });
+            // `before` named slot content appears inside the option.
+            expect(document.body.querySelector('[data-test="before-apple"]')).toBeInTheDocument();
+        });
+
+        it('should render the `option` slot VNodes as-is when no Combobox.Option is returned', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+                slots: {
+                    // Plain element — no Combobox.Option wrapping.
+                    option: ({ option }: any) => <div data-test={`raw-${option.id}`}>{option.name}</div>,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[data-test="raw-apple"]')).toBeInTheDocument();
+            });
+            // The raw div is present but NOT wrapped in a [role="option"] element.
+            const rawEl = document.body.querySelector('[data-test="raw-apple"]');
+            expect(rawEl?.closest('[role="option"]')).toBeNull();
+        });
+
+        it('should render the `sectionTitle` scoped slot for each section', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    getSectionId: 'category',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+                slots: {
+                    sectionTitle: ({ sectionId }: any) => <span data-test="section">Section: {sectionId}</span>,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[data-test="section"]')).toBeInTheDocument();
+            });
+            const titles = Array.from(document.body.querySelectorAll('[data-test="section"]')).map(
+                (el) => el.textContent,
+            );
+            expect(titles).toEqual(expect.arrayContaining(['Section: Pome', 'Section: Tropical', 'Section: Stone']));
+        });
+
+        it('should render the `chip` scoped slot for selected values (multiple mode)', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'multiple',
+                    label: 'Select fruits',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    value: [FRUITS[0]],
+                    translations: MULTI_TRANSLATIONS,
+                },
+                slots: {
+                    // The chip slot must return a `Chip` component. SelectionChipGroup extracts
+                    // the Chip's props/`before` slot and forwards them; the main label still comes
+                    // from `getOptionName`. We assert the `data-test` prop and the `before` slot
+                    // both reach the rendered chip.
+                    chip: ({ option }: any) => (
+                        <Chip data-test={`chip-${option.id}`}>
+                            {{ before: () => <span data-test="chip-before">★</span> }}
+                        </Chip>
+                    ),
+                },
+            });
+            await waitFor(() => {
+                expect(document.body.querySelector('[data-test="chip-apple"]')).toBeInTheDocument();
+            });
+            const chip = document.body.querySelector('[data-test="chip-apple"]');
+            // Label still comes from getOptionName.
+            expect(chip?.textContent).toContain('Apple');
+            // `before` slot from the chip slot is rendered inside the chip.
+            expect(chip?.querySelector('[data-test="chip-before"]')).toBeInTheDocument();
+        });
+
+        it('should render the `beforeOptions` slot above the options', async () => {
+            render(SelectTextField, {
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+                slots: {
+                    beforeOptions: () => <div data-test="before">Before content</div>,
+                },
+            });
+            const user = userEvent.setup();
+            await user.click(getInput());
+            await waitFor(() => {
+                expect(document.body.querySelector('[data-test="before"]')).toBeInTheDocument();
+            });
+            // Ensure it's positioned before the first option in the listbox.
+            const listbox = document.body.querySelector('.lumx-combobox-list');
+            const before = listbox?.querySelector('[data-test="before"]');
+            const firstOption = listbox?.querySelector('[role="option"]');
+            expect(before).toBeTruthy();
+            expect(firstOption).toBeTruthy();
+            // before should appear earlier in document order than the first option.
+            // eslint-disable-next-line no-bitwise
+            expect(before!.compareDocumentPosition(firstOption!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        });
+
+        // ─── class + className merging ───────────────────────────
+
+        it('should merge the `class` prop with the `className` attr passed via $attrs', () => {
+            // Vue parents using template syntax pass `class`; React-style consumers (or core JSX)
+            // pass `className` as an attribute. Both should reach the underlying TextField.
+            render(SelectTextField, {
+                attrs: {
+                    class: 'from-class-prop',
+                    className: 'from-class-name-attr',
+                },
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    translations: TRANSLATIONS,
+                },
+            });
+            const textField = document.body.querySelector('.lumx-text-field')!;
+            expect(textField).toHaveClass('from-class-prop');
+            expect(textField).toHaveClass('from-class-name-attr');
+        });
+
+        // ─── aria-disabled normalization ─────────────────────────
+
+        /*
+         * Compile-time assertions on the exported prop types. Enforced by `vue-tsc`
+         * during `yarn type-check`; no runtime effect. We assert prop shapes rather
+         * than render JSX because constructor overloads don't resolve `EmitsToProps`
+         * handlers in TSX call sites — `@change` / `$emit('change', …)` are the
+         * supported consumer surfaces (covered at runtime by Storybook `play`).
+         */
+        describe('Types', () => {
+            interface TypedFruit extends Fruit {
+                weight: number;
+            }
+            const FRUIT: TypedFruit = { id: 'a', name: 'A', weight: 1 };
+
+            type SingleProps = SingleSelectTextFieldProps<TypedFruit>;
+            type MultipleProps = MultipleSelectTextFieldProps<TypedFruit>;
+
+            /*
+             * Split the constructor overloads into a discriminable union, then pick the
+             * branch matching `selectionType`. `InstanceType` collapses to the last
+             * overload and loses per-branch payload narrowing.
+             */
+            type Overloads<T> = T extends {
+                new (props: infer P1): infer R1;
+                new (props: infer P2): infer R2;
+            }
+                ? { props: P1; instance: R1 } | { props: P2; instance: R2 }
+                : never;
+            type EmitFor<S extends 'single' | 'multiple'> = Extract<
+                Overloads<typeof SelectTextField<TypedFruit>>,
+                { props: { selectionType: S } }
+            >['instance']['$emit'];
+            type SingleEmit = EmitFor<'single'>;
+            type MultipleEmit = EmitFor<'multiple'>;
+
+            it('flows the generic <O> through props', () => {
+                // `toEqualTypeOf` is bidirectional, so wrong-shape values are also rejected.
+                expectTypeOf<SingleProps['options']>().toEqualTypeOf<TypedFruit[] | undefined>();
+                expectTypeOf<SingleProps['value']>().toEqualTypeOf<TypedFruit | undefined>();
+                expectTypeOf<MultipleProps['value']>().toEqualTypeOf<TypedFruit[] | undefined>();
+
+                // Selector functions.
+                expectTypeOf<(o: TypedFruit) => string>().toMatchTypeOf<SingleProps['getOptionId']>();
+                expectTypeOf<(o: TypedFruit) => string | undefined>().toMatchTypeOf<SingleProps['getOptionName']>();
+
+                // Selector key shorthand: only string-valued keys allowed.
+                expectTypeOf<'id'>().toMatchTypeOf<SingleProps['getOptionId']>();
+                expectTypeOf<'name'>().toMatchTypeOf<SingleProps['getOptionId']>();
+                expectTypeOf<'weight'>().not.toMatchTypeOf<SingleProps['getOptionId']>(); // numeric
+                expectTypeOf<'missing'>().not.toMatchTypeOf<SingleProps['getOptionId']>(); // unknown
+            });
+
+            it('narrows the change payload per selectionType', () => {
+                expectTypeOf<SingleEmit>().toBeCallableWith('change', FRUIT);
+                expectTypeOf<SingleEmit>().toBeCallableWith('change', undefined);
+                expectTypeOf<MultipleEmit>().toBeCallableWith('change', [FRUIT]);
+                expectTypeOf<MultipleEmit>().toBeCallableWith('change', undefined);
+            });
+
+            it('types common event payloads on $emit', () => {
+                expectTypeOf<SingleEmit>().toBeCallableWith('search', 'hello');
+                expectTypeOf<SingleEmit>().toBeCallableWith('blur', new FocusEvent('blur'));
+                expectTypeOf<SingleEmit>().toBeCallableWith('focus', new FocusEvent('focus'));
+                expectTypeOf<SingleEmit>().toBeCallableWith('keydown', new KeyboardEvent('keydown'));
+                expectTypeOf<SingleEmit>().toBeCallableWith('clear', new MouseEvent('click'));
+                expectTypeOf<SingleEmit>().toBeCallableWith('open', true);
+                expectTypeOf<SingleEmit>().toBeCallableWith('load-more');
+            });
+        });
+
+        it('should resolve aria-disabled passed as a Vue attr', () => {
+            render(SelectTextField, {
+                attrs: { 'aria-disabled': true },
+                props: {
+                    selectionType: 'single',
+                    label: 'Select a fruit',
+                    options: FRUITS,
+                    getOptionId: 'id',
+                    getOptionName: 'name',
+                    filter: 'auto',
+                    value: FRUITS[0],
+                    translations: TRANSLATIONS,
+                },
+            });
+            // When aria-disabled is true, the clear button is suppressed.
+            expect(document.body.querySelector('button[aria-label="Clear"]')).toBeNull();
+            expect(getInput()).toHaveAttribute('aria-disabled', 'true');
+        });
+    });
+});

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
@@ -1,0 +1,449 @@
+import {
+    type ComponentPublicInstance,
+    type EmitFn,
+    type EmitsToProps,
+    type PublicProps,
+    computed,
+    defineComponent,
+    ref,
+    watch,
+} from 'vue';
+
+import { getWithSelector } from '@lumx/core/js/utils/selectors';
+import { type RenderOptionContext, type BaseSelectTextFieldWrapperProps } from '@lumx/core/js/utils/select/types';
+import { getOptionDisplayName } from '@lumx/core/js/utils/select/getOptionDisplayName';
+import { SelectTextField as UI } from '@lumx/core/js/components/SelectTextField';
+import type { JSXElement } from '@lumx/core/js/types';
+
+import { keysOf, type EmitsOf } from '../../utils/VueToJSX';
+import { isComponentType } from '../../utils/isComponentType';
+import { Combobox } from '../combobox';
+import ComboboxOption from '../combobox/ComboboxOption';
+import SelectionChipGroup from '../chip/SelectionChipGroup';
+import { InfiniteScroll } from '@lumx/vue/utils/InfiniteScroll';
+import { useHasEventListener } from '../../composables/useHasEventListener';
+import { useClassName } from '../../composables/useClassName';
+import { useDisableStateProps } from '../../composables/useDisableStateProps';
+
+/** Props shared across single and multiple selection modes. */
+interface BaseSelectTextFieldProps<O = any> extends BaseSelectTextFieldWrapperProps<O> {
+    /** Content to render before the options list. */
+    beforeOptions?: JSXElement;
+    /** CSS class. */
+    class?: string;
+}
+
+/** Props specific to single selection mode. */
+export interface SingleSelectTextFieldProps<O = any> extends BaseSelectTextFieldProps<O> {
+    /** Selection type. */
+    selectionType: 'single';
+    /** Selected option object. */
+    value?: O;
+}
+
+/** Props specific to multiple selection mode. */
+export interface MultipleSelectTextFieldProps<O = any> extends BaseSelectTextFieldProps<O> {
+    /** Selection type. */
+    selectionType: 'multiple';
+    /** Selected option objects. */
+    value?: O[];
+}
+
+/**
+ * SelectTextField props — supports both single and multiple selection.
+ * Discriminated on `selectionType`: when `'multiple'`, `value` is `O[]`.
+ */
+export type SelectTextFieldProps<O = any> = SingleSelectTextFieldProps<O> | MultipleSelectTextFieldProps<O>;
+
+/**
+ * SelectTextField events schema
+ */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const emitSchema = {
+    /**
+     * Selection change. Payload type depends on `selectionType`:
+     * - `'single'`   → `O | undefined` (option on select, `undefined` on clear).
+     * - `'multiple'` → `O[] | undefined` (`undefined` when fully cleared).
+     *
+     * The runtime validator uses `unknown` since the discriminated payload can't be
+     * expressed without the component generic. The typed payload is restored by the
+     * `change` override on `SelectTextFieldEmits<O, S>`.
+     */
+    change: (_newValue?: unknown) => true,
+    /** User typed in the search input. */
+    search: (_searchText: string) => true,
+    /** Bottom of the options list reached — consumer should fetch the next page. */
+    'load-more': () => true,
+    /** Input lost focus. */
+    blur: (_event?: FocusEvent) => true,
+    /** Input received focus. */
+    focus: (_event?: FocusEvent) => true,
+    /** Key pressed while the input is focused. */
+    keydown: (_event?: KeyboardEvent) => true,
+    /** Clear button clicked (single mode only). */
+    clear: (_event?: MouseEvent) => true,
+    /** Dropdown opened or closed. */
+    open: (_isOpen: boolean) => true,
+};
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/**
+ * SelectTextField emits (adapting to the selection type).
+ */
+type SelectTextFieldEmits<O, S extends 'single' | 'multiple'> = Omit<EmitsOf<typeof emitSchema>, 'change'> & {
+    change: (newValue: (S extends 'multiple' ? O[] : O) | undefined) => void;
+};
+
+type SingleSelectTextFieldPublicProps<O> = SingleSelectTextFieldProps<O> &
+    EmitsToProps<SelectTextFieldEmits<O, 'single'>>;
+type MultipleSelectTextFieldPublicProps<O> = MultipleSelectTextFieldProps<O> &
+    EmitsToProps<SelectTextFieldEmits<O, 'multiple'>>;
+
+/**
+ * SelectTextField component constructor with generic type attached to props
+ *
+ * Vue's `defineComponent` setup-fn overload cannot carry an unbound generic from the setup
+ * signature to the resulting component constructor, so the generic is layered on via cast.
+ */
+export interface SelectTextFieldConstructor {
+    new <O = any>(
+        props: SingleSelectTextFieldPublicProps<O> & PublicProps,
+    ): {
+        $props: SingleSelectTextFieldPublicProps<O>;
+        $emit: EmitFn<SelectTextFieldEmits<O, 'single'>>;
+    };
+    new <O = any>(
+        props: MultipleSelectTextFieldPublicProps<O> & PublicProps,
+    ): {
+        $props: MultipleSelectTextFieldPublicProps<O>;
+        $emit: EmitFn<SelectTextFieldEmits<O, 'multiple'>>;
+    };
+}
+
+/**
+ * A text field with a select dropdown to choose between a list of options.
+ * Supports search/filter, single selection, and multiple selection with chips.
+ *
+ * Scoped slots:
+ * - `option({ option, index })` — custom option rendering inside a `<Combobox.Option>`.
+ * - `sectionTitle({ sectionId, options })` — custom section header rendering.
+ * - `chip({ option, index })` — custom chip rendering (multiple selection only).
+ */
+const SelectTextField = defineComponent(
+    (props: SelectTextFieldProps, { emit, slots, attrs }) => {
+        const isMultiple = computed(() => props.selectionType === 'multiple');
+
+        // Merge `class` prop with `className` attr (React-style attr from core JSX).
+        const className = useClassName(() => props.class);
+
+        /*
+         * Resolve disabled state from props and any React-named attrs (`ariaDisabled`,
+         * `aria-disabled`) forwarded by the core JSX layer. `useDisableStateProps`
+         * normalizes all the variants and provides `isAnyDisabled`.
+         */
+        const { isAnyDisabled, disabledStateProps } = useDisableStateProps(
+            computed(() => ({ ...props, ...attrs }) as Record<string, unknown>),
+        );
+
+        // Track whether the user is actively typing a search.
+        const isSearching = ref(Boolean(props.searchInputValue));
+        const searchText = ref(props.searchInputValue ?? '');
+
+        // ComboboxList is a Vue component, so the ref resolves to its instance — Vue 3 auto-sets
+        // `$el` to the root DOM node (the `<ul>`).
+        const listRef = ref<ComponentPublicInstance | null>(null);
+
+        // Ref to the underlying <input> element (needed to link the SelectionChipGroup)
+        const inputElRef = ref<HTMLInputElement | null>(null);
+
+        // Sync external controlled search value into internal state.
+        watch(
+            () => props.searchInputValue,
+            (newVal) => {
+                if (newVal !== undefined) {
+                    searchText.value = newVal;
+                    isSearching.value = Boolean(newVal);
+                }
+            },
+        );
+
+        // The display value shown in the input.
+        const displayValue = computed(() => {
+            // Guard: multiple mode always shows the search text (chips represent the selection).
+            if (props.selectionType === 'multiple') return searchText.value;
+            // Guard: while typing, always show what the user typed.
+            if (isSearching.value) return searchText.value;
+            // TypeScript now narrows props to SingleSelectTextFieldProps here.
+            return getOptionDisplayName(props.value, props.getOptionName, props.getOptionId);
+        });
+
+        // Map option id selection to option object selection.
+        const handleSelect = (selectedOption: { value: string }) => {
+            const selectedValue = selectedOption.value;
+            const newOption =
+                selectedValue &&
+                props.options?.find((option) => getWithSelector(props.getOptionId, option) === selectedValue);
+
+            if (props.selectionType === 'single') {
+                emit('change', newOption);
+            } else {
+                // TypeScript narrows props to MultipleSelectTextFieldProps here.
+                const currentValue = props.value || [];
+                const existingIndex = currentValue.findIndex(
+                    (item) => getWithSelector(props.getOptionId, item) === selectedValue,
+                );
+
+                if (existingIndex === -1) {
+                    // Skip if no matching option found (e.g. beforeOptions custom actions).
+                    if (newOption) {
+                        emit('change', [...currentValue, newOption]);
+                    }
+                } else {
+                    // Remove option (toggle off)
+                    const updated = [...currentValue];
+                    updated.splice(existingIndex, 1);
+                    emit('change', updated);
+                }
+            }
+
+            // Reset search state after selection.
+            isSearching.value = false;
+            searchText.value = '';
+            emit('search', '');
+        };
+
+        // Handle text input changes (search).
+        const handleInputChange = (inputValue: string) => {
+            isSearching.value = true;
+            searchText.value = inputValue;
+            emit('search', inputValue);
+
+            // When the user clears the input (single mode only), clear the selection too.
+            if (!isMultiple.value && inputValue === '' && props.value !== undefined && props.value !== null) {
+                emit('change', undefined);
+            }
+        };
+
+        // Handle clear button click (single mode only).
+        const handleClear = (event?: MouseEvent) => {
+            emit('change', undefined);
+            isSearching.value = false;
+            searchText.value = '';
+            emit('search', '');
+            emit('clear', event);
+        };
+
+        // Handle blur: reset input to selected value name, then emit blur and search events.
+        const handleBlur = (event?: FocusEvent) => {
+            isSearching.value = false;
+            searchText.value = '';
+            emit('search', '');
+            emit('blur', event);
+        };
+
+        /** Adapt the slots.option to the JSX renderOption */
+        const wrappedRenderOption = computed(() => {
+            const renderOptionSlot = slots.option;
+            if (!renderOptionSlot) return undefined;
+
+            return (option: unknown, { index, value: optionValue, isSelected, description }: RenderOptionContext) => {
+                const vnodes = renderOptionSlot({ option, index });
+                const customOption = vnodes?.find(isComponentType(ComboboxOption));
+
+                // Fallback: consumer didn't return a <Combobox.Option> — render their VNodes as-is.
+                if (!customOption) return vnodes as unknown as JSXElement;
+
+                // Extract slot-overridable props; drop undefined so they don't clobber core defaults.
+                const slotProps: Record<string, any> = customOption.props || {};
+                const definedSlotProps = Object.fromEntries(
+                    Object.entries(slotProps).filter(([, v]) => v !== undefined),
+                );
+
+                // `before`/`after` may be passed as JSX props (attrs) — promote them to named slots.
+                const { before: beforeProp, after: afterProp, ...restSlotProps } = definedSlotProps;
+
+                // Handle slots overrides (default, before and after)
+                const slotChildren = { ...(customOption.children as Record<string, any>) };
+                if (beforeProp !== undefined && !slotChildren.before) {
+                    slotChildren.before = () => beforeProp;
+                }
+                if (afterProp !== undefined && !slotChildren.after) {
+                    slotChildren.after = () => afterProp;
+                }
+
+                return (
+                    <ComboboxOption
+                        key={optionValue}
+                        value={optionValue}
+                        isSelected={isSelected}
+                        description={description ?? undefined}
+                        {...restSlotProps}
+                    >
+                        {slotChildren}
+                    </ComboboxOption>
+                ) as JSXElement;
+            };
+        });
+
+        /*
+         * Wrap the consumer's renderSectionTitle slot.
+         * The scoped slot receives `{ sectionId, options }` and should return
+         * custom JSX to display as the section title.
+         */
+        const wrappedRenderSectionTitle = computed(() => {
+            const renderSectionTitleSlot = slots.sectionTitle;
+            if (!renderSectionTitleSlot) return undefined;
+
+            return (sectionId: string, options: unknown[]) => {
+                return renderSectionTitleSlot({ sectionId, options }) as JSXElement;
+            };
+        });
+
+        /*
+         * Check if a 'load-more' listener is registered on this component
+         * (EmitsToProps mapping for the 'load-more' event produces 'onLoad-more').
+         */
+        const hasLoadMoreListener = useHasEventListener('onLoadMore') || useHasEventListener('onLoad-more');
+
+        const onLoadMore = () => emit('load-more');
+
+        return () => {
+            const showClear =
+                !isMultiple.value &&
+                !isAnyDisabled.value &&
+                (props.hasClearButton ?? true) &&
+                props.value !== undefined &&
+                props.value !== null;
+
+            // TypeScript narrows props to MultipleSelectTextFieldProps inside the truthy branch.
+            const chips =
+                props.selectionType === 'multiple' ? (
+                    <SelectionChipGroup
+                        value={props.value}
+                        theme={props.theme}
+                        getOptionId={props.getOptionId}
+                        getOptionName={props.getOptionName}
+                        onChange={(newValue) => emit('change', newValue)}
+                        inputRef={inputElRef.value}
+                        isDisabled={isAnyDisabled.value}
+                        label={props.translations.chipGroupLabel ?? props.label}
+                        chipRemoveLabel={props.translations.chipRemoveLabel}
+                    >
+                        {{ chip: slots.chip || undefined }}
+                    </SelectionChipGroup>
+                ) : undefined;
+
+            const listStatus = props.listStatus ?? 'idle';
+
+            const beforeOptionsSlot = (props.beforeOptions ?? slots.beforeOptions?.()) as JSXElement | undefined;
+
+            /*
+             * Selector<O> is not assignable to Selector<any> due to function parameter contravariance.
+             * The core template is not generic, so we cast selectors when forwarding to UI().
+             */
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return UI(
+                {
+                    options: props.options,
+                    getOptionId: props.getOptionId as any,
+                    getOptionName: props.getOptionName as any,
+                    getOptionDescription: props.getOptionDescription as any,
+                    renderOption: wrappedRenderOption.value as any,
+                    getSectionId: props.getSectionId as any,
+                    renderSectionTitle: wrappedRenderSectionTitle.value as any,
+                    selected: props.value,
+                    label: props.label,
+                    isMultiselectable: isMultiple.value,
+                    listStatus,
+                    onOpen: (isOpen: boolean) => emit('open', isOpen),
+                    loadingMessage: props.translations.loadingMessage,
+                    emptyMessage: props.translations.emptyMessage,
+                    nbOptionMessage: props.translations.nbOptionMessage,
+                    errorMessage: props.translations.errorMessage,
+                    errorTryReloadMessage: props.translations.errorTryReloadMessage,
+                    inputProps: {
+                        ...props.inputProps,
+                        placeholder: props.placeholder,
+                        icon: props.icon,
+                        value: displayValue.value,
+                        inputRef(el: HTMLInputElement | null) {
+                            inputElRef.value = el;
+                        },
+                        onChange: handleInputChange,
+                        onSelect: handleSelect,
+                        onBlur: handleBlur,
+                        onFocus: (event?: FocusEvent) => emit('focus', event),
+                        onKeyDown: (event?: KeyboardEvent) => emit('keydown', event),
+                        ...disabledStateProps.value,
+                        isRequired: props.isRequired,
+                        hasError: props.hasError,
+                        error: props.error,
+                        helper: props.helper,
+                        id: props.id,
+                        name: props.name,
+                        isValid: props.isValid,
+                        maxLength: props.maxLength,
+                        'aria-label': props.ariaLabel,
+                        clearButtonProps: showClear ? { label: props.translations.clearLabel } : undefined,
+                        onClear: handleClear,
+                        toggleButtonProps: props.translations.showSuggestionsLabel
+                            ? { label: props.translations.showSuggestionsLabel }
+                            : undefined,
+                        filter: props.filter,
+                        openOnFocus: props.openOnFocus,
+                        className: className.value,
+                        theme: props.theme,
+                    },
+                    popoverProps: props.popoverProps,
+                    listProps: { ref: listRef },
+                    chips: chips as JSXElement | undefined,
+                    beforeOptions: beforeOptionsSlot,
+                    onLoadMore: hasLoadMoreListener ? onLoadMore : undefined,
+                    infiniteScrollOptions: { root: listRef.value?.$el ?? null, rootMargin: '100px' },
+                },
+                { Combobox, InfiniteScroll },
+            );
+        };
+    },
+    {
+        name: 'LumxSelectTextField',
+        inheritAttrs: false,
+        props: keysOf<SelectTextFieldProps<unknown>>()(
+            'options',
+            'getOptionId',
+            'getOptionName',
+            'getOptionDescription',
+            'getSectionId',
+            'selectionType',
+            'value',
+            'filter',
+            'searchInputValue',
+            'hasClearButton',
+            'listStatus',
+            'label',
+            'placeholder',
+            'icon',
+            'isDisabled',
+            'aria-disabled',
+            'isRequired',
+            'hasError',
+            'error',
+            'helper',
+            'id',
+            'name',
+            'isValid',
+            'maxLength',
+            'ariaLabel',
+            'inputProps',
+            'popoverProps',
+            'translations',
+            'beforeOptions',
+            'openOnFocus',
+            'class',
+            'theme',
+        ),
+        emits: emitSchema,
+    },
+);
+
+export default SelectTextField as unknown as SelectTextFieldConstructor & typeof SelectTextField;

--- a/packages/lumx-vue/src/components/select-text-field/Stories/CustomRender.vue
+++ b/packages/lumx-vue/src/components/select-text-field/Stories/CustomRender.vue
@@ -1,0 +1,51 @@
+<template>
+    <SelectTextField
+        selection-type="multiple"
+        label="Select fruits"
+        placeholder="Search fruits..."
+        :options="FRUITS"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        get-section-id="category"
+        :value="value"
+        :translations="MULTI_TRANSLATIONS"
+        @change="handleChange"
+    >
+        <template #chip="{ option }">
+            <Chip>
+                <template #before>
+                    <Icon :icon="option.icon" size="xs" />
+                </template>
+                {{ option.name }}
+            </Chip>
+        </template>
+
+        <template #sectionTitle="{ sectionId, options }">
+            <Icon :icon="options[0].categoryIcon" size="xs" />
+            {{ sectionId }}
+        </template>
+
+        <template #option="{ option }">
+            <SelectTextFieldOption :value="option.id">
+                <template #before>
+                    <Icon :icon="option.icon" size="xs" />
+                </template>
+                {{ option.name }}
+            </SelectTextFieldOption>
+        </template>
+    </SelectTextField>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { FRUITS, type Fruit } from '@lumx/core/js/components/SelectTextField/Stories';
+import { MULTI_TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { Chip, Icon, SelectTextField, SelectTextFieldOption } from '@lumx/vue';
+
+const value = ref<Fruit[]>([FRUITS[0], FRUITS[4]]);
+
+function handleChange(newValue: Fruit[] | undefined) {
+    value.value = newValue ?? [];
+}
+</script>

--- a/packages/lumx-vue/src/components/select-text-field/Stories/MultipleWithSearch.vue
+++ b/packages/lumx-vue/src/components/select-text-field/Stories/MultipleWithSearch.vue
@@ -1,0 +1,55 @@
+<template>
+    <SelectTextField
+        selection-type="multiple"
+        label="Select fruits"
+        placeholder="Type to search..."
+        :options="filteredFruits"
+        filter="manual"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        :translations="MULTI_TRANSLATIONS"
+        @change="handleChange"
+        @search="handleSearch"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { MULTI_TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { SelectTextField } from '@lumx/vue';
+
+interface Fruit {
+    id: string;
+    name: string;
+}
+
+const FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'apricot', name: 'Apricot' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'blueberry', name: 'Blueberry' },
+    { id: 'cherry', name: 'Cherry' },
+    { id: 'grape', name: 'Grape' },
+    { id: 'lemon', name: 'Lemon' },
+    { id: 'orange', name: 'Orange' },
+    { id: 'peach', name: 'Peach' },
+    { id: 'strawberry', name: 'Strawberry' },
+];
+
+const value = ref<Fruit[]>([]);
+const filteredFruits = ref(FRUITS);
+
+function handleChange(newValue: Fruit[] | undefined) {
+    value.value = newValue ?? [];
+}
+
+function handleSearch(searchText: string) {
+    if (!searchText) {
+        filteredFruits.value = FRUITS;
+        return;
+    }
+    const lower = searchText.toLowerCase();
+    filteredFruits.value = FRUITS.filter((f) => f.name.toLowerCase().includes(lower));
+}
+</script>

--- a/packages/lumx-vue/src/components/select-text-field/Stories/WithCreatableOptions.vue
+++ b/packages/lumx-vue/src/components/select-text-field/Stories/WithCreatableOptions.vue
@@ -1,0 +1,49 @@
+<template>
+    <SelectTextField
+        selection-type="multiple"
+        label="Select or create a fruit"
+        placeholder="Type to search or create..."
+        :options="options"
+        filter="auto"
+        :get-option-id="String"
+        :value="value"
+        :search-input-value="search"
+        :translations="MULTI_TRANSLATIONS"
+        @change="handleChange"
+        @search="search = $event"
+    >
+        <template v-if="canCreate" #beforeOptions>
+            <SelectTextFieldSection>
+                <SelectTextFieldOption :value="`__create__${search}`" @click="handleCreate(search)">
+                    Create "{{ search }}"
+                </SelectTextFieldOption>
+            </SelectTextFieldSection>
+        </template>
+    </SelectTextField>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { MULTI_TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { SelectTextField, SelectTextFieldOption, SelectTextFieldSection } from '@lumx/vue';
+
+const value = ref<string[]>([]);
+const search = ref('');
+const options = ref(['Apple', 'Banana', 'Cherry', 'Orange']);
+
+function handleChange(newValue: string[] | undefined) {
+    value.value = newValue ?? [];
+}
+
+const canCreate = computed(
+    () => search.value && !options.value.some((o) => o.toLowerCase() === search.value.toLowerCase()),
+);
+
+function handleCreate(name: string) {
+    if (!options.value.includes(name)) {
+        options.value = [...options.value, name];
+    }
+    value.value = [...value.value, name];
+    search.value = '';
+}
+</script>

--- a/packages/lumx-vue/src/components/select-text-field/Stories/WithInfiniteScroll.vue
+++ b/packages/lumx-vue/src/components/select-text-field/Stories/WithInfiniteScroll.vue
@@ -1,0 +1,54 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="items"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="handleChange"
+        @load-more="onLoadMore"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { SelectTextField } from '@lumx/vue';
+
+interface Fruit {
+    id: string;
+    name: string;
+}
+
+const FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'apricot', name: 'Apricot' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'blueberry', name: 'Blueberry' },
+    { id: 'cherry', name: 'Cherry' },
+    { id: 'grape', name: 'Grape' },
+    { id: 'lemon', name: 'Lemon' },
+    { id: 'orange', name: 'Orange' },
+    { id: 'peach', name: 'Peach' },
+    { id: 'strawberry', name: 'Strawberry' },
+];
+
+const value = ref<Fruit>();
+const items = ref<Fruit[]>(FRUITS.map((f, i) => ({ ...f, id: `${f.id}-${i}` })));
+
+function handleChange(newValue: Fruit | undefined) {
+    value.value = newValue;
+}
+
+function onLoadMore() {
+    if (items.value.length >= 200) {
+        return;
+    }
+    const offset = items.value.length;
+    items.value = [...items.value, ...FRUITS.map((f, i) => ({ ...f, id: `${f.id}-${offset + i}` }))];
+}
+</script>

--- a/packages/lumx-vue/src/components/select-text-field/Stories/WithSearch.vue
+++ b/packages/lumx-vue/src/components/select-text-field/Stories/WithSearch.vue
@@ -1,0 +1,55 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Type to search..."
+        :options="filteredFruits"
+        filter="manual"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="handleChange"
+        @search="handleSearch"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { SelectTextField } from '@lumx/vue';
+
+interface Fruit {
+    id: string;
+    name: string;
+}
+
+const FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'apricot', name: 'Apricot' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'blueberry', name: 'Blueberry' },
+    { id: 'cherry', name: 'Cherry' },
+    { id: 'grape', name: 'Grape' },
+    { id: 'lemon', name: 'Lemon' },
+    { id: 'orange', name: 'Orange' },
+    { id: 'peach', name: 'Peach' },
+    { id: 'strawberry', name: 'Strawberry' },
+];
+
+const value = ref<Fruit>();
+const filteredFruits = ref(FRUITS);
+
+function handleChange(newValue: Fruit | undefined) {
+    value.value = newValue;
+}
+
+function handleSearch(searchText: string) {
+    if (!searchText) {
+        filteredFruits.value = FRUITS;
+        return;
+    }
+    const lower = searchText.toLowerCase();
+    filteredFruits.value = FRUITS.filter((f) => f.name.toLowerCase().includes(lower));
+}
+</script>

--- a/packages/lumx-vue/src/components/select-text-field/index.ts
+++ b/packages/lumx-vue/src/components/select-text-field/index.ts
@@ -1,0 +1,28 @@
+import _ComboboxOption from '../combobox/ComboboxOption';
+import _ComboboxSection from '../combobox/ComboboxSection';
+import _ComboboxOptionMoreInfo from '../combobox/ComboboxOptionMoreInfo';
+import _ComboboxOptionSkeleton from '../combobox/ComboboxOptionSkeleton';
+import _ListDivider from '../list/ListDivider';
+
+export {
+    type SelectTextFieldProps,
+    type SingleSelectTextFieldProps,
+    type MultipleSelectTextFieldProps,
+    default as SelectTextField,
+} from './SelectTextField';
+export type { SelectTextFieldStatus, SelectTextFieldTranslations } from '@lumx/core/js/utils/select/types';
+
+/** Selectable option within the dropdown list. */
+export const SelectTextFieldOption = _ComboboxOption;
+
+/** Labelled group of options. */
+export const SelectTextFieldSection = _ComboboxSection;
+
+/** Info icon on an option that reveals a popover with additional details. */
+export const SelectTextFieldOptionMoreInfo = _ComboboxOptionMoreInfo;
+
+/** Skeleton loading placeholder for options being fetched. */
+export const SelectTextFieldOptionSkeleton = _ComboboxOptionSkeleton;
+
+/** Visual separator between option groups (alias for ListDivider). Purely decorative — invisible to screen readers. */
+export const SelectTextFieldDivider = _ListDivider;

--- a/packages/lumx-vue/src/components/text-field/TextField.tsx
+++ b/packages/lumx-vue/src/components/text-field/TextField.tsx
@@ -134,7 +134,7 @@ const TextField = defineComponent(
                 onInput: _oi,
                 onFocus: _of,
                 onBlur: _ob,
-                chips: _chips,
+                chips: chipsAttr,
                 ...inputAttrs
             } = attrs as any;
 
@@ -165,7 +165,7 @@ const TextField = defineComponent(
 
             return (
                 <TextFieldUI
-                    chips={getChipsSlot() ?? undefined}
+                    chips={(getChipsSlot() ?? chipsAttr) || undefined}
                     error={props.error}
                     forceFocusStyle={props.forceFocusStyle}
                     hasError={props.hasError}

--- a/packages/lumx-vue/src/index.ts
+++ b/packages/lumx-vue/src/index.ts
@@ -43,3 +43,4 @@ export * from './components/thumbnail';
 export * from './components/toolbar';
 export * from './components/tooltip';
 export * from './components/user-block';
+export * from './components/select-text-field';

--- a/packages/lumx-vue/src/utils/VueToJSX.ts
+++ b/packages/lumx-vue/src/utils/VueToJSX.ts
@@ -39,3 +39,18 @@ export const keysOf = <T>() => {
         );
     };
 };
+
+/**
+ * Derive the typed Vue emits map from a runtime `emitSchema` object.
+ *
+ * @example
+ * export const emitSchema = {
+ *     change: (_newValue?: unknown) => true,
+ *     search: (_text: string) => true,
+ * };
+ * export type MyEmits<O> = EmitsOf<typeof emitSchema>
+ */
+export type EmitsOf<S> = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [K in keyof S]: S[K] extends (...args: infer A) => any ? (...args: A) => void : never;
+};

--- a/packages/site-demo/content/product/components/select-text-field/index.mdx
+++ b/packages/site-demo/content/product/components/select-text-field/index.mdx
@@ -1,5 +1,5 @@
 ---
-frameworks: ['react']
+frameworks: ['react', 'vue']
 ---
 
 import * as ReactDemoSingleSelection from './react/single-selection.tsx';
@@ -10,7 +10,16 @@ import * as ReactDemoLoading from './react/loading.tsx';
 import * as ReactDemoLoadingMore from './react/loading-more.tsx';
 import * as ReactDemoEmpty from './react/empty.tsx';
 import * as ReactDemoListError from './react/list-error.tsx';
+import * as VueDemoSingleSelection from './vue/single-selection.vue';
+import * as VueDemoMultipleSelection from './vue/multiple-selection.vue';
+import * as VueDemoWithSections from './vue/with-sections.vue';
+import * as VueDemoCustomRender from './vue/custom-render.vue';
+import * as VueDemoLoading from './vue/loading.vue';
+import * as VueDemoLoadingMore from './vue/loading-more.vue';
+import * as VueDemoEmpty from './vue/empty.vue';
+import * as VueDemoListError from './vue/list-error.vue';
 import ReactSelectTextField from 'lumx-docs:@lumx/react/components/select-text-field/SelectTextField';
+import VueSelectTextField from 'lumx-docs:@lumx/vue/components/select-text-field/SelectTextField';
 
 # Select text field
 
@@ -21,13 +30,13 @@ Use them when users need to select one or more items from a searchable dropdown 
 
 Set `selectionType="single"` for single selection mode. Users can type to filter options and select one.
 
-<DemoBlock demo={{ react: ReactDemoSingleSelection }} />
+<DemoBlock demo={{ react: ReactDemoSingleSelection, vue: VueDemoSingleSelection }} />
 
 ## Multiple selection
 
 Set `selectionType="multiple"` to allow selecting multiple options. Selected values are displayed as chips below the input.
 
-<DemoBlock demo={{ react: ReactDemoMultipleSelection  }} />
+<DemoBlock demo={{ react: ReactDemoMultipleSelection, vue: VueDemoMultipleSelection }} />
 
 ## Options
 
@@ -41,7 +50,7 @@ Each option is an object. Use selector props to tell the component how to read e
 
 Options can be grouped in sections via `getSectionId`.
 
-<DemoBlock demo={{ react: ReactDemoWithSections }} />
+<DemoBlock demo={{ react: ReactDemoWithSections, vue: VueDemoWithSections }} />
 
 ### Custom rendering
 
@@ -49,7 +58,7 @@ Beyond simple text customization, options, section title and chips (multiple sel
 
 Extra options can also be injected at the top of the dropdown list — for example, a "Create" option that lets users add new entries on the fly.
 
-<DemoBlock demo={{ react: ReactDemoCustomRender  }} />
+<DemoBlock demo={{ react: ReactDemoCustomRender, vue: VueDemoCustomRender }} />
 
 ## Input options
 
@@ -68,25 +77,25 @@ The select text field dropdown list have alternative states to handle server-bac
 
 Set `listStatus="loading"` to display skeleton placeholders while options are being fetched. Real options are hidden until loading completes.
 
-<DemoBlock demo={{ react: ReactDemoLoading  }} />
+<DemoBlock demo={{ react: ReactDemoLoading, vue: VueDemoLoading }} />
 
 ### Loading more
 
 Set `listStatus="loadingMore"` to append a skeleton placeholder at the bottom of the existing options, indicating that more items are being loaded (e.g. during infinite scroll pagination).
 
-<DemoBlock demo={{ react: ReactDemoLoadingMore  }} />
+<DemoBlock demo={{ react: ReactDemoLoadingMore, vue: VueDemoLoadingMore }} />
 
 ### Empty
 
 Provide `translations.emptyMessage` to display a message when no options are available. The message can be a static string or a function receiving the current input value for dynamic messages.
 
-<DemoBlock demo={{ react: ReactDemoEmpty  }} />
+<DemoBlock demo={{ react: ReactDemoEmpty, vue: VueDemoEmpty }} />
 
 ### Error
 
 Set `listStatus="error"` to display an error state inside the dropdown. Use `translations.errorMessage` for the error title and optionally `translations.errorTryReloadMessage` for a secondary message.
 
-<DemoBlock demo={{ react: ReactDemoListError  }} />
+<DemoBlock demo={{ react: ReactDemoListError, vue: VueDemoListError }} />
 
 ## Filter types
 
@@ -115,4 +124,4 @@ Select text fields can be disabled in two ways:
 
 ## Properties
 
-<PropTable docs={{ react: ReactSelectTextField  }} />
+<PropTable docs={{ react: ReactSelectTextField, vue: VueSelectTextField }} />

--- a/packages/site-demo/content/product/components/select-text-field/vue/custom-render.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/custom-render.vue
@@ -1,0 +1,111 @@
+<template>
+    <SelectTextField
+        selection-type="multiple"
+        label="Select fruits"
+        placeholder="Search fruits..."
+        :options="fruits"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        get-section-id="category"
+        :value="value"
+        :search-input-value="search"
+        :translations="TRANSLATIONS"
+        @change="value = $event ?? []"
+        @search="search = $event"
+    >
+        <template v-if="canCreate" #beforeOptions>
+            <SelectTextFieldSection>
+                <SelectTextFieldOption :value="`__create__${search}`" @click="handleCreate(search)">
+                    Create "{{ search }}"
+                </SelectTextFieldOption>
+            </SelectTextFieldSection>
+        </template>
+
+        <template #option="{ option }">
+            <SelectTextFieldOption :value="option.id">
+                <template #before>
+                    <Icon :icon="option.icon" size="xs" />
+                </template>
+                {{ option.name }}
+            </SelectTextFieldOption>
+        </template>
+
+        <template #sectionTitle="{ sectionId, options }">
+            <Icon :icon="options[0].categoryIcon" size="xs" />
+            {{ sectionId }}
+        </template>
+
+        <template #chip="{ option }">
+            <Chip>
+                <template #before>
+                    <Icon :icon="option.icon" size="xs" />
+                </template>
+                {{ option.name }}
+            </Chip>
+        </template>
+    </SelectTextField>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Chip, Icon, SelectTextField, SelectTextFieldOption, SelectTextFieldSection } from '@lumx/vue';
+import {
+    mdiFoodApple,
+    mdiFoodForkDrink,
+    mdiFruitCitrus,
+    mdiFruitGrapes,
+    mdiFruitPineapple,
+    mdiSprout,
+} from '@lumx/icons';
+
+interface Fruit {
+    id: string;
+    name: string;
+    icon: string;
+    category: string;
+    categoryIcon: string;
+}
+
+const INITIAL_FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple', icon: mdiFoodApple, category: 'Pome', categoryIcon: mdiFoodApple },
+    { id: 'banana', name: 'Banana', icon: mdiSprout, category: 'Tropical', categoryIcon: mdiFruitPineapple },
+    {
+        id: 'pineapple',
+        name: 'Pineapple',
+        icon: mdiFruitPineapple,
+        category: 'Tropical',
+        categoryIcon: mdiFruitPineapple,
+    },
+    { id: 'grape', name: 'Grape', icon: mdiFruitGrapes, category: 'Berry', categoryIcon: mdiFruitGrapes },
+    { id: 'lemon', name: 'Lemon', icon: mdiFruitCitrus, category: 'Citrus', categoryIcon: mdiFruitCitrus },
+    { id: 'orange', name: 'Orange', icon: mdiFruitCitrus, category: 'Citrus', categoryIcon: mdiFruitCitrus },
+];
+
+const TRANSLATIONS = {
+    showSuggestionsLabel: 'Show suggestions',
+    chipGroupLabel: 'Selected fruits',
+    chipRemoveLabel: 'Remove',
+};
+
+const value = ref<Fruit[]>([INITIAL_FRUITS[1], INITIAL_FRUITS[3]]);
+const search = ref('');
+const fruits = ref(INITIAL_FRUITS);
+
+const canCreate = computed(
+    () => search.value && !fruits.value.some((f) => f.name.toLowerCase() === search.value.toLowerCase()),
+);
+
+function handleCreate(name: string) {
+    const newFruit: Fruit = {
+        id: name.toLowerCase(),
+        name,
+        icon: mdiFoodForkDrink,
+        category: 'Custom',
+        categoryIcon: mdiFoodForkDrink,
+    };
+    fruits.value = [...fruits.value, newFruit];
+    value.value = [...value.value, newFruit];
+    search.value = '';
+}
+</script>

--- a/packages/site-demo/content/product/components/select-text-field/vue/empty.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/empty.vue
@@ -1,0 +1,27 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="[]"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SelectTextField } from '@lumx/vue';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    emptyMessage: 'No options available',
+};
+
+const value = ref<{ id: string; name: string } | undefined>();
+</script>

--- a/packages/site-demo/content/product/components/select-text-field/vue/list-error.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/list-error.vue
@@ -1,0 +1,29 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="[]"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        list-status="error"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SelectTextField } from '@lumx/vue';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    errorMessage: 'Failed to load options',
+    errorTryReloadMessage: 'Please try again later',
+};
+
+const value = ref<{ id: string; name: string } | undefined>();
+</script>

--- a/packages/site-demo/content/product/components/select-text-field/vue/loading-more.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/loading-more.vue
@@ -1,0 +1,34 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="FRUITS"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        list-status="loadingMore"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SelectTextField } from '@lumx/vue';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    loadingMessage: 'Loading more options...',
+};
+
+const value = ref<(typeof FRUITS)[number] | undefined>();
+</script>

--- a/packages/site-demo/content/product/components/select-text-field/vue/loading.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/loading.vue
@@ -1,0 +1,34 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="FRUITS"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        list-status="loading"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SelectTextField } from '@lumx/vue';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+    loadingMessage: 'Loading options...',
+};
+
+const value = ref<(typeof FRUITS)[number] | undefined>();
+</script>

--- a/packages/site-demo/content/product/components/select-text-field/vue/multiple-selection.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/multiple-selection.vue
@@ -1,0 +1,42 @@
+<template>
+    <SelectTextField
+        selection-type="multiple"
+        label="Select fruits"
+        placeholder="Search fruits..."
+        :options="FRUITS"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SelectTextField } from '@lumx/vue';
+
+interface Fruit {
+    id: string;
+    name: string;
+}
+
+const FRUITS: Fruit[] = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+    { id: 'grape', name: 'Grape' },
+    { id: 'orange', name: 'Orange' },
+    { id: 'peach', name: 'Peach' },
+    { id: 'strawberry', name: 'Strawberry' },
+];
+
+const TRANSLATIONS = {
+    showSuggestionsLabel: 'Show suggestions',
+    chipGroupLabel: 'Selected fruits',
+    chipRemoveLabel: 'Remove',
+};
+
+const value = ref<Fruit[] | undefined>([FRUITS[0], FRUITS[2]]);
+</script>

--- a/packages/site-demo/content/product/components/select-text-field/vue/single-selection.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/single-selection.vue
@@ -1,0 +1,36 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="FRUITS"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SelectTextField } from '@lumx/vue';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple' },
+    { id: 'banana', name: 'Banana' },
+    { id: 'cherry', name: 'Cherry' },
+    { id: 'grape', name: 'Grape' },
+    { id: 'orange', name: 'Orange' },
+    { id: 'peach', name: 'Peach' },
+    { id: 'strawberry', name: 'Strawberry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+const value = ref<(typeof FRUITS)[number] | undefined>();
+</script>

--- a/packages/site-demo/content/product/components/select-text-field/vue/with-sections.vue
+++ b/packages/site-demo/content/product/components/select-text-field/vue/with-sections.vue
@@ -1,0 +1,39 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="FRUITS"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        get-section-id="category"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { SelectTextField } from '@lumx/vue';
+
+const FRUITS = [
+    { id: 'apple', name: 'Apple', category: 'Pome' },
+    { id: 'banana', name: 'Banana', category: 'Tropical' },
+    { id: 'blueberry', name: 'Blueberry', category: 'Berry' },
+    { id: 'cherry', name: 'Cherry', category: 'Stone' },
+    { id: 'grape', name: 'Grape', category: 'Berry' },
+    { id: 'lemon', name: 'Lemon', category: 'Citrus' },
+    { id: 'orange', name: 'Orange', category: 'Citrus' },
+    { id: 'peach', name: 'Peach', category: 'Stone' },
+    { id: 'strawberry', name: 'Strawberry', category: 'Berry' },
+];
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+const value = ref<(typeof FRUITS)[number] | undefined>();
+</script>

--- a/packages/site-demo/plugins/lumx-prop-table/vue-docgen.js
+++ b/packages/site-demo/plugins/lumx-prop-table/vue-docgen.js
@@ -82,6 +82,35 @@ function getVueComponentName(sourceFile) {
 }
 
 /**
+ * Parse a JSDoc block from a node's leading comment trivia.
+ *
+ * Used for object-property declarations (e.g. `emitSchema.change`) where TS-morph's
+ * `getJsDocs()` returns nothing — JSDoc parsing in the TS compiler is opt-in for
+ * `JSDocableNode` declarations only.
+ *
+ * @param {Node} node - The AST node whose leading comments to inspect
+ * @returns {string} - The first JSDoc block's description text, or '' if none.
+ */
+function extractJsDocFromLeadingComments(node) {
+    const ranges = node.getLeadingCommentRanges?.() || [];
+    for (const range of ranges) {
+        const text = range.getText();
+        if (!text.startsWith('/**')) continue;
+        // Strip the `/**`, `*/`, and per-line ` * ` markers, ignoring `@tag` lines.
+        const inner = text
+            .replace(/^\/\*\*/, '')
+            .replace(/\*\/$/, '')
+            .split('\n')
+            .map((line) => line.replace(/^\s*\*\s?/, '').trimEnd())
+            .filter((line) => !line.startsWith('@'))
+            .join('\n')
+            .trim();
+        if (inner) return inner;
+    }
+    return '';
+}
+
+/**
  * Extract events from a Vue component.
  * Supports two patterns:
  *   1. `emitSchema` const objects with validator functions
@@ -103,15 +132,20 @@ function extractEmits(sourceFile) {
         for (const prop of initializer.getProperties()) {
             if (prop.getKindName() !== 'PropertyAssignment') continue;
 
-            const eventName = prop.getName();
-            const description = getJsDocFromDeclaration(prop);
+            // Strip surrounding quotes for string-literal property names (e.g. `'load-more'`).
+            const eventName = prop.getName().replace(/^['"]|['"]$/g, '');
+            // PropertyAssignment doesn't expose JSDoc via `getJsDocs()` — fall back to
+            // parsing leading comment trivia.
+            const description = getJsDocFromDeclaration(prop) || extractJsDocFromLeadingComments(prop);
             const parameters = [];
 
             // Parse the validator function's parameters for type info
             const validator = prop.getInitializer();
             if (validator && validator.getKindName() === 'ArrowFunction') {
                 for (const param of validator.getParameters()) {
-                    const paramName = param.getName();
+                    // Strip the leading underscore convention (`_event` → `event`) — used
+                    // when the validator can't actually validate (e.g. `unknown` payloads).
+                    const paramName = param.getName().replace(/^_/, '');
                     const paramType = param.getTypeNode()?.getText() || param.getType().getText();
                     const optional = param.hasQuestionToken() || param.hasInitializer();
                     parameters.push({ name: paramName, type: paramType, optional });


### PR DESCRIPTION
## Summary

- Add `SelectTextField` Vue component (`@lumx/vue`) wrapping the existing core `SelectTextField` JSX template
- Supports both `single` and `multiple` selection modes with a discriminated union on `selectionType`
- Features: searchable input, chip group for multi-select, infinite scroll via `load-more` event, custom option/section/chip slots, and controlled search input
- Adds Storybook stories and a full unit test suite (`SelectTextField.test.tsx`, 510+ lines)
- Adds Vue demo files and updates the MDX documentation page for `select-text-field`

## Changes

- **`packages/lumx-vue/src/components/select-text-field/`** — new Vue component with typed emit schema and generic constructor type for TSX consumers
- **`packages/lumx-vue/src/index.ts`** — exports new component
- **`packages/site-demo/content/product/components/select-text-field/`** — Vue demo `.vue` files (single, multiple, sections, search, infinite scroll, custom render, states) + MDX page update
- **Minor fixes** — `SelectionChipGroup` disabled state handling, `ComboboxList` and `TextField` small adjustments, core `select/types.ts` cleanup

StoryBook lumx-react: https://464b0c1f1--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://464b0c1f1--697a023f84e832e23544fb3c.chromatic.com/