### PR TITLE
chore(input-label): add as prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/vue`:
     -   Create the `SelectButton` component
+       `InputLabel`: Added prop `as` to specify the HTML element to use for rendering
 -   `@lumx/react`:
     -   Create the `TimePickerField` component
+    -   `InputLabel`: Added prop `as` to specify the HTML element to use for rendering
 
 ### Fixed
 

--- a/packages/lumx-core/src/js/components/InputLabel/Stories.tsx
+++ b/packages/lumx-core/src/js/components/InputLabel/Stories.tsx
@@ -32,5 +32,10 @@ export function setup({ component: InputLabel }: SetupStoriesOptions) {
         WithCustomTypography: {
             args: { typography: Typography.subtitle1 },
         },
+
+        /** Input label as legend */
+        AsLegend: {
+            args: { as: 'legend' },
+        },
     };
 }

--- a/packages/lumx-core/src/js/components/InputLabel/Tests.ts
+++ b/packages/lumx-core/src/js/components/InputLabel/Tests.ts
@@ -51,5 +51,15 @@ export default (renderOptions: SetupOptions<InputLabelProps>) => {
             expect(label).toHaveClass(CLASSNAME);
             expect(label).toHaveClass(classNames.typography(Typography.body1));
         });
+
+        it('should render as a legend', () => {
+            const { label } = setup(
+                { children: 'The label', as: 'legend', typography: Typography.body1 },
+                renderOptions,
+            );
+            expect(label).toHaveClass(CLASSNAME);
+            expect(label).toHaveClass(classNames.typography(Typography.body1));
+            expect(label.tagName.toLowerCase()).toBe('legend');
+        });
     });
 };

--- a/packages/lumx-core/src/js/components/InputLabel/index.tsx
+++ b/packages/lumx-core/src/js/components/InputLabel/index.tsx
@@ -18,6 +18,8 @@ export interface InputLabelProps extends HasClassName, HasTheme {
     isRequired?: boolean;
     /** ref to the root element */
     ref?: CommonRef;
+    /** HTML tag for rendering the label, defaults to `label` */
+    as?: 'label' | 'legend';
 }
 
 const CLASSNAME = InputLabelClassName;
@@ -29,10 +31,11 @@ const DEFAULT_PROPS: Partial<InputLabelProps> = {};
  * InputLabel component.
  */
 export function InputLabel(props: InputLabelProps) {
-    const { children, className, htmlFor, isRequired, theme, typography, ref, ...forwardedProps } = props;
+    const { children, className, htmlFor, isRequired, theme, as, typography, ref, ...forwardedProps } = props;
+    const ComponentToUse = as || 'label';
 
     return (
-        <label
+        <ComponentToUse
             ref={ref}
             {...forwardedProps}
             htmlFor={htmlFor}
@@ -47,7 +50,7 @@ export function InputLabel(props: InputLabelProps) {
             )}
         >
             {children}
-        </label>
+        </ComponentToUse>
     );
 }
 

--- a/packages/lumx-react/src/components/input-label/InputLabel.stories.tsx
+++ b/packages/lumx-react/src/components/input-label/InputLabel.stories.tsx
@@ -25,3 +25,4 @@ export default {
 export const Default = { ...stories.Default };
 export const IsRequired = { ...stories.IsRequired };
 export const WithCustomTypography = { ...stories.WithCustomTypography };
+export const AsLegend = { ...stories.AsLegend };

--- a/packages/lumx-vue/src/components/input-label/InputLabel.stories.ts
+++ b/packages/lumx-vue/src/components/input-label/InputLabel.stories.ts
@@ -14,3 +14,4 @@ export default {
 export const Default = { ...stories.Default };
 export const IsRequired = { ...stories.IsRequired };
 export const WithCustomTypography = { ...stories.WithCustomTypography };
+export const AsLegend = { ...stories.AsLegend };

--- a/packages/lumx-vue/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-vue/src/components/input-label/InputLabel.tsx
@@ -35,7 +35,7 @@ const InputLabel = defineComponent(
         name: 'InputLabel',
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
-        props: keysOf<InputLabelProps>()('htmlFor', 'id', 'isRequired', 'typography', 'theme', 'class'),
+        props: keysOf<InputLabelProps>()('htmlFor', 'id', 'isRequired', 'typography', 'theme', 'class', 'as'),
     },
 );
 


### PR DESCRIPTION
# General summary

- Adds an `as` prop to `InputLabel` (core + Vue) to allow rendering as a `<legend>` instead of the default `<label>` — useful inside `<fieldset>` elements
- Core: destructures `as` and uses it as the tag, defaulting to `'label'`
- Vue: registers `as` in `keysOf` so it flows through as a prop
- Test: adds a shared test asserting the rendered element tag when `as="legend"` is passed; fixes the assertion (was incorrectly comparing DOM element to a string)

# Screenshots

<!-- N/A — no visual change, only HTML tag switch -->

StoryBook lumx-react: https://3c5886580--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://3c5886580--697a023f84e832e23544fb3c.chromatic.com/