### PR TITLE
feat(icon-button): also render label as hidden text inside the button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
+    -   `IconButton`: render the label as visually hidden text inside the button (kept `aria-label` for backward compat)
 
 ### Fixed
 

--- a/packages/lumx-core/src/js/components/Button/IconButton.tsx
+++ b/packages/lumx-core/src/js/components/Button/IconButton.tsx
@@ -2,6 +2,7 @@ import { Emphasis, Size } from '../../constants';
 import { BaseButtonProps, ButtonRoot } from './ButtonRoot';
 import { Icon } from '../Icon';
 import type { LumxClassName, JSXElement } from '../../types';
+import { classNames } from '../../utils';
 
 export interface IconButtonProps extends BaseButtonProps {
     /**
@@ -57,7 +58,7 @@ export const IconButton = (props: IconButtonProps) => {
         ...forwardedProps
     } = props;
 
-    const defaultChildren = (image ? (
+    const iconNode = (image ? (
         <img
             // no need to set alt as an aria-label is already set on the button
             alt=""
@@ -73,7 +74,12 @@ export const IconButton = (props: IconButtonProps) => {
         ...forwardedProps,
         'aria-label': label,
         variant: 'icon',
-        children: defaultChildren,
+        children: (
+            <>
+                {iconNode}
+                <span className={classNames.visuallyHidden()}>{label}</span>
+            </>
+        ) as unknown as JSXElement,
     });
 };
 

--- a/packages/lumx-core/src/js/components/Button/IconButtonTests.ts
+++ b/packages/lumx-core/src/js/components/Button/IconButtonTests.ts
@@ -35,10 +35,15 @@ export default (renderOptions: SetupOptions<IconButtonProps>) => {
                 expect(img).not.toBeInTheDocument();
             });
 
-            it('should render label', () => {
+            it('should render label as aria-label and visually-hidden text', () => {
                 const label = 'Label';
                 const { iconButton } = setup({ label }, renderOptions);
+                // The accessible name resolves to the label.
                 expect(iconButton).toBe(screen.queryByRole('button', { name: label }));
+                // The label is rendered as in-DOM visually-hidden text.
+                expect(screen.getByText(label)).toBeInTheDocument();
+                // aria-label is still set for backward compatibility.
+                expect(iconButton).toHaveAttribute('aria-label', label);
             });
 
             it('should render icon button with an image', () => {

--- a/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import userEvent from '@testing-library/user-event';
-import { getByRole, getConfig, waitFor } from '@testing-library/dom';
+import { getByRole, getConfig, screen, waitFor } from '@testing-library/dom';
 
 // ─── Fixtures ────────────────────────────────────────────────────
 
@@ -191,7 +191,7 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
         it('should render the toggle button', () => {
             renderWithState(defaultTemplate);
-            const toggleButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Show suggestions"]');
+            const toggleButton = screen.queryByRole('button', { name: 'Show suggestions' });
             expect(toggleButton).toBeTruthy();
         });
 
@@ -205,19 +205,19 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
         it('should render the clear button when value is set', () => {
             renderWithState(defaultTemplate, { value: FRUITS[0] });
-            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            const clearButton = screen.queryByRole('button', { name: 'Clear' });
             expect(clearButton).toBeTruthy();
         });
 
         it('should not render clear button when hasClearButton is false', () => {
             renderWithState(defaultTemplate, { value: FRUITS[0], hasClearButton: false });
-            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            const clearButton = screen.queryByRole('button', { name: 'Clear' });
             expect(clearButton).toBeNull();
         });
 
         it('should not render clear button when no value is selected', () => {
             renderWithState(defaultTemplate);
-            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            const clearButton = screen.queryByRole('button', { name: 'Clear' });
             expect(clearButton).toBeNull();
         });
 
@@ -347,7 +347,7 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
             expect(input.value).toBe('Apple');
 
-            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]')!;
+            const clearButton = screen.queryByRole('button', { name: 'Clear' })!;
             await userEvent.click(clearButton);
 
             await waitFor(() => {
@@ -358,7 +358,7 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
         it('should not show clear button when hasClearButton is false', async () => {
             renderWithState(defaultTemplate, { value: FRUITS[0], hasClearButton: false });
             expect(getInput().value).toBe('Apple');
-            expect(document.body.querySelector('[aria-label="Clear"]')).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
         });
     });
 
@@ -471,7 +471,7 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
             expect(input.value).toBe('Apple');
 
-            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]')!;
+            const clearButton = screen.queryByRole('button', { name: 'Clear' })!;
             await userEvent.click(clearButton);
             await waitFor(() => {
                 expect(input.value).toBe('');
@@ -775,7 +775,7 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
         it('should not show clear button when disabled', () => {
             renderWithState(defaultTemplate, { isDisabled: true, value: FRUITS[0] });
-            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            const clearButton = screen.queryByRole('button', { name: 'Clear' });
             expect(clearButton).toBeNull();
         });
 
@@ -855,7 +855,7 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
         it('should not show clear button when aria-disabled', () => {
             renderWithState(defaultTemplate, { 'aria-disabled': true, value: FRUITS[0] });
-            const clearButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Clear"]');
+            const clearButton = screen.queryByRole('button', { name: 'Clear' });
             expect(clearButton).toBeNull();
         });
 
@@ -867,8 +867,8 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
         it('should disable the toggle button when aria-disabled', () => {
             renderWithState(defaultTemplate, { 'aria-disabled': true });
-            const toggleButton = document.body.querySelector<HTMLButtonElement>('[aria-label="Show suggestions"]');
-            expect(toggleButton?.disabled).toBe(true);
+            const toggleButton = screen.queryByRole('button', { name: 'Show suggestions' });
+            expect(toggleButton).toBeDisabled();
         });
     });
 
@@ -1065,7 +1065,7 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
         it('should not show a clear button in multi mode', () => {
             renderWithState(multiTemplate, { value: [FRUITS[0]] });
-            expect(document.body.querySelector('[aria-label="Clear"]')).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
         });
 
         it('should call onSearch when typing in multi mode', async () => {


### PR DESCRIPTION
# General summary

Render the IconButton's label as a visually-hidden text node inside the button (in addition to keeping the existing `aria-label` for backward compatibility).

This will be useful when we want the button to also label another element. For example, we could have a dropdown menu attached to a button which is labeled by the button with `aria-labelledby={buttonId}`.

StoryBook lumx-react: https://922ba94f0--5fbfb1d508c0520021560f10.chromatic.com/
StoryBook lumx-vue: https://922ba94f0--697a023f84e832e23544fb3c.chromatic.com/