### PR TITLE
docs(time-picker-field): add doc page

### DIFF
--- a/packages/site-demo/content/product/components/time-picker-field/index.mdx
+++ b/packages/site-demo/content/product/components/time-picker-field/index.mdx
@@ -1,0 +1,57 @@
+---
+frameworks: ['react', 'vue']
+---
+
+import * as ReactDemoDefault from './react/default.tsx';
+import * as ReactDemoBounds from './react/bounds.tsx';
+import * as ReactDemoLocale from './react/locale.tsx';
+import * as VueDemoDefault from './vue/default.vue';
+import * as VueDemoBounds from './vue/bounds.vue';
+import * as VueDemoLocale from './vue/locale.vue';
+import ReactTimePickerField from 'lumx-docs:@lumx/react/components/time-picker-field/TimePickerField';
+import VueTimePickerField from 'lumx-docs:@lumx/vue/components/time-picker-field/TimePickerField';
+
+# Time picker field
+
+**Time picker fields let users pick a time of day.**\
+The field generates time suggestions in a dropdonw list with configurable minute interval and also accepts free-form typed input (e.g. `"10:30 PM"`, `"14"`, `"930"`), parsed on blur.
+
+<DemoBlock demo={{ react: ReactDemoDefault, vue: VueDemoDefault }} />
+
+## Bounds
+
+Restrict the pickable range with `minTime` and `maxTime`. Options outside the range remain **visible** in the dropdown but are rendered as disabled. Typed input outside the range is snapped to the nearest bound on blur.
+
+<DemoBlock demo={{ react: ReactDemoBounds, vue: VueDemoBounds }} />
+
+## Locale
+
+Pass a BCP-47 `locale` string to control time formatting. Locales using 24-hour conventions (e.g. `fr-FR`) display options without an AM/PM suffix.
+
+<DemoBlock demo={{ react: ReactDemoLocale, vue: VueDemoLocale }} />
+
+## Step
+
+The `step` prop (default `30`) controls the minute interval between generated options. A `step` of `15` produces 96 entries per day.
+
+## Input options
+
+The time picker field shares the same input options as the [TextField](/product/components/text-field):
+
+- `isDisabled`/`aria-disabled` — prevents interaction with the field.
+- `hasError` and `error` — displays an error state with a message.
+- `isValid` — displays a success state.
+- `isRequired` — marks the field as required.
+- `helper` — displays helper text below the field.
+
+## Accessibility concerns
+
+`TimePickerField` is built on top of [SelectTextField](/product/components/select-text-field) and inherits the combobox pattern.
+
+- Always provide a `label` so the field is properly announced by screen readers.
+- The `translations` prop is required and must include `clearLabel` (for the clear button) and `showSuggestionsLabel` (for the toggle button).
+- Use `helper` to hint at the expected time format for the current locale (e.g. `"e.g. 2:30 PM"`, `"e.g. 14:30"`) and surface any active bounds, so keyboard users typing input know what's accepted.
+
+## Properties
+
+<PropTable docs={{ react: ReactTimePickerField, vue: VueTimePickerField }} />

--- a/packages/site-demo/content/product/components/time-picker-field/react/bounds.tsx
+++ b/packages/site-demo/content/product/components/time-picker-field/react/bounds.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { TimePickerField } from '@lumx/react';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+const at = (hour: number, minute = 0) => {
+    const d = new Date();
+    d.setHours(hour, minute, 0, 0);
+    return d;
+};
+
+export default () => {
+    const [value, onChange] = useState<Date | undefined>(at(10, 0));
+    return (
+        <TimePickerField
+            label="Working hours"
+            helper="Pick a time between 9:00 and 18:00"
+            value={value}
+            onChange={onChange}
+            minTime={at(9, 0)}
+            maxTime={at(18, 0)}
+            translations={TRANSLATIONS}
+        />
+    );
+};

--- a/packages/site-demo/content/product/components/time-picker-field/react/default.tsx
+++ b/packages/site-demo/content/product/components/time-picker-field/react/default.tsx
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+import { TimePickerField } from '@lumx/react';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+export default () => {
+    const [value, onChange] = useState<Date | undefined>();
+    return <TimePickerField label="Time" value={value} onChange={onChange} translations={TRANSLATIONS} />;
+};

--- a/packages/site-demo/content/product/components/time-picker-field/react/locale.tsx
+++ b/packages/site-demo/content/product/components/time-picker-field/react/locale.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { TimePickerField } from '@lumx/react';
+
+const TRANSLATIONS = {
+    clearLabel: 'Effacer',
+    showSuggestionsLabel: 'Afficher les suggestions',
+};
+
+const at = (hour: number, minute: number) => {
+    const d = new Date();
+    d.setHours(hour, minute, 0, 0);
+    return d;
+};
+
+export default () => {
+    const [value, onChange] = useState<Date | undefined>(at(14, 30));
+    return (
+        <TimePickerField label="Heure" locale="fr-FR" value={value} onChange={onChange} translations={TRANSLATIONS} />
+    );
+};

--- a/packages/site-demo/content/product/components/time-picker-field/vue/bounds.vue
+++ b/packages/site-demo/content/product/components/time-picker-field/vue/bounds.vue
@@ -1,0 +1,32 @@
+<template>
+    <TimePickerField
+        label="Working hours"
+        helper="Pick a time between 9:00 and 18:00"
+        locale="en-US"
+        :value="value"
+        :min-time="minTime"
+        :max-time="maxTime"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { TimePickerField } from '@lumx/vue';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+const at = (hour: number, minute: number) => {
+    const d = new Date();
+    d.setHours(hour, minute, 0, 0);
+    return d;
+};
+
+const minTime = at(9, 0);
+const maxTime = at(18, 0);
+const value = ref<Date | undefined>(at(10, 0));
+</script>

--- a/packages/site-demo/content/product/components/time-picker-field/vue/default.vue
+++ b/packages/site-demo/content/product/components/time-picker-field/vue/default.vue
@@ -1,0 +1,20 @@
+<template>
+    <TimePickerField
+        label="Time"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { TimePickerField } from '@lumx/vue';
+
+const TRANSLATIONS = {
+    clearLabel: 'Clear',
+    showSuggestionsLabel: 'Show suggestions',
+};
+
+const value = ref<Date | undefined>();
+</script>

--- a/packages/site-demo/content/product/components/time-picker-field/vue/locale.vue
+++ b/packages/site-demo/content/product/components/time-picker-field/vue/locale.vue
@@ -1,0 +1,27 @@
+<template>
+    <TimePickerField
+        label="Heure"
+        locale="fr-FR"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="value = $event"
+    />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { TimePickerField } from '@lumx/vue';
+
+const TRANSLATIONS = {
+    clearLabel: 'Effacer',
+    showSuggestionsLabel: 'Afficher les suggestions',
+};
+
+const at = (hour: number, minute = 0) => {
+    const d = new Date();
+    d.setHours(hour, minute, 0, 0);
+    return d;
+};
+
+const value = ref<Date | undefined>(at(14, 30));
+</script>


### PR DESCRIPTION
# General summary

Add time picker doc page for react and vue

<img width="768" height="1631" alt="product_components_time-picker-field_" src="https://github.com/user-attachments/assets/fe90008c-0495-4c33-a701-ef60aa64171a" />


