### PR TITLE
fix(focus): fix focus trap when rendered inside shadow DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/vue`:
     -   Include `tsx` components when generating ts declarations
+-   `@lumx/react`, `@lumx/vue`:
+    -   `Dialog`, `Popover`: fix focus trap not working when rendered inside a shadow DOM
 
 ## [4.13.0][] - 2026-05-11
 

--- a/packages/lumx-core/src/js/utils/focus/setupFocusTrap.test.ts
+++ b/packages/lumx-core/src/js/utils/focus/setupFocusTrap.test.ts
@@ -1,182 +1,195 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
-import { setupFocusTrap } from './setupFocusTrap';
+import { describe, expect, it, onTestFinished, vi } from 'vitest';
+import { setupFocusTrap, type SetupFocusTrapOptions } from './setupFocusTrap';
 
-function makeZone(html = '') {
-    document.body.innerHTML = `<div id="zone">${html}</div>`;
-    return document.getElementById('zone') as HTMLElement;
+const TWO_BUTTONS = '<button id="b1">B1</button><button id="b2">B2</button>';
+
+/** Setup a focus trap and auto-cleanup when the test finishes. */
+function trap(options: SetupFocusTrapOptions) {
+    const controller = new AbortController();
+    setupFocusTrap(options, controller.signal);
+    onTestFinished(() => controller.abort());
+    return controller;
 }
 
-function tab({ shift = false } = {}) {
-    const evt = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: shift, bubbles: true, cancelable: true });
-    document.body.dispatchEvent(evt);
+/** Get an element by id from a root, asserting it exists. */
+const byId = (root: Document | ShadowRoot, id: string) => root.getElementById(id) as HTMLElement;
+
+/** Dispatch a Tab keydown (composed so it crosses shadow boundaries). */
+function tab(target: EventTarget = document.body, { shift = false } = {}) {
+    const evt = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: shift,
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+    });
+    target.dispatchEvent(evt);
     return evt;
 }
 
+/** Create a zone in the light DOM. */
+function makeLightZone(html = '') {
+    document.body.innerHTML = `<div id="zone">${html}</div>`;
+    const zone = byId(document, 'zone');
+    return { root: document as Document, zone };
+}
+
+/** Create a zone inside a shadow root. */
+function makeShadowZone(html = '') {
+    document.body.innerHTML = '';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const zone = document.createElement('div');
+    zone.innerHTML = html;
+    shadow.appendChild(zone);
+    return { root: shadow as ShadowRoot, zone };
+}
+
 describe(setupFocusTrap.name, () => {
-    it('should focus the first focusable descendant on setup', () => {
-        const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
-        const controller = new AbortController();
-        setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-        expect(document.activeElement?.id).toBe('b1');
-        controller.abort();
-    });
-
-    it('should focus the explicit focusElement on setup when contained in the zone', () => {
-        const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
-        const focusElement = document.getElementById('b2') as HTMLElement;
-        const controller = new AbortController();
-        setupFocusTrap({ focusZoneElement: zone, focusElement }, controller.signal);
-        expect(document.activeElement?.id).toBe('b2');
-        controller.abort();
-    });
-
-    describe('fallback when no focusable descendant', () => {
-        it('should focus the zone itself and add tabindex="-1" if needed', () => {
-            const zone = makeZone('<p>No focusable</p>');
-            const controller = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-            expect(document.activeElement).toBe(zone);
-            expect(zone.getAttribute('tabindex')).toBe('-1');
-            controller.abort();
-            // Cleanup removes the tabindex it added.
-            expect(zone.hasAttribute('tabindex')).toBe(false);
+    // Tests that behave identically in light and shadow DOM.
+    describe.each([
+        ['light DOM', makeLightZone],
+        ['shadow DOM', makeShadowZone],
+    ])('%s', (_label, makeZone) => {
+        it('should focus the first focusable descendant on setup', () => {
+            const { root, zone } = makeZone(TWO_BUTTONS);
+            trap({ focusZoneElement: zone });
+            expect(root.activeElement?.id).toBe('b1');
         });
 
-        it('should preserve an existing tabindex on the zone', () => {
-            const zone = makeZone('<p>No focusable</p>');
-            zone.setAttribute('tabindex', '0');
-            const controller = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-            expect(document.activeElement).toBe(zone);
-            controller.abort();
-            // Original tabindex preserved.
-            expect(zone.getAttribute('tabindex')).toBe('0');
+        it('should focus the explicit focusElement on setup when contained in the zone', () => {
+            const { root, zone } = makeZone(TWO_BUTTONS);
+            trap({ focusZoneElement: zone, focusElement: byId(root, 'b2') });
+            expect(root.activeElement?.id).toBe('b2');
         });
 
-        it('should pin focus on the zone when Tab is pressed with no focusable descendant', () => {
-            const zone = makeZone('<p>No focusable</p>');
-            const controller = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-
-            // Move focus elsewhere.
-            const outside = document.createElement('button');
-            document.body.appendChild(outside);
-            outside.focus();
-            expect(document.activeElement).toBe(outside);
-
-            const evt = tab();
-            expect(evt.defaultPrevented).toBe(true);
-            expect(document.activeElement).toBe(zone);
-
-            controller.abort();
-        });
-    });
-
-    describe('Tab cycling', () => {
         it('should cycle to first when Tab from last', () => {
-            const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
-            const controller = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-
-            (document.getElementById('b2') as HTMLElement).focus();
-            const evt = tab();
+            const { root, zone } = makeZone(TWO_BUTTONS);
+            trap({ focusZoneElement: zone });
+            const b2 = byId(root, 'b2');
+            b2.focus();
+            const evt = tab(b2);
             expect(evt.defaultPrevented).toBe(true);
-            expect(document.activeElement?.id).toBe('b1');
-            controller.abort();
+            expect(root.activeElement?.id).toBe('b1');
         });
 
         it('should cycle to last when Shift+Tab from first', () => {
-            const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
-            const controller = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-
-            (document.getElementById('b1') as HTMLElement).focus();
-            const evt = tab({ shift: true });
+            const { root, zone } = makeZone(TWO_BUTTONS);
+            trap({ focusZoneElement: zone });
+            const b1 = byId(root, 'b1');
+            b1.focus();
+            const evt = tab(b1, { shift: true });
             expect(evt.defaultPrevented).toBe(true);
-            expect(document.activeElement?.id).toBe('b2');
-            controller.abort();
+            expect(root.activeElement?.id).toBe('b2');
         });
 
-        it('should bring focus into the zone when Tab is pressed from outside', () => {
-            const zone = makeZone('<button id="b1">B1</button><button id="b2">B2</button>');
-            const outside = document.createElement('button');
-            document.body.appendChild(outside);
-
-            const controller = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-
-            outside.focus();
-            const evt = tab();
-            expect(evt.defaultPrevented).toBe(true);
-            expect(document.activeElement?.id).toBe('b1');
+        it('should fall back to the zone element when no focusable descendant, and clean up tabindex', () => {
+            const { root, zone } = makeZone('<p>No focusable</p>');
+            const controller = trap({ focusZoneElement: zone });
+            expect(root.activeElement).toBe(zone);
+            expect(zone.getAttribute('tabindex')).toBe('-1');
+            // Cleanup removes the tabindex it added.
             controller.abort();
-        });
-
-        it('should ignore non-Tab keys', () => {
-            const zone = makeZone('<button id="b1">B1</button>');
-            const controller = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-
-            const evt = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
-            document.body.dispatchEvent(evt);
-            expect(evt.defaultPrevented).toBe(false);
-            controller.abort();
+            expect(zone.hasAttribute('tabindex')).toBe(false);
         });
     });
 
-    describe('listener tower stacking', () => {
-        it('should disable previous trap and re-enable on teardown', () => {
-            const zone1 = document.createElement('div');
-            const zone2 = document.createElement('div');
-            const b1 = document.createElement('button');
-            b1.id = 'b1';
-            const b2 = document.createElement('button');
-            b2.id = 'b2';
-            zone1.appendChild(b1);
-            zone2.appendChild(b2);
-            document.body.append(zone1, zone2);
+    // Light-DOM-only edge cases.
+    it('should preserve an existing tabindex on the zone', () => {
+        const { zone } = makeLightZone('<p>No focusable</p>');
+        zone.setAttribute('tabindex', '0');
+        const controller = trap({ focusZoneElement: zone });
+        expect(document.activeElement).toBe(zone);
+        controller.abort();
+        expect(zone.getAttribute('tabindex')).toBe('0');
+    });
 
-            const c1 = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone1 }, c1.signal);
-            expect(document.activeElement?.id).toBe('b1');
+    it('should pin focus on the zone when Tab is pressed with no focusable descendant', () => {
+        const { zone } = makeLightZone('<p>No focusable</p>');
+        trap({ focusZoneElement: zone });
 
-            const c2 = new AbortController();
-            setupFocusTrap({ focusZoneElement: zone2 }, c2.signal);
-            expect(document.activeElement?.id).toBe('b2');
+        // Move focus elsewhere.
+        const outside = document.createElement('button');
+        document.body.appendChild(outside);
+        outside.focus();
+        expect(document.activeElement).toBe(outside);
 
-            // Tab is now trapped in zone2.
-            b2.focus();
-            tab();
-            expect(document.activeElement?.id).toBe('b2');
+        const evt = tab();
+        expect(evt.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(zone);
+    });
 
-            // Tear down zone2 — zone1 trap re-enables.
-            c2.abort();
-            b1.focus();
-            tab();
-            expect(document.activeElement?.id).toBe('b1');
+    it('should bring focus into the zone when Tab is pressed from outside', () => {
+        const { zone } = makeLightZone(TWO_BUTTONS);
+        const outside = document.createElement('button');
+        document.body.appendChild(outside);
+        trap({ focusZoneElement: zone });
 
-            c1.abort();
-        });
+        outside.focus();
+        const evt = tab();
+        expect(evt.defaultPrevented).toBe(true);
+        expect(document.activeElement?.id).toBe('b1');
+    });
+
+    it('should ignore non-Tab keys', () => {
+        const { zone } = makeLightZone('<button id="b1">B1</button>');
+        trap({ focusZoneElement: zone });
+
+        const evt = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+        document.body.dispatchEvent(evt);
+        expect(evt.defaultPrevented).toBe(false);
     });
 
     it('should be a no-op if signal is already aborted', () => {
-        const zone = makeZone('<button id="b1">B1</button>');
-        const before = document.activeElement;
+        const { zone } = makeLightZone('<button id="b1">B1</button>');
         const controller = new AbortController();
         controller.abort();
         setupFocusTrap({ focusZoneElement: zone }, controller.signal);
-        expect(document.activeElement).toBe(before);
+        expect(document.activeElement).toBe(document.body);
     });
 
-    it('should remove the keydown listener on teardown', () => {
-        const zone = makeZone('<button id="b1">B1</button>');
-        const controller = new AbortController();
-        setupFocusTrap({ focusZoneElement: zone }, controller.signal);
+    it('should disable previous trap and re-enable on teardown (listener tower stacking)', () => {
+        const zone1 = document.createElement('div');
+        const zone2 = document.createElement('div');
+        const b1 = document.createElement('button');
+        b1.id = 'b1';
+        const b2 = document.createElement('button');
+        b2.id = 'b2';
+        zone1.appendChild(b1);
+        zone2.appendChild(b2);
+        document.body.append(zone1, zone2);
 
-        const removeSpy = vi.spyOn(document.body, 'removeEventListener');
-        controller.abort();
-        expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
-        removeSpy.mockRestore();
+        trap({ focusZoneElement: zone1 });
+        expect(document.activeElement?.id).toBe('b1');
+
+        const c2 = trap({ focusZoneElement: zone2 });
+        expect(document.activeElement?.id).toBe('b2');
+
+        // Tab is now trapped in zone2.
+        b2.focus();
+        tab();
+        expect(document.activeElement?.id).toBe('b2');
+
+        // Tear down zone2 — zone1 trap re-enables.
+        c2.abort();
+        b1.focus();
+        tab();
+        expect(document.activeElement?.id).toBe('b1');
+    });
+
+    it('should attach keydown listener to the shadow root, not document, when zone is in shadow DOM', () => {
+        const { root, zone } = makeShadowZone('<button id="b1">B1</button>');
+        const shadowSpy = vi.spyOn(root, 'addEventListener');
+        const docSpy = vi.spyOn(document, 'addEventListener');
+
+        trap({ focusZoneElement: zone });
+
+        expect(shadowSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+        expect(docSpy).not.toHaveBeenCalledWith('keydown', expect.any(Function));
+
+        shadowSpy.mockRestore();
+        docSpy.mockRestore();
     });
 });

--- a/packages/lumx-core/src/js/utils/focus/setupFocusTrap.ts
+++ b/packages/lumx-core/src/js/utils/focus/setupFocusTrap.ts
@@ -1,4 +1,3 @@
-import { DOCUMENT } from '../../constants/browser';
 import { makeListenerTowerContext, type Listener } from '../function/listenerTower';
 import { getFirstAndLastFocusable } from './getFirstAndLastFocusable';
 
@@ -41,14 +40,12 @@ export interface SetupFocusTrapOptions {
 export function setupFocusTrap(options: SetupFocusTrapOptions, signal: AbortSignal): void {
     const { focusZoneElement, focusElement } = options;
 
-    // Body element can be undefined in SSR context.
-    const rootElement = DOCUMENT?.body;
-    if (!rootElement || !focusZoneElement || signal.aborted) {
+    if (!focusZoneElement || signal.aborted) {
         return;
     }
 
-    // Use the shadow root as focus zone when available.
-    const focusZoneElementOrShadowRoot: HTMLElement | ShadowRoot = focusZoneElement.shadowRoot || focusZoneElement;
+    // The root node is either the Document (regular DOM) or a ShadowRoot (shadow DOM portal).
+    const rootNode = focusZoneElement.getRootNode() as Document | ShadowRoot;
 
     // Track whether we added a `tabindex="-1"` so we can restore the original state on teardown.
     let addedTabIndex = false;
@@ -73,7 +70,7 @@ export function setupFocusTrap(options: SetupFocusTrapOptions, signal: AbortSign
             return;
         }
 
-        const focusable = getFirstAndLastFocusable(focusZoneElementOrShadowRoot);
+        const focusable = getFirstAndLastFocusable(focusZoneElement);
 
         // Prevent focus switch if no focusable available — pin focus on the zone itself.
         if (!focusable.first) {
@@ -82,9 +79,7 @@ export function setupFocusTrap(options: SetupFocusTrapOptions, signal: AbortSign
             return;
         }
 
-        const activeElement = focusZoneElement.shadowRoot
-            ? focusZoneElement.shadowRoot.activeElement
-            : DOCUMENT?.activeElement;
+        const { activeElement } = rootNode;
 
         if (
             // No previous focus.
@@ -92,7 +87,7 @@ export function setupFocusTrap(options: SetupFocusTrapOptions, signal: AbortSign
             // Previous focus is at the end of the focus zone.
             (!evt.shiftKey && activeElement === focusable.last) ||
             // Previous focus is outside the focus zone.
-            !focusZoneElementOrShadowRoot.contains(activeElement)
+            !focusZoneElement.contains(activeElement)
         ) {
             focusable.first.focus();
             evt.preventDefault();
@@ -110,17 +105,18 @@ export function setupFocusTrap(options: SetupFocusTrapOptions, signal: AbortSign
         }
     };
 
+    const keydownHandler = trapTabFocusInFocusZone as EventListener;
     const focusTrap: Listener = {
-        enable: () => rootElement.addEventListener('keydown', trapTabFocusInFocusZone),
-        disable: () => rootElement.removeEventListener('keydown', trapTabFocusInFocusZone),
+        enable: () => rootNode.addEventListener('keydown', keydownHandler),
+        disable: () => rootNode.removeEventListener('keydown', keydownHandler),
     };
 
     // SETUP: focus initial element.
-    if (focusElement && focusZoneElementOrShadowRoot.contains(focusElement)) {
+    if (focusElement && focusZoneElement.contains(focusElement)) {
         // Focus the given element.
         focusElement.focus({ preventScroll: true });
     } else {
-        const firstFocusable = getFirstAndLastFocusable(focusZoneElementOrShadowRoot).first;
+        const firstFocusable = getFirstAndLastFocusable(focusZoneElement).first;
         if (firstFocusable) {
             // Focus the first focusable descendant.
             firstFocusable.focus({ preventScroll: true });


### PR DESCRIPTION
CF-1489

# General summary

Use getRootNode() to uniformly detect the root (Document or ShadowRoot) instead of checking focusZoneElement.shadowRoot which was dead code.
This fixes activeElement detection and keydown listener attachment for elements rendered inside a shadow DOM portal (e.g. Dialog in a shadow DOM PortalProvider).

Add shadow DOM unit tests for setupFocusTrap.


[CF-1489]: https://lumapps.atlassian.net/browse/CF-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

StoryBook lumx-vue: https://a6eaf1b7d--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://a6eaf1b7d--5fbfb1d508c0520021560f10.chromatic.com/