### PR TITLE
feat(select-text-field): fallback on option name on custom option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`:
     -   Create the `SelectButton` component
+    -   `SelectTextField`: fallback on the default option name (`getOptionName`) if `renderOption` does not provide the option label
+-   `@lumx/vue`:
+    -   `SelectTextField`: fallback on the default option name (`getOptionName`) if `option` slot does not provide the option label
+
 
 ## [4.12.1][] - 2026-04-30
 

--- a/packages/lumx-core/src/js/utils/select/renderSelectOptions.tsx
+++ b/packages/lumx-core/src/js/utils/select/renderSelectOptions.tsx
@@ -55,8 +55,8 @@ export function renderSelectOptions<O>(
         : undefined;
 
     return options?.map((item, index) => {
-        const id = getWithSelector(getOptionId || getOptionName, item);
-        const name = getWithSelector(getOptionName || getOptionId, item);
+        const id = getWithSelector(getOptionId || getOptionName, item) as string;
+        const name = getWithSelector(getOptionName || getOptionId, item) || id;
         const description = getOptionDescription && getWithSelector(getOptionDescription, item);
         const isSelected = selectedIds?.has(id) ?? false;
 
@@ -64,7 +64,7 @@ export function renderSelectOptions<O>(
         // The consumer receives core-computed context and is responsible for rendering
         // a <Combobox.Option> with those values forwarded.
         if (renderOption) {
-            return renderOption(item, { index, value: id, isSelected, description }) as any;
+            return renderOption(item, { index, value: id, name, isSelected, description }) as any;
         }
 
         return (

--- a/packages/lumx-core/src/js/utils/select/types.ts
+++ b/packages/lumx-core/src/js/utils/select/types.ts
@@ -21,6 +21,8 @@ export interface RenderOptionContext {
     index: number;
     /** Resolved option id (from `getOptionId`). Should be passed as `value` to `<Combobox.Option>`. */
     value: any;
+    /** Resolved option name (from `getOptionName`, falling back to `getOptionId`). */
+    name: string;
     /** Whether this option is currently selected. Should be forwarded as `isSelected`. */
     isSelected: boolean;
     /** Resolved description string (from `getOptionDescription`), if any. Should be forwarded as `description`. */

--- a/packages/lumx-react/src/components/combobox/wrapRenderOption.tsx
+++ b/packages/lumx-react/src/components/combobox/wrapRenderOption.tsx
@@ -19,6 +19,7 @@ type WrappedRenderOption<O> = (option: O, context: RenderOptionContext) => JSXEl
  * - If `renderOption` is `undefined`, returns `undefined` (no custom rendering).
  * - If the consumer returns a `<Combobox.Option>`, its props/children are merged with the
  *   core-computed `value` / `isSelected` / `description` / `key`.
+ *   When the consumer's `<Combobox.Option>` has no children, falls back to the option `name`.
  * - If the consumer returns anything else, returns `null` (skips the option).
  *
  * @param renderOption Consumer-provided render function.
@@ -28,13 +29,13 @@ export function wrapRenderOption<O>(
     renderOption: ((option: O, index: number) => React.ReactNode) | undefined,
 ): WrappedRenderOption<O> | undefined {
     if (!renderOption) return undefined;
-    return (option, { index, value: optionValue, isSelected, description }) => {
+    return (option, { index, value: optionValue, isSelected, description, name }) => {
         const node = renderOption(option, index);
         if (!isComponentType(ComboboxOption)(node)) {
             return null;
         }
 
-        const { children, ...customProps } = (node as React.ReactElement).props;
+        const { children = name, ...customProps } = (node as React.ReactElement).props;
         return (
             <ComboboxOption
                 key={optionValue}

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.stories.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.stories.tsx
@@ -59,9 +59,7 @@ export const CustomRender = () => {
             onChange={(v) => setValue(v ?? [])}
             translations={MULTI_TRANSLATIONS}
             renderOption={(fruit: Fruit) => (
-                <Combobox.Option value={fruit.id} before={<Icon icon={fruit.icon} size="xs" />}>
-                    {fruit.name}
-                </Combobox.Option>
+                <Combobox.Option value={fruit.id} before={<Icon icon={fruit.icon} size="xs" />} />
             )}
             renderSectionTitle={(sectionId: string, options: Fruit[]) => (
                 <>

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
@@ -246,7 +246,10 @@ const SelectTextField = defineComponent(
             const renderOptionSlot = slots.option;
             if (!renderOptionSlot) return undefined;
 
-            return (option: unknown, { index, value: optionValue, isSelected, description }: RenderOptionContext) => {
+            return (
+                option: unknown,
+                { index, value: optionValue, isSelected, description, name }: RenderOptionContext,
+            ) => {
                 const vnodes = renderOptionSlot({ option, index });
                 const customOption = vnodes?.find(isComponentType(ComboboxOption));
 
@@ -269,6 +272,9 @@ const SelectTextField = defineComponent(
                 }
                 if (afterProp !== undefined && !slotChildren.after) {
                     slotChildren.after = () => afterProp;
+                }
+                if (!slotChildren.default) {
+                    slotChildren.default = name;
                 }
 
                 return (


### PR DESCRIPTION
# General summary

When using custom option render, use the option name (`getOptionName` or fallback on `getOptionId`) if no option label/children is provided



StoryBook lumx-react: https://792466ecc--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://792466ecc--697a023f84e832e23544fb3c.chromatic.com/