### PR TITLE
chore(lumx-vue): optional props for dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/vue`:
     -   Create the `SelectButton` component
 
+### Fixed
+
+-   `@lumx/vue`:
+    -   `Dialog`: props `forceFooterDivider` `forceHeaderDivider` and `isLoading` are optional as they should
+
 ## [4.13.0][] - 2026-05-11
 
 ### Added

--- a/packages/lumx-vue/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-vue/src/components/dialog/Dialog.tsx
@@ -19,7 +19,7 @@ import { useTransitionVisibility } from '../../composables/useTransitionVisibili
 import { useDisableBodyScroll } from '../../composables/useDisableBodyScroll';
 import { keysOf, type ClassValue } from '../../utils/VueToJSX';
 
-export type DialogProps = Pick<BaseDialogProps, 'forceFooterDivider' | 'forceHeaderDivider' | 'isLoading'> &
+export type DialogProps = Partial<Pick<BaseDialogProps, 'forceFooterDivider' | 'forceHeaderDivider' | 'isLoading'>> &
     HasCloseMode & {
         /** Additional class name. */
         class?: ClassValue;


### PR DESCRIPTION
# General summary

- `Dialog` Vue component: `forceFooterDivider`, `forceHeaderDivider`, and `isLoading` props are now typed as optional via `Partial<Pick<...>>`, matching their intended optional nature in `BaseDialogProps`

# Screenshots

N/A — no visual change

StoryBook lumx-vue: https://0b4dc97e2--697a023f84e832e23544fb3c.chromatic.com/