### PR TITLE
chore(select-button): minor improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`:
     -   `SelectButton`: fix `SingleSelectButtonProps` and `MultipleSelectButtonProps` generic type
+    -   `SelectButton`: render menu-down icon with `as=Button` (same as when `as` is empty)
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   `@lumx/react`:
+    -   `SelectButton`: fix `SingleSelectButtonProps` and `MultipleSelectButtonProps` generic type
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`:
     -   `SelectButton`: fix `SingleSelectButtonProps` and `MultipleSelectButtonProps` generic type
     -   `SelectButton`: render menu-down icon with `as=Button` (same as when `as` is empty)
+    -   `SelectButton`: fix update button ref on re-render
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
     -   `SelectButton`: `onChange` should provides a value (no `undefined`) and Escape key should not clear selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
     -   `SelectButton`: `onChange` should provides a value (no `undefined`) and Escape key should not clear selection
+    -   `SelectButton`: Fall back to `getOptionId` for the button label when no `getOptionName` is provided
 
 ## [4.15.0][] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
+
+### Fixed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
+
 ## [4.15.0][] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `SelectButton`: render menu-down icon with `as=Button` (same as when `as` is empty)
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
+    -   `SelectButton`: `onChange` should provides a value (no `undefined`) and Escape key should not clear selection
 
 ## [4.15.0][] - 2026-06-01
 

--- a/packages/lumx-core/src/js/components/Combobox/setupComboboxButton.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupComboboxButton.ts
@@ -98,6 +98,13 @@ export function setupComboboxButton(button: HTMLButtonElement, callbacks: Combob
                     }
                     return false;
 
+                case 'Escape':
+                    // Close if open; never clear selection (button-mode has no text input).
+                    if (combobox.isOpen) {
+                        combobox.setIsOpen(false);
+                    }
+                    return true;
+
                 default:
                     // Printable characters → typeahead.
                     if (isPrintableKey(event)) {

--- a/packages/lumx-core/src/js/components/SelectButton/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/Tests.tsx
@@ -102,6 +102,15 @@ export default function selectButtonTests({ components, renderWithState }: Selec
             expect(button.textContent).toContain('Banana');
         });
 
+        it('should fall back to getOptionId for display value when getOptionName is not provided', () => {
+            renderWithState(defaultTemplate, {
+                getOptionName: undefined,
+                value: FRUITS[2],
+            });
+            const button = screen.getByRole('combobox');
+            expect(button.textContent).toContain('banana');
+        });
+
         it('should render options in the listbox', () => {
             renderWithState(defaultTemplate);
             const options = screen.getAllByRole('option');

--- a/packages/lumx-core/src/js/components/SelectButton/index.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/index.tsx
@@ -8,7 +8,7 @@ import {
     BaseSelectComponents,
     BaseSelectProps,
     SelectButtonTranslations,
-    SelectTextFieldStatus,
+    SelectListStatus,
 } from '../../utils/select/types';
 
 /**
@@ -50,7 +50,7 @@ export interface SelectButtonProps<O> extends BaseSelectProps<O> {
      * - `'error'` — Error state: shows an error message in the dropdown.
      * @default 'idle'
      */
-    listStatus?: SelectTextFieldStatus;
+    listStatus?: SelectListStatus;
     /** Optional translations for screen-reader announcements (loading/empty/error/option count). */
     translations?: SelectButtonTranslations;
     /** Callback fired when the dropdown open state changes. */

--- a/packages/lumx-core/src/js/components/SelectButton/index.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/index.tsx
@@ -1,7 +1,7 @@
 import castArray from 'lodash/castArray';
 
 import type { LumxClassName } from '../../types';
-import { getWithSelector } from '../../utils/selectors';
+import { getOptionDisplayName } from '../../utils/select/getOptionDisplayName';
 import { renderSelectOptions } from '../../utils/select/renderSelectOptions';
 import type { ComboboxButtonLabelDisplayMode } from '../Combobox/ComboboxButton';
 import {
@@ -126,7 +126,7 @@ export const SelectButton = <O,>(props: SelectButtonProps<O>, { Combobox, Infini
     const displayValue =
         value != null
             ? castArray(value)
-                  .map((v) => v != null && getWithSelector(getOptionName, v))
+                  .map((v) => getOptionDisplayName(v, getOptionName, getOptionId))
                   .filter(Boolean)
                   .join(', ')
             : '';

--- a/packages/lumx-core/src/js/components/SelectTextField/index.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/index.tsx
@@ -1,6 +1,6 @@
 import type { JSXElement, LumxClassName } from '../../types';
 import { renderSelectOptions } from '../../utils/select/renderSelectOptions';
-import { BaseSelectComponents, BaseSelectProps, SelectTextFieldStatus } from '../../utils/select/types';
+import { BaseSelectComponents, BaseSelectProps, SelectListStatus } from '../../utils/select/types';
 
 /**
  * Defines the props for the core SelectTextField template.
@@ -32,7 +32,7 @@ export interface SelectTextFieldProps<O = any> extends BaseSelectProps<O> {
      * - `'error'` — Error state: shows an error message in the dropdown.
      * @default 'idle'
      */
-    listStatus?: SelectTextFieldStatus;
+    listStatus?: SelectListStatus;
 
     /** Screen reader loading announcement (e.g. "Loading…"). */
     loadingMessage?: string;

--- a/packages/lumx-core/src/js/utils/select/types.ts
+++ b/packages/lumx-core/src/js/utils/select/types.ts
@@ -57,13 +57,13 @@ export interface BaseSelectProps<O> {
      * section id are grouped together. The id is also used as the default displayed
      * label unless `renderSectionTitle` is provided.
      */
-    getSectionId?: Selector<O, string>;
+    getSectionId?: Selector<O, string | undefined>;
     /**
      * Custom section title render function. Receives the section id and the options
      * in that section. Returns custom JSX to display as the section header.
      * When not provided, the section id is used as a plain text label.
      */
-    renderSectionTitle?: (sectionId: string, options: O[]) => JSXElement;
+    renderSectionTitle?: (sectionId: string | undefined, options: O[]) => JSXElement;
 }
 
 export interface BaseSelectComponents {

--- a/packages/lumx-core/src/js/utils/select/types.ts
+++ b/packages/lumx-core/src/js/utils/select/types.ts
@@ -3,14 +3,14 @@ import type { HasTheme } from '../../types/HasTheme';
 import type { JSXElement, Selector } from '../../types';
 
 /**
- * Status of the SelectTextField dropdown list.
+ * Status of the select dropdown list.
  *
  * - `'idle'` — Default state, no loading indicators.
  * - `'loading'` — Full loading: shows skeleton placeholders, hides real options.
  * - `'loadingMore'` — Paginated loading: appends a skeleton after existing options.
  * - `'error'` — Error state: shows an error message in the dropdown.
  */
-export type SelectTextFieldStatus = 'idle' | 'loading' | 'loadingMore' | 'error';
+export type SelectListStatus = 'idle' | 'loading' | 'loadingMore' | 'error';
 
 /**
  * Context passed to the `renderOption` callback alongside the option object.
@@ -171,7 +171,7 @@ export interface BaseSelectButtonWrapperProps<O>
      * Status of the dropdown list.
      * @default 'idle'
      */
-    listStatus?: SelectTextFieldStatus;
+    listStatus?: SelectListStatus;
     /** Optional translations for screen-reader announcements (loading/empty/error/option count). */
     translations?: SelectButtonTranslations;
 }
@@ -194,7 +194,7 @@ export interface BaseSelectTextFieldWrapperProps<O>
      * Status of the dropdown list.
      * @default 'idle'
      */
-    listStatus?: SelectTextFieldStatus;
+    listStatus?: SelectListStatus;
     /**
      * Controls how the combobox filters options as the user types.
      *

--- a/packages/lumx-react/src/components/combobox/ComboboxButton.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxButton.tsx
@@ -1,4 +1,4 @@
-import { ElementType, useEffect, useRef } from 'react';
+import { ElementType, useEffect, useRef, useState } from 'react';
 
 import { setupComboboxButton } from '@lumx/core/js/components/Combobox/setupComboboxButton';
 import {
@@ -51,9 +51,9 @@ export const ComboboxButton = Object.assign(
             // If `as` is provided, use it directly; otherwise use the LumX Button (full theme/disabled behavior).
             const ButtonComp = as ?? Button;
 
-            const internalRef = useRef<HTMLButtonElement>(null);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const mergedRef = useMergeRefs(ref as any, internalRef, anchorRef as any);
+            // Track the button DOM element via state (instead of useRef) so it re-triggers the useEffect
+            const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null);
+            const mergedRef = useMergeRefs(ref as any, setButtonElement, anchorRef as any);
 
             // Keep onSelect in a ref to avoid re-creating the handle on every render
             const onSelectRef = useRef(onSelect);
@@ -61,9 +61,8 @@ export const ComboboxButton = Object.assign(
 
             // Create the combobox handle with button-mode controller on mount
             useEffect(() => {
-                const button = internalRef.current;
-                if (!button) return undefined;
-                const handle = setupComboboxButton(button, {
+                if (!buttonElement) return undefined;
+                const handle = setupComboboxButton(buttonElement, {
                     onSelect(option) {
                         onSelectRef.current?.(option);
                     },
@@ -73,7 +72,7 @@ export const ComboboxButton = Object.assign(
                     handle.destroy();
                     setHandle(null);
                 };
-            }, [setHandle]);
+            }, [buttonElement, setHandle]);
 
             return UI(
                 {

--- a/packages/lumx-react/src/components/select-button/SelectButton.stories.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.stories.tsx
@@ -56,7 +56,7 @@ export const CustomRender = () => {
             isClickable
             isSelected={!!value}
             after={<Icon icon={mdiMenuDown} />}
-            renderSectionTitle={(sectionId: string, options: Fruit[]) => (
+            renderSectionTitle={(sectionId, options) => (
                 <>
                     <Icon icon={options[0].categoryIcon} size="xs" />
                     {sectionId}

--- a/packages/lumx-react/src/components/select-button/SelectButton.test.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.test.tsx
@@ -58,7 +58,7 @@ describe('<SelectButton>', () => {
             // Option-typed props
             expectTypeOf<Props['options']>().toEqualTypeOf<Fruit[] | undefined>();
             expectTypeOf<Props['value']>().toEqualTypeOf<Fruit | undefined>();
-            expectTypeOf<Props['onChange']>().toEqualTypeOf<((newValue?: Fruit) => void) | undefined>();
+            expectTypeOf<Props['onChange']>().toEqualTypeOf<((newValue: Fruit) => void) | undefined>();
 
             // Selector functions on Fruit
             expectTypeOf<(o: Fruit) => string>().toExtend<Props['getOptionId']>();
@@ -78,7 +78,7 @@ describe('<SelectButton>', () => {
             type Props = MultipleSelectButtonProps<Fruit>;
 
             expectTypeOf<Props['value']>().toEqualTypeOf<Fruit[] | undefined>();
-            expectTypeOf<Props['onChange']>().toEqualTypeOf<((newValue?: Fruit[]) => void) | undefined>();
+            expectTypeOf<Props['onChange']>().toEqualTypeOf<((newValue: Fruit[]) => void) | undefined>();
             // `selectionType` is the inference site for `S` and is therefore
             // optional at the type level. Runtime still requires `'multiple'`
             // to opt into multi-select.
@@ -94,7 +94,7 @@ describe('<SelectButton>', () => {
                 getOptionId: 'id',
                 value: aFruit,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                onChange: (newValue?: Fruit) => undefined,
+                onChange: (newValue: Fruit) => undefined,
             } as const;
             expectTypeOf(singleProps).toExtend<SelectButtonProps<Fruit>>();
 
@@ -105,7 +105,7 @@ describe('<SelectButton>', () => {
                 selectionType: 'multiple' as const,
                 value: [aFruit] as Fruit[],
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                onChange: (newValue?: Fruit[]) => undefined,
+                onChange: (newValue: Fruit[]) => undefined,
             };
             // For multi-select, use the dedicated alias (which sets `S='multiple'`).
             expectTypeOf(multiProps).toExtend<MultipleSelectButtonProps<Fruit>>();
@@ -121,7 +121,7 @@ describe('<SelectButton>', () => {
                 size: 'm',
                 value: aFruit,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                onChange: (newValue?: Fruit) => undefined,
+                onChange: (newValue: Fruit) => undefined,
             } as const;
             expectTypeOf(buttonOnlyProps).toExtend<SelectButtonProps<Fruit>>();
         });
@@ -158,7 +158,7 @@ describe('<SelectButton>', () => {
                 icon: 'mdi-apple',
                 value: aFruit,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                onChange: (newValue?: Fruit) => undefined,
+                onChange: (newValue: Fruit) => undefined,
             } as const;
             expectTypeOf(iconProps).toExtend<SelectButtonProps<Fruit, typeof IconButton>>();
         });
@@ -173,7 +173,7 @@ describe('<SelectButton>', () => {
                 size: 's',
                 value: aFruit,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                onChange: (newValue?: Fruit) => undefined,
+                onChange: (newValue: Fruit) => undefined,
             } as const;
             expectTypeOf(chipProps).toExtend<SelectButtonProps<Fruit, typeof Chip>>();
         });
@@ -187,7 +187,7 @@ describe('<SelectButton>', () => {
                 rightIcon: 'mdi-down',
                 value: aFruit,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                onChange: (newValue?: Fruit) => undefined,
+                onChange: (newValue: Fruit) => undefined,
             } as const;
             expectTypeOf(linkProps).toExtend<SelectButtonProps<Fruit, typeof Link>>();
         });

--- a/packages/lumx-react/src/components/select-button/SelectButton.test.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.test.tsx
@@ -126,6 +126,28 @@ describe('<SelectButton>', () => {
             expectTypeOf(buttonOnlyProps).toExtend<SelectButtonProps<Fruit>>();
         });
 
+        it('inherits Button props (isDisabled, …) on the default trigger aliases', () => {
+            expectTypeOf<SingleSelectButtonProps<Fruit>['isDisabled']>().toEqualTypeOf<boolean | undefined>();
+            expectTypeOf<MultipleSelectButtonProps<Fruit>['isDisabled']>().toEqualTypeOf<boolean | undefined>();
+
+            // Other LumX Button props must also survive on the default trigger.
+            expectTypeOf<'isDisabled'>().toExtend<keyof SingleSelectButtonProps<Fruit>>();
+            expectTypeOf<'emphasis'>().toExtend<keyof SingleSelectButtonProps<Fruit>>();
+            expectTypeOf<'size'>().toExtend<keyof SingleSelectButtonProps<Fruit>>();
+            expectTypeOf<'leftIcon'>().toExtend<keyof SingleSelectButtonProps<Fruit>>();
+
+            const disabledProps = {
+                label: 'Pick',
+                options: [] as Fruit[],
+                getOptionId: 'id',
+                isDisabled: true,
+                value: aFruit,
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                onChange: (newValue: Fruit) => undefined,
+            } as const;
+            expectTypeOf(disabledProps).toExtend<SelectButtonProps<Fruit>>();
+        });
+
         it('exposes IconButton-specific props when as={IconButton}', () => {
             // IconButton's `icon` and `hideTooltip` must be accepted when as={IconButton}.
             const iconProps = {
@@ -168,6 +190,14 @@ describe('<SelectButton>', () => {
                 onChange: (newValue?: Fruit) => undefined,
             } as const;
             expectTypeOf(linkProps).toExtend<SelectButtonProps<Fruit, typeof Link>>();
+        });
+
+        it('strips the GenericProps index signature from the public aliases', () => {
+            // The raw props type still carries `GenericProps`'s `[propName: string]: any`.
+            expectTypeOf<string>().toExtend<keyof SelectButtonProps<Fruit>>();
+            // `NamedProps` removes it from the exported aliases.
+            expectTypeOf<string>().not.toExtend<keyof SingleSelectButtonProps<Fruit>>();
+            expectTypeOf<string>().not.toExtend<keyof MultipleSelectButtonProps<Fruit>>();
         });
     });
 

--- a/packages/lumx-react/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.tsx
@@ -191,6 +191,9 @@ export const SelectButton = (React.forwardRef as ForwardRefSelectButton)((props,
         [getOptionId, isMultiple, onChange, options, value],
     );
 
+    // If as is defined and not the Button, render as, else render DefaultButton (with mdiMenuDown right icon)
+    const buttonAs = as && as !== Button ? as : DefaultButton;
+
     return UI(
         {
             options,
@@ -204,8 +207,7 @@ export const SelectButton = (React.forwardRef as ForwardRefSelectButton)((props,
             isMultiselectable: isMultiple,
             label,
             labelDisplayMode,
-            // With no `as`, the default trigger adds the chevron.
-            buttonProps: { ...buttonProps, as: as ?? DefaultButton, ref },
+            buttonProps: { ...buttonProps, as: buttonAs, ref },
             popoverProps,
             listProps: { ref: setListElement },
             handleSelect,

--- a/packages/lumx-react/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.tsx
@@ -5,7 +5,7 @@ import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
 import type { GenericProps, NamedProps } from '@lumx/core/js/types';
 import { SelectButton as UI, type SelectButtonProps as UIProps } from '@lumx/core/js/components/SelectButton';
 import { type ComboboxButtonLabelDisplayMode } from '@lumx/core/js/components/Combobox/ComboboxButton';
-import { type SelectButtonTranslations, type SelectTextFieldStatus } from '@lumx/core/js/utils/select/types';
+import { type SelectButtonTranslations, type SelectListStatus } from '@lumx/core/js/utils/select/types';
 import { ComponentRef } from '@lumx/react/utils/type';
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
 import { forwardRef } from '@lumx/react/utils/react/forwardRef';
@@ -70,7 +70,7 @@ type CommonSelectButtonProps<O> = SelectButtonSelectProps<O> &
          * Status of the dropdown list (loading, error, etc.).
          * @default 'idle'
          */
-        listStatus?: SelectTextFieldStatus;
+        listStatus?: SelectListStatus;
         /** Screen-reader translations (loading/empty/error/option count). */
         translations?: SelectButtonTranslations;
     };

--- a/packages/lumx-react/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.tsx
@@ -85,8 +85,8 @@ type CommonSelectButtonProps<O> = SelectButtonSelectProps<O> &
  * fully replaced and only props valid for that component apply.
  *
  * Discriminated on `selectionType`:
- * - default / `'single'` → `value?: O`, `onChange?: (newValue?: O) => void`.
- * - `'multiple'`         → `value?: O[]`, `onChange?: (newValue?: O[]) => void`.
+ * - default / `'single'` → `value?: O`, `onChange?: (newValue: O) => void`.
+ * - `'multiple'`         → `value?: O[]`, `onChange?: (newValue: O[]) => void`.
  *
  * `as` and `selectionType` are top-level on this type (rather than buried in
  * an intersection or union member) so that TS can infer `E` from `as` and
@@ -115,7 +115,7 @@ export type SelectButtonProps<
         /** Selected option(s). Shape depends on `selectionType`. */
         value?: S extends 'multiple' ? O[] : O;
         /** Called when the selection changes. Shape depends on `selectionType`. */
-        onChange?: S extends 'multiple' ? (newValue?: O[]) => void : (newValue?: O) => void;
+        onChange?: S extends 'multiple' ? (newValue: O[]) => void : (newValue: O) => void;
     };
 
 /**

--- a/packages/lumx-react/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.tsx
@@ -50,7 +50,7 @@ type SelectButtonSelectProps<O> = Omit<
  * Forwarded trigger props for a given element `E`, minus the keys that the
  * component manages internally.
  */
-type TriggerProps<E extends ElementType> = Omit<NamedProps<React.ComponentPropsWithoutRef<E>>, OmittedKeys>;
+type TriggerProps<E extends ElementType> = Omit<NamedProps<React.ComponentProps<E>>, OmittedKeys>;
 
 /**
  * Common base — Select-specific props plus the ARIA / label / popover layer.
@@ -120,19 +120,16 @@ export type SelectButtonProps<
 
 /**
  * Single-selection props (`selectionType` defaults to `'single'`).
- * Backwards-compatible alias — existing consumers do not need to set `selectionType`.
  */
-export type SingleSelectButtonProps<O, E extends ElementType = typeof DefaultButton> = SelectButtonProps<
-    O,
-    E,
-    'single'
+export type SingleSelectButtonProps<O, E extends ElementType = typeof DefaultButton> = NamedProps<
+    SelectButtonProps<O, E, 'single'>
 >;
 
-/** Multi-selection props (`selectionType: 'multiple'` is required to opt in). */
-export type MultipleSelectButtonProps<O, E extends ElementType = typeof DefaultButton> = SelectButtonProps<
-    O,
-    E,
-    'multiple'
+/**
+ * Multi-selection props (`selectionType: 'multiple'` is required to opt in).
+ */
+export type MultipleSelectButtonProps<O, E extends ElementType = typeof DefaultButton> = NamedProps<
+    SelectButtonProps<O, E, 'multiple'>
 >;
 
 /**

--- a/packages/lumx-react/src/components/select-button/index.ts
+++ b/packages/lumx-react/src/components/select-button/index.ts
@@ -1,7 +1,11 @@
 import { ComboboxOption } from '../combobox/ComboboxOption';
 import { SelectButton as _SelectButton } from './SelectButton';
 
-export type { SelectTextFieldStatus, SelectButtonTranslations } from '@lumx/core/js/utils/select/types';
+export type {
+    SelectListStatus,
+    SelectListStatus as SelectButtonStatus,
+    SelectButtonTranslations,
+} from '@lumx/core/js/utils/select/types';
 export type { SelectButtonProps, SingleSelectButtonProps, MultipleSelectButtonProps } from './SelectButton';
 
 /**

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.stories.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.stories.tsx
@@ -61,7 +61,7 @@ export const CustomRender = () => {
             renderOption={(fruit: Fruit) => (
                 <Combobox.Option value={fruit.id} before={<Icon icon={fruit.icon} size="xs" />} />
             )}
-            renderSectionTitle={(sectionId: string, options: Fruit[]) => (
+            renderSectionTitle={(sectionId, options) => (
                 <>
                     <Icon icon={options[0].categoryIcon} size="xs" />
                     {sectionId}

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
@@ -24,7 +24,7 @@ interface BaseSelectTextFieldProps<O = any> extends BaseSelectTextFieldWrapperPr
      * in that section. Returns custom JSX to display as the section header.
      * When not provided, the section id is used as a plain text label.
      */
-    renderSectionTitle?: (sectionId: string, options: O[]) => React.ReactNode;
+    renderSectionTitle?: (sectionId: string | undefined, options: O[]) => React.ReactNode;
     /**
      * Callback fired when the search input text changes.
      * Independent of `filter`: both can be used together (e.g. client-side

--- a/packages/lumx-react/src/components/select-text-field/index.ts
+++ b/packages/lumx-react/src/components/select-text-field/index.ts
@@ -10,7 +10,8 @@ export {
     type SingleSelectTextFieldProps,
     type MultipleSelectTextFieldProps,
 } from './SelectTextField';
-export type { SelectTextFieldStatus, SelectTextFieldTranslations } from '@lumx/core/js/utils/select/types';
+export type { SelectListStatus, SelectListStatus as SelectTextFieldStatus } from '@lumx/core/js/utils/select/types';
+export type { SelectTextFieldTranslations } from '@lumx/core/js/utils/select/types';
 
 /**
  * SelectTextField compound component.

--- a/packages/lumx-vue/src/components/combobox/useWrappedRenderSectionTitleSlot.tsx
+++ b/packages/lumx-vue/src/components/combobox/useWrappedRenderSectionTitleSlot.tsx
@@ -3,7 +3,7 @@ import { type ComputedRef, type Slot, computed } from 'vue';
 import type { JSXElement } from '@lumx/core/js/types';
 
 /** Render function passed as `renderSectionTitle` to a core Select* template. */
-type WrappedRenderSectionTitle = (sectionId: string, options: unknown[]) => JSXElement;
+type WrappedRenderSectionTitle = (sectionId: string | undefined, options: unknown[]) => JSXElement;
 
 /**
  * Adapts a Vue scoped section-title slot into the `renderSectionTitle` callback shape
@@ -14,6 +14,6 @@ export function useWrappedRenderSectionTitleSlot(
 ): ComputedRef<WrappedRenderSectionTitle | undefined> {
     return computed(() => {
         if (!slot) return undefined;
-        return (sectionId: string, options: unknown[]) => slot({ sectionId, options }) as JSXElement;
+        return (sectionId: string | undefined, options: unknown[]) => slot({ sectionId, options }) as JSXElement;
     });
 }

--- a/packages/lumx-vue/src/components/select-button/SelectButton.test.tsx
+++ b/packages/lumx-vue/src/components/select-button/SelectButton.test.tsx
@@ -337,9 +337,7 @@ describe('<SelectButton>', () => {
 
             it('narrows the change payload per selectionType', () => {
                 expectTypeOf<SingleEmit>().toBeCallableWith('change', FRUIT);
-                expectTypeOf<SingleEmit>().toBeCallableWith('change', undefined);
                 expectTypeOf<MultipleEmit>().toBeCallableWith('change', [FRUIT]);
-                expectTypeOf<MultipleEmit>().toBeCallableWith('change', undefined);
             });
 
             it('types common event payloads on $emit', () => {

--- a/packages/lumx-vue/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-vue/src/components/select-button/SelectButton.tsx
@@ -118,13 +118,13 @@ export type SelectButtonProps<O = any> = SingleSelectButtonProps<O> | MultipleSe
 export const emitSchema = {
     /**
      * Selection change. Payload type depends on `selectionType`:
-     * - default / `'single'` → `O | undefined` (option on select).
-     * - `'multiple'`         → `O[] | undefined` (toggled array).
+     * - default / `'single'` → `O` (selected option).
+     * - `'multiple'`         → `O[]` (toggled array).
      *
      * The runtime validator uses `unknown` since the typed payload can't be expressed
      * without the component generic. The typed payload is restored via `SelectButtonEmits`.
      */
-    change: (_newValue?: unknown) => true,
+    change: (_newValue: unknown) => true,
     /** Bottom of the options list reached — consumer should fetch the next page. */
     'load-more': () => true,
     /** Dropdown opened or closed. */
@@ -136,7 +136,7 @@ export const emitSchema = {
  * SelectButton emits typed over the option type O and the selection type S.
  */
 type SelectButtonEmits<O, S extends 'single' | 'multiple'> = Omit<EmitsOf<typeof emitSchema>, 'change'> & {
-    change: (newValue: (S extends 'multiple' ? O[] : O) | undefined) => void;
+    change: (newValue: S extends 'multiple' ? O[] : O) => void;
 };
 
 type SingleSelectButtonPublicProps<O> = SingleSelectButtonProps<O> & EmitsToProps<SelectButtonEmits<O, 'single'>>;
@@ -228,8 +228,7 @@ const SelectButton = defineComponent(
                 selectedOption?.value,
                 isMultiple.value,
             );
-            // Preserve previous behaviour of normalizing falsy single-mode results to `undefined`.
-            emit('change', next || undefined);
+            emit('change', next);
         };
 
         /*

--- a/packages/lumx-vue/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-vue/src/components/select-button/SelectButton.tsx
@@ -286,7 +286,7 @@ const SelectButton = defineComponent(
             /** Custom option rendering inside a `<SelectButtonOption>`. */
             option: { option: unknown; index: number };
             /** Custom section header rendering. */
-            sectionTitle: { sectionId: string; options: unknown[] };
+            sectionTitle: { sectionId: string | undefined; options: unknown[] };
         }>,
         props: keysOf<SelectButtonProps<unknown>>()(
             'options',

--- a/packages/lumx-vue/src/components/select-button/index.ts
+++ b/packages/lumx-vue/src/components/select-button/index.ts
@@ -7,7 +7,11 @@ export {
     type MultipleSelectButtonProps,
     type SelectButtonButtonSlotProps,
 } from './SelectButton';
-export type { SelectTextFieldStatus, SelectButtonTranslations } from '@lumx/core/js/utils/select/types';
+export type {
+    SelectListStatus,
+    SelectListStatus as SelectButtonStatus,
+    SelectButtonTranslations,
+} from '@lumx/core/js/utils/select/types';
 
 /** Selectable option within the dropdown list. */
 export const SelectButtonOption = _ComboboxOption;

--- a/packages/lumx-vue/src/components/select-text-field/index.ts
+++ b/packages/lumx-vue/src/components/select-text-field/index.ts
@@ -10,7 +10,8 @@ export {
     type MultipleSelectTextFieldProps,
     default as SelectTextField,
 } from './SelectTextField';
-export type { SelectTextFieldStatus, SelectTextFieldTranslations } from '@lumx/core/js/utils/select/types';
+export type { SelectListStatus, SelectListStatus as SelectTextFieldStatus } from '@lumx/core/js/utils/select/types';
+export type { SelectTextFieldTranslations } from '@lumx/core/js/utils/select/types';
 
 /** Selectable option within the dropdown list. */
 export const SelectTextFieldOption = _ComboboxOption;


### PR DESCRIPTION
## Summary

### Fixes (`@lumx/core`, `@lumx/react`, `@lumx/vue`)

- **SelectButton: label fallback to `getOptionId`** — When `getOptionName` is not provided, the button label now falls back to `getOptionId` instead of rendering empty text. Uses the shared `getOptionDisplayName` utility.
- **SelectButton: Escape key no longer clears selection** — In button-mode (no text input), pressing Escape now only closes the dropdown without clearing the current selection. The `onChange` type is updated to never pass `undefined` (i.e. `(newValue: O) => void` instead of `(newValue?: O) => void`).
- **SelectButton: menu-down icon with `as=Button`** — Previously, passing `as={Button}` explicitly would skip the default chevron icon. Now the menu-down icon renders whenever `as` is `Button` or omitted.
- **ComboboxButton: fix ref change re-initialization** — Replaced `useRef` with `useState` for the button DOM element so that `setupComboboxButton` is re-invoked when the ref changes (e.g. on re-render with a new trigger element).

### Type improvements (`@lumx/react`)

- **`SingleSelectButtonProps` / `MultipleSelectButtonProps`** — Wrapped with `NamedProps` to strip the `GenericProps` index signature from the public aliases, giving consumers cleaner type-checking.
- **`TriggerProps`** — Uses `React.ComponentProps<E>` instead of the deprecated `React.ComponentPropsWithoutRef<E>`.

### Renames & API housekeeping (`@lumx/core`, `@lumx/react`, `@lumx/vue`)

- **`SelectTextFieldStatus` → `SelectListStatus`** — Renamed to reflect that the type is shared between `SelectButton` and `SelectTextField`. Backwards-compatible aliases (`SelectButtonStatus`, `SelectTextFieldStatus`) are re-exported from both React and Vue packages.
- **`getSectionId` accepts `undefined`** — The `getSectionId` selector and `renderSectionTitle` callback now accept `string | undefined`, allowing options without a section.

## Testing

- Unit test added: button label falls back to `getOptionId` when `getOptionName` is not provided
- Type-level tests updated: `onChange` no longer accepts `undefined`, `NamedProps` strips index signature, `Button` props (`isDisabled`, `emphasis`, `size`, `leftIcon`) are accessible on default trigger aliases
- Existing `commonTestsSuiteRTL` / `commonTestsSuiteTL` suites cover standard behavior

StoryBook lumx-react: https://d0edfb879--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://d0edfb879--697a023f84e832e23544fb3c.chromatic.com/