### PR TITLE
chore(select-button): forward ref to the trigger button

### DIFF
--- a/packages/lumx-react/src/components/select-button/SelectButton.test.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.test.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { expectTypeOf } from 'vitest';
 
 import selectButtonTests from '@lumx/core/js/components/SelectButton/Tests';
+import { commonTestsSuiteRTL, SetupRenderOptions } from '@lumx/react/testing/utils';
 import { SelectButton, type SelectButtonProps, type SingleSelectButtonProps, type MultipleSelectButtonProps } from '.';
 import { Combobox } from '../combobox';
 import { IconButton } from '../button';
 import { Chip } from '../chip';
 import { Link } from '../link';
+
+/**
+ * Setup a basic SelectButton
+ */
+function setup(props: Partial<SelectButtonProps<string>> = {}, options: SetupRenderOptions = {}) {
+    render(<SelectButton label="Select a fruit" options={[]} getOptionId={String} {...props} />, options);
+    return { button: screen.getByRole('combobox') };
+}
 
 /**
  * Render a SelectButton template with controlled state management.
@@ -160,5 +169,13 @@ describe('<SelectButton>', () => {
             } as const;
             expectTypeOf(linkProps).toExtend<SelectButtonProps<Fruit, typeof Link>>();
         });
+    });
+
+    // Common tests suite (classes, refs and attributes forwarding)
+    commonTestsSuiteRTL(setup, {
+        baseClassName: 'lumx-combobox-button',
+        forwardRef: 'button',
+        forwardClassName: 'button',
+        forwardAttributes: 'button',
     });
 });

--- a/packages/lumx-react/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, useCallback, useState } from 'react';
+import React, { ElementType, type ForwardedRef, useCallback, useState } from 'react';
 
 import { mdiMenuDown } from '@lumx/icons';
 import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
@@ -136,16 +136,27 @@ export type MultipleSelectButtonProps<O, E extends ElementType = typeof DefaultB
 >;
 
 /**
+ * `React.forwardRef` re-typed to preserve our polymorphic generics
+ * `<O, E, S>` (which the stock `React.forwardRef` would erase).
+ */
+type ForwardRefSelectButton = (
+    render: (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        props: any,
+        ref: ForwardedRef<unknown>,
+    ) => React.ReactNode,
+) => {
+    <O, E extends ElementType = typeof DefaultButton, S extends 'single' | 'multiple' = 'single'>(
+        props: SelectButtonProps<O, E, S>,
+    ): React.ReactNode;
+    displayName?: string;
+};
+
+/**
  * A button trigger with a dropdown to select an option (single mode) or
  * options (multi mode) from a list. Polymorphic — pass `as` to customize the trigger element.
  */
-export const SelectButton = <
-    O,
-    E extends ElementType = typeof DefaultButton,
-    S extends 'single' | 'multiple' = 'single',
->(
-    props: SelectButtonProps<O, E, S>,
-) => {
+export const SelectButton = (React.forwardRef as ForwardRefSelectButton)((props, ref) => {
     const {
         options,
         getOptionId,
@@ -165,10 +176,8 @@ export const SelectButton = <
         listStatus,
         translations,
         as,
-        ref,
         ...buttonProps
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } = props as any;
+    } = props;
     const [listElement, setListElement] = useState<HTMLElement | null>(null);
 
     const isMultiple = selectionType === 'multiple';
@@ -198,8 +207,7 @@ export const SelectButton = <
             isMultiselectable: isMultiple,
             label,
             labelDisplayMode,
-            // With no `as`, the default trigger adds the chevron. With `as`, the
-            // caller is responsible for any trailing affordance.
+            // With no `as`, the default trigger adds the chevron.
             buttonProps: { ...buttonProps, as: as ?? DefaultButton, ref },
             popoverProps,
             listProps: { ref: setListElement },
@@ -212,6 +220,6 @@ export const SelectButton = <
         },
         { Combobox, InfiniteScroll },
     );
-};
+});
 
 SelectButton.displayName = 'SelectButton';


### PR DESCRIPTION
# General summary

Add forward ref on SelectButton (not adding to the CHANGELOG since it's expected on all components and it's not released yet)



StoryBook lumx-react: https://eaafe4212--5fbfb1d508c0520021560f10.chromatic.com/