### PR TITLE
chore(vue): add ClassValue type and strengthen class prop typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   `@lumx/react`, `@lumx/vue`:
+-   `@lumx/react`:
     -   `Combobox`: fix `Enter` key not propagating when on input without active option
+-   `@lumx/vue`:
+    -   `Combobox`: fix `Enter` key not propagating when on input without active option
+    -   `class` attr can now be a string, an array of strings or an array of objects.
 
 ## [4.12.1][] - 2026-04-30
 

--- a/packages/lumx-vue/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/lumx-vue/src/components/alert-dialog/AlertDialog.tsx
@@ -5,7 +5,7 @@ import type { GenericProps, JSXElement } from '@lumx/core/js/types';
 
 import { useId } from '../../composables/useId';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf } from '../../utils/VueToJSX';
+import { keysOf, type ClassValue } from '../../utils/VueToJSX';
 
 import Dialog from '../dialog/Dialog';
 import Button from '../button/Button';
@@ -20,7 +20,7 @@ type ButtonActionProps = {
 
 export interface AlertDialogProps extends Pick<BaseAlertDialogProps, 'kind' | 'title'> {
     /** Additional class name. */
-    class?: string;
+    class?: ClassValue;
     /** Size variant. */
     size?: DialogSizes;
     /** Whether the dialog is open. */

--- a/packages/lumx-vue/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-vue/src/components/dialog/Dialog.tsx
@@ -17,12 +17,12 @@ import { useFocusTrap } from '../../composables/useFocusTrap';
 import { useRestoreFocusOnClose } from '../../composables/useRestoreFocusOnClose';
 import { useTransitionVisibility } from '../../composables/useTransitionVisibility';
 import { useDisableBodyScroll } from '../../composables/useDisableBodyScroll';
-import { keysOf } from '../../utils/VueToJSX';
+import { keysOf, type ClassValue } from '../../utils/VueToJSX';
 
 export type DialogProps = Pick<BaseDialogProps, 'forceFooterDivider' | 'forceHeaderDivider' | 'isLoading'> &
     HasCloseMode & {
         /** Additional class name. */
-        class?: string;
+        class?: ClassValue;
         /** Whether the dialog is open. */
         isOpen?: boolean;
         /** Size variant. */

--- a/packages/lumx-vue/src/components/image-block/ImageCaption.tsx
+++ b/packages/lumx-vue/src/components/image-block/ImageCaption.tsx
@@ -4,7 +4,7 @@ import { ImageCaption as UI } from '@lumx/core/js/components/ImageBlock/ImageCap
 import { type HorizontalAlignment, type Theme } from '@lumx/core/js/constants';
 
 import { useTheme } from '../../composables/useTheme';
-import { keysOf } from '../../utils/VueToJSX';
+import { keysOf, type ClassValue } from '../../utils/VueToJSX';
 import { FlexBox } from '../flex-box';
 import { Text } from '../text';
 
@@ -13,7 +13,7 @@ type ImageCaptionProps = {
     align?: HorizontalAlignment;
     baseClassName?: string;
     captionStyle?: Record<string, any>;
-    class?: string;
+    class?: ClassValue;
     description?: any;
     descriptionProps?: Record<string, any>;
     tags?: any;

--- a/packages/lumx-vue/src/components/radio-button/RadioGroup.tsx
+++ b/packages/lumx-vue/src/components/radio-button/RadioGroup.tsx
@@ -4,11 +4,11 @@ import { RadioGroup as RadioGroupUI, CLASSNAME, COMPONENT_NAME } from '@lumx/cor
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf } from '../../utils/VueToJSX';
+import { keysOf, type ClassValue } from '../../utils/VueToJSX';
 
 export interface RadioGroupProps {
     /** CSS class name */
-    class?: string;
+    class?: ClassValue;
 }
 
 export { CLASSNAME, COMPONENT_NAME };

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
@@ -15,7 +15,7 @@ import { getOptionDisplayName } from '@lumx/core/js/utils/select/getOptionDispla
 import { SelectTextField as UI } from '@lumx/core/js/components/SelectTextField';
 import type { JSXElement } from '@lumx/core/js/types';
 
-import { keysOf, type EmitsOf } from '../../utils/VueToJSX';
+import { keysOf, type ClassValue, type EmitsOf } from '../../utils/VueToJSX';
 import { isComponentType } from '../../utils/isComponentType';
 import { Combobox } from '../combobox';
 import ComboboxOption from '../combobox/ComboboxOption';
@@ -30,7 +30,7 @@ interface BaseSelectTextFieldProps<O = any> extends BaseSelectTextFieldWrapperPr
     /** Content to render before the options list. */
     beforeOptions?: JSXElement;
     /** CSS class. */
-    class?: string;
+    class?: ClassValue;
 }
 
 /** Props specific to single selection mode. */

--- a/packages/lumx-vue/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-vue/src/components/tooltip/Tooltip.tsx
@@ -15,7 +15,7 @@ import { useCallbackOnEscape } from '../../composables/useCallbackOnEscape';
 import { useTooltipOpen } from './useTooltipOpen';
 import { useInjectTooltipRef } from './useInjectTooltipRef';
 import { provideTooltipContext } from './context';
-import { keysOf } from '../../utils/VueToJSX';
+import { keysOf, type ClassValue } from '../../utils/VueToJSX';
 import { Portal } from '../../utils/Portal';
 
 export type { TooltipPlacement };
@@ -25,7 +25,7 @@ export type { TooltipPlacement };
  */
 export interface TooltipProps extends CoreTooltipProps {
     /** Class name forwarded to the tooltip popup */
-    class?: string;
+    class?: ClassValue;
 }
 
 /**

--- a/packages/lumx-vue/src/composables/useClassName.ts
+++ b/packages/lumx-vue/src/composables/useClassName.ts
@@ -2,6 +2,7 @@ import { type ComputedRef, type MaybeRefOrGetter } from 'vue';
 
 import { classNames } from '@lumx/core/js/utils';
 
+import { type ClassValue } from '../utils/VueToJSX';
 import { useAttrFallback } from './useAttrFallback';
 
 /**
@@ -17,6 +18,12 @@ import { useAttrFallback } from './useAttrFallback';
  * @param  classProp The Vue `class` prop value (or a getter/ref returning it).
  * @return Computed ref holding the merged class string (or undefined when empty).
  */
-export function useClassName(classProp: MaybeRefOrGetter<string | undefined>): ComputedRef<string | undefined> {
-    return useAttrFallback(classProp, 'className', classNames.join as any);
+export function useClassName(classProp: MaybeRefOrGetter<ClassValue>): ComputedRef<string | undefined> {
+    // `classNames.join` handles all ClassValue forms (string, array, object) natively.
+    // The outer cast is needed because useAttrFallback<ClassValue> can't infer string | undefined.
+    return useAttrFallback(
+        classProp,
+        'className',
+        (vue, fallback) => classNames.join(vue, fallback as string | undefined) || undefined,
+    ) as ComputedRef<string | undefined>;
 }

--- a/packages/lumx-vue/src/testing/commonTestsSuiteVTL.tsx
+++ b/packages/lumx-vue/src/testing/commonTestsSuiteVTL.tsx
@@ -69,22 +69,41 @@ export function commonTestsSuiteVTL<S extends GenericProps>(setup: SetupFunction
         }
 
         if (forwardClassName) {
-            it('should forward any CSS class', async () => {
-                const modifiedProps = {
-                    class: 'component component--is-tested',
-                };
-                const wrappers = await setup(modifiedProps);
-                expect(wrappers[forwardClassName]).toHaveClass(modifiedProps.class);
+            /** Assert that no class token appears more than once on an element. */
+            const expectNoDuplicateClass = (el: HTMLElement) => {
+                const classList = Array.from(el.classList);
+                expect(new Set(classList).size).toBe(classList.length);
+            };
+
+            it('should forward any CSS class without duplication', async () => {
+                const wrappers = await setup({ class: 'component component--is-tested' });
+                const el = wrappers[forwardClassName] as HTMLElement;
+                expect(el).toHaveClass('component component--is-tested');
+                expectNoDuplicateClass(el);
             });
 
-            it('should forward className attr and merge it with class prop', async () => {
-                const modifiedProps = {
-                    class: 'from-class-prop',
-                    className: 'from-class-name-attr',
-                };
-                const wrappers = await setup(modifiedProps);
-                expect(wrappers[forwardClassName]).toHaveClass('from-class-prop');
-                expect(wrappers[forwardClassName]).toHaveClass('from-class-name-attr');
+            it('should accept an array of class names', async () => {
+                const wrappers = await setup({ class: ['class-a', 'class-b'] });
+                const el = wrappers[forwardClassName] as HTMLElement;
+                expect(el).toHaveClass('class-a');
+                expect(el).toHaveClass('class-b');
+                expectNoDuplicateClass(el);
+            });
+
+            it('should accept an object of conditional class names', async () => {
+                const wrappers = await setup({ class: { 'class-active': true, 'class-disabled': false } });
+                const el = wrappers[forwardClassName] as HTMLElement;
+                expect(el).toHaveClass('class-active');
+                expect(el).not.toHaveClass('class-disabled');
+                expectNoDuplicateClass(el);
+            });
+
+            it('should merge className attr with class prop without duplication', async () => {
+                const wrappers = await setup({ class: 'from-class-prop', className: 'from-class-name-attr' });
+                const el = wrappers[forwardClassName] as HTMLElement;
+                expect(el).toHaveClass('from-class-prop');
+                expect(el).toHaveClass('from-class-name-attr');
+                expectNoDuplicateClass(el);
             });
         }
     });

--- a/packages/lumx-vue/src/utils/VueToJSX.ts
+++ b/packages/lumx-vue/src/utils/VueToJSX.ts
@@ -1,4 +1,11 @@
 import { PropsToOverride } from '@lumx/core/js/types';
+
+/**
+ * Mirrors the value types accepted by Vue's class binding (and `normalizeClass`):
+ * a string, an object mapping class names to booleans, an array of any of the above, or falsy.
+ */
+export type ClassValue = string | number | boolean | null | undefined | ClassValue[] | Record<string, unknown>;
+
 /**
  * Props interface for components wrapped with VueToJSX.
  * It omits JSX-specific props like `children` and `className` and adds Vue's `class`.
@@ -11,7 +18,7 @@ export type VueToJSXProps<Props, OmitProps extends keyof Props = never> = Omit<
     PropsToOverride | 'children' | 'className' | OmitProps
 > & {
     /** Class name forwarded to the root element of the component. */
-    class?: string;
+    class?: ClassValue;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Introduces `ClassValue` type in `@lumx/vue` (`VueToJSX.ts`) matching the recursive type accepted by Vue's `normalizeClass` and the `classnames` package
- Replaces `class?: string` with `class?: ClassValue` across all Vue components that expose the `class` prop, enabling arrays and objects in addition to strings
- Updates `useClassName` composable to accept `MaybeRefOrGetter<ClassValue>` instead of `string | undefined`
- Adds four class-management tests to `commonTestsSuiteVTL` covering: no-duplication on string class, array `ClassValue`, object `ClassValue`, and `class` + `className` merge — all components with `forwardClassName` inherit them automatically

## Affected files

- `packages/lumx-vue/src/utils/VueToJSX.ts` — new `ClassValue` export
- `packages/lumx-vue/src/composables/useClassName.ts` — updated parameter type
- `packages/lumx-vue/src/components/alert-dialog/AlertDialog.tsx`
- `packages/lumx-vue/src/components/dialog/Dialog.tsx`
- `packages/lumx-vue/src/components/image-block/ImageCaption.tsx`
- `packages/lumx-vue/src/components/radio-button/RadioGroup.tsx`
- `packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx`
- `packages/lumx-vue/src/components/tooltip/Tooltip.tsx`
- `packages/lumx-vue/src/testing/commonTestsSuiteVTL.tsx` — 4 new class tests

## Testing

- All 1249 Vue unit tests pass
- Type-check clean (`yarn type-check:vue`)
- New tests verify string, array, and object class formats are applied without duplication, and that `class` + `className` merge correctly

StoryBook lumx-vue: https://3dd80a70c--697a023f84e832e23544fb3c.chromatic.com/