### PR TITLE
fix(combobox): allow propagation of Enter key with no option active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `SelectTextField`: fallback on the default option name (`getOptionName`) if `option` slot does not provide the option label
 
 
+### Fixed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `Combobox`: fix `Enter` key not propagating when on input without active option
+
 ## [4.12.1][] - 2026-04-30
 
 ### Fixed
@@ -23,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `Combobox`: align prop types across core, React and Vue (single source of truth for `filter`, `openOnFocus`, `onSelect`)
     -   `SelectionChipGroup`: on Enter/Space chip removal, move focus to the next chip (fallback to previous chip, then to the input)
-    -   `Dialog`, `Lightbox`, `Popover`: allow focus on `aria-disabled` and correclty fallback to the container instead of staying on the trigger when no focusable are detected
+    -   `Dialog`, `Lightbox`, `Popover`: allow focus on `aria-disabled` and correctly fallback to the container instead of staying on the trigger when no focusable are detected
 
 ## [4.12.0][] - 2026-04-22
 

--- a/packages/lumx-core/src/js/components/Combobox/Tests.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Tests.tsx
@@ -893,6 +893,42 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             });
         });
 
+        it('should NOT open listbox on Enter when closed (lets form submit)', async () => {
+            renderWithState(t.inputTemplate);
+            const input = getInput();
+            // Focus input without clicking (click would open the popup).
+            input.focus();
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+
+            // fireEvent.keyDown returns `false` if the listener called preventDefault.
+            const notPrevented = fireEvent.keyDown(input, { key: 'Enter' });
+
+            // Popup must remain closed.
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+            // Default must NOT be prevented — required for the surrounding form to submit on Enter.
+            expect(notPrevented).toBe(true);
+        });
+
+        it('should close listbox on Enter when open with no active descendant (and prevent default)', async () => {
+            renderWithState(t.inputTemplate);
+            const input = getInput();
+            await userEvent.click(input);
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+            // Sanity: no option is virtually focused.
+            expect(input).toHaveAttribute('aria-activedescendant', '');
+
+            const notPrevented = fireEvent.keyDown(input, { key: 'Enter' });
+
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'false');
+            });
+            // The combobox consumed Enter to close the popup → default IS prevented
+            expect(notPrevented).toBe(false);
+        });
+
         it('should close listbox on Escape then clear on second Escape', async () => {
             renderWithState(t.inputTemplate);
             const input = getInput();

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -203,11 +203,14 @@ export function setupCombobox(
                         if (!handle.isMultiSelect && !isActionCell(activeItem)) {
                             handle.setIsOpen(false);
                         }
-                    } else if (!handle.isMultiSelect) {
-                        // No active item — toggle open/close.
-                        handle.setIsOpen(!handle.isOpen);
+                        flag = true;
+                    } else if (handle.isOpen && !handle.isMultiSelect) {
+                        // Open with no active item (single select) => close the popup.
+                        handle.setIsOpen(false);
+                        flag = true;
                     }
-                    flag = true;
+                    // Otherwise (closed popup, or multi-select with no active item),
+                    // let Enter pass through so it can submit a surrounding form
                     break;
 
                 case 'ArrowDown':


### PR DESCRIPTION
# General summary

In a combobox input, key down event on `Enter` should propagate when no option is active in the listbox (key nav has not started, `aria-activedescendant` is empty)


StoryBook lumx-vue: https://91e6dfca9--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://91e6dfca9--5fbfb1d508c0520021560f10.chromatic.com/