### PR TITLE
fix(SelectionChipGroup): focus next chip on Enter/Space chip removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `Combobox`: align prop types across core, React and Vue (single source of truth for `filter`, `openOnFocus`, `onSelect`)
+    -   `SelectionChipGroup`: on Enter/Space chip removal, move focus to the next chip (fallback to previous chip, then to the input)
 
 ## [4.12.0][] - 2026-04-22
 

--- a/packages/lumx-core/src/js/components/Chip/SelectionChipGroupTests.ts
+++ b/packages/lumx-core/src/js/components/Chip/SelectionChipGroupTests.ts
@@ -32,9 +32,14 @@ export const setup = (propsOverride: any = {}, { render, ...options }: SetupOpti
 interface CoreTestOptions extends SetupOptions<any> {
     /**
      * Render a stateful SelectionChipGroup that updates its own value on change.
-     * When provided, enables roving tabindex recovery tests.
+     * Should also render a sibling `<input>` element wired via `inputRef` so the
+     * keyboard navigation tests can assert focus fallback to the input.
+     *
+     * When provided, enables roving tabindex recovery and keyboard navigation tests.
+     *
+     * @param initialValue Optional initial value (defaults to all 3 testOptions).
      */
-    renderStateful?: () => void;
+    renderStateful?: (initialValue?: any[]) => void;
 }
 
 export default (renderOptions: CoreTestOptions) => {
@@ -265,6 +270,30 @@ export default (renderOptions: CoreTestOptions) => {
                 expect(onChange).toHaveBeenCalledWith([testOptions[0], testOptions[2]]);
             });
 
+            it('should focus next chip on Enter/Space when chip is removed', async () => {
+                setup({}, renderOptions);
+                const chips = screen.getAllByRole('option');
+                chips[0].focus();
+                await userEvent.keyboard('{Enter}');
+                expect(chips[1]).toHaveFocus();
+            });
+
+            it('should focus next chip on Space when chip is removed', async () => {
+                setup({}, renderOptions);
+                const chips = screen.getAllByRole('option');
+                chips[1].focus();
+                await userEvent.keyboard(' ');
+                expect(chips[2]).toHaveFocus();
+            });
+
+            it('should fall back to previous chip on Enter when last chip is removed', async () => {
+                setup({}, renderOptions);
+                const chips = screen.getAllByRole('option');
+                chips[2].focus();
+                await userEvent.keyboard('{Enter}');
+                expect(chips[1]).toHaveFocus();
+            });
+
             it('should not trigger onChange on other keys', async () => {
                 const onChange = vi.fn();
                 setup({ onChange }, renderOptions);
@@ -305,6 +334,26 @@ export default (renderOptions: CoreTestOptions) => {
                         expect(remainingChips).toHaveLength(2);
                         expect(remainingChips[0]).toHaveAttribute('tabIndex', '0');
                         expect(remainingChips[0]).toHaveFocus();
+                    });
+                });
+            });
+
+            describe.each([
+                ['{Backspace}', 'Backspace'],
+                ['{Enter}', 'Enter'],
+                [' ', 'Space'],
+            ])('Keyboard navigation focus fallback to input on %s', (key) => {
+                it('should focus input when no chip remains', async () => {
+                    renderStateful([testOptions[0]]);
+
+                    const input = screen.getByRole('textbox');
+                    const chips = screen.getAllByRole('option');
+                    chips[0].focus();
+                    await userEvent.keyboard(key);
+
+                    await waitFor(() => {
+                        expect(screen.queryAllByRole('option')).toHaveLength(0);
+                        expect(input).toHaveFocus();
                     });
                 });
             });

--- a/packages/lumx-core/src/js/components/Chip/setupSelectionChipGroupEvents.ts
+++ b/packages/lumx-core/src/js/components/Chip/setupSelectionChipGroupEvents.ts
@@ -32,24 +32,34 @@ export interface SetupSelectionChipGroupEventsOptions<O> {
 }
 
 /**
- * Finds the previous enabled chip before the given chip element using a TreeWalker.
- * If no currentChip is provided, returns the last enabled chip in the container.
+ * Find the nearest enabled chip in the given direction relative to `anchor`.
+ *
+ * - When `anchor` is provided, walks one step in `direction` from it.
+ * - When `anchor` is omitted, returns the first enabled chip from the matching
+ *   end of the container (last chip for 'previous', first for 'next').
  */
-function findPreviousChip(container: HTMLElement, currentChip?: Element | null): HTMLElement | undefined {
+function findSiblingChip(
+    container: HTMLElement,
+    direction: 'next' | 'previous',
+    anchor?: Element | null,
+): HTMLElement | undefined {
     const walker = createSelectorTreeWalker(container, ENABLED_CHIP_SELECTOR);
 
-    if (!currentChip) {
-        // Find the last enabled chip by walking to the end.
+    if (anchor) {
+        walker.currentNode = anchor;
+        const node = direction === 'next' ? walker.nextNode() : walker.previousNode();
+        return (node as HTMLElement) || undefined;
+    }
+
+    // No anchor: walk from the matching end of the container.
+    if (direction === 'previous') {
         let last: HTMLElement | undefined;
         while (walker.nextNode()) {
             last = walker.currentNode as HTMLElement;
         }
         return last;
     }
-
-    // Position the walker at the current chip and walk backward.
-    walker.currentNode = currentChip;
-    return (walker.previousNode() as HTMLElement) || undefined;
+    return (walker.nextNode() as HTMLElement) || undefined;
 }
 
 /** Remove an option by its id and call onChange. */
@@ -91,9 +101,6 @@ export function setupSelectionChipGroupEvents<O>(options: SetupSelectionChipGrou
     };
 
     // Delegated keydown handler on the chip group container.
-    // Enter/Space trigger removal (like click).
-    // Backspace also removes but explicitly moves focus to previous chip (overriding the
-    // roving tabindex MutationObserver which defaults to moving focus forward).
     const handleKeyDown = (evt: KeyboardEvent) => {
         const chip = getChip(evt.target);
         const optionId = chip?.dataset.optionId;
@@ -102,14 +109,23 @@ export function setupSelectionChipGroupEvents<O>(options: SetupSelectionChipGrou
             return;
         }
 
+        // Compute focus fallback target before removing the chip.
+        let focusTarget: HTMLElement | undefined;
         if (evt.key === 'Backspace') {
-            // Move focus to previous option (instead of next in listbox)
-            const previousChip = findPreviousChip(container, chip);
-            const focusTarget = previousChip || options.getInput?.();
-            if (focusTarget) {
-                focusTarget.focus();
-                focusTarget.setAttribute('tabindex', '0');
-            }
+            // Custom behavior (not WAI-ARIA recommendation) => focus the previous chip, fallback on input (no more chips)
+            focusTarget = findSiblingChip(container, 'previous', chip) || options.getInput?.() || undefined;
+        } else {
+            // WAI-ARIA recommendation when removing an option in a listbox => focus the next chip, fallback on previous chip
+            // (bonus: we fallback on input when there is no more chips)
+            focusTarget =
+                findSiblingChip(container, 'next', chip) ||
+                findSiblingChip(container, 'previous', chip) ||
+                options.getInput?.() ||
+                undefined;
+        }
+        if (focusTarget) {
+            focusTarget.focus();
+            focusTarget.setAttribute('tabindex', '0');
         }
 
         evt.preventDefault();
@@ -132,7 +148,7 @@ export function setupSelectionChipGroupEvents<O>(options: SetupSelectionChipGrou
             evt.stopPropagation();
             evt.preventDefault();
 
-            const lastChip = findPreviousChip(container);
+            const lastChip = findSiblingChip(container, 'previous');
             lastChip?.focus();
         };
         input.addEventListener('keydown', inputHandler);

--- a/packages/lumx-react/src/components/chip/SelectionChipGroup.test.tsx
+++ b/packages/lumx-react/src/components/chip/SelectionChipGroup.test.tsx
@@ -36,16 +36,21 @@ const setup = (propOverrides: Partial<SelectionChipGroupProps<TestOption>> = {})
 
 const StatefulSelectionChipGroup = (props: Partial<SelectionChipGroupProps<TestOption>>) => {
     const [value, setValue] = useState(props.value ?? testOptions);
+    const inputRef = React.useRef<HTMLInputElement>(null);
     return (
-        <SelectionChipGroup
-            getOptionId="id"
-            getOptionName="name"
-            label="Test chips"
-            chipRemoveLabel="Remove"
-            {...props}
-            value={value}
-            onChange={(newValue) => setValue(newValue ?? [])}
-        />
+        <>
+            <SelectionChipGroup
+                getOptionId="id"
+                getOptionName="name"
+                label="Test chips"
+                chipRemoveLabel="Remove"
+                {...props}
+                value={value}
+                onChange={(newValue) => setValue(newValue ?? [])}
+                inputRef={inputRef}
+            />
+            <input ref={inputRef} />
+        </>
     );
 };
 
@@ -53,7 +58,7 @@ describe('<SelectionChipGroup />', () => {
     // Core tests
     BaseSelectionChipGroupTests({
         render: (props: any) => render(<SelectionChipGroup {...props} />),
-        renderStateful: () => render(<StatefulSelectionChipGroup />),
+        renderStateful: (initialValue?: TestOption[]) => render(<StatefulSelectionChipGroup value={initialValue} />),
         screen,
     });
 
@@ -151,32 +156,6 @@ describe('<SelectionChipGroup />', () => {
                 expect(chips[1]).not.toHaveAttribute('aria-disabled');
                 // Chip 3: getChipProps sets isDisabled=true, renderChip returns undefined => getChipProps wins
                 expect(chips[2]).toHaveAttribute('aria-disabled', 'true');
-            });
-        });
-
-        describe('Keyboard navigation', () => {
-            it('should remove chip and focus input on Backspace', async () => {
-                const onChange = vi.fn();
-                const inputRef = React.createRef<HTMLInputElement>();
-                const { container } = setup({
-                    value: [testOptions[0]],
-                    onChange,
-                    inputRef,
-                });
-
-                const input = document.createElement('input');
-                (inputRef as any).current = input;
-                container.appendChild(input);
-
-                const chips = screen.getAllByRole('option');
-                const firstChip = chips[0];
-
-                firstChip.focus();
-                await userEvent.keyboard('{Backspace}');
-
-                expect(onChange).toHaveBeenCalledTimes(1);
-                expect(onChange).toHaveBeenCalledWith([]);
-                expect(input).toHaveFocus();
             });
         });
 

--- a/packages/lumx-vue/src/components/chip/SelectionChipGroup.test.ts
+++ b/packages/lumx-vue/src/components/chip/SelectionChipGroup.test.ts
@@ -12,23 +12,33 @@ const testOptions = [
     { id: '3', name: 'Banana' },
 ];
 
-const StatefulWrapper = defineComponent({
-    setup() {
-        const value = ref([...testOptions]);
-        const onChange = (newValue?: any[]) => {
-            value.value = newValue ?? [];
-        };
-        return () =>
-            h(SelectionChipGroup, {
-                value: value.value,
-                getOptionId: 'id',
-                getOptionName: 'name',
-                label: 'Test chips',
-                chipRemoveLabel: 'Remove',
-                onChange,
-            });
-    },
-});
+const createStatefulWrapper = (initialValue: any[] = [...testOptions]) =>
+    defineComponent({
+        setup() {
+            const value = ref([...initialValue]);
+            const inputRef = ref<HTMLInputElement | null>(null);
+            const onChange = (newValue?: any[]) => {
+                value.value = newValue ?? [];
+            };
+            return () =>
+                h('div', [
+                    h(SelectionChipGroup, {
+                        value: value.value,
+                        getOptionId: 'id',
+                        getOptionName: 'name',
+                        label: 'Test chips',
+                        chipRemoveLabel: 'Remove',
+                        inputRef: inputRef.value,
+                        onChange,
+                    }),
+                    h('input', {
+                        ref: (el: any) => {
+                            inputRef.value = el;
+                        },
+                    }),
+                ]);
+        },
+    });
 
 describe('<SelectionChipGroup />', () => {
     const renderComponent = (props: any, options?: any) =>
@@ -40,7 +50,7 @@ describe('<SelectionChipGroup />', () => {
     // Core tests
     BaseSelectionChipGroupTests({
         render: renderComponent,
-        renderStateful: () => render(StatefulWrapper),
+        renderStateful: (initialValue?: any[]) => render(createStatefulWrapper(initialValue)),
         screen,
     });
 


### PR DESCRIPTION
# General summary

- `SelectionChipGroup`: on Enter/Space chip removal, move focus to the next chip (fallback to the previous chip, then to the input). Backspace behavior is unchanged (previous chip → input).
- Refactor: merged `findPreviousChip` / `findNextChip` into a single `findSiblingChip(container, direction, anchor?)` helper.
- Tests: moved input-fallback keyboard tests into the shared core `SelectionChipGroupTests.ts` (covers Backspace, Enter, Space) by extending the `renderStateful` helper to render an associated `<input>`. React and Vue stateful wrappers now share the same coverage.

StoryBook lumx-react: https://0ae59946e--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://0ae59946e--697a023f84e832e23544fb3c.chromatic.com/