### PR TITLE
fix(focus-trap): factorize trap logic into core, fallback to zone, allow aria-disabled focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `Combobox`: align prop types across core, React and Vue (single source of truth for `filter`, `openOnFocus`, `onSelect`)
     -   `SelectionChipGroup`: on Enter/Space chip removal, move focus to the next chip (fallback to previous chip, then to the input)
+    -   `Dialog`, `Lightbox`, `Popover`: allow focus on `aria-disabled` and correclty fallback to the container instead of staying on the trigger when no focusable are detected
 
 ## [4.12.0][] - 2026-04-22
 

--- a/packages/lumx-core/src/js/utils/focus/constants.ts
+++ b/packages/lumx-core/src/js/utils/focus/constants.ts
@@ -2,6 +2,11 @@
 export const TABBABLE_ELEMENTS_SELECTOR =
     'a[href], button, textarea, input:not([type="hidden"]):not([hidden]), [tabindex]';
 
-/** CSS selector matching element that are disabled (should not receive focus). */
-export const DISABLED_SELECTOR =
-    '[hidden], [tabindex="-1"], [disabled]:not([disabled="false"]), [aria-disabled]:not([aria-disabled="false"])';
+/**
+ * CSS selector matching elements that should be excluded from focus traversal.
+ *
+ * Note: `aria-disabled` is intentionally NOT in this list — per ARIA semantics, an `aria-disabled` element
+ * remains focusable (and discoverable by assistive tech). To remove an element from the tab order, use
+ * `tabindex="-1"` instead.
+ */
+export const DISABLED_SELECTOR = '[hidden], [tabindex="-1"], [disabled]:not([disabled="false"])';

--- a/packages/lumx-core/src/js/utils/focus/getFirstAndLastFocusable.test.ts
+++ b/packages/lumx-core/src/js/utils/focus/getFirstAndLastFocusable.test.ts
@@ -99,17 +99,21 @@ describe(getFirstAndLastFocusable.name, () => {
                 />
             `);
         });
+
+        it('should keep aria-disabled (focusable per ARIA semantics)', () => {
+            const element = htmlToElement('<div><button aria-disabled /><button /></div>');
+            const focusable = getFirstAndLastFocusable(element);
+            expect(focusable.first).toMatchInlineSnapshot(`
+                <button
+                  aria-disabled=""
+                />
+            `);
+        });
     });
 
     describe('skip disabled elements', () => {
         it('should skip disabled', () => {
             const element = htmlToElement('<div><button disabled /><button /></div>');
-            const focusable = getFirstAndLastFocusable(element);
-            expect(focusable.first).toMatchInlineSnapshot('<button />');
-        });
-
-        it('should skip aria-disabled', () => {
-            const element = htmlToElement('<div><button aria-disabled /><button /></div>');
             const focusable = getFirstAndLastFocusable(element);
             expect(focusable.first).toMatchInlineSnapshot('<button />');
         });

--- a/packages/lumx-core/src/js/utils/focus/getFocusableElements.test.ts
+++ b/packages/lumx-core/src/js/utils/focus/getFocusableElements.test.ts
@@ -96,21 +96,24 @@ describe(getFocusableElements.name, () => {
                 ]
             `);
         });
+
+        it('should keep aria-disabled (focusable per ARIA semantics)', () => {
+            const element = htmlToElement('<div><button aria-disabled /><button /></div>');
+            const focusable = getFocusableElements(element);
+            expect(focusable).toMatchInlineSnapshot(`
+                [
+                  <button
+                    aria-disabled=""
+                  />,
+                  <button />,
+                ]
+            `);
+        });
     });
 
     describe('skip disabled elements', () => {
         it('should skip disabled', () => {
             const element = htmlToElement('<div><button disabled /><button /></div>');
-            const focusable = getFocusableElements(element);
-            expect(focusable).toMatchInlineSnapshot(`
-                [
-                  <button />,
-                ]
-            `);
-        });
-
-        it('should skip aria-disabled', () => {
-            const element = htmlToElement('<div><button aria-disabled /><button /></div>');
             const focusable = getFocusableElements(element);
             expect(focusable).toMatchInlineSnapshot(`
                 [

--- a/packages/lumx-core/src/js/utils/focus/index.ts
+++ b/packages/lumx-core/src/js/utils/focus/index.ts
@@ -1,3 +1,4 @@
 export { getFirstAndLastFocusable } from './getFirstAndLastFocusable';
 export { getFocusableElements } from './getFocusableElements';
+export { setupFocusTrap, type SetupFocusTrapOptions } from './setupFocusTrap';
 export { TABBABLE_ELEMENTS_SELECTOR, DISABLED_SELECTOR } from './constants';

--- a/packages/lumx-core/src/js/utils/focus/setupFocusTrap.test.ts
+++ b/packages/lumx-core/src/js/utils/focus/setupFocusTrap.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { setupFocusTrap } from './setupFocusTrap';
+
+function makeZone(html = '') {
+    document.body.innerHTML = `<div id="zone">${html}</div>`;
+    return document.getElementById('zone') as HTMLElement;
+}
+
+function tab({ shift = false } = {}) {
+    const evt = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: shift, bubbles: true, cancelable: true });
+    document.body.dispatchEvent(evt);
+    return evt;
+}
+
+describe(setupFocusTrap.name, () => {
+    it('should focus the first focusable descendant on setup', () => {
+        const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
+        const controller = new AbortController();
+        setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+        expect(document.activeElement?.id).toBe('b1');
+        controller.abort();
+    });
+
+    it('should focus the explicit focusElement on setup when contained in the zone', () => {
+        const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
+        const focusElement = document.getElementById('b2') as HTMLElement;
+        const controller = new AbortController();
+        setupFocusTrap({ focusZoneElement: zone, focusElement }, controller.signal);
+        expect(document.activeElement?.id).toBe('b2');
+        controller.abort();
+    });
+
+    describe('fallback when no focusable descendant', () => {
+        it('should focus the zone itself and add tabindex="-1" if needed', () => {
+            const zone = makeZone('<p>No focusable</p>');
+            const controller = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+            expect(document.activeElement).toBe(zone);
+            expect(zone.getAttribute('tabindex')).toBe('-1');
+            controller.abort();
+            // Cleanup removes the tabindex it added.
+            expect(zone.hasAttribute('tabindex')).toBe(false);
+        });
+
+        it('should preserve an existing tabindex on the zone', () => {
+            const zone = makeZone('<p>No focusable</p>');
+            zone.setAttribute('tabindex', '0');
+            const controller = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+            expect(document.activeElement).toBe(zone);
+            controller.abort();
+            // Original tabindex preserved.
+            expect(zone.getAttribute('tabindex')).toBe('0');
+        });
+
+        it('should pin focus on the zone when Tab is pressed with no focusable descendant', () => {
+            const zone = makeZone('<p>No focusable</p>');
+            const controller = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+
+            // Move focus elsewhere.
+            const outside = document.createElement('button');
+            document.body.appendChild(outside);
+            outside.focus();
+            expect(document.activeElement).toBe(outside);
+
+            const evt = tab();
+            expect(evt.defaultPrevented).toBe(true);
+            expect(document.activeElement).toBe(zone);
+
+            controller.abort();
+        });
+    });
+
+    describe('Tab cycling', () => {
+        it('should cycle to first when Tab from last', () => {
+            const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
+            const controller = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+
+            (document.getElementById('b2') as HTMLElement).focus();
+            const evt = tab();
+            expect(evt.defaultPrevented).toBe(true);
+            expect(document.activeElement?.id).toBe('b1');
+            controller.abort();
+        });
+
+        it('should cycle to last when Shift+Tab from first', () => {
+            const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
+            const controller = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+
+            (document.getElementById('b1') as HTMLElement).focus();
+            const evt = tab({ shift: true });
+            expect(evt.defaultPrevented).toBe(true);
+            expect(document.activeElement?.id).toBe('b2');
+            controller.abort();
+        });
+
+        it('should bring focus into the zone when Tab is pressed from outside', () => {
+            const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
+            const outside = document.createElement('button');
+            document.body.appendChild(outside);
+
+            const controller = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+
+            outside.focus();
+            const evt = tab();
+            expect(evt.defaultPrevented).toBe(true);
+            expect(document.activeElement?.id).toBe('b1');
+            controller.abort();
+        });
+
+        it('should ignore non-Tab keys', () => {
+            const zone = makeZone('<button id="b1">B1</button>');
+            const controller = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+
+            const evt = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+            document.body.dispatchEvent(evt);
+            expect(evt.defaultPrevented).toBe(false);
+            controller.abort();
+        });
+    });
+
+    describe('listener tower stacking', () => {
+        it('should disable previous trap and re-enable on teardown', () => {
+            const zone1 = document.createElement('div');
+            const zone2 = document.createElement('div');
+            const b1 = document.createElement('button');
+            b1.id = 'b1';
+            const b2 = document.createElement('button');
+            b2.id = 'b2';
+            zone1.appendChild(b1);
+            zone2.appendChild(b2);
+            document.body.append(zone1, zone2);
+
+            const c1 = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone1 }, c1.signal);
+            expect(document.activeElement?.id).toBe('b1');
+
+            const c2 = new AbortController();
+            setupFocusTrap({ focusZoneElement: zone2 }, c2.signal);
+            expect(document.activeElement?.id).toBe('b2');
+
+            // Tab is now trapped in zone2.
+            b2.focus();
+            tab();
+            expect(document.activeElement?.id).toBe('b2');
+
+            // Tear down zone2 — zone1 trap re-enables.
+            c2.abort();
+            b1.focus();
+            tab();
+            expect(document.activeElement?.id).toBe('b1');
+
+            c1.abort();
+        });
+    });
+
+    it('should be a no-op if signal is already aborted', () => {
+        const zone = makeZone('<button id="b1">B1</button>');
+        const before = document.activeElement;
+        const controller = new AbortController();
+        controller.abort();
+        setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+        expect(document.activeElement).toBe(before);
+    });
+
+    it('should remove the keydown listener on teardown', () => {
+        const zone = makeZone('<button id="b1">B1</button>');
+        const controller = new AbortController();
+        setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+
+        const removeSpy = vi.spyOn(document.body, 'removeEventListener');
+        controller.abort();
+        expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+        removeSpy.mockRestore();
+    });
+});

--- a/packages/lumx-core/src/js/utils/focus/setupFocusTrap.ts
+++ b/packages/lumx-core/src/js/utils/focus/setupFocusTrap.ts
@@ -1,0 +1,146 @@
+import { DOCUMENT } from '../../constants/browser';
+import { makeListenerTowerContext, type Listener } from '../function/listenerTower';
+import { getFirstAndLastFocusable } from './getFirstAndLastFocusable';
+
+/**
+ * Shared listener tower for focus traps.
+ *
+ * When multiple traps are activated, only the last registered one is active. When it tears down, the previously
+ * registered trap is re-enabled.
+ */
+const FOCUS_TRAPS = makeListenerTowerContext();
+
+export interface SetupFocusTrapOptions {
+    /** The element in which to trap the focus. */
+    focusZoneElement: HTMLElement;
+    /**
+     * The element to focus when the trap is activated.
+     * Falls back to the first focusable element inside the zone, then to the zone element itself.
+     */
+    focusElement?: HTMLElement | null;
+}
+
+/**
+ * Trap 'Tab' focus switch inside the `focusZoneElement`.
+ *
+ * Setup behavior:
+ * 1. Focus `focusElement` if provided and contained in the zone.
+ * 2. Otherwise focus the first focusable descendant.
+ * 3. Otherwise focus the zone element itself (falling back to setting `tabindex="-1"` if needed) so that
+ *    keyboard users (especially screen reader users) land inside the trapped region (e.g. an empty dialog).
+ *
+ * Tab key behavior:
+ * - With at least one focusable descendant: focus cycles between the first and last focusable in the zone.
+ * - With no focusable descendant: Tab is swallowed and focus is restored to the zone element itself.
+ *
+ * Multiple traps stack — only the latest one is active; previous traps re-enable when the latest is torn down.
+ *
+ * @param options Trap configuration.
+ * @param signal  AbortSignal used to tear down the trap.
+ */
+export function setupFocusTrap(options: SetupFocusTrapOptions, signal: AbortSignal): void {
+    const { focusZoneElement, focusElement } = options;
+
+    // Body element can be undefined in SSR context.
+    const rootElement = DOCUMENT?.body;
+    if (!rootElement || !focusZoneElement || signal.aborted) {
+        return;
+    }
+
+    // Use the shadow root as focus zone when available.
+    const focusZoneElementOrShadowRoot: HTMLElement | ShadowRoot = focusZoneElement.shadowRoot || focusZoneElement;
+
+    // Track whether we added a `tabindex="-1"` so we can restore the original state on teardown.
+    let addedTabIndex = false;
+
+    /** Make the zone element programmatically focusable (so we can fall back to it). */
+    const ensureZoneIsFocusable = () => {
+        if (!focusZoneElement.hasAttribute('tabindex')) {
+            focusZoneElement.setAttribute('tabindex', '-1');
+            addedTabIndex = true;
+        }
+    };
+
+    /** Focus the zone element itself as a last-resort fallback. */
+    const focusZoneFallback = () => {
+        ensureZoneIsFocusable();
+        focusZoneElement.focus({ preventScroll: true });
+    };
+
+    // Trap 'Tab' key down focus switch into the focus zone.
+    const trapTabFocusInFocusZone = (evt: KeyboardEvent) => {
+        if (evt.key !== 'Tab') {
+            return;
+        }
+
+        const focusable = getFirstAndLastFocusable(focusZoneElementOrShadowRoot);
+
+        // Prevent focus switch if no focusable available — pin focus on the zone itself.
+        if (!focusable.first) {
+            evt.preventDefault();
+            focusZoneFallback();
+            return;
+        }
+
+        const activeElement = focusZoneElement.shadowRoot
+            ? focusZoneElement.shadowRoot.activeElement
+            : DOCUMENT?.activeElement;
+
+        if (
+            // No previous focus.
+            !activeElement ||
+            // Previous focus is at the end of the focus zone.
+            (!evt.shiftKey && activeElement === focusable.last) ||
+            // Previous focus is outside the focus zone.
+            !focusZoneElementOrShadowRoot.contains(activeElement)
+        ) {
+            focusable.first.focus();
+            evt.preventDefault();
+            return;
+        }
+
+        if (
+            // Focus order reversed.
+            evt.shiftKey &&
+            // Previous focus is at the start of the focus zone.
+            activeElement === focusable.first
+        ) {
+            focusable.last.focus();
+            evt.preventDefault();
+        }
+    };
+
+    const focusTrap: Listener = {
+        enable: () => rootElement.addEventListener('keydown', trapTabFocusInFocusZone),
+        disable: () => rootElement.removeEventListener('keydown', trapTabFocusInFocusZone),
+    };
+
+    // SETUP: focus initial element.
+    if (focusElement && focusZoneElementOrShadowRoot.contains(focusElement)) {
+        // Focus the given element.
+        focusElement.focus({ preventScroll: true });
+    } else {
+        const firstFocusable = getFirstAndLastFocusable(focusZoneElementOrShadowRoot).first;
+        if (firstFocusable) {
+            // Focus the first focusable descendant.
+            firstFocusable.focus({ preventScroll: true });
+        } else {
+            // No focusable descendant — fall back to the zone itself (e.g. an empty dialog).
+            focusZoneFallback();
+        }
+    }
+
+    FOCUS_TRAPS.register(focusTrap);
+
+    // TEARDOWN.
+    signal.addEventListener(
+        'abort',
+        () => {
+            FOCUS_TRAPS.unregister(focusTrap);
+            if (addedTabIndex) {
+                focusZoneElement.removeAttribute('tabindex');
+            }
+        },
+        { once: true },
+    );
+}

--- a/packages/lumx-react/src/hooks/useFocusTrap.test.tsx
+++ b/packages/lumx-react/src/hooks/useFocusTrap.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
 import { vi } from 'vitest';
-import * as focusUtils from '@lumx/core/js/utils/focus/getFirstAndLastFocusable';
+import * as setupFocusTrapModule from '@lumx/core/js/utils/focus/setupFocusTrap';
 import { useFocusTrap } from './useFocusTrap';
 
-vi.mock('@lumx/core/js/utils/focus/getFirstAndLastFocusable', () => ({
-    getFirstAndLastFocusable: vi.fn(),
+vi.mock('@lumx/core/js/utils/focus/setupFocusTrap', () => ({
+    setupFocusTrap: vi.fn(),
 }));
 
 const TestComponent = ({ zone, focusElement }: any) => {
@@ -13,28 +13,44 @@ const TestComponent = ({ zone, focusElement }: any) => {
 };
 
 describe('useFocusTrap', () => {
-    it('should focus the first focusable element when activated', () => {
-        const zone = document.createElement('div');
-        const first = document.createElement('button');
-        const last = document.createElement('button');
-        const focusSpy = vi.spyOn(first, 'focus');
-
-        (focusUtils.getFirstAndLastFocusable as any).mockReturnValue({ first, last });
-
-        render(<TestComponent zone={zone} />);
-        expect(focusSpy).toHaveBeenCalled();
+    beforeEach(() => {
+        (setupFocusTrapModule.setupFocusTrap as any).mockClear();
     });
 
-    it('should focus the specified focusElement', () => {
+    it('should call setupFocusTrap with the zone and abort signal', () => {
         const zone = document.createElement('div');
-        const first = document.createElement('button');
-        const specified = document.createElement('button');
-        zone.appendChild(specified);
-        const focusSpy = vi.spyOn(specified, 'focus');
+        render(<TestComponent zone={zone} />);
 
-        (focusUtils.getFirstAndLastFocusable as any).mockReturnValue({ first });
+        expect(setupFocusTrapModule.setupFocusTrap).toHaveBeenCalledWith(
+            { focusZoneElement: zone, focusElement: undefined },
+            expect.any(AbortSignal),
+        );
+    });
 
-        render(<TestComponent zone={zone} focusElement={specified} />);
-        expect(focusSpy).toHaveBeenCalled();
+    it('should pass focusElement through to setupFocusTrap', () => {
+        const zone = document.createElement('div');
+        const focusElement = document.createElement('button');
+        render(<TestComponent zone={zone} focusElement={focusElement} />);
+
+        expect(setupFocusTrapModule.setupFocusTrap).toHaveBeenCalledWith(
+            { focusZoneElement: zone, focusElement },
+            expect.any(AbortSignal),
+        );
+    });
+
+    it('should not call setupFocusTrap when zone is falsy', () => {
+        render(<TestComponent zone={null} />);
+        expect(setupFocusTrapModule.setupFocusTrap).not.toHaveBeenCalled();
+    });
+
+    it('should abort the signal on unmount', () => {
+        const zone = document.createElement('div');
+        const { unmount } = render(<TestComponent zone={zone} />);
+
+        const signal = (setupFocusTrapModule.setupFocusTrap as any).mock.calls[0][1] as AbortSignal;
+        expect(signal.aborted).toBe(false);
+
+        unmount();
+        expect(signal.aborted).toBe(true);
     });
 });

--- a/packages/lumx-react/src/hooks/useFocusTrap.ts
+++ b/packages/lumx-react/src/hooks/useFocusTrap.ts
@@ -1,93 +1,28 @@
 import { useEffect } from 'react';
 
-import { DOCUMENT } from '@lumx/react/constants';
-import { getFirstAndLastFocusable } from '@lumx/core/js/utils/focus/getFirstAndLastFocusable';
+import { setupFocusTrap } from '@lumx/core/js/utils/focus/setupFocusTrap';
 import { Falsy } from '@lumx/react/utils/type';
-import { Listener, makeListenerTowerContext } from '@lumx/core/js/utils/function/listenerTower';
-
-const FOCUS_TRAPS = makeListenerTowerContext();
 
 /**
  * Trap 'Tab' focus switch inside the `focusZoneElement`.
  *
- * If multiple focus trap are activated, only the last one is maintained and when a focus trap closes, the previous one
+ * If multiple focus traps are activated, only the last one is maintained and when a focus trap closes, the previous one
  * gets activated again.
+ *
+ * If the zone has no focusable descendant, the zone element itself receives focus (with a fallback `tabindex="-1"`).
  *
  * @param focusZoneElement The element in which to trap the focus.
  * @param focusElement     The element to focus when the focus trap is activated (otherwise the first focusable element
- *                         will be focused).
+ *                         will be focused — and finally the zone element itself if no focusable is found).
  */
 export function useFocusTrap(focusZoneElement: HTMLElement | Falsy, focusElement?: HTMLElement | null): void {
     useEffect(() => {
-        // Body element can be undefined in SSR context.
-        const rootElement = DOCUMENT?.body;
-
-        if (!rootElement || !focusZoneElement) {
+        if (!focusZoneElement) {
             return undefined;
         }
 
-        // Use the shadow root as focusZoneElement when available
-        const focusZoneElementOrShadowRoot = focusZoneElement.shadowRoot || focusZoneElement;
-
-        // Trap 'Tab' key down focus switch into the focus zone.
-        const trapTabFocusInFocusZone = (evt: KeyboardEvent) => {
-            const { key } = evt;
-            if (key !== 'Tab') {
-                return;
-            }
-
-            const focusable = getFirstAndLastFocusable(focusZoneElementOrShadowRoot);
-
-            // Prevent focus switch if no focusable available.
-            if (!focusable.first) {
-                evt.preventDefault();
-                return;
-            }
-
-            const activeElement = focusZoneElement.shadowRoot
-                ? focusZoneElement.shadowRoot.activeElement
-                : document.activeElement;
-
-            if (
-                // No previous focus
-                !activeElement ||
-                // Previous focus is at the end of the focus zone.
-                (!evt.shiftKey && activeElement === focusable.last) ||
-                // Previous focus is outside the focus zone
-                !focusZoneElementOrShadowRoot.contains(activeElement)
-            ) {
-                focusable.first.focus();
-                evt.preventDefault();
-                return;
-            }
-
-            if (
-                // Focus order reversed
-                evt.shiftKey &&
-                // Previous focus is at the start of the focus zone.
-                activeElement === focusable.first
-            ) {
-                focusable.last.focus();
-                evt.preventDefault();
-            }
-        };
-
-        const focusTrap: Listener = {
-            enable: () => rootElement.addEventListener('keydown', trapTabFocusInFocusZone),
-            disable: () => rootElement.removeEventListener('keydown', trapTabFocusInFocusZone),
-        };
-
-        // SETUP:
-        if (focusElement && focusZoneElementOrShadowRoot.contains(focusElement)) {
-            // Focus the given element.
-            focusElement.focus({ preventScroll: true });
-        } else {
-            // Focus the first focusable element in the zone.
-            getFirstAndLastFocusable(focusZoneElementOrShadowRoot).first?.focus({ preventScroll: true });
-        }
-        FOCUS_TRAPS.register(focusTrap);
-
-        // TEARDOWN:
-        return () => FOCUS_TRAPS.unregister(focusTrap);
+        const controller = new AbortController();
+        setupFocusTrap({ focusZoneElement, focusElement }, controller.signal);
+        return () => controller.abort();
     }, [focusElement, focusZoneElement]);
 }

--- a/packages/lumx-vue/src/composables/useFocusTrap.ts
+++ b/packages/lumx-vue/src/composables/useFocusTrap.ts
@@ -1,14 +1,13 @@
-import { watchPostEffect, isRef, onUnmounted, type Ref } from 'vue';
-import { getFirstAndLastFocusable } from '@lumx/core/js/utils/focus/getFirstAndLastFocusable';
-import { makeListenerTowerContext, type Listener } from '@lumx/core/js/utils/function/listenerTower';
-
-const FOCUS_TRAPS = makeListenerTowerContext();
+import { isRef, onScopeDispose, watchPostEffect, type Ref } from 'vue';
+import { setupFocusTrap } from '@lumx/core/js/utils/focus/setupFocusTrap';
 
 /**
  * Trap 'Tab' focus switch inside the `focusZoneElement`.
  *
  * If multiple focus traps are activated, only the last one is maintained and when a focus trap closes, the previous one
  * gets activated again.
+ *
+ * If the zone has no focusable descendant, the zone element itself receives focus (with a fallback `tabindex="-1"`).
  *
  * @param focusZoneElementRef The element in which to trap the focus (or ref to it). Falsy disables the trap.
  * @param focusElementRef     The element to focus when the focus trap is activated (or ref to it).
@@ -17,7 +16,14 @@ export function useFocusTrap(
     focusZoneElementRef: Ref<HTMLElement | null | undefined | false> | HTMLElement | null | undefined | false,
     focusElementRef?: Ref<HTMLElement | null | undefined> | HTMLElement | null | undefined,
 ): void {
-    let currentTrap: Listener | undefined;
+    let currentController: AbortController | undefined;
+
+    const tearDown = () => {
+        if (currentController) {
+            currentController.abort();
+            currentController = undefined;
+        }
+    };
 
     watchPostEffect((onCleanup) => {
         const focusZoneElement = isRef(focusZoneElementRef) ? focusZoneElementRef.value : focusZoneElementRef;
@@ -25,76 +31,12 @@ export function useFocusTrap(
 
         if (!focusZoneElement) return;
 
-        // Use the shadow root as focusZoneElement when available
-        const focusZoneElementOrShadowRoot = (focusZoneElement as HTMLElement).shadowRoot || focusZoneElement;
+        const controller = new AbortController();
+        currentController = controller;
+        setupFocusTrap({ focusZoneElement, focusElement }, controller.signal);
 
-        // Trap 'Tab' key down focus switch into the focus zone.
-        const trapTabFocusInFocusZone = (evt: KeyboardEvent) => {
-            const { key } = evt;
-            if (key !== 'Tab') return;
-
-            const focusable = getFirstAndLastFocusable(focusZoneElementOrShadowRoot as HTMLElement);
-
-            // Prevent focus switch if no focusable available.
-            if (!focusable.first) {
-                evt.preventDefault();
-                return;
-            }
-
-            const activeElement = (focusZoneElement as HTMLElement).shadowRoot
-                ? (focusZoneElement as HTMLElement).shadowRoot!.activeElement
-                : document.activeElement;
-
-            if (
-                // No previous focus
-                !activeElement ||
-                // Previous focus is at the end of the focus zone.
-                (!evt.shiftKey && activeElement === focusable.last) ||
-                // Previous focus is outside the focus zone
-                !focusZoneElementOrShadowRoot.contains(activeElement)
-            ) {
-                focusable.first.focus();
-                evt.preventDefault();
-                return;
-            }
-
-            if (
-                // Focus order reversed
-                evt.shiftKey &&
-                // Previous focus is at the start of the focus zone.
-                activeElement === focusable.first
-            ) {
-                focusable.last!.focus();
-                evt.preventDefault();
-            }
-        };
-
-        const focusTrap: Listener = {
-            enable: () => document.body.addEventListener('keydown', trapTabFocusInFocusZone),
-            disable: () => document.body.removeEventListener('keydown', trapTabFocusInFocusZone),
-        };
-
-        // SETUP:
-        if (focusElement && focusZoneElementOrShadowRoot.contains(focusElement)) {
-            // Focus the given element.
-            focusElement.focus({ preventScroll: true });
-        } else {
-            // Focus the first focusable element in the zone.
-            getFirstAndLastFocusable(focusZoneElementOrShadowRoot as HTMLElement).first?.focus({ preventScroll: true });
-        }
-        FOCUS_TRAPS.register(focusTrap);
-        currentTrap = focusTrap;
-
-        onCleanup(() => {
-            FOCUS_TRAPS.unregister(focusTrap);
-            currentTrap = undefined;
-        });
+        onCleanup(tearDown);
     });
 
-    onUnmounted(() => {
-        if (currentTrap) {
-            FOCUS_TRAPS.unregister(currentTrap);
-            currentTrap = undefined;
-        }
-    });
+    onScopeDispose(tearDown);
 }


### PR DESCRIPTION
## Summary

- Factorize focus trap setup logic from `@lumx/react` and `@lumx/vue` into a shared `setupFocusTrap` util in `@lumx/core`
- Allow focus on `aria-disabled` elements and correctly fallback to the container (zone) instead of staying on the trigger when no focusable element is detected — fixes focus behavior in `Dialog`, `Lightbox`, `Popover`

## Changes

- `@lumx/core`: new `setupFocusTrap` util + tests; updated focus constants/helpers
- `@lumx/react`: `useFocusTrap` now delegates to the core util
- `@lumx/vue`: `useFocusTrap` composable simplified to use the core util
- `CHANGELOG.md`: documented user-facing fix

StoryBook lumx-react: https://fc7be7493--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://fc7be7493--697a023f84e832e23544fb3c.chromatic.com/