### PR TITLE
fix(lumx-core): include .tsx files in TypeScript declaration generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/vue`:
     -   Create the `SelectButton` component
 
+### Fixed
+
+-   `@lumx/vue`:
+    -   Include `tsx` components when generating ts declarations
+
 ## [4.13.0][] - 2026-05-11
 
 ### Added

--- a/packages/lumx-core/rollup.config.mjs
+++ b/packages/lumx-core/rollup.config.mjs
@@ -54,7 +54,7 @@ export default {
                 target: 'ESNext',
                 module: 'ESNext',
             },
-            include: path.join(SRC_PATH, '**', '*.ts'),
+            include: path.join(SRC_PATH, '**', '*.{ts,tsx}'),
             exclude: ['**/*.test.*'],
         }),
         copy({


### PR DESCRIPTION
# General summary

- Fix `@rollup/plugin-typescript` `include` pattern in `@lumx/core`'s build config: was `**/*.ts`, now `**/*.{ts,tsx}`
- 21 components implemented as `.tsx` files (including `Dialog`, `Tooltip`, `Avatar`, `Popover`, etc.) were silently excluded from declaration emit, producing no `index.d.ts` in the dist
- Consumers importing from `@lumx/core/js/components/<Name>` got unresolvable types; TypeScript fell back to treating `Pick<any, K>` as all-required props, causing spurious required-prop errors

# Screenshots

N/A — build tooling fix only.

StoryBook lumx-react: https://e37a3c9d4--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://e37a3c9d4--697a023f84e832e23544fb3c.chromatic.com/