### PR TITLE
chore(vue): fix onFocus / onBlur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/vue`:
     -   Create the `TimePickerField` component
+    -   `RawInputText`, `RawInputTextarea`: add `focus` and `blur` events
+
+### Fixed
+
+-   `@lumx/react`:
+    -   `RawInputText`, `RawInputTextarea`: fix `onFocus`/`onBlur` callbacks being silently discarded
+-   `@lumx/vue`:
+    -   `Avatar`: fix `click` and `keypress` event forwarding
+    -   `Tab`: fix `focus` and `keypress` event forwarding
 
 ## [4.14.0][] - 2026-05-25
 

--- a/packages/lumx-core/src/js/components/TextField/RawInputText.tsx
+++ b/packages/lumx-core/src/js/components/TextField/RawInputText.tsx
@@ -17,6 +17,8 @@ export interface RawInputTextProps extends HasTheme, HasClassName {
     ref?: CommonRef;
     handleChange?: (value: string, name?: string, event?: any) => void;
     handleInput?: (value: string, name?: string, event?: any) => void;
+    handleFocus?: (event?: any) => void;
+    handleBlur?: (event?: any) => void;
 }
 /**
  * Component default props.
@@ -36,6 +38,8 @@ export const RawInputText = (props: RawInputTextProps) => {
         value,
         handleChange,
         handleInput,
+        handleFocus,
+        handleBlur,
         type = DEFAULT_PROPS.type,
         name,
         ref,
@@ -65,6 +69,8 @@ export const RawInputText = (props: RawInputTextProps) => {
             )}
             onChange={handleOnChange}
             onInput={handleOnInput}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
             value={value}
         />
     );

--- a/packages/lumx-core/src/js/components/TextField/RawInputTextarea.tsx
+++ b/packages/lumx-core/src/js/components/TextField/RawInputTextarea.tsx
@@ -15,6 +15,8 @@ export interface RawInputTextareaProps extends HasTheme, HasClassName {
     ref?: CommonRef;
     handleChange?: (value: string, name?: string, event?: any) => void;
     handleInput?: (value: string, name?: string, event?: any) => void;
+    handleFocus?: (event?: any) => void;
+    handleBlur?: (event?: any) => void;
 }
 
 /**
@@ -35,6 +37,8 @@ export const RawInputTextarea = (props: RawInputTextareaProps) => {
         value,
         handleChange,
         handleInput,
+        handleFocus,
+        handleBlur,
         rows = DEFAULT_PROPS.rows,
         name,
         ref,
@@ -63,6 +67,8 @@ export const RawInputTextarea = (props: RawInputTextareaProps) => {
             )}
             onChange={handleOnChange}
             onInput={handleOnInput}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
             value={value}
             rows={rows}
         />

--- a/packages/lumx-core/src/js/types/jsx/PropsToOverride.ts
+++ b/packages/lumx-core/src/js/types/jsx/PropsToOverride.ts
@@ -7,6 +7,7 @@ export type PropsToOverride =
     | 'handleKeyPress'
     | 'handleClose'
     | 'handleFocus'
+    | 'handleBlur'
     | 'handleBeforeClick'
     | 'handleAfterClick'
     | 'handleMouseEnter'

--- a/packages/lumx-react/src/components/text-field/RawInputText.tsx
+++ b/packages/lumx-react/src/components/text-field/RawInputText.tsx
@@ -30,12 +30,14 @@ export { DEFAULT_PROPS };
  */
 export const RawInputText = forwardRef<RawInputTextProps, HTMLInputElement>((props, ref) => {
     const defaultTheme = useTheme() || Theme.light;
-    const { theme = defaultTheme, onChange, ...restOfProps } = props;
+    const { theme = defaultTheme, onChange, onFocus, onBlur, ...restOfProps } = props;
 
     return UI({
         ...restOfProps,
         ref,
         theme,
         handleChange: onChange,
+        handleFocus: onFocus as any,
+        handleBlur: onBlur as any,
     });
 });

--- a/packages/lumx-react/src/components/text-field/RawInputTextarea.tsx
+++ b/packages/lumx-react/src/components/text-field/RawInputTextarea.tsx
@@ -41,6 +41,8 @@ export const RawInputTextarea = forwardRef<Omit<RawInputTextareaProps, 'type'>, 
         minimumRows = DEFAULT_PROPS.minimumRows as number,
         value,
         onChange,
+        onFocus,
+        onBlur,
         ...restOfProps
     } = props;
     const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -54,5 +56,7 @@ export const RawInputTextarea = forwardRef<Omit<RawInputTextareaProps, 'type'>, 
         value,
         rows,
         handleChange: onChange,
+        handleFocus: onFocus as any,
+        handleBlur: onBlur as any,
     });
 });

--- a/packages/lumx-vue/src/components/avatar/Avatar.test.ts
+++ b/packages/lumx-vue/src/components/avatar/Avatar.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/vue';
+import { fireEvent, render, screen } from '@testing-library/vue';
 import BaseAvatarTests, { setup } from '@lumx/core/js/components/Avatar/Tests';
 import { CLASSNAME } from '@lumx/core/js/components/Avatar';
 import { commonTestsSuiteVTL, SetupRenderOptions } from '@lumx/vue/testing';
@@ -43,6 +43,26 @@ describe('<Avatar />', () => {
                 slots: { badge: '<span>Badge</span>' },
             });
             expect(document.querySelector(`.${CLASSNAME}__badge`)).toBeInTheDocument();
+        });
+
+        it('should emit click event when the thumbnail is clicked', async () => {
+            const { emitted } = render(Avatar, {
+                props: { image: 'test.png', alt: 'Avatar' },
+                attrs: { onClick: () => {} },
+            });
+            // onClick presence makes ThumbnailUI render as a <button>
+            await fireEvent.click(screen.getByRole('button'));
+            expect(emitted('click')).toHaveLength(1);
+        });
+
+        it('should render thumbnail as a button when a keypress listener is present', () => {
+            // Verifies Avatar correctly forwards onKeypress to Thumbnail's handleKeyPress,
+            // making Thumbnail render as <button> (isClickable=true).
+            render(Avatar, {
+                props: { image: 'test.png', alt: 'Avatar' },
+                attrs: { onKeypress: () => {} },
+            });
+            expect(screen.getByRole('button')).toBeInTheDocument();
         });
     });
 });

--- a/packages/lumx-vue/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-vue/src/components/avatar/Avatar.tsx
@@ -30,25 +30,32 @@ export type AvatarProps = VueToJSXProps<UIProps, 'image' | 'actions' | 'badge'> 
     thumbnailProps?: Omit<ThumbnailProps, 'image' | 'alt' | 'size' | 'theme' | 'aspectRatio'>;
 };
 
+export const emitSchema = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    click: (_event?: MouseEvent) => true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    keypress: (_event?: KeyboardEvent) => true,
+};
+
 const Avatar = defineComponent(
-    (props: AvatarProps, { slots }) => {
+    (props: AvatarProps, { emit, slots }) => {
         const attrs = useAttrs();
         const defaultTheme = useTheme();
         const className = useClassName(() => props.class);
 
+        const handleClick = (event: Event) => emit('click', event as MouseEvent);
+        const handleKeyPress = (event: Event) => emit('keypress', event as KeyboardEvent);
+
         return () => {
             const { image, alt, size = DEFAULT_PROPS.size, theme, linkProps, linkAs, thumbnailProps } = props;
             const resolvedTheme = theme || defaultTheme.value;
-
-            // Extract event handlers from attrs to forward to Thumbnail (not to root div)
-            const { onClick, onKeyPress, ...restAttrs } = { ...attrs } as any;
 
             const actionsContent = slots.actions?.() as JSXElement;
             const badgeContent = slots.badge?.() as JSXElement;
 
             return (
                 <AvatarUI
-                    {...restAttrs}
+                    {...(attrs as any)}
                     className={className.value}
                     theme={resolvedTheme}
                     size={size}
@@ -59,8 +66,8 @@ const Avatar = defineComponent(
                             linkProps={linkProps}
                             linkAs={linkAs}
                             class={element('thumbnail')}
-                            onClick={onClick}
-                            onKeyPress={onKeyPress}
+                            onClick={handleClick}
+                            onKeyPress={handleKeyPress}
                             {...thumbnailProps}
                             aspectRatio={AspectRatio.square}
                             size={size}
@@ -77,6 +84,7 @@ const Avatar = defineComponent(
         name: 'LumxAvatar',
         inheritAttrs: false,
         props: keysOf<AvatarProps>()('image', 'alt', 'size', 'theme', 'linkProps', 'linkAs', 'thumbnailProps', 'class'),
+        emits: emitSchema,
     },
 );
 

--- a/packages/lumx-vue/src/components/tabs/Tab.test.ts
+++ b/packages/lumx-vue/src/components/tabs/Tab.test.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/vue';
+import { fireEvent, render, screen } from '@testing-library/vue';
 import BaseTabTests, { setup } from '@lumx/core/js/components/Tabs/Tests';
 import { CLASSNAME } from '@lumx/core/js/components/Tabs/Tab';
 import { commonTestsSuiteVTL, SetupRenderOptions } from '@lumx/vue/testing';
@@ -23,5 +23,19 @@ describe('<Tab />', () => {
         forwardClassName: 'tab',
         forwardAttributes: 'tab',
         forwardRef: 'tab',
+    });
+
+    describe('Vue', () => {
+        it('should emit focus event when the tab is focused', async () => {
+            const { emitted } = render(Tab, { props: { label: 'Tab' } });
+            await fireEvent.focus(screen.getByRole('tab'));
+            expect(emitted('focus')).toHaveLength(1);
+        });
+
+        it('should emit keypress event when a key is pressed on the tab', async () => {
+            const { emitted } = render(Tab, { props: { label: 'Tab' } });
+            await fireEvent.keyPress(screen.getByRole('tab'));
+            expect(emitted('keypress')).toHaveLength(1);
+        });
     });
 });

--- a/packages/lumx-vue/src/components/tabs/Tab.tsx
+++ b/packages/lumx-vue/src/components/tabs/Tab.tsx
@@ -28,19 +28,28 @@ export { CLASSNAME, COMPONENT_NAME, DEFAULT_PROPS };
  * @param  props Component props.
  * @return Vue element.
  */
+export const emitSchema = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    focus: (_event?: FocusEvent) => true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    keypress: (_event?: KeyboardEvent) => true,
+};
+
 const Tab = defineComponent(
-    (props: TabProps) => {
+    (props: TabProps, { emit }) => {
         const attrs = useAttrs();
         const className = useClassName(() => props.class);
         const { isAnyDisabled } = useDisableStateProps(computed(() => ({ ...props, ...attrs })));
         const tabState = useTabProviderContext('tab', props.id as string | undefined);
         const isActive = computed(() => props.isActive || tabState.value?.isActive);
 
+        const handleFocus = (event: FocusEvent) => emit('focus', event);
+        const handleKeyPress = (event: KeyboardEvent) => emit('keypress', event);
+
         return () => {
-            const { onFocus, onKeypress, onKeyPress, ...restAttrs } = attrs as any;
             return (
                 <TabUI
-                    {...restAttrs}
+                    {...attrs}
                     id={props.id}
                     className={className.value}
                     icon={props.icon}
@@ -53,8 +62,8 @@ const Tab = defineComponent(
                     changeToTab={tabState.value?.changeToTab}
                     tabId={tabState.value?.tabId}
                     tabPanelId={tabState.value?.tabPanelId}
-                    handleFocus={(event: FocusEvent) => (onFocus as any)?.(event)}
-                    handleKeyPress={(event: KeyboardEvent) => ((onKeypress || onKeyPress) as any)?.(event)}
+                    handleFocus={handleFocus}
+                    handleKeyPress={handleKeyPress}
                     keyPressProp="onKeypress"
                     tabIndexProp="tabindex"
                     Icon={Icon}
@@ -67,6 +76,7 @@ const Tab = defineComponent(
         name: 'LumxTab',
         inheritAttrs: false,
         props: keysOf<TabProps>()('icon', 'iconProps', 'id', 'isActive', 'isDisabled', 'label', 'class'),
+        emits: emitSchema,
     },
 );
 

--- a/packages/lumx-vue/src/components/text-field/RawInputText.test.ts
+++ b/packages/lumx-vue/src/components/text-field/RawInputText.test.ts
@@ -39,6 +39,20 @@ describe('<RawInputText />', () => {
             expect(inputEvents).toHaveLength(1);
             expect((inputEvents as any)[0][0]).toBe('a');
         });
+
+        it('should emit focus event when input is focused', async () => {
+            const { emitted } = render(RawInputText, { props: { value: '' } });
+            const input = document.querySelector('input') as HTMLInputElement;
+            await fireEvent.focus(input);
+            expect(emitted('focus')).toHaveLength(1);
+        });
+
+        it('should emit blur event when input is blurred', async () => {
+            const { emitted } = render(RawInputText, { props: { value: '' } });
+            const input = document.querySelector('input') as HTMLInputElement;
+            await fireEvent.blur(input);
+            expect(emitted('blur')).toHaveLength(1);
+        });
     });
 
     commonTestsSuiteVTL(setupRawInputText, {

--- a/packages/lumx-vue/src/components/text-field/RawInputText.tsx
+++ b/packages/lumx-vue/src/components/text-field/RawInputText.tsx
@@ -16,6 +16,10 @@ export const emitSchema = {
     change: (value: string, _name?: string, _event?: Event) => typeof value === 'string',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     input: (value: string, _name?: string, _event?: Event) => typeof value === 'string',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    focus: (_event?: FocusEvent) => true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    blur: (_event?: FocusEvent) => true,
 };
 
 /**
@@ -40,6 +44,14 @@ const RawInputText = defineComponent(
             emit('input', value, name, event);
         };
 
+        const handleFocus = (event?: any) => {
+            emit('focus', event);
+        };
+
+        const handleBlur = (event?: any) => {
+            emit('blur', event);
+        };
+
         return () => {
             return (
                 <RawInputTextUI
@@ -51,6 +63,8 @@ const RawInputText = defineComponent(
                     theme={props.theme || defaultTheme.value}
                     handleChange={handleChange}
                     handleInput={handleInput}
+                    handleFocus={handleFocus}
+                    handleBlur={handleBlur}
                 />
             );
         };

--- a/packages/lumx-vue/src/components/text-field/RawInputTextarea.test.ts
+++ b/packages/lumx-vue/src/components/text-field/RawInputTextarea.test.ts
@@ -39,6 +39,20 @@ describe('<RawInputTextarea />', () => {
             expect(inputEvents).toHaveLength(1);
             expect((inputEvents as any)[0][0]).toBe('hello');
         });
+
+        it('should emit focus event when textarea is focused', async () => {
+            const { emitted } = render(RawInputTextarea, { props: { value: '' } });
+            const textarea = document.querySelector('textarea') as HTMLTextAreaElement;
+            await fireEvent.focus(textarea);
+            expect(emitted('focus')).toHaveLength(1);
+        });
+
+        it('should emit blur event when textarea is blurred', async () => {
+            const { emitted } = render(RawInputTextarea, { props: { value: '' } });
+            const textarea = document.querySelector('textarea') as HTMLTextAreaElement;
+            await fireEvent.blur(textarea);
+            expect(emitted('blur')).toHaveLength(1);
+        });
     });
 
     commonTestsSuiteVTL(setupRawInputTextarea, {

--- a/packages/lumx-vue/src/components/text-field/RawInputTextarea.tsx
+++ b/packages/lumx-vue/src/components/text-field/RawInputTextarea.tsx
@@ -18,6 +18,10 @@ export const emitSchema = {
     change: (value: string, _name?: string, _event?: Event) => typeof value === 'string',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     input: (value: string, _name?: string, _event?: Event) => typeof value === 'string',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    focus: (_event?: FocusEvent) => true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    blur: (_event?: FocusEvent) => true,
 };
 
 /**
@@ -49,6 +53,14 @@ const RawInputTextarea = defineComponent(
             emit('input', value, name, event);
         };
 
+        const handleFocus = (event?: any) => {
+            emit('focus', event);
+        };
+
+        const handleBlur = (event?: any) => {
+            emit('blur', event);
+        };
+
         return () => {
             return (
                 <RawInputTextareaUI
@@ -61,6 +73,8 @@ const RawInputTextarea = defineComponent(
                     theme={props.theme || defaultTheme.value}
                     handleChange={handleChange}
                     handleInput={handleInput}
+                    handleFocus={handleFocus}
+                    handleBlur={handleBlur}
                 />
             );
         };


### PR DESCRIPTION
# General summary

- Add `handleFocus` / `handleBlur` props to core `RawInputText` and `RawInputTextarea`, wired to the underlying `<input>` / `<textarea>` elements
- Add `handleBlur` to the `PropsToOverride` union type so Vue wrappers treat it as an emitted event rather than a forwarded attr
- Emit `focus` and `blur` events from Vue `RawInputText` and `RawInputTextarea` via proper `emitSchema` entries
- Refactor Vue `Avatar` and `Tab` to use `emitSchema` + emit-based handlers instead of manual attr extraction (fragile `const { onClick, onFocus, … } = attrs` pattern)

# Screenshots

<!-- N/A — no visual change -->

StoryBook lumx-vue: https://14e4ddb16--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://14e4ddb16--5fbfb1d508c0520021560f10.chromatic.com/