### PR TITLE
fix(flag): add white background to match Figma design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectionChipGroup`: fix disabled chip event
+    -   `Flag`: fix opaque white background
 
 ## [4.11.0][] - 2026-04-15
 

--- a/packages/lumx-core/src/scss/components/flag/_index.scss
+++ b/packages/lumx-core/src/scss/components/flag/_index.scss
@@ -12,6 +12,7 @@
     padding: 0 $lumx-spacing-unit;
     margin: 0;
     border-radius: math.div(map.get($lumx-sizes, lumx-base-const("size", "XS")), 2);
+    background-color: lumx-color-variant("light", "N");
 
     &--is-truncated {
         max-width: 100%;


### PR DESCRIPTION
Fix https://lumapps.atlassian.net/browse/LX-72

## Summary

- The `Flag` component had no `background-color` set, leaving it transparent
- The [Figma design](https://www.figma.com/design/oBsCET5MB3dQMDkBAc214t?node-id=7889:28595) specifies a white (`light/N`) background for all color variants
- Added `background-color: lumx-color-variant("light", "N")` to the base flag class in `_index.scss`

## Test plan

- [ ] Visually verify the Flag component displays a white background in Storybook for all color variants (default, blue, green, yellow, red)
- [ ] Check that the component still looks correct on colored or non-white backgrounds (flag should stand out against the container)

StoryBook lumx-vue: https://a1ef67da6--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: [Deploying...](https://github.com/lumapps/design-system/actions/runs/24667093950?pr=1640)