### PR TITLE
fix(combobox): align Combobox prop types across core, react and vue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `Combobox`: align prop types across core, React and Vue (single source of truth for `filter`, `openOnFocus`, `onSelect`)
+
 ## [4.12.0][] - 2026-04-22
 
 ### Added

--- a/packages/lumx-core/src/js/components/Combobox/ComboboxButton.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/ComboboxButton.tsx
@@ -1,5 +1,6 @@
 import type { CommonRef, HasClassName, JSXElement, LumxClassName } from '../../types';
 import { classNames } from '../../utils';
+import type { ComboboxCallbacks } from './types';
 
 /**
  * Label display mode for the ComboboxButton.
@@ -12,7 +13,7 @@ export type ComboboxButtonLabelDisplayMode = 'show-selection' | 'show-label' | '
 /**
  * Defines the props for the core ComboboxButton template.
  */
-export interface ComboboxButtonProps extends HasClassName {
+export interface ComboboxButtonProps extends HasClassName, ComboboxCallbacks {
     /** The label for the button (used for ARIA and tooltip). */
     label: string;
     /** The currently selected value to display. */

--- a/packages/lumx-core/src/js/components/Combobox/ComboboxInput.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/ComboboxInput.tsx
@@ -1,11 +1,12 @@
 import { mdiChevronUp, mdiChevronDown } from '@lumx/icons';
 import type { CommonRef, HasClassName, HasTheme, LumxClassName } from '../../types';
 import { getDisabledState } from '../../utils/disabledState';
+import type { ComboboxCallbacks, ComboboxInputOptions } from './types';
 
 /**
  * Defines the props for the core ComboboxInput template.
  */
-export interface ComboboxInputProps extends HasClassName, HasTheme {
+export interface ComboboxInputProps extends HasClassName, HasTheme, ComboboxCallbacks, ComboboxInputOptions {
     /** The ID of the listbox element (for aria-controls). */
     listboxId?: string;
     /** Whether the combobox is open. */
@@ -20,12 +21,21 @@ export interface ComboboxInputProps extends HasClassName, HasTheme {
     toggleButtonProps?: Record<string, any>;
     /** Toggle callback for the chevron button. */
     handleToggle?(): void;
-    /**
-     * Controls how the combobox filters options as the user types.
-     * When `'off'`, the input is rendered as `readOnly`.
-     */
-    filter?: 'auto' | 'manual' | 'off';
 }
+
+/**
+ * Props from the core `ComboboxInputProps` that framework wrappers (React/Vue)
+ * are expected to provide internally or re-type with framework-specific equivalents
+ * (e.g. React refs, framework-specific button props). Wrappers should omit these
+ * keys when exposing the core props to consumers.
+ */
+export type ComboboxInputPropsToOverride =
+    | 'listboxId'
+    | 'isOpen'
+    | 'inputRef'
+    | 'textFieldRef'
+    | 'toggleButtonProps'
+    | 'handleToggle';
 
 /**
  * Injected framework-specific components for ComboboxInput rendering.

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -375,7 +375,7 @@ export function setupCombobox(
         },
 
         select(option: HTMLElement | null) {
-            callbacks.onSelect({ value: option ? getOptionValue(option) : '' }, handle);
+            callbacks.onSelect?.({ value: option ? getOptionValue(option) : '' });
         },
 
         registerOption(element: HTMLElement, callback: (isFiltered: boolean) => void): () => void {

--- a/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
@@ -1,26 +1,8 @@
-import type { ComboboxCallbacks, ComboboxHandle } from './types';
+import type { ComboboxCallbacks, ComboboxHandle, ComboboxInputOptions } from './types';
 import { setupCombobox } from './setupCombobox';
 
 /** Options for configuring the input-mode combobox controller. */
-export interface SetupComboboxInputOptions extends ComboboxCallbacks {
-    /**
-     * Controls how the combobox filters options as the user types.
-     *
-     * - `'auto'` (default) — Options are automatically filtered client-side.
-     * - `'manual'` — Filtering is the consumer's responsibility.
-     * - `'off'` — Like `'manual'`, and `openOnFocus` defaults to `true`.
-     *   The core template renders the input as `readOnly`.
-     */
-    filter?: 'auto' | 'manual' | 'off';
-    /**
-     * When true, the combobox opens automatically when the input receives focus.
-     * When false (default, unless `filter` is `'off'`), the combobox only opens
-     * on click, typing, or keyboard navigation.
-     *
-     * @default false (true when filter is 'off')
-     */
-    openOnFocus?: boolean;
-}
+export interface SetupComboboxInputOptions extends ComboboxCallbacks, ComboboxInputOptions {}
 
 /**
  * Set up a combobox with an input trigger (autocomplete/filter pattern).
@@ -37,6 +19,7 @@ export interface SetupComboboxInputOptions extends ComboboxCallbacks {
  * @returns A ComboboxHandle for interacting with the combobox.
  */
 export function setupComboboxInput(input: HTMLInputElement, options: SetupComboboxInputOptions): ComboboxHandle {
+    let handle: ComboboxHandle;
     const { filter = 'auto', onSelect: optionOnSelect } = options;
     const openOnFocus = options.openOnFocus ?? filter === 'off';
     const autoFilter = filter === 'auto';
@@ -55,22 +38,22 @@ export function setupComboboxInput(input: HTMLInputElement, options: SetupCombob
      * Wraps the consumer's onSelect to perform input-mode side effects after selection:
      * clears the active descendant, resets the filter, and re-opens the popup.
      */
-    const onSelect = (option: { value: string }, combobox: ComboboxHandle) => {
-        optionOnSelect(option, combobox);
+    const onSelect = (option: { value: string }) => {
+        optionOnSelect?.(option);
 
         // Clear the active item. In multi-select, keep visual focus so the
         // user can continue navigating after selection.
-        if (!combobox.isMultiSelect) {
-            combobox.focusNav?.clear();
+        if (!handle.isMultiSelect) {
+            handle.focusNav?.clear();
         }
         userHasTyped = false;
-        combobox.setIsOpen(true);
+        handle.setIsOpen(true);
         if (autoFilter) {
-            combobox.setFilter('');
+            handle.setFilter('');
         }
     };
 
-    const handle = setupCombobox({ onSelect }, { wrapNavigation: true }, (combobox, signal) => {
+    handle = setupCombobox({ onSelect }, { wrapNavigation: true }, (combobox, signal) => {
         signal.addEventListener('abort', () => {
             userHasTyped = false;
         });

--- a/packages/lumx-core/src/js/components/Combobox/types.ts
+++ b/packages/lumx-core/src/js/components/Combobox/types.ts
@@ -43,8 +43,33 @@ export interface ComboboxEventMap {
 
 /** Callbacks provided by the consumer (React/Vue) to react to combobox state changes. */
 export interface ComboboxCallbacks {
-    /** Called when an option is selected (click or keyboard). Receives the combobox handle for post-selection side effects. */
-    onSelect(option: { value: string }, handle: ComboboxHandle): void;
+    /** Called when an option is selected (click or keyboard). */
+    onSelect?(option: { value: string }): void;
+}
+
+/**
+ * Behavioral options for input-mode combobox (autocomplete/filter pattern).
+ * Shared between the core JSX template props (`ComboboxInputProps`) and the
+ * runtime controller options (`SetupComboboxInputOptions`).
+ */
+export interface ComboboxInputOptions {
+    /**
+     * Controls how the combobox filters options as the user types.
+     *
+     * - `'auto'` (default) — Options are automatically filtered client-side.
+     * - `'manual'` — Filtering is the consumer's responsibility.
+     * - `'off'` — Like `'manual'`, but the input is rendered as `readOnly`
+     *   and `openOnFocus` defaults to `true`.
+     */
+    filter?: 'auto' | 'manual' | 'off';
+    /**
+     * When true, the combobox opens automatically when the input receives focus.
+     * When false (default, unless `filter` is `'off'`), the combobox only opens
+     * on click, typing, or keyboard navigation.
+     *
+     * @default false (true when filter is 'off')
+     */
+    openOnFocus?: boolean;
 }
 
 /** Handle returned by `setupCombobox`. Used by framework wrappers and mode controllers. */

--- a/packages/lumx-react/src/components/combobox/ComboboxButton.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxButton.tsx
@@ -27,10 +27,7 @@ export type ComboboxButtonProps<E extends ElementType = typeof Button> = Omit<
     'children' | 'role' | 'aria-controls' | 'aria-haspopup' | 'aria-expanded' | 'aria-activedescendant'
 > &
     HasRequiredLinkHref<E> &
-    ReactToJSX<UIProps> & {
-        /** Called when an option is selected. */
-        onSelect?: (option: { value: string }) => void;
-    };
+    ReactToJSX<UIProps>;
 
 /**
  * Combobox.Button component - Button trigger for select-only combobox mode.

--- a/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
@@ -1,9 +1,16 @@
 import { type Ref, useCallback, useEffect, useRef } from 'react';
 
 import { setupComboboxInput } from '@lumx/core/js/components/Combobox/setupComboboxInput';
-import { ComboboxInput as UI, COMPONENT_NAME, CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxInput';
+import {
+    ComboboxInput as UI,
+    ComboboxInputProps as UIProps,
+    ComboboxInputPropsToOverride,
+    COMPONENT_NAME,
+    CLASSNAME,
+} from '@lumx/core/js/components/Combobox/ComboboxInput';
 import { forwardRef } from '@lumx/react/utils/react/forwardRef';
 import { useMergeRefs } from '@lumx/react/utils/react/mergeRefs';
+import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
 import { IconButton, IconButtonProps } from '../button';
 import { TextField, TextFieldProps } from '../text-field';
 import { useComboboxContext } from './context/ComboboxContext';
@@ -13,34 +20,13 @@ import { useComboboxOpen } from './context/useComboboxOpen';
  * Props for Combobox.Input component.
  * Note: role, aria-autocomplete, aria-controls, aria-expanded are set internally and cannot be overridden.
  */
-export interface ComboboxInputProps extends TextFieldProps {
-    /** Reference to the input element. */
-    inputRef?: Ref<HTMLInputElement>;
+export interface ComboboxInputProps extends TextFieldProps, ReactToJSX<UIProps, ComboboxInputPropsToOverride> {
     /**
      * Props for the toggle button.
      * When provided, a chevron button will be rendered in the text field's afterElement
      * to toggle the listbox visibility.
      */
     toggleButtonProps?: Pick<IconButtonProps, 'label'> & Partial<Omit<IconButtonProps, 'label'>>;
-    /** Called when an option is selected. */
-    onSelect?: (option: { value: string }) => void;
-    /**
-     * Controls how the combobox filters options as the user types.
-     *
-     * - `'auto'` (default) — Options are automatically filtered client-side.
-     * - `'manual'` — Filtering is the consumer's responsibility.
-     * - `'off'` — Like `'manual'`, but the input is rendered as `readOnly`
-     *   and `openOnFocus` defaults to `true`.
-     */
-    filter?: 'auto' | 'manual' | 'off';
-    /**
-     * When true, the combobox opens automatically when the input receives focus.
-     * When false (default, unless `filter` is `'off'`), the combobox only opens
-     * on click, typing, or keyboard navigation.
-     *
-     * @default false (true when filter is 'off')
-     */
-    openOnFocus?: boolean;
 }
 
 /**

--- a/packages/lumx-react/src/components/combobox/ComboboxList.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxList.tsx
@@ -4,28 +4,16 @@ import { forwardRef } from '@lumx/react/utils/react/forwardRef';
 import { useMergeRefs } from '@lumx/react/utils/react/mergeRefs';
 import {
     ComboboxList as UI,
+    ComboboxListProps as UIProps,
     COMPONENT_NAME,
     CLASSNAME,
-    type ComboboxListType,
 } from '@lumx/core/js/components/Combobox/ComboboxList';
-import { ListProps } from '@lumx/react/components/list';
+import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
 import { useComboboxContext } from './context/ComboboxContext';
 import { ComboboxListContext } from './context/ComboboxListContext';
 
-/**
- * Props for Combobox.List component.
- * Note: role, id are set internally and cannot be overridden.
- */
-export interface ComboboxListProps extends ListProps {
-    /** Accessible label for the listbox (required for accessibility). */
-    'aria-label': string;
-    /**
-     * The popup type. Set to "grid" when options have action buttons (Combobox.OptionAction).
-     * Enables 2D keyboard navigation and switches ARIA roles from listbox/option to grid/gridcell.
-     * @default 'listbox'
-     */
-    type?: ComboboxListType;
-}
+/** Props for Combobox.List component. */
+export interface ComboboxListProps extends ReactToJSX<UIProps, 'aria-busy'> {}
 
 /**
  * Combobox.List component - wraps List with listbox ARIA attributes.

--- a/packages/lumx-vue/src/components/combobox/ComboboxButton.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxButton.tsx
@@ -23,8 +23,6 @@ export type ComboboxButtonProps = VueToJSXProps<UIProps, 'label'> & {
     value?: string;
     /** Controls how the label/value is displayed. @default 'show-selection' */
     labelDisplayMode?: ComboboxButtonLabelDisplayMode;
-    /** Called when an option is selected. */
-    onSelect?: (option: { value: string }) => void;
 };
 
 /**

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -1,6 +1,12 @@
 import { defineComponent, onMounted, onUnmounted, ref } from 'vue';
 
-import { ComboboxInput as UI, COMPONENT_NAME, CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxInput';
+import {
+    ComboboxInput as UI,
+    ComboboxInputProps as UIProps,
+    ComboboxInputPropsToOverride,
+    COMPONENT_NAME,
+    CLASSNAME,
+} from '@lumx/core/js/components/Combobox/ComboboxInput';
 import { setupComboboxInput } from '@lumx/core/js/components/Combobox/setupComboboxInput';
 
 import { useClassName } from '../../composables/useClassName';
@@ -17,33 +23,14 @@ import { useComboboxOpen } from './context/useComboboxOpen';
  * Props for Combobox.Input component.
  * Note: role, aria-autocomplete, aria-controls, aria-expanded are set internally and cannot be overridden.
  */
-export type ComboboxInputProps = VueToJSXProps<TextFieldProps, 'inputRef' | 'textFieldRef'> & {
+export interface ComboboxInputProps extends TextFieldProps, VueToJSXProps<UIProps, ComboboxInputPropsToOverride> {
     /**
      * Props for the toggle button.
      * When provided, a chevron button will be rendered in the text field's afterElement
      * to toggle the listbox visibility.
      */
     toggleButtonProps?: Pick<IconButtonProps, 'label'> & Partial<Omit<IconButtonProps, 'label'>>;
-    /** Called when an option is selected. */
-    onSelect?: (option: { value: string }) => void;
-    /**
-     * Controls how the combobox filters options as the user types.
-     *
-     * - `'auto'` (default) — Options are automatically filtered client-side.
-     * - `'manual'` — Filtering is the consumer's responsibility.
-     * - `'off'` — Like `'manual'`, but the input is rendered as `readOnly`
-     *   and `openOnFocus` defaults to `true`.
-     */
-    filter?: 'auto' | 'manual' | 'off';
-    /**
-     * When true, the combobox opens automatically when the input receives focus.
-     * When false (default, unless `filter` is `'off'`), the combobox only opens
-     * on click, typing, or keyboard navigation.
-     *
-     * @default false (true when filter is 'off')
-     */
-    openOnFocus?: boolean;
-};
+}
 
 /**
  * Combobox.Input component - wraps TextField with combobox ARIA attributes.
@@ -127,10 +114,11 @@ const ComboboxInput = defineComponent(
                     filter,
                     textFieldRef: (el: HTMLElement | null) => {
                         anchorRef.value = el;
+                        props.textFieldRef?.(el);
                     },
                     inputRef: (el: HTMLInputElement | null) => {
                         inputEl.value = el;
-                        (attrs as any).inputRef?.(el);
+                        props.inputRef?.(el);
                     },
                     toggleButtonProps,
                     handleToggle,
@@ -168,6 +156,8 @@ const ComboboxInput = defineComponent(
             'name',
             'type',
             'minimumRows',
+            'inputRef',
+            'textFieldRef',
             'toggleButtonProps',
             'onSelect',
             'filter',


### PR DESCRIPTION
Improve type re-use across ComboboxInput, ComboboxButton and ComboboxList in React and Vue

StoryBook lumx-react: https://3b89d20ce--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://3b89d20ce--697a023f84e832e23544fb3c.chromatic.com/