### PR TITLE
chore(combobox): rework render when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
+    -   `Combobox`: only render option list when open; refactor focus navigation utilities
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `SelectButton`, `SelectTextField`: allow undefined section id in `getSectionId`
     -   `SelectButton`: `onChange` should provides a value (no `undefined`) and Escape key should not clear selection
     -   `SelectButton`: Fall back to `getOptionId` for the button label when no `getOptionName` is provided
+    -   `Popover`: set `hidden` on the popover root when closed (`closeMode="hide"`) so it is excluded from the accessibility tree
 
 ## [4.15.0][] - 2026-06-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,14 @@ New components: **always implement in core first**, then add React/Vue wrappers.
 
 ## TESTING
 
-Two suites, both powered by Vitest:
+Two suites, both powered by Vitest. Both use Testing Library (`@testing-library/react` / `@testing-library/vue` / `@testing-library/dom`), so these query conventions apply to **both unit tests and Storybook `play` functions**:
+
+-   Prefer Testing Library queries over `document.body.querySelector`
+    - use `screen.getByRole`/`queryByRole` instead of `[role=...]` selectors
+    - use `screen.getByTestId` instead of `[data-testid=...]` selectors
+    - use the custom queries in `packages/lumx-core/src/testing/queries.ts` (`getByClassName`/`queryByClassName`/`getByTagName`, etc.)
+    - use `find*` queries instead of `waitFor` when possible
+-   Prefer repeating queries and checks in tests rather than factorizing in utils to make the test more self contained
 
 **Unit tests** (`*.test.tsx` / `*.test.ts`) — co-located with components, never in `__tests__/`:
 
@@ -70,7 +77,7 @@ Two suites, both powered by Vitest:
 
 **Storybook tests** (`*.stories.tsx` / `*.stories.ts`) — Vitest browser mode running inside Playwright:
 
--   Stories can define `play` functions for interaction testing
+-   Stories can define `play` functions for interaction testing (with testing-library via the `storybook/test` module)
 -   Screenshots are optionally taken and diffed against baselines stored in `__vis__/`
 -   `yarn test:storybook` — runs all Storybook tests across React and Vue
 

--- a/packages/lumx-core/src/js/components/Combobox/ComboboxOptionTests.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/ComboboxOptionTests.tsx
@@ -1,4 +1,7 @@
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/dom';
 import { CLASSNAME as COMBOBOX_OPTION_CLASSNAME } from './ComboboxOption';
+import { getByClassName, queryByClassName } from '../../../testing/queries';
 import { ComboboxNamespace } from './Tests';
 
 type RenderResult = { unmount: () => void; container: HTMLElement };
@@ -9,7 +12,7 @@ type RenderResult = { unmount: () => void; container: HTMLElement };
  */
 export interface ComboboxOptionTestSetup {
     /** Combobox compound component namespace */
-    Combobox: Pick<ComboboxNamespace, 'Provider' | 'List' | 'Option'>;
+    Combobox: Pick<ComboboxNamespace, 'Provider' | 'Input' | 'List' | 'Option'>;
     /**
      * Render a JSX template and return a result with a container.
      * The template is a zero-argument function returning a JSX element.
@@ -40,7 +43,7 @@ export default function comboboxOptionTests({ Combobox, render }: ComboboxOption
      * Returns the root <li> element, the action element (role="option" / role="gridcell"),
      * and the render result.
      */
-    const setup = ({
+    const setup = async ({
         listType,
         value = 'apple',
         isSelected,
@@ -54,6 +57,11 @@ export default function comboboxOptionTests({ Combobox, render }: ComboboxOption
     }: SetupOptions = {}) => {
         const result = render(() => (
             <Combobox.Provider>
+                <Combobox.Input
+                    placeholder="Pick a fruit…"
+                    onChange={() => {}}
+                    toggleButtonProps={{ label: 'Fruits' }}
+                />
                 <Combobox.List aria-label="Fruits" type={listType}>
                     <Combobox.Option
                         value={value}
@@ -70,45 +78,43 @@ export default function comboboxOptionTests({ Combobox, render }: ComboboxOption
                 </Combobox.List>
             </Combobox.Provider>
         ));
-        // In standard list mode the action element carries role="option";
-        // in grid mode it carries role="gridcell".
-        const action = document.body.querySelector<HTMLElement>('[role="option"], [role="gridcell"]')!;
-        // The root <li> is the closest list item ancestor of the action.
-        const item = action?.closest('li') as HTMLElement;
-        return { ...result, action, item };
+        // Open the combobox
+        await userEvent.click(screen.getByRole('combobox'));
+        const action = await (listType === 'grid' ? screen.findByRole('gridcell') : screen.findByRole('option'));
+        return { ...result, action };
     };
 
     describe('Combobox.Option', () => {
         // ── ARIA attributes ──────────────────────────────────────────────
 
         describe('ARIA attributes', () => {
-            it('should render the action element with role="option"', () => {
-                setup();
-                expect(document.body.querySelector('[role="option"]')).toBeInTheDocument();
+            it('should render the action element with role="option"', async () => {
+                await setup();
+                expect(screen.queryByRole('option')).toBeInTheDocument();
             });
 
-            it('should set aria-selected="false" by default', () => {
-                const { action } = setup();
+            it('should set aria-selected="false" by default', async () => {
+                const { action } = await setup();
                 expect(action).toHaveAttribute('aria-selected', 'false');
             });
 
-            it('should set aria-selected="true" when isSelected is true', () => {
-                const { action } = setup({ isSelected: true });
+            it('should set aria-selected="true" when isSelected is true', async () => {
+                const { action } = await setup({ isSelected: true });
                 expect(action).toHaveAttribute('aria-selected', 'true');
             });
 
-            it('should set aria-disabled="true" when isDisabled is true', () => {
-                const { action } = setup({ isDisabled: true });
+            it('should set aria-disabled="true" when isDisabled is true', async () => {
+                const { action } = await setup({ isDisabled: true });
                 expect(action).toHaveAttribute('aria-disabled', 'true');
             });
 
-            it('should not set aria-disabled when isDisabled is false', () => {
-                const { action } = setup({ isDisabled: false });
+            it('should not set aria-disabled when isDisabled is false', async () => {
+                const { action } = await setup({ isDisabled: false });
                 expect(action).not.toHaveAttribute('aria-disabled');
             });
 
-            it('should expose data-value matching the value prop on the action element', () => {
-                const { action } = setup({ value: 'banana' });
+            it('should expose data-value matching the value prop on the action element', async () => {
+                const { action } = await setup({ value: 'banana' });
                 expect(action).toHaveAttribute('data-value', 'banana');
             });
         });
@@ -116,30 +122,30 @@ export default function comboboxOptionTests({ Combobox, render }: ComboboxOption
         // ── Description ──────────────────────────────────────────────────
 
         describe('Description', () => {
-            it('should render a description block with the correct class and text', () => {
-                setup({ description: 'A round red fruit' });
-                const descEl = document.body.querySelector(`.${COMBOBOX_OPTION_CLASSNAME}__description`);
+            it('should render a description block with the correct class and text', async () => {
+                await setup({ description: 'A round red fruit' });
+                const descEl = getByClassName(document.body, `${COMBOBOX_OPTION_CLASSNAME}__description`);
                 expect(descEl).toBeInTheDocument();
                 expect(descEl).toHaveTextContent('A round red fruit');
             });
 
-            it('should link the action element to the description via aria-describedby', () => {
-                const { action } = setup({ description: 'A round red fruit' });
-                const descEl = document.body.querySelector(`.${COMBOBOX_OPTION_CLASSNAME}__description`);
+            it('should link the action element to the description via aria-describedby', async () => {
+                const { action } = await setup({ description: 'A round red fruit' });
+                const descEl = getByClassName(document.body, `${COMBOBOX_OPTION_CLASSNAME}__description`);
                 const describedBy = action.getAttribute('aria-describedby');
                 expect(describedBy).toBeTruthy();
-                expect(describedBy).toContain(descEl!.id);
+                expect(describedBy).toContain(descEl.id);
             });
 
-            it('should expose the description as the action accessible description', () => {
-                const { action } = setup({ description: 'A round red fruit' });
+            it('should expose the description as the action accessible description', async () => {
+                const { action } = await setup({ description: 'A round red fruit' });
                 expect(action).toHaveAccessibleDescription('A round red fruit');
             });
 
-            it('should not render a description block when description is not set', () => {
-                setup();
+            it('should not render a description block when description is not set', async () => {
+                await setup();
                 expect(
-                    document.body.querySelector(`.${COMBOBOX_OPTION_CLASSNAME}__description`),
+                    queryByClassName(document.body, `${COMBOBOX_OPTION_CLASSNAME}__description`),
                 ).not.toBeInTheDocument();
             });
         });
@@ -147,43 +153,39 @@ export default function comboboxOptionTests({ Combobox, render }: ComboboxOption
         // ── Slots — before / after ───────────────────────────────────────
 
         describe('Slots — before / after', () => {
-            it('should render before content', () => {
-                setup({ before: <span data-testid="before-content">icon</span> });
-                expect(document.body.querySelector('[data-testid="before-content"]')).toBeInTheDocument();
+            it('should render before content', async () => {
+                await setup({ before: <span data-testid="before-content">icon</span> });
+                expect(screen.getByTestId('before-content')).toBeInTheDocument();
             });
 
-            it('should render after content', () => {
-                setup({ after: <span data-testid="after-content">badge</span> });
-                expect(document.body.querySelector('[data-testid="after-content"]')).toBeInTheDocument();
+            it('should render after content', async () => {
+                await setup({ after: <span data-testid="after-content">badge</span> });
+                expect(screen.getByTestId('after-content')).toBeInTheDocument();
             });
         });
 
         // ── Tooltip wrapping ─────────────────────────────────────────────
 
         describe('Tooltip wrapping', () => {
-            it('should not render a tooltip when tooltipProps is omitted', () => {
-                setup();
+            it('should not render a tooltip when tooltipProps is omitted', async () => {
+                await setup();
                 // The tooltip popup is mounted with role="tooltip" (via Portal).
-                expect(document.body.querySelector('[role="tooltip"]')).not.toBeInTheDocument();
+                expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
             });
 
-            it('should render a tooltip when tooltipProps is provided (forceOpen)', () => {
-                setup({ tooltipProps: { label: 'Extra info', forceOpen: true } });
-                expect(document.body.querySelector('[role="tooltip"]')).toBeInTheDocument();
+            it('should render a tooltip when tooltipProps is provided (forceOpen)', async () => {
+                await setup({ tooltipProps: { label: 'Extra info', forceOpen: true } });
+                expect(screen.getByRole('tooltip')).toBeInTheDocument();
             });
         });
 
         // ── Grid mode ────────────────────────────────────────────────────
 
         describe('Grid mode', () => {
-            it('should render the action element with role="gridcell" inside a grid list', () => {
-                const { action } = setup({ listType: 'grid' });
+            it('should render the action element with role="gridcell" within a role="row" inside a grid list', async () => {
+                const { action } = await setup({ listType: 'grid' });
                 expect(action).toHaveAttribute('role', 'gridcell');
-            });
-
-            it('should render the list item with role="row" inside a grid list', () => {
-                const { item } = setup({ listType: 'grid' });
-                expect(item).toHaveAttribute('role', 'row');
+                expect(action.closest('li')).toHaveAttribute('role', 'row');
             });
         });
     });

--- a/packages/lumx-core/src/js/components/Combobox/Stories.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Stories.tsx
@@ -30,8 +30,8 @@ export function setup({
     const meta = {
         component: Combobox.Provider,
         async play() {
-            userEvent.tab();
-            userEvent.keyboard('{ArrowDown}');
+            await userEvent.tab();
+            await userEvent.keyboard('{ArrowDown}');
         },
     };
 

--- a/packages/lumx-core/src/js/components/Combobox/TestStories.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/TestStories.tsx
@@ -7,9 +7,11 @@
  *
  * The majority of combobox tests have been migrated to jsdom in Tests.tsx.
  */
-import { expect, userEvent, within, waitFor } from 'storybook/test';
+import { expect, screen, userEvent, within, waitFor } from 'storybook/test';
 import type { SetupStoriesOptions } from '@lumx/core/stories/types';
-import { createTemplates, type ComboboxNamespace } from './Tests';
+import { queryAllByClassName } from '../../../testing/queries';
+import { CLASSNAME as COMBOBOX_OPTION_MORE_INFO_CLASSNAME } from './ComboboxOptionMoreInfo';
+import { createTemplates, getActiveOption, type ComboboxNamespace } from './Tests';
 
 // ─── Fixtures ────────────────────────────────────────────────────
 
@@ -17,26 +19,10 @@ const MORE_INFO_FRUITS = ['Apple', 'Banana', 'Cherry'];
 
 // ─── Helpers ─────────────────────────────────────────────────────
 
-function getInput(canvasElement: HTMLElement): HTMLInputElement {
-    return within(canvasElement).getByPlaceholderText('Pick a fruit…') as HTMLInputElement;
-}
-
-function getActiveOption(): HTMLElement | null {
-    return document.body.querySelector('[role="option"][data-focus-visible-added="true"]');
-}
-
-function getVisibleOptions(): HTMLElement[] {
-    return Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]:not([data-filtered])'));
-}
-
-/** Helper: get all OptionMoreInfo info icon buttons. */
-function getMoreInfoButtons(): HTMLElement[] {
-    return Array.from(document.body.querySelectorAll<HTMLElement>('.lumx-combobox-option-more-info'));
-}
-
 /** Helper: get a visible (open) OptionMoreInfo popover element. */
 function getVisibleMoreInfoPopover(): HTMLElement | null {
-    return document.body.querySelector('.lumx-combobox-option-more-info__popover:not(.lumx-popover--is-hidden)');
+    const popovers = queryAllByClassName(document.body, 'lumx-combobox-option-more-info__popover');
+    return popovers.find((p) => !p.classList.contains('lumx-popover--is-hidden')) ?? null;
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -54,8 +40,8 @@ export function setup({
     };
     decorators: 'withValueOnChange';
 }>) {
-    // Reuse templates from Tests.tsx for the input template
-    const { inputTemplate } = createTemplates(Combobox, IconButton);
+    // Reuse templates from Tests.tsx for the input and button templates
+    const { inputTemplate, buttonTemplate } = createTemplates(Combobox, IconButton);
 
     // ─── Browser-only templates ──────────────────────────────────
 
@@ -104,6 +90,12 @@ export function setup({
         render: inputTemplate,
     };
 
+    const comboboxButtonStory = {
+        args: { value: '' },
+        decorators: [withValueOnChange({ onChangeProp: 'onSelect', valueExtract: (v: any) => v?.value })],
+        render: buttonTemplate,
+    };
+
     const optionMoreInfoStory = {
         args: { value: '' },
         argTypes: { onToggle: { action: 'toggle' } },
@@ -121,134 +113,17 @@ export function setup({
     // Browser-only tests
     // ═══════════════════════════════════════════════════════════════
 
-    const AutoFilterOptions = {
-        ...comboboxInputStory,
-        play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
-            await userEvent.click(input);
-
-            await waitFor(() => {
-                expect(input).toHaveAttribute('aria-expanded', 'true');
-            });
-
-            // All 10 options should be visible initially
-            let visibleOptions = getVisibleOptions();
-            expect(visibleOptions).toHaveLength(10);
-
-            // Type "B" → "Banana", "Blueberry" and "Strawberry" match (case-insensitive includes)
-            await userEvent.type(input, 'B');
-
-            await waitFor(() => {
-                visibleOptions = getVisibleOptions();
-                expect(visibleOptions).toHaveLength(3);
-                expect(visibleOptions.map((o) => o.textContent)).toEqual(['Banana', 'Blueberry', 'Strawberry']);
-            });
-
-            // Continue typing "a" (input now "Ba") → only "Banana" matches
-            await userEvent.type(input, 'a');
-
-            await waitFor(() => {
-                visibleOptions = getVisibleOptions();
-                expect(visibleOptions).toHaveLength(1);
-                expect(visibleOptions[0].textContent).toBe('Banana');
-            });
-
-            // Clear input → all options visible again
-            await userEvent.clear(input);
-
-            await waitFor(() => {
-                visibleOptions = getVisibleOptions();
-                expect(visibleOptions).toHaveLength(10);
-            });
-        },
-    };
-
-    // ─── Browser-only filter templates ─────────────────────────
-
-    const filterOffStory = {
-        args: { value: '' },
-        decorators: [withValueOnChange()],
-        render: ({ value, onChange, onSelect }: any) => (
-            <Combobox.Provider>
-                <Combobox.Input
-                    value={value}
-                    onChange={onChange}
-                    onSelect={onSelect}
-                    filter="off"
-                    placeholder="Pick a fruit…"
-                    toggleButtonProps={{ label: 'Fruits' }}
-                />
-                <Combobox.Popover>
-                    <Combobox.List aria-label="Fruits">
-                        {[
-                            'Apple',
-                            'Apricot',
-                            'Banana',
-                            'Blueberry',
-                            'Cherry',
-                            'Grape',
-                            'Lemon',
-                            'Orange',
-                            'Peach',
-                            'Strawberry',
-                        ].map((fruit) => (
-                            <Combobox.Option key={fruit} value={fruit}>
-                                {fruit}
-                            </Combobox.Option>
-                        ))}
-                    </Combobox.List>
-                </Combobox.Popover>
-            </Combobox.Provider>
-        ),
-    };
-
-    /**
-     * Verifies that filter="off" makes the input readOnly, opens on focus,
-     * and allows selecting via keyboard navigation.
-     */
-    const FilterOffOpenOnFocus = {
-        ...filterOffStory,
-        play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
-
-            // Input should be readOnly
-            expect(input.readOnly).toBe(true);
-
-            // Should open on focus
-            input.focus();
-            await waitFor(() => {
-                expect(input).toHaveAttribute('aria-expanded', 'true');
-            });
-
-            // All 10 options visible (no filtering)
-            const visibleOptions = getVisibleOptions();
-            expect(visibleOptions).toHaveLength(10);
-
-            // Navigate and select
-            await userEvent.keyboard('{ArrowDown}');
-            await waitFor(() => {
-                expect(getActiveOption()!.textContent).toBe('Apple');
-            });
-
-            await userEvent.keyboard('{Enter}');
-            await waitFor(() => {
-                expect(input.value).toBe('Apple');
-                expect(input).toHaveAttribute('aria-expanded', 'false');
-            });
-        },
-    };
-
     const MouseHoverDoesNotActivateOption = {
         ...comboboxInputStory,
         play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
+            const input = within(canvasElement).getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const options = getVisibleOptions();
+            const options = screen.queryAllByRole('option');
             const bananaOption = options.find((o) => o.textContent === 'Banana')!;
             await userEvent.hover(bananaOption);
 
@@ -269,7 +144,7 @@ export function setup({
             </div>
         ),
         play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
+            const input = within(canvasElement).getByRole<HTMLInputElement>('combobox');
 
             await userEvent.click(input);
             await waitFor(() => {
@@ -288,14 +163,14 @@ export function setup({
     const MouseHoverThenKeyboardNav = {
         ...comboboxInputStory,
         play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
+            const input = within(canvasElement).getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const options = getVisibleOptions();
+            const options = screen.queryAllByRole('option');
             const cherryOption = options.find((o) => o.textContent === 'Cherry')!;
             await userEvent.hover(cherryOption);
             await expect(getActiveOption()).toBeNull();
@@ -315,7 +190,7 @@ export function setup({
     const OptionMoreInfoKeyboardHighlight = {
         ...optionMoreInfoStory,
         play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
+            const input = within(canvasElement).getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -353,7 +228,7 @@ export function setup({
     const OptionMoreInfoMouseHover = {
         ...optionMoreInfoStory,
         play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
+            const input = within(canvasElement).getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -362,7 +237,7 @@ export function setup({
 
             await expect(getVisibleMoreInfoPopover()).toBeNull();
 
-            const infoButtons = getMoreInfoButtons();
+            const infoButtons = queryAllByClassName(document.body, COMBOBOX_OPTION_MORE_INFO_CLASSNAME);
             await expect(infoButtons.length).toBeGreaterThan(0);
             await userEvent.hover(infoButtons[0]);
 
@@ -397,7 +272,7 @@ export function setup({
     const OptionMoreInfoAriaDescribedBy = {
         ...optionMoreInfoStory,
         play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
+            const input = within(canvasElement).getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -422,45 +297,112 @@ export function setup({
         },
     };
 
-    /**
-     * Verifies the withValueOnChange decorator correctly propagates the
-     * selected option value back into the input.
-     */
-    const SelectOptionUpdatesInput = {
-        ...comboboxInputStory,
+    const ButtonTypeaheadFromClosed = {
+        ...comboboxButtonStory,
         play: async ({ canvasElement }: any) => {
-            const input = getInput(canvasElement);
-            await userEvent.click(input);
+            const button = within(canvasElement).getByTestId('combobox-button');
+            button.focus();
+            await expect(button).toHaveAttribute('aria-expanded', 'false');
 
+            // Single printable char from closed: opens and lands on the first match.
+            await userEvent.keyboard('b');
             await waitFor(() => {
-                expect(input).toHaveAttribute('aria-expanded', 'true');
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                const banana = screen.queryAllByRole('option').find((o) => o.textContent === 'Banana');
+                expect(banana).toBeTruthy();
+                expect(button).toHaveAttribute('aria-activedescendant', banana!.id);
             });
+        },
+    };
 
-            // Navigate to "Cherry" (5th option) and select it with Enter
-            // eslint-disable-next-line no-await-in-loop
-            for (let i = 0; i < 5; i++) await userEvent.keyboard('{ArrowDown}');
-            await waitFor(() => {
-                expect(getActiveOption()!.textContent).toBe('Cherry');
-            });
+    const ButtonTypeaheadWhileOpen = {
+        ...comboboxButtonStory,
+        play: async ({ canvasElement }: any) => {
+            const button = within(canvasElement).getByTestId('combobox-button');
+            button.focus();
 
+            // Open first (no active option).
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
-                expect(input.value).toBe('Cherry');
-                expect(input).toHaveAttribute('aria-expanded', 'false');
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
+            });
+            await expect(button).toHaveAttribute('aria-activedescendant', '');
+
+            // Typeahead while open lands on the match synchronously.
+            await userEvent.keyboard('o');
+            await waitFor(() => {
+                const orange = screen.queryAllByRole('option').find((o) => o.textContent === 'Orange');
+                expect(orange).toBeTruthy();
+                expect(button).toHaveAttribute('aria-activedescendant', orange!.id);
+            });
+        },
+    };
+
+    const ButtonEndFromClosed = {
+        ...comboboxButtonStory,
+        play: async ({ canvasElement }: any) => {
+            const button = within(canvasElement).getByTestId('combobox-button');
+            button.focus();
+            await expect(button).toHaveAttribute('aria-expanded', 'false');
+
+            await userEvent.keyboard('{End}');
+            await waitFor(() => {
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                const options = screen.queryAllByRole('option');
+                const last = options[options.length - 1];
+                expect(last).toBeTruthy();
+                expect(button).toHaveAttribute('aria-activedescendant', last.id);
+            });
+        },
+    };
+
+    const ButtonHomeFromClosed = {
+        ...comboboxButtonStory,
+        play: async ({ canvasElement }: any) => {
+            const button = within(canvasElement).getByTestId('combobox-button');
+            button.focus();
+            await expect(button).toHaveAttribute('aria-expanded', 'false');
+
+            await userEvent.keyboard('{Home}');
+            await waitFor(() => {
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                const first = screen.queryAllByRole('option')[0];
+                expect(first).toBeTruthy();
+                expect(button).toHaveAttribute('aria-activedescendant', first.id);
+            });
+        },
+    };
+
+    const ButtonArrowDownFromClosed = {
+        ...comboboxButtonStory,
+        play: async ({ canvasElement }: any) => {
+            const button = within(canvasElement).getByTestId('combobox-button');
+            button.focus();
+            await expect(button).toHaveAttribute('aria-expanded', 'false');
+
+            await userEvent.keyboard('{ArrowDown}');
+            await waitFor(() => {
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                const first = screen.queryAllByRole('option')[0];
+                expect(first).toBeTruthy();
+                expect(button).toHaveAttribute('aria-activedescendant', first.id);
             });
         },
     };
 
     return {
         meta,
-        AutoFilterOptions,
-        FilterOffOpenOnFocus,
-        SelectOptionUpdatesInput,
         MouseHoverDoesNotActivateOption,
         ClickAwayClosesPopup,
         MouseHoverThenKeyboardNav,
         OptionMoreInfoKeyboardHighlight,
         OptionMoreInfoMouseHover,
         OptionMoreInfoAriaDescribedBy,
+        ButtonTypeaheadFromClosed,
+        ButtonTypeaheadWhileOpen,
+        ButtonEndFromClosed,
+        ButtonHomeFromClosed,
+        ButtonArrowDownFromClosed,
     };
 }

--- a/packages/lumx-core/src/js/components/Combobox/Tests.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Tests.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable no-await-in-loop */
 import userEvent from '@testing-library/user-event';
-import { fireEvent, waitFor } from '@testing-library/dom';
+import { fireEvent, screen, waitFor, within } from '@testing-library/dom';
 import { mdiDelete, mdiPencil } from '@lumx/icons';
+import { queryByClassName, queryAllByClassName } from '../../../testing/queries';
 import { CLASSNAME as COMBOBOX_LIST_CLASSNAME } from './ComboboxList';
 import { CLASSNAME as COMBOBOX_OPTION_CLASSNAME } from './ComboboxOption';
 import { CLASSNAME as COMBOBOX_OPTION_SKELETON_CLASSNAME } from './ComboboxOptionSkeleton';
@@ -64,50 +65,20 @@ export interface ComboboxTestSetup {
 }
 
 // ─── DOM Helpers ─────────────────────────────────────────────────
-// Options are rendered in a portal (document.body), outside the component container.
-// All option/listbox queries target document.body.
 
-function getInput(): HTMLInputElement {
-    return document.body.querySelector<HTMLInputElement>('input[placeholder="Pick a fruit…"]')!;
-}
-
-function getButtonTrigger(): HTMLButtonElement {
-    return document.body.querySelector<HTMLButtonElement>('[data-testid="combobox-button"]')!;
-}
-
-function getToggleButton(): HTMLButtonElement | null {
-    return document.body.querySelector<HTMLButtonElement>('button[aria-controls]');
-}
-
-function getStateContainer(): HTMLElement | null {
-    return document.body.querySelector<HTMLElement>(`.${COMBOBOX_STATE_CLASSNAME}`);
-}
-
-function getActiveOption(): HTMLElement | null {
-    return document.body.querySelector('[role="option"][data-focus-visible-added="true"]');
-}
-
-function getVisibleOptions(): HTMLElement[] {
-    return Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]:not([data-filtered])'));
-}
-
-function getAllOptions(): HTMLElement[] {
-    return Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]'));
-}
-
-function getListbox(listboxId: string): HTMLElement | null {
-    return document.getElementById(listboxId);
+export function getActiveOption(): HTMLElement | null {
+    return screen.queryAllByRole('option').find((el) => el.hasAttribute('data-focus-visible-added')) ?? null;
 }
 
 function getActiveCell(): HTMLElement | null {
-    return document.body.querySelector('[role="gridcell"][data-focus-visible-added="true"]');
+    return screen.queryAllByRole('gridcell').find((el) => el.hasAttribute('data-focus-visible-added')) ?? null;
 }
 
 function getVisibleGridOptions(): HTMLElement[] {
-    const rows = Array.from(document.body.querySelectorAll('[role="row"]')) as HTMLElement[];
+    const rows = screen.queryAllByRole('row');
     return rows
-        .map((row) => row.querySelector('[role="gridcell"]') as HTMLElement | null)
-        .filter((cell): cell is HTMLElement => cell !== null && !cell.hasAttribute('data-filtered'));
+        .map((row) => within(row).queryAllByRole('gridcell')[0])
+        .filter((cell): cell is HTMLElement => cell !== undefined);
 }
 
 // ─── Templates ───────────────────────────────────────────────────
@@ -725,7 +696,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Input trigger - ARIA attributes', () => {
         it('should have correct textbox ARIA attributes', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             expect(input).toHaveAttribute('role', 'combobox');
             expect(input).toHaveAttribute('aria-autocomplete', 'list');
@@ -741,15 +712,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             });
 
             await waitFor(() => {
-                const listbox = getListbox(controlsId);
-                expect(listbox).not.toBeNull();
-                expect(listbox).toHaveAttribute('role', 'listbox');
+                const listbox = screen.getByRole('listbox');
+                expect(controlsId).toBe(listbox.id);
             });
         });
 
         it('should have correct listbox ARIA attributes', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -757,26 +727,23 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             });
 
             // Verify the scroll wrapper is rendered inside the popover
-            const popover = document.body.querySelector(`.${COMBOBOX_POPOVER_CLASSNAME}`);
+            const popover = queryByClassName(document.body, COMBOBOX_POPOVER_CLASSNAME);
             expect(popover).not.toBeNull();
-            const scrollWrapper = popover!.querySelector(`.${COMBOBOX_POPOVER_CLASSNAME}__scroll`);
+            const scrollWrapper = queryByClassName(popover!, `${COMBOBOX_POPOVER_CLASSNAME}__scroll`);
             expect(scrollWrapper).not.toBeNull();
 
-            const listboxId = input.getAttribute('aria-controls')!;
-            const listbox = getListbox(listboxId)!;
+            const listbox = screen.getByRole('listbox');
 
             expect(listbox).toHaveAttribute('role', 'listbox');
             expect(listbox).toHaveAttribute('aria-label', 'Fruits');
             expect(listbox.classList.contains(COMBOBOX_LIST_CLASSNAME)).toBe(true);
 
-            const options = Array.from(listbox.querySelectorAll('[role="option"]'));
+            const options = within(listbox).queryAllByRole('option');
             expect(options.length).toBe(FRUITS.length);
 
             for (const opt of options) {
                 expect(opt.id).toBeTruthy();
-                // Each option trigger should have the combobox option trigger class
                 expect(opt.classList.contains(`${COMBOBOX_OPTION_CLASSNAME}__action`)).toBe(true);
-                // The parent list item should have the combobox option class
                 const listItem = opt.closest(`.${COMBOBOX_OPTION_CLASSNAME}`);
                 expect(listItem).not.toBeNull();
             }
@@ -784,22 +751,22 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should render option description with correct class', async () => {
             renderWithState(t.descriptionTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const descriptionEl = document.body.querySelector(`.${COMBOBOX_OPTION_CLASSNAME}__description`);
+            const descriptionEl = queryByClassName(document.body, `${COMBOBOX_OPTION_CLASSNAME}__description`);
             expect(descriptionEl).not.toBeNull();
             expect(descriptionEl!.textContent).toBe('A round red fruit');
         });
 
         it('should have toggle button with correct ARIA attributes', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
-            const button = getToggleButton()!;
+            const input = screen.getByRole<HTMLInputElement>('combobox');
+            const button = screen.queryByRole('button', { name: 'Fruits' })!;
             expect(button).not.toBeNull();
 
             expect(button).toHaveAttribute('tabindex', '-1');
@@ -823,7 +790,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Input trigger - Keyboard support', () => {
         it('should open and focus first option on ArrowDown', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -844,7 +811,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should open without moving focus on Alt+ArrowDown', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -859,7 +826,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should focus last option on ArrowUp', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -880,7 +847,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should close listbox on Enter', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -895,7 +862,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should NOT open listbox on Enter when closed (lets form submit)', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             // Focus input without clicking (click would open the popup).
             input.focus();
             expect(input).toHaveAttribute('aria-expanded', 'false');
@@ -911,7 +878,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should close listbox on Enter when open with no active descendant (without preventing default)', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -931,7 +898,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should close listbox on Escape then clear on second Escape', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -959,7 +926,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should select on Enter and close', async () => {
             const onSelect = vi.fn();
             renderWithState(t.inputTemplate, { value: '', onSelect });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -984,7 +951,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should close on Escape and clear active descendant', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1006,7 +973,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should cycle options with ArrowDown', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1032,7 +999,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should cycle options with ArrowUp', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1055,7 +1022,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should return focus to input on ArrowRight', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
             await userEvent.type(input, 'A');
 
@@ -1075,7 +1042,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should return focus to input on ArrowLeft', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
             await userEvent.type(input, 'A');
 
@@ -1095,7 +1062,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should return focus to input on Home', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
             await userEvent.type(input, 'App');
 
@@ -1116,7 +1083,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should return focus to input on End', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
             await userEvent.type(input, 'App');
 
@@ -1137,7 +1104,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should return focus to input and filter on typing', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1154,7 +1121,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await waitFor(() => {
                 // Banana, Blueberry, Strawberry (includes match)
-                expect(getVisibleOptions().length).toBe(3);
+                expect(screen.queryAllByRole('option').length).toBe(3);
             });
         });
     });
@@ -1166,7 +1133,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Input trigger - DOM focus', () => {
         it('should keep DOM focus on textbox during navigation', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1190,7 +1157,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should remove toggle button from tab sequence', () => {
             renderWithState(t.inputTemplate);
-            const button = getToggleButton()!;
+            const button = screen.queryByRole('button', { name: 'Fruits' })!;
             expect(button).toHaveAttribute('tabindex', '-1');
         });
     });
@@ -1203,14 +1170,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should select option on click', async () => {
             const onSelect = vi.fn();
             renderWithState(t.inputTemplate, { value: '', onSelect });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const orangeOption = getVisibleOptions().find((o) => o.textContent === 'Orange')!;
+            const orangeOption = screen.queryAllByRole('option').find((o) => o.textContent === 'Orange')!;
             await userEvent.click(orangeOption);
 
             expect(input.value).toBe('Orange');
@@ -1220,7 +1187,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should filter options by typing', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1230,14 +1197,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.type(input, 'bl');
 
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(1);
-                expect(getVisibleOptions()[0].textContent).toBe('Blueberry');
+                expect(screen.queryAllByRole('option').length).toBe(1);
+                expect(screen.queryAllByRole('option')[0].textContent).toBe('Blueberry');
             });
         });
 
         it('should select after filtering', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1247,7 +1214,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.type(input, 'lem');
 
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(1);
+                expect(screen.queryAllByRole('option').length).toBe(1);
             });
 
             await userEvent.keyboard('{ArrowDown}');
@@ -1264,8 +1231,8 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should open and focus input on toggle button click', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
-            const button = getToggleButton()!;
+            const input = screen.getByRole<HTMLInputElement>('combobox');
+            const button = screen.queryByRole('button', { name: 'Fruits' })!;
 
             expect(input).toHaveAttribute('aria-expanded', 'false');
 
@@ -1290,14 +1257,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should select option on click and fire onSelect', async () => {
             const onSelect = vi.fn();
             renderWithState(t.inputTemplate, { value: '', onSelect });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const grapeOption = getVisibleOptions().find((o) => o.textContent === 'Grape')!;
+            const grapeOption = screen.queryAllByRole('option').find((o) => o.textContent === 'Grape')!;
             await userEvent.click(grapeOption);
 
             expect(input.value).toBe('Grape');
@@ -1308,14 +1275,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should keep focus on input after clicking option', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const orangeOption = getVisibleOptions().find((o) => o.textContent === 'Orange')!;
+            const orangeOption = screen.queryAllByRole('option').find((o) => o.textContent === 'Orange')!;
             await userEvent.click(orangeOption);
 
             expect(document.activeElement).toBe(input);
@@ -1323,7 +1290,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should reopen listbox when typing after Escape', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1333,7 +1300,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.type(input, 'ap');
             await waitFor(() => {
                 // Apple, Apricot, Grape (includes match)
-                expect(getVisibleOptions().length).toBe(3);
+                expect(screen.queryAllByRole('option').length).toBe(3);
             });
 
             await userEvent.keyboard('{Escape}');
@@ -1346,9 +1313,55 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
                 expect(input.value).toBe('app');
-                expect(getVisibleOptions().length).toBe(1);
-                expect(getVisibleOptions()[0].textContent).toBe('Apple');
+                expect(screen.queryAllByRole('option').length).toBe(1);
+                expect(screen.queryAllByRole('option')[0].textContent).toBe('Apple');
             });
+        });
+    });
+
+    // ───────────────────────────────────────────────────────────────
+    // Children unmounted while closed
+    // ───────────────────────────────────────────────────────────────
+    //
+    // NOTE: keyboard-open *navigation* (ArrowDown/Up/Home/End/typeahead landing on
+    // an option when opening from closed) is deferred until the option children
+    // commit. That timing only reproduces reliably in a real browser, so those
+    // assertions live in the browser test stories (TestStories.tsx), not here.
+
+    describe('Children unmounted while closed', () => {
+        it('should not render option children while closed', () => {
+            renderWithState(t.inputTemplate);
+            const input = screen.getByRole<HTMLInputElement>('combobox');
+            expect(input).toHaveAttribute('aria-expanded', 'false');
+            // Children are gated on isOpen — nothing mounted while closed.
+            expect(screen.queryAllByRole('option').length).toBe(0);
+        });
+
+        it('should render option children once opened', async () => {
+            renderWithState(t.inputTemplate);
+            await userEvent.click(screen.getByRole('combobox'));
+            await waitFor(() => {
+                expect(screen.queryAllByRole('option').length).toBe(FRUITS.length);
+            });
+        });
+
+        it('should not navigate after quickly closing then reopening (intent cleared)', async () => {
+            renderWithState(t.inputTemplate);
+            const input = screen.getByRole<HTMLInputElement>('combobox');
+            input.focus();
+
+            // Open with ArrowDown (stores a navigation intent)…
+            await userEvent.keyboard('{ArrowDown}');
+            // …then immediately close before/at the same tick (Escape clears the intent).
+            await userEvent.keyboard('{Escape}');
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'false');
+            });
+
+            // Reopen via click — no stored intent, so no option should be virtually focused.
+            await userEvent.click(screen.getByRole('combobox'));
+            expect(getActiveOption()).toBeNull();
+            expect(input).toHaveAttribute('aria-activedescendant', '');
         });
     });
 
@@ -1359,7 +1372,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Button trigger - ARIA attributes', () => {
         it('should have correct button ARIA attributes', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
 
             expect(button).toHaveAttribute('role', 'combobox');
             expect(button).toHaveAttribute('aria-haspopup', 'listbox');
@@ -1372,10 +1385,10 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const listbox = document.body.querySelector('[role="listbox"]')!;
+            const listbox = screen.getByRole('listbox');
             expect(listbox).toHaveAttribute('role', 'listbox');
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             for (const opt of options) {
                 expect(opt.id).toBeTruthy();
             }
@@ -1385,7 +1398,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Button trigger - Open/close', () => {
         it('should open on Enter', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await waitFor(() => {
@@ -1401,7 +1414,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should open on Space', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await waitFor(() => {
@@ -1416,7 +1429,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should close on Escape without selecting', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{End}');
@@ -1435,7 +1448,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should toggle on click', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
 
             await userEvent.click(button);
             await waitFor(() => {
@@ -1452,18 +1465,18 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Button trigger - Navigation', () => {
         it('should navigate with ArrowDown', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
-            const firstOption = getAllOptions()[0]!;
+            const firstOption = screen.queryAllByRole('option')[0]!;
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
                 expect(button).toHaveAttribute('aria-activedescendant', firstOption.id);
             });
 
             await userEvent.keyboard('{ArrowDown}');
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', options[1].id);
             });
@@ -1471,17 +1484,17 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should not wrap on ArrowDown at last option', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
             await userEvent.keyboard('{End}');
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const lastOption = options[options.length - 1];
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', lastOption.id);
@@ -1495,17 +1508,17 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should not wrap on ArrowUp at first option', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
             await userEvent.keyboard('{ArrowDown}');
-            const firstOption = getAllOptions()[0]!;
+            const firstOption = screen.queryAllByRole('option')[0]!;
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', firstOption.id);
             });
@@ -1518,16 +1531,16 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should navigate with Home and End', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const first = options[0];
             const last = options[options.length - 1];
 
@@ -1542,18 +1555,21 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             });
         });
 
+        // NOTE: Home/End *from closed* (open + jump in one key press) is deferred until
+        // the option children commit and is covered by the browser test stories.
+
         it('should jump to last option on PageDown', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             await userEvent.keyboard('{Home}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', options[0].id);
@@ -1567,16 +1583,16 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should jump to first option on PageUp', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             await userEvent.keyboard('{End}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', options[options.length - 1].id);
@@ -1590,7 +1606,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should toggle data-focus-visible-added on navigation', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -1613,14 +1629,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should select on Enter', async () => {
             const onSelect = vi.fn();
             renderWithState(t.buttonTemplate, { value: '', onSelect }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
             await userEvent.keyboard('{ArrowDown}');
             await userEvent.keyboard('{ArrowDown}');
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', options[2].id);
             });
@@ -1636,16 +1652,16 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should select on Space', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const last = options[options.length - 1];
             await userEvent.keyboard('{End}');
             await waitFor(() => {
@@ -1661,7 +1677,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should select on Tab', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -1669,7 +1685,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
                 await userEvent.keyboard('{ArrowDown}');
             }
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', options[4].id);
             });
@@ -1683,14 +1699,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should select option on click', async () => {
             const onSelect = vi.fn();
             renderWithState(t.buttonTemplate, { value: '', onSelect }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
 
             await userEvent.click(button);
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const grape = options.find((o) => o.textContent === 'Grape')!;
             await userEvent.click(grape);
             await waitFor(() => {
@@ -1703,13 +1719,20 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should select on Alt+ArrowUp', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
-            await userEvent.keyboard('{ArrowDown}');
+            // Open first so the typeahead below runs against committed options (the
+            // open-from-closed deferral is covered by the browser test stories).
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => {
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
+            });
+
             await userEvent.keyboard('o');
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const orange = options.find((o) => o.textContent === 'Orange')!;
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', orange.id);
@@ -1724,18 +1747,22 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     });
 
     describe('Button trigger - Typeahead', () => {
+        // NOTE: typeahead *from closed* (open + jump to match in one key press) is
+        // deferred until the option children commit and is covered by the browser
+        // test stories (TestStories.tsx). The tests below open first, then typeahead.
+
         it('should navigate to matching option on single char', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const banana = options.find((o) => o.textContent === 'Banana')!;
             await userEvent.keyboard('b');
             await waitFor(() => {
@@ -1745,11 +1772,19 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should navigate to matching option on multi char', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
+            // Open first so this jsdom test exercises multi-char matching only, not the
+            // deferred open-from-closed path (covered by the browser test stories).
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => {
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
+            });
+
             await userEvent.keyboard('bl');
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const blueberry = options.find((o) => o.textContent === 'Blueberry')!;
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', blueberry.id);
@@ -1758,16 +1793,16 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should cycle through matches on repeated single char', async () => {
             renderWithState(t.buttonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{Enter}');
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
-                expect(getAllOptions().length).toBeGreaterThan(0);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const apple = options.find((o) => o.textContent === 'Apple')!;
             const apricot = options.find((o) => o.textContent === 'Apricot')!;
 
@@ -1786,7 +1821,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Button trigger - Label display', () => {
         it('should display selected value', async () => {
             renderWithState(t.buttonTemplate, { value: 'Apple' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
 
             expect(button.textContent).toBe('Apple');
 
@@ -1795,7 +1830,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const banana = options.find((o) => o.textContent === 'Banana')!;
             await userEvent.click(banana);
 
@@ -1806,7 +1841,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should always show label when labelDisplayMode="show-label"', async () => {
             renderWithState(t.showLabelButtonTemplate, { value: 'Apple' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
 
             expect(button.textContent).toBe('Select a fruit');
 
@@ -1815,7 +1850,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             const banana = options.find((o) => o.textContent === 'Banana')!;
             await userEvent.click(banana);
 
@@ -1827,7 +1862,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should show empty text when labelDisplayMode="show-tooltip"', () => {
             renderWithState(t.showTooltipButtonTemplate, { value: 'Apple' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
 
             expect(button.textContent).toBe('');
             expect(button).toHaveAttribute('role', 'combobox');
@@ -1842,27 +1877,27 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('filter="manual"', () => {
         it('should not auto-filter options when typing', async () => {
             renderWithState(t.manualFilterTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            expect(getVisibleOptions().length).toBe(FRUITS.length);
+            expect(screen.queryAllByRole('option').length).toBe(FRUITS.length);
 
             await userEvent.type(input, 'bl');
 
             // All options should remain visible — no auto-filter
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(FRUITS.length);
+                expect(screen.queryAllByRole('option').length).toBe(FRUITS.length);
             });
         });
 
         it('should still allow selecting options', async () => {
             const onSelect = vi.fn();
             renderWithState(t.manualFilterTemplate, { value: '', onSelect });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1884,7 +1919,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should not have readOnly on the input', async () => {
             renderWithState(t.manualFilterTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             expect(input.readOnly).toBe(false);
         });
     });
@@ -1892,7 +1927,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('filter="off"', () => {
         it('should set input to readOnly', async () => {
             renderWithState(t.filterOffTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             await waitFor(() => {
                 expect(input.readOnly).toBe(true);
@@ -1901,7 +1936,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should open on focus (openOnFocus defaults to true)', async () => {
             renderWithState(t.filterOffTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             expect(input).toHaveAttribute('aria-expanded', 'false');
 
@@ -1915,7 +1950,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should still allow selecting options', async () => {
             const onSelect = vi.fn();
             renderWithState(t.filterOffTemplate, { value: '', onSelect });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -1937,21 +1972,21 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should show all options (no filtering)', async () => {
             renderWithState(t.filterOffTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            expect(getVisibleOptions().length).toBe(FRUITS.length);
+            expect(screen.queryAllByRole('option').length).toBe(FRUITS.length);
         });
     });
 
     describe('openOnFocus', () => {
         it('should open on focus when openOnFocus is true', async () => {
             renderWithState(t.openOnFocusTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             expect(input).toHaveAttribute('aria-expanded', 'false');
 
@@ -1964,7 +1999,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should not open on focus when openOnFocus is false', async () => {
             renderWithState(t.noOpenOnFocusTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             expect(input).toHaveAttribute('aria-expanded', 'false');
 
@@ -1976,7 +2011,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should open on click even when openOnFocus is false', async () => {
             renderWithState(t.noOpenOnFocusTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             expect(input).toHaveAttribute('aria-expanded', 'false');
 
@@ -1989,7 +2024,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should default to not opening on focus (filter="auto")', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             expect(input).toHaveAttribute('aria-expanded', 'false');
 
@@ -2007,14 +2042,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Edge cases', () => {
         it('should fall back to textContent when option has no value prop', async () => {
             renderWithState(t.noValueButtonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
 
             await userEvent.click(button);
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const grape = getAllOptions().find((o) => o.textContent === 'Grape')!;
+            const grape = screen.queryAllByRole('option').find((o) => o.textContent === 'Grape')!;
             expect(grape).not.toHaveAttribute('data-value');
             await userEvent.click(grape);
 
@@ -2025,7 +2060,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should jump to selected option on ArrowDown', async () => {
             renderWithState(t.selectedButtonTemplate, { value: 'Cherry' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -2033,7 +2068,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const cherry = getAllOptions().find((o) => o.textContent === 'Cherry')!;
+            const cherry = screen.queryAllByRole('option').find((o) => o.textContent === 'Cherry')!;
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-activedescendant', cherry.id);
             });
@@ -2041,7 +2076,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should not change open state on blur then re-focus', async () => {
             renderWithState(t.inputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
 
             await userEvent.click(input);
             await waitFor(() => {
@@ -2061,7 +2096,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Disabled options', () => {
         it('should navigate to disabled option but not select it (input trigger)', async () => {
             renderWithState(t.disabledInputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
@@ -2092,13 +2127,13 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const bananaOption = getVisibleOptions().find((o) => o.textContent === 'Banana')!;
+            const bananaOption = screen.queryAllByRole('option').find((o) => o.textContent === 'Banana')!;
             await userEvent.click(bananaOption);
 
             expect(input.value).toBe('');
             expect(input).toHaveAttribute('aria-expanded', 'true');
 
-            const cherryOption = getVisibleOptions().find((o) => o.textContent === 'Cherry')!;
+            const cherryOption = screen.queryAllByRole('option').find((o) => o.textContent === 'Cherry')!;
             await userEvent.click(cherryOption);
             await waitFor(() => {
                 expect(input.value).toBe('Cherry');
@@ -2108,7 +2143,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should navigate to disabled option but not select it (button trigger)', async () => {
             renderWithState(t.disabledButtonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -2136,13 +2171,13 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const bananaOption = getAllOptions().find((o) => o.textContent === 'Banana')!;
+            const bananaOption = screen.queryAllByRole('option').find((o) => o.textContent === 'Banana')!;
             await userEvent.click(bananaOption);
 
             expect(button.textContent).toBe('Select a fruit');
             expect(button).toHaveAttribute('aria-expanded', 'true');
 
-            const cherryOption = getAllOptions().find((o) => o.textContent === 'Cherry')!;
+            const cherryOption = screen.queryAllByRole('option').find((o) => o.textContent === 'Cherry')!;
             await userEvent.click(cherryOption);
             await waitFor(() => {
                 expect(button.textContent).toBe('Cherry');
@@ -2158,7 +2193,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Grid combobox - ARIA attributes', () => {
         it('should have correct grid ARIA attributes (input trigger)', async () => {
             renderWithState(t.gridInputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2168,35 +2203,34 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             expect(input).toHaveAttribute('aria-haspopup', 'grid');
 
             const controlsId = input.getAttribute('aria-controls')!;
-            const grid = document.getElementById(controlsId)!;
+            const grid = screen.getByRole('grid');
+            expect(controlsId).toBe(grid.id);
             expect(grid).toHaveAttribute('role', 'grid');
             expect(grid.classList.contains(COMBOBOX_LIST_CLASSNAME)).toBe(true);
 
-            const rows = Array.from(grid.querySelectorAll('[role="row"]'));
+            const rows = within(grid).queryAllByRole('row');
             expect(rows.length).toBe(GRID_FRUITS.length);
 
             for (const row of rows) {
-                const cells = row.querySelectorAll('[role="gridcell"]');
+                const cells = within(row).queryAllByRole('gridcell');
                 expect(cells.length).toBe(3);
 
-                const firstCell = cells[0] as HTMLElement;
+                const firstCell = cells[0];
                 expect(firstCell).toHaveAttribute('data-value');
                 expect(firstCell).toHaveAttribute('aria-selected');
-                // First cell (option trigger) should have the option trigger class
                 expect(firstCell.classList.contains(`${COMBOBOX_OPTION_CLASSNAME}__action`)).toBe(true);
 
-                for (const cell of Array.from(cells)) {
-                    expect((cell as HTMLElement).id).toBeTruthy();
+                for (const cell of cells) {
+                    expect(cell.id).toBeTruthy();
                 }
 
-                // Row should have the combobox option class
                 expect(row.classList.contains(COMBOBOX_OPTION_CLASSNAME)).toBe(true);
             }
         });
 
         it('should have correct grid ARIA attributes (button trigger)', async () => {
             renderWithState(t.gridButtonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             await userEvent.click(button);
 
             await waitFor(() => {
@@ -2205,13 +2239,13 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             expect(button).toHaveAttribute('aria-haspopup', 'grid');
 
-            const grid = document.body.querySelector('[role="grid"]')!;
+            const grid = screen.getByRole('grid');
             expect(grid).not.toBeNull();
 
-            const rows = Array.from(grid.querySelectorAll('[role="row"]'));
+            const rows = within(grid).queryAllByRole('row');
             expect(rows.length).toBe(GRID_FRUITS.length);
             for (const row of rows) {
-                const cells = row.querySelectorAll('[role="gridcell"]');
+                const cells = within(row).queryAllByRole('gridcell');
                 expect(cells.length).toBe(2);
             }
         });
@@ -2220,7 +2254,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Grid combobox - Input trigger keyboard', () => {
         it('should navigate rows with ArrowDown/Up', async () => {
             renderWithState(t.gridInputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2254,7 +2288,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should navigate cells with ArrowLeft/Right', async () => {
             renderWithState(t.gridInputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2278,8 +2312,8 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await userEvent.keyboard('{ArrowLeft}');
             active = getActiveCell()!;
-            const row = active.closest('[role="row"]')!;
-            const firstCell = row.querySelector('[role="gridcell"]') as HTMLElement;
+            const row = active.closest<HTMLElement>('[role="row"]')!;
+            const firstCell = within(row).queryAllByRole('gridcell')[0]!;
             expect(firstCell.textContent).toBe('Apple');
 
             expect(document.activeElement).toBe(input);
@@ -2288,7 +2322,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should select option on Enter', async () => {
             const onSelect = vi.fn();
             renderWithState(t.gridInputTemplate, { value: '', onSelect });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2314,7 +2348,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             const onEdit = vi.fn();
             const onDelete = vi.fn();
             renderWithState(t.gridInputTemplate, { value: '', onEdit, onDelete });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2330,8 +2364,8 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.keyboard('{ArrowRight}');
 
             const active = getActiveCell()!;
-            const row = active.closest('[role="row"]')!;
-            const firstCell = row.querySelector('[role="gridcell"]');
+            const row = active.closest<HTMLElement>('[role="row"]')!;
+            const firstCell = within(row).queryAllByRole('gridcell')[0];
             expect(active).not.toBe(firstCell);
 
             await userEvent.keyboard('{Enter}');
@@ -2345,7 +2379,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should remember column position across rows', async () => {
             renderWithState(t.gridInputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2359,30 +2393,30 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await userEvent.keyboard('{ArrowRight}');
             const editCellApple = getActiveCell()!;
-            const appleRow = editCellApple.closest('[role="row"]')!;
-            const appleCells = Array.from(appleRow.querySelectorAll('[role="gridcell"]'));
+            const appleRow = editCellApple.closest<HTMLElement>('[role="row"]')!;
+            const appleCells = within(appleRow).queryAllByRole('gridcell');
             expect(appleCells.indexOf(editCellApple)).toBe(1);
 
             await userEvent.keyboard('{ArrowDown}');
             const editCellBanana = getActiveCell()!;
-            const bananaRow = editCellBanana.closest('[role="row"]')!;
-            const bananaCells = Array.from(bananaRow.querySelectorAll('[role="gridcell"]'));
+            const bananaRow = editCellBanana.closest<HTMLElement>('[role="row"]')!;
+            const bananaCells = within(bananaRow).queryAllByRole('gridcell');
             expect(bananaCells.indexOf(editCellBanana)).toBe(1);
-            const bananaFirstCell = bananaCells[0] as HTMLElement;
+            const bananaFirstCell = bananaCells[0];
             expect(bananaFirstCell.textContent).toBe('Banana');
 
             await userEvent.keyboard('{ArrowDown}');
             const editCellCherry = getActiveCell()!;
-            const cherryRow = editCellCherry.closest('[role="row"]')!;
-            const cherryCells = Array.from(cherryRow.querySelectorAll('[role="gridcell"]'));
+            const cherryRow = editCellCherry.closest<HTMLElement>('[role="row"]')!;
+            const cherryCells = within(cherryRow).queryAllByRole('gridcell');
             expect(cherryCells.indexOf(editCellCherry)).toBe(1);
-            const cherryFirstCell = cherryCells[0] as HTMLElement;
+            const cherryFirstCell = cherryCells[0];
             expect(cherryFirstCell.textContent).toBe('Cherry');
         });
 
         it('should filter grid options by typing', async () => {
             renderWithState(t.gridInputTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2415,7 +2449,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should select grid option on click', async () => {
             const onSelect = vi.fn();
             renderWithState(t.gridInputTemplate, { value: '', onSelect });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2434,18 +2468,18 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             const onEdit = vi.fn();
             const onDelete = vi.fn();
             renderWithState(t.gridInputTemplate, { value: '', onEdit, onDelete });
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
-            const grid = document.body.querySelector('[role="grid"]')!;
-            const rows = Array.from(grid.querySelectorAll('[role="row"]'));
+            const grid = screen.getByRole('grid');
+            const rows = within(grid).queryAllByRole('row');
             const appleRow = rows[0];
-            const cells = Array.from(appleRow.querySelectorAll('[role="gridcell"]'));
-            const deleteCell = cells[cells.length - 1] as HTMLElement;
+            const cells = within(appleRow).queryAllByRole('gridcell');
+            const deleteCell = cells[cells.length - 1];
 
             await userEvent.click(deleteCell);
 
@@ -2458,7 +2492,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Grid combobox - Button trigger keyboard', () => {
         it('should navigate rows with ArrowDown/Up', async () => {
             renderWithState(t.gridButtonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -2484,7 +2518,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should navigate cells with ArrowLeft/Right', async () => {
             renderWithState(t.gridButtonTemplate, { value: '' }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -2495,8 +2529,8 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await userEvent.keyboard('{ArrowRight}');
             const active = getActiveCell()!;
-            const row = active.closest('[role="row"]')!;
-            const firstCell = row.querySelector('[role="gridcell"]') as HTMLElement;
+            const row = active.closest<HTMLElement>('[role="row"]')!;
+            const firstCell = within(row).queryAllByRole('gridcell')[0]!;
             expect(active).not.toBe(firstCell);
 
             await userEvent.keyboard('{ArrowRight}');
@@ -2504,15 +2538,15 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await userEvent.keyboard('{ArrowLeft}');
             const backActive = getActiveCell()!;
-            const backRow = backActive.closest('[role="row"]')!;
-            const backFirstCell = backRow.querySelector('[role="gridcell"]') as HTMLElement;
+            const backRow = backActive.closest<HTMLElement>('[role="row"]')!;
+            const backFirstCell = within(backRow).queryAllByRole('gridcell')[0]!;
             expect(backFirstCell.textContent).toBe('Apple');
         });
 
         it('should select option on Enter', async () => {
             const onSelect = vi.fn();
             renderWithState(t.gridButtonTemplate, { value: '', onSelect }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -2534,7 +2568,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
         it('should fire action on Space on action cell', async () => {
             const onDelete = vi.fn();
             renderWithState(t.gridButtonTemplate, { value: '', onDelete }, BUTTON_STATE);
-            const button = getButtonTrigger();
+            const button = screen.getByTestId('combobox-button');
             button.focus();
 
             await userEvent.keyboard('{ArrowDown}');
@@ -2544,8 +2578,8 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await userEvent.keyboard('{ArrowRight}');
             const active = getActiveCell()!;
-            const row = active.closest('[role="row"]')!;
-            const firstCell = row.querySelector('[role="gridcell"]') as HTMLElement;
+            const row = active.closest<HTMLElement>('[role="row"]')!;
+            const firstCell = within(row).queryAllByRole('gridcell')[0]!;
             expect(active).not.toBe(firstCell);
 
             await userEvent.keyboard(' ');
@@ -2562,7 +2596,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Combobox.State - Live region', () => {
         it('should always render a live region element', () => {
             renderWithState(t.emptyStateTemplate);
-            const stateEl = getStateContainer();
+            const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
             expect(stateEl).toBeInTheDocument();
             expect(stateEl).toHaveAttribute('role', 'status');
             expect(stateEl).toHaveAttribute('aria-live', 'polite');
@@ -2573,7 +2607,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Combobox.State - Empty state', () => {
         it('should be visually hidden when list has options', async () => {
             renderWithState(t.emptyStateTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2581,14 +2615,14 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             });
 
             // Options are visible — state container should be visually hidden
-            const stateEl = getStateContainer();
+            const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
             expect(stateEl).toBeInTheDocument();
             expect(stateEl!.className).toContain(VISUALLY_HIDDEN);
         });
 
         it('should show empty message when all options are filtered out', async () => {
             renderWithState(t.emptyStateTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2599,11 +2633,11 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.type(input, 'z');
 
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(0);
+                expect(screen.queryAllByRole('option').length).toBe(0);
             });
 
             await waitFor(() => {
-                const stateEl = getStateContainer();
+                const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
                 expect(stateEl).toBeInTheDocument();
                 expect(stateEl!.className).not.toContain(VISUALLY_HIDDEN);
                 expect(stateEl).toHaveTextContent('No results for "z"');
@@ -2612,7 +2646,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should hide empty message when options reappear', async () => {
             renderWithState(t.emptyStateTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2622,21 +2656,23 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             // Filter to empty
             await userEvent.type(input, 'z');
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(0);
-                expect(getStateContainer()!.className).not.toContain(VISUALLY_HIDDEN);
+                expect(screen.queryAllByRole('option').length).toBe(0);
+                expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)!.className).not.toContain(
+                    VISUALLY_HIDDEN,
+                );
             });
 
             // Clear input — options reappear
             await userEvent.clear(input);
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBeGreaterThan(0);
-                expect(getStateContainer()!.className).toContain(VISUALLY_HIDDEN);
+                expect(screen.queryAllByRole('option').length).toBeGreaterThan(0);
+                expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)!.className).toContain(VISUALLY_HIDDEN);
             });
         });
 
         it('should pass input value to emptyMessage callback', async () => {
             renderWithState(t.emptyStateTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2645,17 +2681,19 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await userEvent.type(input, 'z');
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(0);
+                expect(screen.queryAllByRole('option').length).toBe(0);
             });
 
             await waitFor(() => {
-                expect(getStateContainer()).toHaveTextContent('No results for "z"');
+                expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)).toHaveTextContent(
+                    'No results for "z"',
+                );
             });
         });
 
         it('should update input value in emptyMessage when typing while empty', async () => {
             renderWithState(t.emptyStateTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2665,13 +2703,17 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             // Type "z" — list becomes empty
             await userEvent.type(input, 'z');
             await waitFor(() => {
-                expect(getStateContainer()).toHaveTextContent('No results for "z"');
+                expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)).toHaveTextContent(
+                    'No results for "z"',
+                );
             });
 
             // Keep typing "zz" — list stays empty, message should update
             await userEvent.type(input, 'z');
             await waitFor(() => {
-                expect(getStateContainer()).toHaveTextContent('No results for "zz"');
+                expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)).toHaveTextContent(
+                    'No results for "zz"',
+                );
             });
         });
     });
@@ -2679,7 +2721,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Combobox.State - Option count message', () => {
         it('should show option count message when list has options', async () => {
             renderWithState(t.nbOptionMessageTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2687,7 +2729,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             });
 
             await waitFor(() => {
-                const stateEl = getStateContainer();
+                const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
                 expect(stateEl).toBeInTheDocument();
                 expect(stateEl).toHaveTextContent('10 result(s) available');
             });
@@ -2695,7 +2737,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should update option count when filtering reduces visible options', async () => {
             renderWithState(t.nbOptionMessageTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2705,18 +2747,18 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.type(input, 'bl');
 
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(1);
+                expect(screen.queryAllByRole('option').length).toBe(1);
             });
 
             await waitFor(() => {
-                const stateEl = getStateContainer();
+                const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
                 expect(stateEl).toHaveTextContent('1 result(s) available');
             });
         });
 
         it('should show empty message instead of option count when all options are filtered out', async () => {
             renderWithState(t.nbOptionMessageTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2726,11 +2768,11 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.type(input, 'z');
 
             await waitFor(() => {
-                expect(getVisibleOptions().length).toBe(0);
+                expect(screen.queryAllByRole('option').length).toBe(0);
             });
 
             await waitFor(() => {
-                const stateEl = getStateContainer();
+                const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
                 expect(stateEl).toHaveTextContent('No results');
                 expect(stateEl).not.toHaveTextContent('result(s) available');
             });
@@ -2740,7 +2782,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     describe('Combobox.State - Error state', () => {
         it('should show error message', async () => {
             renderWithState(t.errorStateTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2750,7 +2792,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             // Content is deferred after open to allow the aria-live region
             // to become visible in the accessibility tree first.
             await waitFor(() => {
-                const stateEl = getStateContainer();
+                const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
                 expect(stateEl).toBeInTheDocument();
                 expect(stateEl!.className).not.toContain(VISUALLY_HIDDEN);
                 expect(stateEl).toHaveTextContent('Service unavailable');
@@ -2759,7 +2801,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should show secondary error message', async () => {
             renderWithState(t.errorStateTemplate);
-            const input = getInput();
+            const input = screen.getByRole<HTMLInputElement>('combobox');
             await userEvent.click(input);
 
             await waitFor(() => {
@@ -2767,14 +2809,16 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             });
 
             await waitFor(() => {
-                expect(getStateContainer()).toHaveTextContent('Please try again later');
+                expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)).toHaveTextContent(
+                    'Please try again later',
+                );
             });
         });
 
         it('should have role=status on the state container', () => {
             renderWithState(t.errorStateTemplate);
-            expect(getStateContainer()).toHaveAttribute('role', 'status');
-            expect(getStateContainer()).toHaveAttribute('aria-live', 'polite');
+            expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)).toHaveAttribute('role', 'status');
+            expect(queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME)).toHaveAttribute('aria-live', 'polite');
         });
     });
 
@@ -2783,36 +2827,45 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     // ───────────────────────────────────────────────────────────────
 
     describe('Combobox.OptionSkeleton - Rendering', () => {
-        it('should render skeleton items with role="none"', () => {
+        it('should render skeleton items with role="none"', async () => {
             renderWithState(t.loadingTemplate);
-            const skeletons = document.body.querySelectorAll(`.${COMBOBOX_OPTION_SKELETON_CLASSNAME}`);
+            await userEvent.click(screen.getByRole('combobox'));
+            const skeletons = queryAllByClassName(document.body, COMBOBOX_OPTION_SKELETON_CLASSNAME);
             expect(skeletons.length).toBe(3);
 
-            for (const skeleton of Array.from(skeletons)) {
+            for (const skeleton of skeletons) {
                 expect(skeleton).toHaveAttribute('role', 'none');
             }
         });
 
-        it('should not render any role="option" elements', () => {
+        it('should not render any role="option" elements', async () => {
             renderWithState(t.loadingTemplate);
-            const options = getAllOptions();
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = screen.queryAllByRole('option');
             expect(options.length).toBe(0);
+        });
+
+        it('should not render skeleton children while closed', () => {
+            renderWithState(t.loadingTemplate);
+            const skeletons = queryAllByClassName(document.body, COMBOBOX_OPTION_SKELETON_CLASSNAME);
+            expect(skeletons.length).toBe(0);
         });
 
         it('should set aria-busy on the listbox when skeletons are mounted', async () => {
             renderWithState(t.loadingTemplate);
+            await userEvent.click(screen.getByRole('combobox'));
             await waitFor(() => {
-                const listbox = document.body.querySelector('[role="listbox"]');
-                expect(listbox).toHaveAttribute('aria-busy', 'true');
+                expect(screen.queryByRole('listbox')).toHaveAttribute('aria-busy', 'true');
             });
         });
     });
 
     describe('Combobox.OptionSkeleton - Load more pattern', () => {
-        it('should render skeletons appended after real options', () => {
+        it('should render skeletons appended after real options', async () => {
             renderWithState(t.loadMoreTemplate);
-            const options = getAllOptions();
-            const skeletons = document.body.querySelectorAll(`.${COMBOBOX_OPTION_SKELETON_CLASSNAME}`);
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = screen.queryAllByRole('option');
+            const skeletons = queryAllByClassName(document.body, COMBOBOX_OPTION_SKELETON_CLASSNAME);
 
             expect(options.length).toBe(FRUITS.length);
             expect(skeletons.length).toBe(3);
@@ -2820,43 +2873,44 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
         it('should set aria-busy on the listbox when skeletons are appended', async () => {
             renderWithState(t.loadMoreTemplate);
+            await userEvent.click(screen.getByRole('combobox'));
             await waitFor(() => {
-                const listbox = document.body.querySelector('[role="listbox"]');
-                expect(listbox).toHaveAttribute('aria-busy', 'true');
+                expect(screen.queryByRole('listbox')).toHaveAttribute('aria-busy', 'true');
             });
         });
     });
 
     describe('Combobox.OptionSkeleton - Section loading', () => {
-        it('should render skeletons inside a section', () => {
+        it('should render skeletons inside a section', async () => {
             renderWithState(t.sectionLoadingTemplate);
-            const skeletons = document.body.querySelectorAll(`.${COMBOBOX_OPTION_SKELETON_CLASSNAME}`);
+            await userEvent.click(screen.getByRole('combobox'));
+            const skeletons = queryAllByClassName(document.body, COMBOBOX_OPTION_SKELETON_CLASSNAME);
             expect(skeletons.length).toBe(3);
 
             // Real options should still be present in the other section
-            const options = getAllOptions();
+            const options = screen.queryAllByRole('option');
             expect(options.length).toBe(3);
         });
 
         it('should aria-hide a skeleton-only section', async () => {
             renderWithState(t.sectionLoadingTemplate);
+            await userEvent.click(screen.getByRole('combobox'));
 
             await waitFor(() => {
                 // Re-query to get fresh elements after state updates
-                const secs = document.body.querySelectorAll(`.${COMBOBOX_SECTION_CLASSNAME}`);
+                const secs = queryAllByClassName(document.body, COMBOBOX_SECTION_CLASSNAME);
                 expect(secs.length).toBeGreaterThanOrEqual(1);
 
                 // The section with real options should NOT be aria-hidden
-                const optionSection = Array.from(secs).find((s) => s.querySelector('[role="option"]'));
+                const optionSection = secs.find((s) => within(s).queryAllByRole('option').length > 0);
                 if (optionSection) {
                     expect(optionSection).not.toHaveAttribute('aria-hidden');
                 }
 
-                // The skeleton-only section should be aria-hidden
-                const skeletonSection = Array.from(secs).find(
+                const skeletonSection = secs.find(
                     (s) =>
-                        s.querySelector(`.${COMBOBOX_OPTION_SKELETON_CLASSNAME}`) &&
-                        !s.querySelector('[role="option"]'),
+                        queryAllByClassName(s, COMBOBOX_OPTION_SKELETON_CLASSNAME).length > 0 &&
+                        within(s).queryAllByRole('option').length === 0,
                 );
                 expect(skeletonSection).toBeTruthy();
                 expect(skeletonSection).toHaveAttribute('aria-hidden', 'true');
@@ -2865,9 +2919,10 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
     });
 
     describe('Combobox.State - Loading state', () => {
-        it('should suppress empty message while skeletons are mounted', () => {
+        it('should suppress empty message while skeletons are mounted', async () => {
             renderWithState(t.loadingTemplate);
-            const stateEl = getStateContainer();
+            await userEvent.click(screen.getByRole('combobox'));
+            const stateEl = queryByClassName(document.body, COMBOBOX_STATE_CLASSNAME);
             expect(stateEl).toBeInTheDocument();
             // Should not show "No results" since we have skeletons (loading)
             expect(stateEl).not.toHaveTextContent('No results');

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -1,12 +1,5 @@
 import { type FocusNavigationController } from '../../utils/focusNavigation';
-import {
-    getOptionValue,
-    goToSelectedOrFirst,
-    goToSelectedOrLast,
-    isActionCell,
-    isOptionDisabled,
-    notifySection,
-} from './utils';
+import { getOptionValue, isActionCell, isOptionDisabled, isSelected, notifySection } from './utils';
 import { setupListbox } from './setupListbox';
 import type {
     ComboboxCallbacks,
@@ -191,10 +184,10 @@ export function setupCombobox(
 
             switch (event.key) {
                 case 'Enter':
-                    if (handle.isOpen && nav?.hasActiveItem && nav.activeItem) {
+                    if (handle.isOpen && nav?.selectors.activeItem) {
                         // Capture activeItem before click — the click handler may close
                         // the popover and clear the focus navigation state.
-                        const { activeItem } = nav;
+                        const { activeItem } = nav.selectors;
                         // "Click" on active option
                         if (!isOptionDisabled(activeItem)) {
                             activeItem.click();
@@ -213,41 +206,37 @@ export function setupCombobox(
                     // let Enter pass through so it can submit a surrounding form
                     break;
 
+                // Open if closed, else move focus within listbox (wrap if enabled).
                 case 'ArrowDown':
-                    if (nav?.hasNavigableItems) {
-                        if (handle.isOpen && !altKey) {
-                            if (nav.hasActiveItem) {
-                                if (nav.type === 'grid') {
-                                    nav.goDown();
-                                } else if (!nav.goToOffset(1) && wrapNavigation) {
-                                    nav.goToFirst();
-                                }
-                            } else {
-                                goToSelectedOrFirst(nav);
-                            }
+                    if (!handle.isOpen) {
+                        handle.setIsOpen(true);
+                        // Focus first or selected item on open.
+                        if (!altKey) nav?.goTo((s) => s.getMatching(isSelected) ?? s.getFirst());
+                    } else if (nav?.selectors.hasNavigableItems && !altKey) {
+                        if (nav.selectors.activeItem) {
+                            // Go down
+                            nav.goDown();
                         } else {
-                            // Open the listbox and focus selected option, fall back to first.
-                            handle.setIsOpen(true);
-                            if (!altKey) goToSelectedOrFirst(nav);
+                            // Focus first or selected item when no active item.
+                            nav.goTo((s) => s.getMatching(isSelected) ?? s.getFirst());
                         }
                     }
                     flag = true;
                     break;
 
+                // Open if closed, else move focus within listbox (wrap if enabled).
                 case 'ArrowUp':
-                    if (nav?.hasNavigableItems) {
-                        if (!handle.isOpen && !altKey) {
-                            // Open the listbox and focus selected option, fall back to last.
-                            handle.setIsOpen(true);
-                            goToSelectedOrLast(nav);
-                        } else if (handle.isOpen && nav.hasActiveItem) {
-                            if (nav.type === 'grid') {
-                                nav.goUp();
-                            } else if (!nav.goToOffset(-1) && wrapNavigation) {
-                                nav.goToLast();
-                            }
-                        } else if (handle.isOpen && !nav.hasActiveItem && !altKey) {
-                            goToSelectedOrLast(nav);
+                    if (!handle.isOpen && !altKey) {
+                        handle.setIsOpen(true);
+                        // Focus last or selected item on open.
+                        nav?.goTo((s) => s.getMatching(isSelected) ?? s.getLast());
+                    } else if (handle.isOpen && nav?.selectors.hasNavigableItems) {
+                        if (nav.selectors.activeItem) {
+                            // Go up
+                            nav.goUp();
+                        } else if (!altKey) {
+                            // Focus last or selected item when no active item.
+                            nav.goTo((s) => s.getMatching(isSelected) ?? s.getLast());
                         }
                     }
                     flag = true;
@@ -264,14 +253,14 @@ export function setupCombobox(
                     break;
 
                 case 'PageUp':
-                    if (handle.isOpen && nav?.hasActiveItem) {
+                    if (handle.isOpen && nav?.selectors.activeItem) {
                         nav.goToOffset(-10);
                     }
                     flag = true;
                     break;
 
                 case 'PageDown':
-                    if (handle.isOpen && nav?.hasActiveItem) {
+                    if (handle.isOpen && nav?.selectors.activeItem) {
                         nav.goToOffset(10);
                     }
                     flag = true;
@@ -322,7 +311,7 @@ export function setupCombobox(
         }
 
         if (listbox && !focusNav) {
-            focusNav = setupListbox(handle, abortController.signal, notify);
+            focusNav = setupListbox(handle, abortController.signal, notify, { wrapNavigation });
         }
     }
 
@@ -365,20 +354,15 @@ export function setupCombobox(
             // Update aria-expanded on trigger
             trigger?.setAttribute('aria-expanded', String(isOpen));
             notify('open', isOpen);
-
-            // When opening, always notify the current options state so that
-            // subscribers (ComboboxState) get the correct initial value.
-            // Without this, a list that starts empty never fires `optionsChange`
-            // because `lastOptionsLength` is initialized to `0` and `notifyVisibilityChange`
-            // only fires on *changes*.
-            if (isOpen) {
-                const inputValue = trigger?.value ?? '';
-                notify('optionsChange', { optionsLength: lastOptionsLength, inputValue });
-            }
         },
 
         select(option: HTMLElement | null) {
             callbacks.onSelect?.({ value: option ? getOptionValue(option) : '' });
+        },
+
+        flushPendingNavigation() {
+            // Do navigations actions we could not do because the combobox items were not mounted yet
+            focusNav?.flushPendingNavigation();
         },
 
         registerOption(element: HTMLElement, callback: (isFiltered: boolean) => void): () => void {
@@ -477,7 +461,7 @@ export function setupCombobox(
             if (trigger && abortController) {
                 if (!hadListbox) {
                     // First listbox — set up focus nav and listbox listeners
-                    focusNav = setupListbox(handle, abortController.signal, notify);
+                    focusNav = setupListbox(handle, abortController.signal, notify, { wrapNavigation });
                 } else {
                     // Replacing listbox — full re-attach
                     detach();

--- a/packages/lumx-core/src/js/components/Combobox/setupComboboxButton.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupComboboxButton.ts
@@ -2,7 +2,7 @@ import type { ComboboxCallbacks, ComboboxHandle } from './types';
 import { setupCombobox } from './setupCombobox';
 import { createTypeahead } from '../../utils/typeahead';
 import { createSelectorTreeWalker } from '../../utils/browser/createSelectorTreeWalker';
-import { getOptionValue } from './utils';
+import { getOptionLabel } from './utils';
 
 /** Is the key a single printable character (not Space, no modifier keys)? */
 function isPrintableKey({ key, altKey, ctrlKey, metaKey }: KeyboardEvent): boolean {
@@ -33,7 +33,7 @@ export function setupComboboxButton(button: HTMLButtonElement, callbacks: Combob
                 const selector = combobox.focusNav?.type === 'grid' ? '[role="gridcell"]' : '[role="option"]';
                 return createSelectorTreeWalker(combobox.listbox, selector);
             },
-            getOptionValue,
+            getOptionLabel,
             signal,
         );
 
@@ -46,17 +46,17 @@ export function setupComboboxButton(button: HTMLButtonElement, callbacks: Combob
             switch (event.key) {
                 case 'Tab':
                     // Selects the focused option
-                    if (combobox.isOpen && nav?.hasActiveItem && nav.activeItem) {
-                        combobox.select(nav.activeItem);
+                    if (combobox.isOpen && nav?.selectors.activeItem) {
+                        combobox.select(nav.selectors.activeItem);
                     }
                     // Return false to continue normal 'Tab' behavior (focus next).
                     return false;
 
                 case ' ':
                     // Space acts like Enter in button mode.
-                    if (combobox.isOpen && nav?.hasActiveItem && nav.activeItem) {
+                    if (combobox.isOpen && nav?.selectors.activeItem) {
                         // Click the active item — delegated handler handles select + close.
-                        nav.activeItem.click();
+                        nav.selectors.activeItem.click();
                     } else {
                         combobox.setIsOpen(true);
                     }
@@ -64,8 +64,8 @@ export function setupComboboxButton(button: HTMLButtonElement, callbacks: Combob
 
                 case 'ArrowUp':
                     // Alt+ArrowUp: select the focused option and close.
-                    if (event.altKey && combobox.isOpen && nav?.hasActiveItem && nav.activeItem) {
-                        combobox.select(nav.activeItem);
+                    if (event.altKey && combobox.isOpen && nav?.selectors.activeItem) {
+                        combobox.select(nav.selectors.activeItem);
                         combobox.setIsOpen(false);
                         return true;
                     }
@@ -73,18 +73,20 @@ export function setupComboboxButton(button: HTMLButtonElement, callbacks: Combob
                     return false;
 
                 case 'Home':
+                    // `goTo` focuses the first option immediately when open, or defers
+                    // until the options commit when opening from closed.
                     combobox.setIsOpen(true);
-                    nav?.goToFirst();
+                    nav?.goTo((n) => n.getFirst());
                     return true;
 
                 case 'End':
                     combobox.setIsOpen(true);
-                    nav?.goToLast();
+                    nav?.goTo((n) => n.getLast());
                     return true;
 
                 case 'ArrowLeft':
                     // Grid mode: navigate to previous cell.
-                    if (nav?.type === 'grid' && combobox.isOpen && nav.hasActiveItem) {
+                    if (nav?.type === 'grid' && combobox.isOpen && nav.selectors.activeItem) {
                         nav.goLeft();
                         return true;
                     }
@@ -92,7 +94,7 @@ export function setupComboboxButton(button: HTMLButtonElement, callbacks: Combob
 
                 case 'ArrowRight':
                     // Grid mode: navigate to next cell.
-                    if (nav?.type === 'grid' && combobox.isOpen && nav.hasActiveItem) {
+                    if (nav?.type === 'grid' && combobox.isOpen && nav.selectors.activeItem) {
                         nav.goRight();
                         return true;
                     }
@@ -109,10 +111,8 @@ export function setupComboboxButton(button: HTMLButtonElement, callbacks: Combob
                     // Printable characters → typeahead.
                     if (isPrintableKey(event)) {
                         combobox.setIsOpen(true);
-                        const match = typeahead.handle(event.key, nav?.activeItem ?? null);
-                        if (match && nav) {
-                            nav.goToItem(match);
-                        }
+                        typeahead.handle(event.key, nav?.selectors.activeItem ?? null);
+                        nav?.goTo((n) => typeahead.rematch(n.activeItem));
                         return true;
                     }
                     return false;

--- a/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
@@ -128,7 +128,7 @@ export function setupComboboxInput(input: HTMLInputElement, options: SetupCombob
                 case 'ArrowLeft':
                 case 'ArrowRight':
                     // Grid mode: navigate cells when active item exists.
-                    if (nav?.type === 'grid' && nav.hasActiveItem) {
+                    if (nav?.type === 'grid' && nav.selectors.activeItem) {
                         if (event.key === 'ArrowLeft') nav.goLeft();
                         else nav.goRight();
                         return true;

--- a/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
@@ -28,6 +28,7 @@ export function setupListbox(
     handle: ComboboxHandle,
     signal: AbortSignal,
     notify: <K extends keyof ComboboxEventMap>(event: K, value: ComboboxEventMap[K]) => void,
+    options?: { wrapNavigation?: boolean },
 ): FocusNavigationController {
     const trigger = handle.trigger!;
     const listbox = handle.listbox!;
@@ -90,6 +91,7 @@ export function setupListbox(
                 type: 'list',
                 container: listbox,
                 itemSelector,
+                wrap: options?.wrapNavigation,
                 getActiveItem: () => {
                     const id = trigger.getAttribute('aria-activedescendant');
                     return id ? (document.getElementById(id) as HTMLElement | null) : null;

--- a/packages/lumx-core/src/js/components/Combobox/types.ts
+++ b/packages/lumx-core/src/js/components/Combobox/types.ts
@@ -103,6 +103,14 @@ export interface ComboboxHandle {
     select(option: HTMLElement | null): void;
 
     /**
+     * Replay the pending navigation intent stored on the focus navigation controller via
+     * its `goTo` resolver. Called by the framework wrapper after the option children
+     * commit (keyboard opens from the closed state defer navigation until then). No-op
+     * when nothing is pending.
+     */
+    flushPendingNavigation(): void;
+
+    /**
      * Register an option DOM element for filter notifications.
      * The element's textContent is used as the searchable text.
      * The callback is invoked immediately with the current filter state,

--- a/packages/lumx-core/src/js/components/Combobox/utils.ts
+++ b/packages/lumx-core/src/js/components/Combobox/utils.ts
@@ -1,12 +1,23 @@
-import type { FocusNavigationController } from '../../utils/focusNavigation';
 import type { OptionRegistration, SectionRegistration, SectionState } from './types';
 
 /**
  * Get the value for a combobox option element.
  * Uses `data-value` when set; falls back to the element's trimmed `textContent`.
+ *
+ * This is the *selection* value , which may differ from the visible label
  */
 export function getOptionValue(option: HTMLElement): string {
     if (option.dataset.value !== undefined) return option.dataset.value;
+    return option.textContent?.trim() ?? '';
+}
+
+/**
+ * Get the visible label for a combobox option element (its trimmed `textContent`).
+ *
+ * Used for typeahead matching: the user types the characters they see, which is the
+ * option's label — not its `data-value` (which can be an unrelated id).
+ */
+export function getOptionLabel(option: HTMLElement): string {
     return option.textContent?.trim() ?? '';
 }
 
@@ -22,18 +33,7 @@ export function isActionCell(cell: HTMLElement): boolean {
     return row.querySelector('[role="gridcell"]') !== cell;
 }
 
-/** Predicate matching an option element that carries `aria-selected="true"`. */
 export const isSelected = (el: Element) => el.getAttribute('aria-selected') === 'true';
-
-/** Navigate to the selected option, or to the first option if none is selected. */
-export function goToSelectedOrFirst(nav: FocusNavigationController) {
-    if (!nav.goToItemMatching(isSelected)) nav.goToFirst();
-}
-
-/** Navigate to the selected option, or to the last option if none is selected. */
-export function goToSelectedOrLast(nav: FocusNavigationController) {
-    if (!nav.goToItemMatching(isSelected)) nav.goToLast();
-}
 
 /**
  * Compute the current state of a section and notify when it changed.

--- a/packages/lumx-core/src/js/components/Popover/index.tsx
+++ b/packages/lumx-core/src/js/components/Popover/index.tsx
@@ -184,6 +184,7 @@ export const Popover = (props: PopoverUIProps, { Portal, ClickAwayProvider, Them
                         'is-hidden': Boolean(isHidden),
                     }),
                 )}
+                hidden={isHidden || undefined}
                 style={isHidden ? undefined : popoverStyle}
                 data-popper-placement={position}
             >

--- a/packages/lumx-core/src/js/components/SelectButton/TestStories.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/TestStories.tsx
@@ -122,10 +122,76 @@ export function setup({
         },
     };
 
+    // ─── Typeahead (options unmounted while closed) ──────────────
+
+    const TYPEAHEAD_FRUITS = [
+        { id: '0', name: 'Apricot' },
+        { id: '1', name: 'Apple' },
+        { id: '2', name: 'Banana' },
+        { id: '3', name: 'Blueberry' },
+        { id: '4', name: 'Cherry' },
+        { id: '5', name: 'Orange' },
+    ];
+
+    const typeaheadTemplate = (props: any) => (
+        <SelectButton
+            label="Select a fruit"
+            options={TYPEAHEAD_FRUITS}
+            getOptionId="id"
+            getOptionName="name"
+            {...props}
+        />
+    );
+
+    const getActiveOptionId = (button: HTMLElement) => button.getAttribute('aria-activedescendant');
+
+    const TypeaheadWhileOpen = {
+        render: () => renderWithState(typeaheadTemplate),
+        play: async ({ canvasElement }: any) => {
+            const button = within(canvasElement).getByRole('combobox');
+
+            // Open via click (mouse), like the user does.
+            await userEvent.click(button);
+            await waitFor(() => {
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                expect(screen.getAllByRole('option').length).toBeGreaterThan(0);
+            });
+
+            // Type a printable character: active descendant lands on the first match
+            // by visible label ("Banana"), even though its id ("2") does not start with "b".
+            await userEvent.keyboard('b');
+            await waitFor(() => {
+                const banana = screen.getAllByRole('option').find((o) => o.textContent === 'Banana');
+                expect(banana).toBeTruthy();
+                expect(getActiveOptionId(button)).toBe(banana!.id);
+            });
+        },
+    };
+
+    const TypeaheadFromClosed = {
+        render: () => renderWithState(typeaheadTemplate),
+        play: async ({ canvasElement }: any) => {
+            const button = within(canvasElement).getByRole('combobox');
+            button.focus();
+            await expect(button).toHaveAttribute('aria-expanded', 'false');
+
+            // First keystroke opens AND lands on the first match once options commit.
+            await userEvent.keyboard('b');
+            await waitFor(() => {
+                expect(button).toHaveAttribute('aria-expanded', 'true');
+                const banana = screen.getAllByRole('option').find((o) => o.textContent === 'Banana');
+                expect(banana).toBeTruthy();
+                expect(getActiveOptionId(button)).toBe(banana!.id);
+            });
+        },
+    };
+
     return {
         meta,
         ClickOutsideCloses,
         SelectionUpdates,
         WithInfiniteScroll,
+        TypeaheadWhileOpen,
+        TypeaheadFromClosed,
     };
 }

--- a/packages/lumx-core/src/js/components/SelectButton/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/Tests.tsx
@@ -111,24 +111,27 @@ export default function selectButtonTests({ components, renderWithState }: Selec
             expect(button.textContent).toContain('banana');
         });
 
-        it('should render options in the listbox', () => {
+        it('should render options in the listbox', async () => {
             renderWithState(defaultTemplate);
-            const options = screen.getAllByRole('option');
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = (await screen.findAllByRole('option')).filter((o) => !o.hasAttribute('data-filtered'));
             expect(options).toHaveLength(FRUITS.length);
             expect(options[0].textContent).toBe('Apple');
         });
 
-        it('should mark selected option with aria-selected', () => {
+        it('should mark selected option with aria-selected', async () => {
             renderWithState(defaultTemplate, { value: FRUITS[1] });
-            const options = screen.getAllByRole('option');
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = (await screen.findAllByRole('option')).filter((o) => !o.hasAttribute('data-filtered'));
             expect(options[0].getAttribute('aria-selected')).toBe('false');
             expect(options[1].getAttribute('aria-selected')).toBe('true');
             expect(options[2].getAttribute('aria-selected')).toBe('false');
         });
 
-        it('should render option descriptions when getOptionDescription is provided', () => {
+        it('should render option descriptions when getOptionDescription is provided', async () => {
             renderWithState(defaultTemplate, { getOptionDescription: 'description' });
-            const options = screen.getAllByRole('option');
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = (await screen.findAllByRole('option')).filter((o) => !o.hasAttribute('data-filtered'));
             const describedBy = options[0].getAttribute('aria-describedby');
             expect(describedBy).toBeTruthy();
             const descriptionId = describedBy!.split(' ')[0];

--- a/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
@@ -67,6 +67,19 @@ function getInput(): HTMLInputElement {
     return document.body.querySelector<HTMLInputElement>('[role="combobox"]')!;
 }
 
+/**
+ * Open the dropdown by clicking the combobox input and wait for it to be expanded.
+ * Option / section / skeleton children are unmounted while the dropdown is closed,
+ * so any assertion on their presence must open the dropdown first.
+ */
+async function openByClick(): Promise<void> {
+    const input = getInput();
+    await userEvent.click(input);
+    await waitFor(() => {
+        expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+}
+
 function getListbox(): HTMLElement | null {
     return document.body.querySelector<HTMLElement>('.lumx-combobox-list[role="listbox"]');
 }
@@ -221,8 +234,9 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
             expect(clearButton).toBeNull();
         });
 
-        it('should render options in the listbox', () => {
+        it('should render options in the listbox', async () => {
             renderWithState(defaultTemplate);
+            await openByClick();
             const options = getAllOptions();
             expect(options).toHaveLength(FRUITS.length);
             expect(options[0].textContent).toBe('Apple');
@@ -230,8 +244,9 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
             expect(options[2].textContent).toBe('Banana');
         });
 
-        it('should render option descriptions when getOptionDescription is provided', () => {
+        it('should render option descriptions when getOptionDescription is provided', async () => {
             renderWithState(defaultTemplate, { getOptionDescription: 'description' });
+            await openByClick();
             const options = getAllOptions();
             const describedBy = options[0].getAttribute('aria-describedby');
             expect(describedBy).toBeTruthy();
@@ -240,8 +255,9 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
             expect(description?.textContent).toBe('A sweet red fruit');
         });
 
-        it('should mark selected option with aria-selected', () => {
+        it('should mark selected option with aria-selected', async () => {
             renderWithState(defaultTemplate, { value: FRUITS[1] }); // Apricot
+            await openByClick();
             const options = getAllOptions();
             expect(options[0].getAttribute('aria-selected')).toBe('false');
             expect(options[1].getAttribute('aria-selected')).toBe('true');
@@ -255,18 +271,20 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
             expect(input.value).toBe('Apple');
         });
 
-        it('should render sections when getSectionId is provided', () => {
+        it('should render sections when getSectionId is provided', async () => {
             renderWithState(defaultTemplate, {
                 getSectionId: 'category',
             });
+            await openByClick();
             const groups = document.body.querySelectorAll('[role="group"]');
             expect(groups.length).toBeGreaterThan(0);
         });
 
-        it('should render beforeOptions content', () => {
+        it('should render beforeOptions content', async () => {
             renderWithState(defaultTemplate, {
                 beforeOptions: <div data-testid="before-content">Before</div>,
             });
+            await openByClick();
             const beforeContent = document.body.querySelector('[data-testid="before-content"]');
             expect(beforeContent).toBeTruthy();
             expect(beforeContent?.textContent).toBe('Before');

--- a/packages/lumx-core/src/js/utils/browser/lastDescendant.test.ts
+++ b/packages/lumx-core/src/js/utils/browser/lastDescendant.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { lastDescendant } from './lastDescendant';
+
+describe('lastDescendant', () => {
+    it('should return the element itself when it has no children', () => {
+        const el = document.createElement('div');
+        expect(lastDescendant(el)).toBe(el);
+    });
+
+    it('should return the last child for elements with one level of children', () => {
+        const parent = document.createElement('div');
+        const child1 = document.createElement('span');
+        const child2 = document.createElement('span');
+        parent.append(child1, child2);
+
+        expect(lastDescendant(parent)).toBe(child2);
+    });
+
+    it('should return the deepest last child for deeply nested elements', () => {
+        const parent = document.createElement('div');
+        const child = document.createElement('div');
+        const grandchild = document.createElement('span');
+        parent.append(child);
+        child.append(grandchild);
+
+        expect(lastDescendant(parent)).toBe(grandchild);
+    });
+});

--- a/packages/lumx-core/src/js/utils/browser/lastDescendant.ts
+++ b/packages/lumx-core/src/js/utils/browser/lastDescendant.ts
@@ -1,0 +1,6 @@
+/** Deepest last-child descendant of `el` (or `el` itself if it has no children). */
+export function lastDescendant(element: HTMLElement): HTMLElement {
+    let node: Element = element;
+    while (node.lastElementChild) node = node.lastElementChild;
+    return node as HTMLElement;
+}

--- a/packages/lumx-core/src/js/utils/focusNavigation/createGridFocusNavigation.test.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/createGridFocusNavigation.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { createGridFocusNavigation } from './createGridFocusNavigation';
 
-import type { FocusNavigationCallbacks } from './types';
+import type { FocusNavigationCallbacks, FocusNavigationSelectors } from './types';
 
 function createContainer(html: string): HTMLElement {
     const div = document.createElement('div');
@@ -83,8 +83,8 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.activeItem).toBeNull();
-            expect(nav.hasActiveItem).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
         });
 
         it('should detect navigable items', () => {
@@ -92,7 +92,7 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.hasNavigableItems).toBe(true);
+            expect(nav.selectors.hasNavigableItems).toBe(true);
         });
 
         it('should detect no navigable items in empty container', () => {
@@ -100,18 +100,18 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.hasNavigableItems).toBe(false);
+            expect(nav.selectors.hasNavigableItems).toBe(false);
         });
     });
 
-    describe('goToFirst / goToLast', () => {
+    describe('goTo getFirst / getLast', () => {
         it('should navigate to first cell (row 0, col 0)', () => {
             const container = createGrid(3, 3);
             const { callbacks, activated } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.goToFirst()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            expect(nav.goTo((s) => s.getFirst())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
             expect(activated).toHaveLength(1);
         });
 
@@ -120,8 +120,8 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.goToLast()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.goTo((s) => s.getLast())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('should return false on empty grid', () => {
@@ -129,8 +129,8 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.goToFirst()).toBe(false);
-            expect(nav.goToLast()).toBe(false);
+            expect(nav.goTo((s) => s.getFirst())).toBe(false);
+            expect(nav.goTo((s) => s.getLast())).toBe(false);
         });
     });
 
@@ -140,9 +140,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-1-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-0');
         });
 
         it('goUp should move to the previous row', () => {
@@ -150,9 +150,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goUp()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-1-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-0');
         });
 
         it('goDown should return false at last row without wrap', () => {
@@ -160,9 +160,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goDown()).toBe(false);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('goUp should return false at first row without wrap', () => {
@@ -170,9 +170,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goUp()).toBe(false);
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
         });
 
         it('goDown with no active item should go to first row', () => {
@@ -181,7 +181,7 @@ describe('createGridFocusNavigation', () => {
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
         });
 
         it('goUp with no active item should go to last row', () => {
@@ -190,7 +190,7 @@ describe('createGridFocusNavigation', () => {
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
             expect(nav.goUp()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
     });
 
@@ -202,16 +202,16 @@ describe('createGridFocusNavigation', () => {
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
 
             // Navigate to cell-0-2 (row 0, col 2)
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
-            expect(nav.activeItem?.id).toBe('cell-0-2');
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-2');
 
             // Go down — should stay in col 2
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-1-2');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-2');
 
             // Go down again — should stay in col 2
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-2-2');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-2');
         });
 
         it('should clamp column when moving to a shorter row', () => {
@@ -221,52 +221,52 @@ describe('createGridFocusNavigation', () => {
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
 
             // Navigate to cell-0-2 (row 0 has 3 cells)
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
-            expect(nav.activeItem?.id).toBe('cell-0-2');
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-2');
 
             // Go down to row 1 (only 1 cell) — col should clamp to 0
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-1-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-0');
 
             // Go down to row 2 (2 cells) — remembered col is still 2, clamps to 1
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-2-1');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-1');
         });
 
-        it('goToFirst should reset column memory to 0', () => {
+        it('goTo getFirst should reset column memory to 0', () => {
             const container = createGrid(3, 3);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
 
             // Set column memory to 2
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
 
-            // goToFirst resets column memory
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            // goTo getFirst resets column memory
+            nav.goTo((s) => s.getFirst());
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
 
             // Subsequent goDown should use col 0
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-1-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-0');
         });
 
-        it('goToLast should reset column memory to 0', () => {
+        it('goTo getLast should reset column memory to 0', () => {
             const container = createGrid(3, 3);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
 
             // Set column memory to 2
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
 
-            // goToLast resets column memory
-            nav.goToLast();
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            // goTo getLast resets column memory
+            nav.goTo((s) => s.getLast());
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
 
             // Subsequent goUp should use col 0
             nav.goUp();
-            expect(nav.activeItem?.id).toBe('cell-1-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-0');
         });
     });
 
@@ -276,9 +276,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goRight()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-1');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-1');
         });
 
         it('goLeft should move to previous cell in the same row', () => {
@@ -286,9 +286,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
             expect(nav.goLeft()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-1');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-1');
         });
 
         it('goRight should return false at end of row without wrap', () => {
@@ -296,7 +296,7 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
             expect(nav.goRight()).toBe(false);
         });
 
@@ -305,7 +305,7 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goLeft()).toBe(false);
         });
 
@@ -323,14 +323,14 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             nav.goRight();
             nav.goRight();
-            expect(nav.activeItem?.id).toBe('cell-0-2');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-2');
 
             // Column memory should be 2 — goDown should land on col 2
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-1-2');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-2');
         });
     });
 
@@ -340,9 +340,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container, wrap: true }, callbacks, ac.signal);
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
         });
 
         it('goUp should wrap from first row to last', () => {
@@ -350,9 +350,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container, wrap: true }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goUp()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('goRight should wrap to first cell of next row', () => {
@@ -360,9 +360,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container, wrap: true }, callbacks, ac.signal);
-            nav.goToItem(container.querySelector('#cell-0-1') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-0-1') as HTMLElement);
             expect(nav.goRight()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-1-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-0');
         });
 
         it('goLeft should wrap to last cell of previous row', () => {
@@ -370,9 +370,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container, wrap: true }, callbacks, ac.signal);
-            nav.goToItem(container.querySelector('#cell-1-0') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-1-0') as HTMLElement);
             expect(nav.goLeft()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-1');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-1');
         });
 
         it('goRight should wrap from last cell of last row to first cell of first row', () => {
@@ -380,9 +380,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container, wrap: true }, callbacks, ac.signal);
-            nav.goToItem(container.querySelector('#cell-1-1') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-1-1') as HTMLElement);
             expect(nav.goRight()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
         });
 
         it('goLeft should wrap from first cell of first row to last cell of last row', () => {
@@ -390,21 +390,21 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container, wrap: true }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goLeft()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-1-1');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-1');
         });
     });
 
-    describe('goToItem', () => {
+    describe('goTo with item selector', () => {
         it('should navigate to a specific cell', () => {
             const container = createGrid(3, 3);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
             const cell = container.querySelector('#cell-1-2') as HTMLElement;
-            expect(nav.goToItem(cell)).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-1-2');
+            expect(nav.goTo(() => cell)).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-2');
         });
 
         it('should update column memory', () => {
@@ -412,11 +412,11 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
 
             // Column memory should be 2
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-1-2');
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-2');
         });
 
         it('should return false for element not in the grid', () => {
@@ -425,11 +425,11 @@ describe('createGridFocusNavigation', () => {
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
             const outsider = document.createElement('div');
-            expect(nav.goToItem(outsider)).toBe(false);
+            expect(nav.goTo(() => outsider)).toBe(false);
         });
     });
 
-    describe('goToItemMatching', () => {
+    describe('goTo with getMatching', () => {
         it('should navigate to first cell matching predicate', () => {
             const container = createContainer(`
                 <div role="grid">
@@ -446,16 +446,17 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.goToItemMatching((el) => el.getAttribute('aria-selected') === 'true')).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-1');
+            expect(nav.goTo((n) => n.getMatching((el) => el.getAttribute('aria-selected') === 'true'))).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-1');
         });
 
-        it('should return false when no cell matches', () => {
+        it('should defer when no cell matches', () => {
             const container = createGrid(2, 2);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.goToItemMatching(() => false)).toBe(false);
+            expect(nav.goTo((n) => n.getMatching(() => false))).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
         });
 
         it('should update column memory to matched cell column', () => {
@@ -463,12 +464,12 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToItemMatching((el) => el.id === 'cell-1-2');
-            expect(nav.activeItem?.id).toBe('cell-1-2');
+            nav.goTo((n) => n.getMatching((el) => el.id === 'cell-1-2'));
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-2');
 
             // Column memory should be 2
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-2-2');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-2');
         });
     });
 
@@ -478,9 +479,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goToOffset(2)).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('should navigate backward by row offset', () => {
@@ -488,9 +489,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goToOffset(-2)).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('should clamp at boundaries', () => {
@@ -498,9 +499,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goToOffset(5)).toBe(false);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('should start from first row when no active item and offset is positive', () => {
@@ -509,7 +510,7 @@ describe('createGridFocusNavigation', () => {
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
             expect(nav.goToOffset(1)).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
         });
 
         it('should start from last row when no active item and offset is negative', () => {
@@ -518,7 +519,7 @@ describe('createGridFocusNavigation', () => {
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
             expect(nav.goToOffset(-1)).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-4-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-4-0');
         });
 
         it('should respect column memory with offset', () => {
@@ -526,9 +527,9 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToItem(container.querySelector('#cell-0-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#cell-0-2') as HTMLElement);
             expect(nav.goToOffset(3)).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-3-2');
+            expect(nav.selectors.activeItem?.id).toBe('cell-3-2');
         });
 
         it('offset 0 should return true if active item exists, false otherwise', () => {
@@ -537,7 +538,7 @@ describe('createGridFocusNavigation', () => {
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
             expect(nav.goToOffset(0)).toBe(false);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goToOffset(0)).toBe(true);
         });
     });
@@ -548,10 +549,10 @@ describe('createGridFocusNavigation', () => {
             const { callbacks, deactivated, counter } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             nav.clear();
-            expect(nav.activeItem).toBeNull();
-            expect(nav.hasActiveItem).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
             expect(deactivated).toHaveLength(1);
             expect(counter.clearCount).toBe(1);
         });
@@ -571,7 +572,7 @@ describe('createGridFocusNavigation', () => {
                 },
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             nav.goDown();
             expect(order).toEqual(['activate:cell-0-0', 'deactivate:cell-0-0', 'activate:cell-1-0']);
         });
@@ -589,7 +590,7 @@ describe('createGridFocusNavigation', () => {
                 },
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             nav.clear();
             expect(order).toEqual(['activate:cell-0-0', 'deactivate:cell-0-0', 'clear']);
         });
@@ -601,107 +602,11 @@ describe('createGridFocusNavigation', () => {
             const { callbacks, deactivated, counter } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             ac.abort();
-            expect(nav.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
             expect(deactivated).toHaveLength(1);
             expect(counter.clearCount).toBe(1);
-        });
-    });
-
-    describe('isRowVisible filtering', () => {
-        it('should skip rows where isRowVisible returns false', () => {
-            const container = createContainer(`
-                <div role="grid">
-                    <div role="row" id="row-0">
-                        <div role="gridcell" id="cell-0-0">A</div>
-                    </div>
-                    <div role="row" id="row-1" data-hidden>
-                        <div role="gridcell" id="cell-1-0">B</div>
-                    </div>
-                    <div role="row" id="row-2">
-                        <div role="gridcell" id="cell-2-0">C</div>
-                    </div>
-                </div>
-            `);
-            const { callbacks } = makeCallbacks();
-            const ac = new AbortController();
-            const nav = createGridFocusNavigation(
-                {
-                    ...GRID_OPTIONS,
-                    container,
-                    isRowVisible: (row) => !row.hasAttribute('data-hidden'),
-                },
-                callbacks,
-                ac.signal,
-            );
-
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('cell-0-0');
-
-            // goDown should skip the hidden row and go to row-2
-            nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-2-0');
-        });
-
-        it('should report no navigable items when all rows are hidden', () => {
-            const container = createContainer(`
-                <div role="grid">
-                    <div role="row" data-hidden>
-                        <div role="gridcell" id="cell-0-0">A</div>
-                    </div>
-                </div>
-            `);
-            const { callbacks } = makeCallbacks();
-            const ac = new AbortController();
-            const nav = createGridFocusNavigation(
-                {
-                    ...GRID_OPTIONS,
-                    container,
-                    isRowVisible: (row) => !row.hasAttribute('data-hidden'),
-                },
-                callbacks,
-                ac.signal,
-            );
-            expect(nav.hasNavigableItems).toBe(false);
-            expect(nav.goToFirst()).toBe(false);
-        });
-
-        it('should match Combobox usage pattern (isRowVisible via child attribute)', () => {
-            const container = createContainer(`
-                <div role="grid">
-                    <div role="row" id="row-0">
-                        <div role="gridcell" id="cell-0-0">Visible</div>
-                    </div>
-                    <div role="row" id="row-1">
-                        <div role="gridcell" id="cell-1-0" data-filtered>Filtered</div>
-                    </div>
-                    <div role="row" id="row-2">
-                        <div role="gridcell" id="cell-2-0">Visible</div>
-                    </div>
-                </div>
-            `);
-            const { callbacks } = makeCallbacks();
-            const ac = new AbortController();
-            const nav = createGridFocusNavigation(
-                {
-                    ...GRID_OPTIONS,
-                    container,
-                    isRowVisible: (row) => !row.querySelector('[role="gridcell"]')?.hasAttribute('data-filtered'),
-                },
-                callbacks,
-                ac.signal,
-            );
-
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('cell-0-0');
-
-            nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-2-0');
-
-            // goToLast should land on the last visible row
-            nav.goToLast();
-            expect(nav.activeItem?.id).toBe('cell-2-0');
         });
     });
 
@@ -711,8 +616,8 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToLast();
-            expect(nav.activeItem?.id).toBe('cell-1-0');
+            nav.goTo((s) => s.getLast());
+            expect(nav.selectors.activeItem?.id).toBe('cell-1-0');
 
             // Dynamically add a new row
             const newRow = document.createElement('div');
@@ -722,7 +627,7 @@ describe('createGridFocusNavigation', () => {
             container.appendChild(newRow);
 
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('should skip a dynamically removed row', () => {
@@ -730,13 +635,13 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
 
             // Remove row-1
             container.querySelector('#row-1')!.remove();
 
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            expect(nav.selectors.activeItem?.id).toBe('cell-2-0');
         });
 
         it('should update hasNavigableItems after all rows are removed', () => {
@@ -744,46 +649,73 @@ describe('createGridFocusNavigation', () => {
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
             const nav = createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
-            expect(nav.hasNavigableItems).toBe(true);
+            expect(nav.selectors.hasNavigableItems).toBe(true);
 
             container.querySelector('#row-0')!.remove();
-            expect(nav.hasNavigableItems).toBe(false);
+            expect(nav.selectors.hasNavigableItems).toBe(false);
+        });
+    });
+
+    describe('resolve-based navigation (goTo)', () => {
+        const makeNav = (container: HTMLElement, ac: AbortController) => {
+            const { callbacks } = makeCallbacks();
+            return createGridFocusNavigation({ ...GRID_OPTIONS, container }, callbacks, ac.signal);
+        };
+
+        it('should expose read accessors without moving focus', () => {
+            const container = createGrid(2, 2);
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
+
+            expect(nav.selectors.getFirst()?.id).toBe('cell-0-0');
+            expect(nav.selectors.getLast()?.id).toBe('cell-1-0');
+            expect(nav.selectors.getMatching((el) => el.id === 'cell-1-1')?.id).toBe('cell-1-1');
+            expect(nav.selectors.activeItem).toBeNull();
         });
 
-        it('should reflect dynamically changed row visibility', () => {
-            const container = createContainer(`
-                <div role="grid">
-                    <div role="row" id="row-0">
-                        <div role="gridcell" id="cell-0-0">A</div>
-                    </div>
-                    <div role="row" id="row-1">
-                        <div role="gridcell" id="cell-1-0">B</div>
-                    </div>
-                    <div role="row" id="row-2">
-                        <div role="gridcell" id="cell-2-0">C</div>
-                    </div>
-                </div>
-            `);
-            const { callbacks } = makeCallbacks();
+        it('should resolve and move focus immediately when the target exists', () => {
+            const container = createGrid(2, 2);
             const ac = new AbortController();
-            const nav = createGridFocusNavigation(
-                {
-                    ...GRID_OPTIONS,
-                    container,
-                    isRowVisible: (row) => !row.hasAttribute('data-hidden'),
-                },
-                callbacks,
-                ac.signal,
-            );
+            const nav = makeNav(container, ac);
 
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('cell-0-0');
+            const moved = nav.goTo((n) => n.getFirst());
+            expect(moved).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('cell-0-0');
+        });
 
-            // Dynamically hide row-1
-            container.querySelector('#row-1')!.setAttribute('data-hidden', '');
+        it('should defer and retry until rows are available', () => {
+            // Start with an empty grid so the resolver returns null.
+            const container = createContainer('<div role="grid"></div>');
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
 
-            nav.goDown();
-            expect(nav.activeItem?.id).toBe('cell-2-0');
+            const moved = nav.goTo((n) => n.getFirst());
+            expect(moved).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
+
+            // A row with a cell mounts, then flush.
+            container.innerHTML = '<div role="row" id="late-row"><div role="gridcell" id="late-cell">X</div></div>';
+
+            nav.flushPendingNavigation();
+            expect(nav.selectors.activeItem?.id).toBe('late-cell');
+        });
+
+        it('should discard a deferred intent on clear', () => {
+            const container = createContainer('<div role="grid"></div>');
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
+
+            const resolve = vi.fn((n: FocusNavigationSelectors) => n.getFirst());
+            nav.goTo(resolve);
+
+            nav.clear();
+
+            // After clear, a flush must not replay the intent — even once cells exist.
+            container.innerHTML = '<div role="row" id="late-row"><div role="gridcell" id="late-cell">X</div></div>';
+            resolve.mockClear();
+            nav.flushPendingNavigation();
+            expect(resolve).not.toHaveBeenCalled();
+            expect(nav.selectors.activeItem).toBeNull();
         });
     });
 });

--- a/packages/lumx-core/src/js/utils/focusNavigation/createGridFocusNavigation.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/createGridFocusNavigation.ts
@@ -1,14 +1,25 @@
-import { createSelectorTreeWalker } from '../browser/createSelectorTreeWalker';
 import { createActiveItemState } from './createActiveItemState';
-import type { FocusNavigationCallbacks, FocusNavigationController, GridNavigationOptions } from './types';
+import { createPendingNavigation } from './createPendingNavigation';
+import type {
+    FocusNavigationCallbacks,
+    FocusNavigationController,
+    FocusNavigationSelectors,
+    GridNavigationOptions,
+} from './types';
+import { lastDescendant } from '../browser/lastDescendant';
+import { createSelectorTreeWalker } from '../browser/createSelectorTreeWalker';
+import { first } from '../iterable/first';
 
 /**
  * Create a focus navigation controller for a 2D grid.
  *
+ * Resolves rows and cells by querying the DOM and commits focus by updating the
+ * active-item state (which fires {@link FocusNavigationCallbacks}).
+ *
  * Supports Up/Down between rows (with column memory) and Left/Right between cells
  * (with wrapping across rows).
  *
- * @param options Grid navigation options (container, rowSelector, cellSelector, isRowVisible, wrap).
+ * @param options Grid navigation options (container, rowSelector, cellSelector, wrap).
  * @param callbacks Callbacks for focus state changes.
  * @param signal AbortSignal for cleanup.
  * @returns FocusNavigationController instance.
@@ -18,89 +29,52 @@ export function createGridFocusNavigation(
     callbacks: FocusNavigationCallbacks,
     signal: AbortSignal,
 ): FocusNavigationController {
-    const { container, rowSelector, cellSelector, isRowVisible, wrap = false } = options;
+    const { container, rowSelector, cellSelector, wrap = false } = options;
     const state = createActiveItemState(callbacks, signal);
-    /** Remembered column index for Up/Down navigation (column memory). */
-    let rememberedCol = 0;
 
-    /** Check if a row element is visible (passes the isRowVisible filter). */
-    function isVisible(row: HTMLElement): boolean {
-        return !isRowVisible || isRowVisible(row);
-    }
+    const isNavigableRow = (row: HTMLElement) => row.querySelector(cellSelector) !== null;
+    const getFirstCell = (row: HTMLElement) => row.querySelector<HTMLElement>(cellSelector);
+    const getRowCells = (row: HTMLElement) => Array.from(row.querySelectorAll<HTMLElement>(cellSelector));
 
-    /** Check if a row is navigable (visible with at least one cell). */
-    function isNavigableRow(row: HTMLElement): boolean {
-        return isVisible(row) && row.querySelector(cellSelector) !== null;
-    }
+    /** Lazily walk navigable rows from `start` in a `direction`, projecting each row through `dive`. */
+    function* findRows(
+        start: HTMLElement | 'first' | 'last' = 'first',
+        direction: 'next' | 'prev' = 'next',
+        dive?: (row: HTMLElement) => HTMLElement | undefined | null,
+    ) {
+        // Tree walker
+        const walker = createSelectorTreeWalker(container, rowSelector);
 
-    /** Create a TreeWalker scoped to row elements within the container. */
-    function createRowWalker(): TreeWalker {
-        return createSelectorTreeWalker(container, rowSelector);
-    }
+        // Start at a specific row
+        if (start instanceof HTMLElement) walker.currentNode = start;
+        // Start from the last
+        else if (start === 'last') walker.currentNode = lastDescendant(container);
 
-    /**
-     * Iterate navigable rows from the container using a TreeWalker.
-     * - `'first'`: returns the first navigable row (or null).
-     * - `'last'`: returns the last navigable row (or null).
-     * - `'all'`: returns all navigable rows as an array.
-     */
-    function findVisibleRows(mode: 'first'): HTMLElement | null;
-    function findVisibleRows(mode: 'last'): HTMLElement | null;
-    function findVisibleRows(mode: 'all'): HTMLElement[];
-    function findVisibleRows(mode: 'first' | 'last' | 'all'): HTMLElement | HTMLElement[] | null {
-        const walker = createRowWalker();
-        if (mode === 'all') {
-            const result: HTMLElement[] = [];
-            let node = walker.nextNode() as HTMLElement | null;
-            while (node) {
-                if (isNavigableRow(node)) result.push(node);
-                node = walker.nextNode() as HTMLElement | null;
+        // Walk nodes
+        let node: HTMLElement | null;
+        do {
+            node = (direction === 'next' ? walker.nextNode() : walker.previousNode()) as HTMLElement | null;
+            if (node && isNavigableRow(node)) {
+                const result = dive ? dive(node) : node;
+                if (result) yield result;
             }
-            return result;
-        }
-        let found: HTMLElement | null = null;
-        let node = walker.nextNode() as HTMLElement | null;
-        while (node) {
-            if (isNavigableRow(node)) {
-                if (mode === 'first') return node;
-                found = node;
-            }
-            node = walker.nextNode() as HTMLElement | null;
-        }
-        return found;
+        } while (node);
     }
 
-    /** Get the cells within a single row element. */
-    function getRowCells(row: HTMLElement): HTMLElement[] {
-        return Array.from(row.querySelectorAll<HTMLElement>(cellSelector));
-    }
+    const findFirstVisibleRow = () => first(findRows());
+    const findLastVisibleRow = () => first(findRows('last', 'prev'));
 
-    /** Find the row element containing a cell, using closest(). */
     function findParentRow(cell: HTMLElement): HTMLElement | null {
         const row = cell.closest<HTMLElement>(rowSelector);
         return row && container.contains(row) ? row : null;
     }
 
-    /**
-     * Walk to the next or previous visible row (with cells) from a given row
-     * using a TreeWalker. Avoids building the full visible rows array.
-     */
-    function findAdjacentVisibleRow(fromRow: HTMLElement, direction: 'next' | 'prev'): HTMLElement | null {
-        const walker = createRowWalker();
-        walker.currentNode = fromRow;
-        const advance = direction === 'next' ? () => walker.nextNode() : () => walker.previousNode();
-        let node = advance() as HTMLElement | null;
-        while (node) {
-            if (isNavigableRow(node)) return node;
-            node = advance() as HTMLElement | null;
-        }
-        return null;
-    }
+    /** Deferred navigation intent (replayed once cells are committed to the DOM). */
+    const pending = createPendingNavigation(signal);
+    /** Remembered column index for Up/Down navigation (column memory). */
+    let rememberedCol = 0;
 
-    /**
-     * Activate the cell at the given column in a row element.
-     * Clamps col to the row's available cells.
-     */
+    /** Activate the cell at the given column in a row element. */
     function focusCellInRow(row: HTMLElement, col: number): boolean {
         const cells = getRowCells(row);
         if (cells.length === 0) return false;
@@ -109,15 +83,29 @@ export function createGridFocusNavigation(
         return true;
     }
 
+    /** Activate the given cell (validates it is in the grid, updates column memory). */
+    function activateCell(item: HTMLElement): boolean {
+        const row = findParentRow(item);
+        if (!row) return false;
+        const cells = getRowCells(row);
+        const col = cells.indexOf(item);
+        if (col === -1) return false;
+        rememberedCol = col;
+        state.setActive(item);
+        return true;
+    }
+
+    /** Got to first cell in first row */
     function goToFirst(): boolean {
-        const row = findVisibleRows('first');
+        const row = findFirstVisibleRow();
         if (!row) return false;
         rememberedCol = 0;
         return focusCellInRow(row, 0);
     }
 
+    /** Got to first cell in last row */
     function goToLast(): boolean {
-        const row = findVisibleRows('last');
+        const row = findLastVisibleRow();
         if (!row) return false;
         rememberedCol = 0;
         return focusCellInRow(row, 0);
@@ -145,8 +133,8 @@ export function createGridFocusNavigation(
 
         // Wrap to the adjacent row (or opposite boundary row), activating the first or last cell.
         const rowDirection = step > 0 ? 'next' : 'prev';
-        const adjacentRow = findAdjacentVisibleRow(currentRow, rowDirection);
-        const targetRow = adjacentRow ?? (step > 0 ? findVisibleRows('first') : findVisibleRows('last'));
+        const adjacentRow = first(findRows(currentRow, rowDirection));
+        const targetRow = adjacentRow ?? (step > 0 ? findFirstVisibleRow() : findLastVisibleRow());
         if (!targetRow) return false;
 
         const targetCells = getRowCells(targetRow);
@@ -167,36 +155,39 @@ export function createGridFocusNavigation(
         const currentRow = findParentRow(state.active);
         if (!currentRow) return false;
 
-        const adjacentRow = findAdjacentVisibleRow(currentRow, direction);
+        const adjacentRow = first(findRows(currentRow, direction));
         if (adjacentRow) return focusCellInRow(adjacentRow, rememberedCol);
 
         if (wrap) {
             // Wrap to the opposite boundary row.
-            const wrapRow = direction === 'next' ? findVisibleRows('first') : findVisibleRows('last');
+            const wrapRow = direction === 'next' ? findFirstVisibleRow() : findLastVisibleRow();
             if (wrapRow) return focusCellInRow(wrapRow, rememberedCol);
         }
         return false;
     }
 
-    return {
-        type: 'grid',
-
+    const selectors: FocusNavigationSelectors = {
         get activeItem() {
             return state.active;
         },
-        get hasActiveItem() {
-            return state.active !== null;
-        },
         get hasNavigableItems() {
-            return findVisibleRows('first') !== null;
+            return first(findRows()) !== null;
         },
+        // First cell in first row
+        getFirst: () => first(findRows('first', 'next', getFirstCell)),
+        // First cell in last row
+        getLast: () => first(findRows('last', 'prev', getFirstCell)),
+        // First cell matching predicate
+        getMatching: (predicate) => first(findRows('first', 'next', (row) => getRowCells(row).find(predicate))),
+    };
 
-        goToFirst,
-        goToLast,
+    return {
+        type: 'grid',
+        selectors,
 
         goToOffset(offset: number): boolean {
             if (offset === 0) return state.active !== null;
-            const visibleRows = findVisibleRows('all');
+            const visibleRows = Array.from(findRows());
             if (visibleRows.length === 0) return false;
 
             if (!state.active) {
@@ -218,40 +209,24 @@ export function createGridFocusNavigation(
             return focusCellInRow(visibleRows[targetIdx], rememberedCol);
         },
 
-        goToItemMatching(predicate: (item: HTMLElement) => boolean): boolean {
-            // Iterate visible rows lazily — short-circuit on first match.
-            const walker = createRowWalker();
-            let row = walker.nextNode() as HTMLElement | null;
-            while (row) {
-                if (isNavigableRow(row)) {
-                    const cells = getRowCells(row);
-                    for (let c = 0; c < cells.length; c++) {
-                        if (predicate(cells[c])) {
-                            rememberedCol = c;
-                            state.setActive(cells[c]);
-                            return true;
-                        }
-                    }
-                }
-                row = walker.nextNode() as HTMLElement | null;
+        clear(): void {
+            state.clear();
+            pending.clear();
+        },
+
+        goTo(resolve: (selectors: FocusNavigationSelectors) => HTMLElement | null): boolean {
+            const target = resolve(selectors);
+            if (target && activateCell(target)) {
+                pending.clear();
+                return true;
             }
+            // Target not resolvable yet (e.g. cells not committed to the DOM) — defer
+            pending.defer(() => this.goTo(resolve));
             return false;
         },
 
-        goToItem(item: HTMLElement): boolean {
-            // Use closest() to find the parent row, then find col within that row only.
-            const row = findParentRow(item);
-            if (!row || !isVisible(row)) return false;
-            const cells = getRowCells(row);
-            const col = cells.indexOf(item);
-            if (col === -1) return false;
-            rememberedCol = col;
-            state.setActive(item);
-            return true;
-        },
-
-        clear(): void {
-            state.clear();
+        flushPendingNavigation(): void {
+            pending.flush();
         },
 
         goUp(): boolean {

--- a/packages/lumx-core/src/js/utils/focusNavigation/createListFocusNavigation.test.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/createListFocusNavigation.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { createListFocusNavigation } from './createListFocusNavigation';
 
-import type { FocusNavigationCallbacks } from './types';
+import type { FocusNavigationCallbacks, FocusNavigationSelectors } from './types';
 
 function createContainer(html: string): HTMLElement {
     const div = document.createElement('div');
@@ -86,8 +86,8 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.activeItem).toBeNull();
-            expect(nav.hasActiveItem).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
         });
 
         it('should detect navigable items', () => {
@@ -105,7 +105,7 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.hasNavigableItems).toBe(true);
+            expect(nav.selectors.hasNavigableItems).toBe(true);
         });
 
         it('should detect no navigable items in empty container', () => {
@@ -123,11 +123,11 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.hasNavigableItems).toBe(false);
+            expect(nav.selectors.hasNavigableItems).toBe(false);
         });
     });
 
-    describe('goToFirst / goToLast', () => {
+    describe('goTo getFirst / getLast', () => {
         it('should navigate to first item', () => {
             const container = createList(3);
             const { callbacks, activated } = makeCallbacks();
@@ -143,8 +143,8 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToFirst()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.goTo((s) => s.getFirst())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
             expect(activated).toHaveLength(1);
         });
 
@@ -163,8 +163,8 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToLast()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.goTo((s) => s.getLast())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
         it('should return false on empty list', () => {
@@ -182,8 +182,8 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToFirst()).toBe(false);
-            expect(nav.goToLast()).toBe(false);
+            expect(nav.goTo((s) => s.getFirst())).toBe(false);
+            expect(nav.goTo((s) => s.getLast())).toBe(false);
         });
     });
 
@@ -203,9 +203,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goToOffset(2)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
         it('should navigate backward by offset', () => {
@@ -223,9 +223,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goToOffset(-2)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
         it('should clamp at boundaries without wrap', () => {
@@ -244,9 +244,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goToOffset(5)).toBe(false);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
         it('should wrap with wrap enabled', () => {
@@ -265,9 +265,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goToOffset(1)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
         });
 
         it('should start from first when no active item and offset is positive', () => {
@@ -286,7 +286,7 @@ describe('createListFocusNavigation', () => {
                 ac.signal,
             );
             expect(nav.goToOffset(1)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
         });
 
         it('should start from last when no active item and offset is negative', () => {
@@ -305,11 +305,11 @@ describe('createListFocusNavigation', () => {
                 ac.signal,
             );
             expect(nav.goToOffset(-1)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-4');
+            expect(nav.selectors.activeItem?.id).toBe('opt-4');
         });
     });
 
-    describe('goToItem', () => {
+    describe('goTo with item selector', () => {
         it('should navigate to a specific item', () => {
             const container = createList(3);
             const { callbacks } = makeCallbacks();
@@ -326,8 +326,8 @@ describe('createListFocusNavigation', () => {
                 ac.signal,
             );
             const item = container.querySelector('#opt-1') as HTMLElement;
-            expect(nav.goToItem(item)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.goTo(() => item)).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
         it('should return false for item not matching selector', () => {
@@ -346,11 +346,11 @@ describe('createListFocusNavigation', () => {
                 ac.signal,
             );
             const item = container.querySelector('#not-option') as HTMLElement;
-            expect(nav.goToItem(item)).toBe(false);
+            expect(nav.goTo(() => item)).toBe(false);
         });
     });
 
-    describe('goToItemMatching', () => {
+    describe('goTo with getMatching', () => {
         it('should navigate to first item matching predicate', () => {
             const container = createContainer(`
                 <div>
@@ -372,11 +372,11 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToItemMatching((el) => el.getAttribute('aria-selected') === 'true')).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.goTo((n) => n.getMatching((el) => el.getAttribute('aria-selected') === 'true'))).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
-        it('should return false when no item matches', () => {
+        it('should defer when no item matches', () => {
             const container = createList(3);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
@@ -391,7 +391,8 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToItemMatching(() => false)).toBe(false);
+            expect(nav.goTo((n) => n.getMatching(() => false))).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
         });
     });
 
@@ -411,10 +412,10 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             nav.clear();
-            expect(nav.activeItem).toBeNull();
-            expect(nav.hasActiveItem).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
             expect(deactivated).toHaveLength(1);
             expect(counter.clearCount).toBe(1);
         });
@@ -437,9 +438,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
         it('goUp should navigate backward', () => {
@@ -458,9 +459,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goUp()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
         it('goLeft/goRight should be no-ops in vertical mode', () => {
@@ -479,7 +480,7 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goLeft()).toBe(false);
             expect(nav.goRight()).toBe(false);
         });
@@ -502,9 +503,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goRight()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
         it('goLeft should navigate backward', () => {
@@ -523,9 +524,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToLast();
+            nav.goTo((s) => s.getLast());
             expect(nav.goLeft()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
         it('goUp/goDown should be no-ops in horizontal mode', () => {
@@ -544,7 +545,7 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goUp()).toBe(false);
             expect(nav.goDown()).toBe(false);
         });
@@ -566,12 +567,12 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('opt-0');
+            nav.goTo((s) => s.getFirst());
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('opt-4');
+            expect(nav.selectors.activeItem?.id).toBe('opt-4');
         });
     });
 
@@ -600,10 +601,10 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('opt-0');
+            nav.goTo((s) => s.getFirst());
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
             nav.goDown();
-            expect(nav.activeItem?.id).toBe('opt-3');
+            expect(nav.selectors.activeItem?.id).toBe('opt-3');
         });
 
         it('should skip disabled items when navigating backward', () => {
@@ -622,13 +623,13 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToLast();
-            expect(nav.activeItem?.id).toBe('opt-4');
+            nav.goTo((s) => s.getLast());
+            expect(nav.selectors.activeItem?.id).toBe('opt-4');
             nav.goUp();
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
-        it('goToFirst should skip leading disabled items', () => {
+        it('goTo getFirst should skip leading disabled items', () => {
             const container = createListWithDisabled([0, 1]);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
@@ -644,11 +645,11 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToFirst()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.goTo((s) => s.getFirst())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
-        it('goToLast should skip trailing disabled items', () => {
+        it('goTo getLast should skip trailing disabled items', () => {
             const container = createListWithDisabled([3, 4]);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
@@ -664,11 +665,11 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToLast()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.goTo((s) => s.getLast())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
-        it('goToFirst should return false when all items are disabled', () => {
+        it('goTo getFirst should return false when all items are disabled', () => {
             const container = createListWithDisabled([0, 1, 2, 3, 4]);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
@@ -684,7 +685,7 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToFirst()).toBe(false);
+            expect(nav.goTo((s) => s.getFirst())).toBe(false);
         });
 
         it('hasNavigableItems should return false when all items are disabled', () => {
@@ -703,7 +704,7 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.hasNavigableItems).toBe(false);
+            expect(nav.selectors.hasNavigableItems).toBe(false);
         });
 
         it('should wrap around disabled items', () => {
@@ -723,10 +724,10 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToItem(container.querySelector('#opt-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#opt-2') as HTMLElement);
             // Next enabled item wrapping around should be opt-0
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
         });
 
         it('should return false when navigation cannot find an enabled item without wrap', () => {
@@ -746,11 +747,11 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToItem(container.querySelector('#opt-2') as HTMLElement);
+            nav.goTo(() => container.querySelector('#opt-2') as HTMLElement);
             expect(nav.goDown()).toBe(false);
         });
 
-        it('goToItem should still navigate to a disabled item directly', () => {
+        it('goTo should still navigate to a disabled item directly', () => {
             const container = createListWithDisabled([1]);
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
@@ -767,8 +768,8 @@ describe('createListFocusNavigation', () => {
                 ac.signal,
             );
             const disabledItem = container.querySelector('#opt-1') as HTMLElement;
-            expect(nav.goToItem(disabledItem)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.goTo(() => disabledItem)).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
         });
 
         it('should skip disabled items with goToOffset > 1', () => {
@@ -787,10 +788,10 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             // offset 2 should skip opt-1 (disabled) and land on opt-2, then skip opt-3 (disabled) and land on opt-4
             expect(nav.goToOffset(2)).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-4');
+            expect(nav.selectors.activeItem?.id).toBe('opt-4');
         });
 
         it('should not land on a disabled item when offset exceeds available enabled items', () => {
@@ -811,11 +812,11 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goToOffset(3)).toBe(true);
             // Should land on opt-4 (the only reachable enabled item), not on a disabled one
-            expect(nav.activeItem?.id).toBe('opt-4');
-            expect(nav.activeItem?.getAttribute('aria-disabled')).not.toBe('true');
+            expect(nav.selectors.activeItem?.id).toBe('opt-4');
+            expect(nav.selectors.activeItem?.getAttribute('aria-disabled')).not.toBe('true');
         });
 
         it('should return false when offset exceeds all enabled items without wrap', () => {
@@ -836,10 +837,10 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             expect(nav.goToOffset(2)).toBe(false);
             // Active item must not have changed
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
         });
     });
 
@@ -869,7 +870,7 @@ describe('createListFocusNavigation', () => {
                 },
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             nav.goDown();
             expect(order).toEqual(['activate:opt-0', 'deactivate:opt-0', 'activate:opt-1']);
         });
@@ -899,7 +900,7 @@ describe('createListFocusNavigation', () => {
                 },
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             nav.clear();
             expect(order).toEqual(['activate:opt-0', 'deactivate:opt-0', 'clear']);
         });
@@ -921,9 +922,9 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
+            nav.goTo((s) => s.getFirst());
             ac.abort();
-            expect(nav.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
             expect(deactivated).toHaveLength(1);
             expect(counter.clearCount).toBe(1);
         });
@@ -946,8 +947,8 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToLast();
-            expect(nav.activeItem?.id).toBe('opt-2');
+            nav.goTo((s) => s.getLast());
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
 
             // Dynamically add a new item after the last one.
             const newItem = document.createElement('div');
@@ -958,7 +959,7 @@ describe('createListFocusNavigation', () => {
 
             // Navigation should pick up the new item.
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-3');
+            expect(nav.selectors.activeItem?.id).toBe('opt-3');
         });
 
         it('should skip a dynamically removed item', () => {
@@ -977,15 +978,15 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('opt-0');
+            nav.goTo((s) => s.getFirst());
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
 
             // Remove opt-1 from the DOM.
             container.querySelector('#opt-1')!.remove();
 
             // Navigating forward should skip opt-1 and go to opt-2.
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
         it('should handle navigating when the active item was removed', () => {
@@ -1004,17 +1005,17 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToItem(container.querySelector('#opt-1') as HTMLElement);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            nav.goTo(() => container.querySelector('#opt-1') as HTMLElement);
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
 
             // Remove the active item from the DOM.
             container.querySelector('#opt-1')!.remove();
 
             // With stateless approach, getActiveItem returns null since the element
             // is no longer in the DOM. Navigating should start from first/last.
-            expect(nav.activeItem).toBeNull();
-            expect(nav.goToFirst()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem).toBeNull();
+            expect(nav.goTo((s) => s.getFirst())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
         });
 
         it('should reflect dynamically changed disabled state', () => {
@@ -1034,15 +1035,15 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            nav.goToFirst();
-            expect(nav.activeItem?.id).toBe('opt-0');
+            nav.goTo((s) => s.getFirst());
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
 
             // Dynamically disable opt-1.
             container.querySelector('#opt-1')!.setAttribute('aria-disabled', 'true');
 
             // Navigation should skip the newly disabled item.
             expect(nav.goDown()).toBe(true);
-            expect(nav.activeItem?.id).toBe('opt-2');
+            expect(nav.selectors.activeItem?.id).toBe('opt-2');
         });
 
         it('should update hasNavigableItems after items are removed', () => {
@@ -1060,16 +1061,16 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.hasNavigableItems).toBe(true);
+            expect(nav.selectors.hasNavigableItems).toBe(true);
 
             // Remove all items.
             container.querySelector('#opt-0')!.remove();
             container.querySelector('#opt-1')!.remove();
 
-            expect(nav.hasNavigableItems).toBe(false);
+            expect(nav.selectors.hasNavigableItems).toBe(false);
         });
 
-        it('should update goToFirst/goToLast after items are added', () => {
+        it('should update getFirst/getLast after items are added', () => {
             const container = createContainer('<div role="listbox"></div>');
             const { callbacks } = makeCallbacks();
             const ac = new AbortController();
@@ -1084,8 +1085,8 @@ describe('createListFocusNavigation', () => {
                 callbacks,
                 ac.signal,
             );
-            expect(nav.goToFirst()).toBe(false);
-            expect(nav.goToLast()).toBe(false);
+            expect(nav.goTo((s) => s.getFirst())).toBe(false);
+            expect(nav.goTo((s) => s.getLast())).toBe(false);
 
             // Dynamically add items.
             const item0 = document.createElement('div');
@@ -1098,12 +1099,107 @@ describe('createListFocusNavigation', () => {
             item1.id = 'new-1';
             container.appendChild(item1);
 
-            expect(nav.goToFirst()).toBe(true);
-            expect(nav.activeItem?.id).toBe('new-0');
+            expect(nav.goTo((s) => s.getFirst())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('new-0');
 
             nav.clear();
-            expect(nav.goToLast()).toBe(true);
-            expect(nav.activeItem?.id).toBe('new-1');
+            expect(nav.goTo((s) => s.getLast())).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('new-1');
+        });
+    });
+
+    describe('resolve-based navigation (goTo)', () => {
+        const itemSelector = '[role="option"]:not([data-filtered])';
+        const makeNav = (container: HTMLElement, ac: AbortController) => {
+            const { callbacks } = makeCallbacks();
+            return createListFocusNavigation(
+                { type: 'list', container, itemSelector, getActiveItem: makeGetActiveItem(container, itemSelector) },
+                callbacks,
+                ac.signal,
+            );
+        };
+
+        it('should expose read accessors without moving focus', () => {
+            const container = createList(3, [1]); // index 1 filtered out
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
+
+            expect(nav.selectors.getFirst()?.id).toBe('opt-0');
+            expect(nav.selectors.getLast()?.id).toBe('opt-2');
+            expect(nav.selectors.getMatching((el) => el.id === 'opt-2')?.id).toBe('opt-2');
+            // No accessor moved focus.
+            expect(nav.selectors.activeItem).toBeNull();
+        });
+
+        it('should resolve and move focus immediately when the target exists', () => {
+            const container = createList(3);
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
+
+            const moved = nav.goTo((n) => n.getFirst());
+            expect(moved).toBe(true);
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
+        });
+
+        it('should defer and retry until the resolver finds a target', () => {
+            // Start with no items so the resolver returns null.
+            const container = createContainer('<div role="listbox"></div>');
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
+
+            const moved = nav.goTo((n) => n.getFirst());
+            expect(moved).toBe(false);
+            expect(nav.selectors.activeItem).toBeNull();
+
+            // Items mount, then flush.
+            const option = document.createElement('div');
+            option.setAttribute('role', 'option');
+            option.id = 'late-0';
+            container.appendChild(option);
+
+            nav.flushPendingNavigation();
+            expect(nav.selectors.activeItem?.id).toBe('late-0');
+        });
+
+        it('should re-run the resolver (not cache the element) on each flush', () => {
+            const container = createContainer('<div role="listbox"></div>');
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
+
+            const resolve = vi.fn((n: FocusNavigationSelectors) => n.getFirst());
+            nav.goTo(resolve);
+            expect(resolve).toHaveBeenCalledTimes(1);
+
+            const option = document.createElement('div');
+            option.setAttribute('role', 'option');
+            option.id = 'late-0';
+            container.appendChild(option);
+
+            nav.flushPendingNavigation();
+            expect(resolve).toHaveBeenCalledTimes(2);
+            expect(nav.selectors.activeItem?.id).toBe('late-0');
+        });
+
+        it('should discard a deferred intent on clear', () => {
+            const container = createContainer('<div role="listbox"></div>');
+            const ac = new AbortController();
+            const nav = makeNav(container, ac);
+
+            const resolve = vi.fn((n: FocusNavigationSelectors) => n.getFirst());
+            nav.goTo(resolve);
+
+            nav.clear();
+
+            // After clear, a flush must not replay the intent — even once items exist.
+            const option = document.createElement('div');
+            option.setAttribute('role', 'option');
+            option.id = 'late-0';
+            container.appendChild(option);
+
+            resolve.mockClear();
+            nav.flushPendingNavigation();
+            expect(resolve).not.toHaveBeenCalled();
+            expect(nav.selectors.activeItem).toBeNull();
         });
     });
 });

--- a/packages/lumx-core/src/js/utils/focusNavigation/createListFocusNavigation.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/createListFocusNavigation.ts
@@ -1,20 +1,11 @@
+import { createPendingNavigation } from './createPendingNavigation';
+import type {
+    FocusNavigationCallbacks,
+    ListFocusNavigationController,
+    ListFocusNavigationSelectors,
+    ListNavigationOptions,
+} from './types';
 import { createSelectorTreeWalker } from '../browser/createSelectorTreeWalker';
-import type { FocusNavigationCallbacks, ListFocusNavigationController, ListNavigationOptions } from './types';
-
-/**
- * Transition the active item: deactivate the current one (if any) and activate the new one.
- * Reads the current active item via `getActiveItem` so there is no internal state to desync.
- */
-function transition(
-    getActiveItem: () => HTMLElement | null,
-    callbacks: FocusNavigationCallbacks,
-    newItem: HTMLElement,
-): void {
-    const current = getActiveItem();
-    if (current === newItem) return;
-    if (current) callbacks.onDeactivate(current);
-    callbacks.onActivate(newItem);
-}
 
 /**
  * Create a focus navigation controller for a 1D list.
@@ -46,10 +37,7 @@ export function createListFocusNavigation(
     /** Combined CSS selector matching enabled (non-disabled) items. */
     const enabledItemSelector = itemDisabledSelector ? `${itemSelector}:not(${itemDisabledSelector})` : itemSelector;
 
-    /**
-     * Create a TreeWalker over items in the container.
-     * @param enabledOnly When true (default), disabled items are skipped.
-     */
+    /** Create a TreeWalker over items in the container. */
     function createItemWalker(enabledOnly = true): TreeWalker {
         const selector = enabledOnly ? enabledItemSelector : itemSelector;
         return createSelectorTreeWalker(container, selector);
@@ -66,123 +54,84 @@ export function createListFocusNavigation(
         return items.length > 0 ? items[items.length - 1] : null;
     }
 
-    /** Navigate to the first enabled item and activate it. */
-    function goToFirst(): boolean {
-        const first = findFirstEnabled();
-        if (!first) return false;
-        transition(getActiveItem, callbacks, first);
-        return true;
-    }
+    // Deferred navigation intent (replayed once items are committed to the DOM)
+    const pending = createPendingNavigation(signal);
 
-    /** Navigate to the last enabled item and activate it. */
-    function goToLast(): boolean {
-        const last = findLastEnabled();
-        if (!last) return false;
-        transition(getActiveItem, callbacks, last);
-        return true;
-    }
-
-    function navigateByOffset(offset: number): boolean {
-        const active = getActiveItem();
-        if (offset === 0) return active !== null;
-
+    /** Find item at offset (lazily walk nodes) */
+    function findAtOffset(offset: number): HTMLElement | null {
         const forward = offset > 0;
         const stepsNeeded = Math.abs(offset);
+        const active = getActiveItem();
 
-        // No active item — fall back to first/last.
-        if (!active) {
-            const started = forward ? goToFirst() : goToLast();
-            if (!started) return false;
-            if (stepsNeeded === 1) return true;
-            return navigateByOffset(forward ? offset - 1 : offset + 1);
+        const walker = createItemWalker();
+        const step = forward ? () => walker.nextNode() : () => walker.previousNode();
+
+        let target: HTMLElement | null = null;
+        let remaining = stepsNeeded;
+
+        if (active) {
+            // Walk from the active item.
+            walker.currentNode = active;
+        } else if (!forward) {
+            // Walking backward with no active item: position at the last enabled item
+            target = walker.lastChild() as HTMLElement | null;
+            if (!target) return null;
+            remaining -= 1;
         }
 
-        // Walk from the active item using a TreeWalker.
-        const walker = createItemWalker();
-        walker.currentNode = active;
-
-        const step = forward ? () => walker.nextNode() : () => walker.previousNode();
-        let stepsCompleted = 0;
-        let lastFound: HTMLElement | null = null;
-
-        for (let i = 0; i < stepsNeeded; i++) {
+        for (let i = 0; i < remaining; i++) {
             const next = step() as HTMLElement | null;
             if (next) {
-                lastFound = next;
-                stepsCompleted += 1;
-            } else if (wrap) {
-                // Hit boundary — wrap around to the opposite end.
+                target = next;
+            } else if (active && wrap) {
+                // Hit boundary with an active item — wrap around to the opposite end.
                 const wrapped = forward ? findFirstEnabled() : findLastEnabled();
                 if (!wrapped || wrapped === active) break;
-                lastFound = wrapped;
-                stepsCompleted += 1;
+                target = wrapped;
                 walker.currentNode = wrapped;
             } else {
                 break;
             }
         }
-
-        if (stepsCompleted === 0) return false;
-        transition(getActiveItem, callbacks, lastFound!);
-        return true;
+        return target;
     }
 
-    const navigateForward = () => navigateByOffset(1);
-    const navigateBackward = () => navigateByOffset(-1);
+    function findMatching(predicate: (item: HTMLElement) => boolean): HTMLElement | null {
+        const walker = createItemWalker(false);
+        let node = walker.nextNode() as HTMLElement | null;
+        while (node) {
+            if (predicate(node)) return node;
+            node = walker.nextNode() as HTMLElement | null;
+        }
+        return null;
+    }
 
-    /** Clear the active item. */
+    /** Clear the active item and discard any pending navigation intent. */
     function clear(): void {
         const current = getActiveItem();
         if (current) {
             callbacks.onDeactivate(current);
         }
+        pending.clear();
         callbacks.onClear?.();
     }
 
     // Cleanup on abort.
     signal.addEventListener('abort', clear);
 
-    return {
-        type: 'list',
+    const selectors: ListFocusNavigationSelectors = {
         enabledItemSelector,
 
         get activeItem() {
             return getActiveItem();
         },
-        get hasActiveItem() {
-            return getActiveItem() !== null;
-        },
         get hasNavigableItems() {
             return container.querySelector(enabledItemSelector) !== null;
         },
 
-        goToFirst,
-        goToLast,
-
-        goToItem(item: HTMLElement): boolean {
-            if (!item.matches(itemSelector)) return false;
-            if (!container.contains(item)) return false;
-            transition(getActiveItem, callbacks, item);
-            return true;
-        },
-
-        goToOffset(offset: number): boolean {
-            return navigateByOffset(offset);
-        },
-
-        goToItemMatching(predicate: (item: HTMLElement) => boolean): boolean {
-            const walker = createItemWalker(false);
-            let node = walker.nextNode() as HTMLElement | null;
-            while (node) {
-                if (predicate(node)) {
-                    transition(getActiveItem, callbacks, node);
-                    return true;
-                }
-                node = walker.nextNode() as HTMLElement | null;
-            }
-            return false;
-        },
-
+        getFirst: findFirstEnabled,
+        getLast: findLastEnabled,
+        getMatching: findMatching,
         findNearestEnabled(anchor: Node): HTMLElement | null {
             if (!container.contains(anchor)) return findFirstEnabled();
 
@@ -201,23 +150,65 @@ export function createListFocusNavigation(
             walker.currentNode = anchor;
             return walker.previousNode() as HTMLElement | null;
         },
+    };
+
+    /**
+     * Navigate via a resolver. The resolver receives the selectors to find the target.
+     * If the target is valid, focus is committed (deactivate current, activate target).
+     * If the target is not resolvable yet, the intent is deferred for later replay.
+     */
+    function goTo(resolve: (selectors: ListFocusNavigationSelectors) => HTMLElement | null): boolean {
+        const target = resolve(selectors);
+        if (target && target.matches(itemSelector) && container.contains(target)) {
+            const current = getActiveItem();
+            if (current !== target) {
+                if (current) callbacks.onDeactivate(current);
+                callbacks.onActivate(target);
+            }
+            pending.clear();
+            return true;
+        }
+        // Target not resolvable yet (e.g. items not committed to the DOM) — defer
+        pending.defer(() => goTo(resolve));
+        return false;
+    }
+
+    /** Go to the item at the given offset from the active item. */
+    function goToOffset(offset: number): boolean {
+        if (offset === 0) return getActiveItem() !== null;
+        const target = findAtOffset(offset);
+        if (!target) return false;
+        return goTo(() => target);
+    }
+
+    return {
+        type: 'list',
+        selectors,
+
+        goToOffset,
 
         clear,
 
+        goTo,
+
+        flushPendingNavigation(): void {
+            pending.flush();
+        },
+
         goUp(): boolean {
-            return direction === 'vertical' ? navigateBackward() : false;
+            return direction === 'vertical' ? goToOffset(-1) : false;
         },
 
         goDown(): boolean {
-            return direction === 'vertical' ? navigateForward() : false;
+            return direction === 'vertical' ? goToOffset(1) : false;
         },
 
         goLeft(): boolean {
-            return direction === 'horizontal' ? navigateBackward() : false;
+            return direction === 'horizontal' ? goToOffset(-1) : false;
         },
 
         goRight(): boolean {
-            return direction === 'horizontal' ? navigateForward() : false;
+            return direction === 'horizontal' ? goToOffset(1) : false;
         },
     };
 }

--- a/packages/lumx-core/src/js/utils/focusNavigation/createPendingNavigation.test.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/createPendingNavigation.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { createPendingNavigation } from './createPendingNavigation';
+
+describe('createPendingNavigation', () => {
+    it('should report no pending intent initially', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        expect(pending.hasPending).toBe(false);
+    });
+
+    it('should store a deferred intent', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        pending.defer(() => true);
+        expect(pending.hasPending).toBe(true);
+    });
+
+    it('should run and clear the intent on flush when it returns true', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        const navigate = vi.fn(() => true);
+        pending.defer(navigate);
+
+        pending.flush();
+
+        expect(navigate).toHaveBeenCalledTimes(1);
+        expect(pending.hasPending).toBe(false);
+    });
+
+    it('should keep the intent pending when the thunk returns false', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        const navigate = vi.fn(() => false);
+        pending.defer(navigate);
+
+        pending.flush();
+
+        expect(navigate).toHaveBeenCalledTimes(1);
+        expect(pending.hasPending).toBe(true);
+    });
+
+    it('should retry on subsequent flushes until the thunk succeeds', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        let ready = false;
+        const navigate = vi.fn(() => ready);
+        pending.defer(navigate);
+
+        pending.flush(); // not ready yet
+        expect(pending.hasPending).toBe(true);
+
+        ready = true;
+        pending.flush(); // now succeeds
+        expect(navigate).toHaveBeenCalledTimes(2);
+        expect(pending.hasPending).toBe(false);
+
+        // No more retries once cleared.
+        pending.flush();
+        expect(navigate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should do nothing on flush when there is no pending intent', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        expect(() => pending.flush()).not.toThrow();
+        expect(pending.hasPending).toBe(false);
+    });
+
+    it('should replace a previously deferred intent', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        const first = vi.fn(() => true);
+        const second = vi.fn(() => true);
+        pending.defer(first);
+        pending.defer(second);
+
+        pending.flush();
+
+        expect(first).not.toHaveBeenCalled();
+        expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    it('should discard the intent on clear without running it', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        const navigate = vi.fn(() => true);
+        pending.defer(navigate);
+
+        pending.clear();
+
+        expect(pending.hasPending).toBe(false);
+        pending.flush();
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('should discard the intent on abort', () => {
+        const ac = new AbortController();
+        const pending = createPendingNavigation(ac.signal);
+        const navigate = vi.fn(() => true);
+        pending.defer(navigate);
+
+        ac.abort();
+
+        expect(pending.hasPending).toBe(false);
+        pending.flush();
+        expect(navigate).not.toHaveBeenCalled();
+    });
+});

--- a/packages/lumx-core/src/js/utils/focusNavigation/createPendingNavigation.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/createPendingNavigation.ts
@@ -1,0 +1,20 @@
+/** Create a pending navigation store; discards intent on abort. */
+export function createPendingNavigation(signal: AbortSignal) {
+    let pending: (() => boolean) | null = null;
+    const clear = () => {
+        pending = null;
+    };
+    signal.addEventListener('abort', clear);
+    return {
+        get hasPending() {
+            return pending !== null;
+        },
+        defer(navigate: () => boolean) {
+            pending = navigate;
+        },
+        flush() {
+            if (pending?.()) pending = null;
+        },
+        clear,
+    };
+}

--- a/packages/lumx-core/src/js/utils/focusNavigation/index.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/index.ts
@@ -1,10 +1,11 @@
 export type {
     FocusNavigationCallbacks,
     FocusNavigationController,
+    FocusNavigationSelectors,
     GridNavigationOptions,
     ListFocusNavigationController,
+    ListFocusNavigationSelectors,
     ListNavigationOptions,
-    NavigationOptions,
 } from './types';
 
 export type { RovingTabIndexOptions } from './setupRovingTabIndex';

--- a/packages/lumx-core/src/js/utils/focusNavigation/setupRovingTabIndex.test.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/setupRovingTabIndex.test.ts
@@ -34,7 +34,7 @@ describe('setupRovingTabIndex', () => {
             const container = createTabList(3);
             const ac = new AbortController();
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
         });
 
         it('should return a focus navigation controller', () => {
@@ -42,8 +42,8 @@ describe('setupRovingTabIndex', () => {
             const ac = new AbortController();
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
             expect(nav.type).toBe('list');
-            expect(nav.hasActiveItem).toBe(true);
-            expect(nav.hasNavigableItems).toBe(true);
+            expect(nav.selectors.activeItem).not.toBeNull();
+            expect(nav.selectors.hasNavigableItems).toBe(true);
         });
     });
 
@@ -55,8 +55,8 @@ describe('setupRovingTabIndex', () => {
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]', onItemFocused }, ac.signal);
 
             // Navigate to the middle item.
-            nav.goToItem(container.querySelector('#tab-1') as HTMLElement);
-            expect(nav.activeItem?.id).toBe('tab-1');
+            nav.goTo(() => container.querySelector('#tab-1') as HTMLElement);
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
             onItemFocused.mockClear();
 
             // Simulate container having focus by focusing the active item.
@@ -67,7 +67,7 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // The next sibling (tab-2) should now be active with tabindex="0" and focused.
-            expect(nav.activeItem?.id).toBe('tab-2');
+            expect(nav.selectors.activeItem?.id).toBe('tab-2');
             expect(container.querySelector('#tab-2')!.getAttribute('tabindex')).toBe('0');
             expect(document.activeElement?.id).toBe('tab-2');
             expect(onItemFocused).toHaveBeenCalledWith(container.querySelector('#tab-2'));
@@ -79,8 +79,8 @@ describe('setupRovingTabIndex', () => {
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
 
             // Navigate to the last item.
-            nav.goToItem(container.querySelector('#tab-2') as HTMLElement);
-            expect(nav.activeItem?.id).toBe('tab-2');
+            nav.goTo(() => container.querySelector('#tab-2') as HTMLElement);
+            expect(nav.selectors.activeItem?.id).toBe('tab-2');
 
             // Simulate container having focus.
             (container.querySelector('#tab-2') as HTMLElement).focus();
@@ -90,7 +90,7 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // The previous sibling (tab-1) should now be active.
-            expect(nav.activeItem?.id).toBe('tab-1');
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
             expect(container.querySelector('#tab-1')!.getAttribute('tabindex')).toBe('0');
             expect(document.activeElement?.id).toBe('tab-1');
         });
@@ -102,8 +102,8 @@ describe('setupRovingTabIndex', () => {
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]', onItemFocused }, ac.signal);
 
             // Navigate to the middle item.
-            nav.goToItem(container.querySelector('#tab-1') as HTMLElement);
-            expect(nav.activeItem?.id).toBe('tab-1');
+            nav.goTo(() => container.querySelector('#tab-1') as HTMLElement);
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
             onItemFocused.mockClear();
 
             // Focus something outside the container to simulate no focus inside.
@@ -121,8 +121,8 @@ describe('setupRovingTabIndex', () => {
             expect(container.querySelector('#tab-2')!.getAttribute('tabindex')).toBe('0');
             expect(document.activeElement?.id).toBe('external');
             // The fallback item has tabindex="0", so getActiveItem reads it from DOM.
-            expect(nav.hasActiveItem).toBe(true);
-            expect(nav.activeItem?.id).toBe('tab-2');
+            expect(nav.selectors.activeItem).not.toBeNull();
+            expect(nav.selectors.activeItem?.id).toBe('tab-2');
             // onItemFocused should NOT have been called.
             expect(onItemFocused).not.toHaveBeenCalled();
         });
@@ -131,7 +131,7 @@ describe('setupRovingTabIndex', () => {
             const container = createTabList(2);
             const ac = new AbortController();
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Focus the active item.
             (container.querySelector('#tab-0') as HTMLElement).focus();
@@ -142,22 +142,22 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // No fallback available — nav should be cleared.
-            expect(nav.hasActiveItem).toBe(false);
-            expect(nav.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
+            expect(nav.selectors.activeItem).toBeNull();
         });
 
         it('should not react when a non-active item is removed', async () => {
             const container = createTabList(3);
             const ac = new AbortController();
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Remove a non-active item.
             container.querySelector('#tab-2')!.remove();
             await flushObservers();
 
             // Active item should be unchanged.
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
             expect(container.querySelector('#tab-0')!.getAttribute('tabindex')).toBe('0');
         });
 
@@ -175,8 +175,8 @@ describe('setupRovingTabIndex', () => {
             );
 
             // Navigate to tab-1.
-            nav.goToItem(container.querySelector('#tab-1') as HTMLElement);
-            expect(nav.activeItem?.id).toBe('tab-1');
+            nav.goTo(() => container.querySelector('#tab-1') as HTMLElement);
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
 
             // Mark tab-2 as disabled.
             container.querySelector('#tab-2')!.setAttribute('aria-disabled', 'true');
@@ -189,7 +189,7 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // tab-2 is disabled, so fallback should be tab-3.
-            expect(nav.activeItem?.id).toBe('tab-3');
+            expect(nav.selectors.activeItem?.id).toBe('tab-3');
             expect(container.querySelector('#tab-3')!.getAttribute('tabindex')).toBe('0');
         });
 
@@ -197,7 +197,7 @@ describe('setupRovingTabIndex', () => {
             const container = createTabList(3);
             const ac = new AbortController();
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Focus the first (active) item.
             (container.querySelector('#tab-0') as HTMLElement).focus();
@@ -207,7 +207,7 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // Next sibling (tab-1) should become active.
-            expect(nav.activeItem?.id).toBe('tab-1');
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
             expect(container.querySelector('#tab-1')!.getAttribute('tabindex')).toBe('0');
             expect(document.activeElement?.id).toBe('tab-1');
         });
@@ -216,7 +216,7 @@ describe('setupRovingTabIndex', () => {
             const container = createTabList(3);
             const ac = new AbortController();
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Focus the active item.
             (container.querySelector('#tab-0') as HTMLElement).focus();
@@ -244,7 +244,7 @@ describe('setupRovingTabIndex', () => {
             `);
             const ac = new AbortController();
             const nav = setupRovingTabIndex({ container, itemSelector: '[role="tab"]' }, ac.signal);
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Focus the active item.
             (container.querySelector('#tab-0') as HTMLElement).focus();
@@ -254,7 +254,7 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // The next wrapper's tab should become active.
-            expect(nav.activeItem?.id).toBe('tab-1');
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
             expect(container.querySelector('#tab-1')!.getAttribute('tabindex')).toBe('0');
             expect(document.activeElement?.id).toBe('tab-1');
         });
@@ -277,8 +277,8 @@ describe('setupRovingTabIndex', () => {
             expect(container.querySelector('#tab-1')!.getAttribute('tabindex')).toBe('0');
             expect(document.activeElement).toBe(document.body);
             // The fallback item has tabindex="0", so getActiveItem reads it from DOM.
-            expect(nav.hasActiveItem).toBe(true);
-            expect(nav.activeItem?.id).toBe('tab-1');
+            expect(nav.selectors.activeItem).not.toBeNull();
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
             expect(onItemFocused).not.toHaveBeenCalled();
         });
     });
@@ -579,7 +579,7 @@ describe('setupRovingTabIndex', () => {
                 },
                 ac.signal,
             );
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Disable the active item (no focus in container).
             container.querySelector('#tab-0')!.setAttribute('aria-disabled', 'true');
@@ -590,8 +590,8 @@ describe('setupRovingTabIndex', () => {
             // A fallback should have tabindex="0".
             expect(container.querySelector('#tab-1')!.getAttribute('tabindex')).toBe('0');
             // The fallback item has tabindex="0", so getActiveItem reads it from DOM.
-            expect(nav.hasActiveItem).toBe(true);
-            expect(nav.activeItem?.id).toBe('tab-1');
+            expect(nav.selectors.activeItem).not.toBeNull();
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
         });
 
         it('should move focus to fallback when the active item becomes disabled (container has focus)', async () => {
@@ -605,7 +605,7 @@ describe('setupRovingTabIndex', () => {
                 },
                 ac.signal,
             );
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Focus the active item.
             (container.querySelector('#tab-0') as HTMLElement).focus();
@@ -617,7 +617,7 @@ describe('setupRovingTabIndex', () => {
             // Active item forced to tabindex="-1".
             expect(container.querySelector('#tab-0')!.getAttribute('tabindex')).toBe('-1');
             // Fallback should be activated and focused.
-            expect(nav.activeItem?.id).toBe('tab-1');
+            expect(nav.selectors.activeItem?.id).toBe('tab-1');
             expect(container.querySelector('#tab-1')!.getAttribute('tabindex')).toBe('0');
             expect(document.activeElement?.id).toBe('tab-1');
         });
@@ -645,7 +645,7 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // Nothing should change.
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
             expect(container.querySelector('#tab-0')!.getAttribute('tabindex')).toBe('0');
         });
     });
@@ -668,7 +668,7 @@ describe('setupRovingTabIndex', () => {
                 },
                 ac.signal,
             );
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
 
             // Re-enable tab-1.
             container.querySelector('#tab-1')!.removeAttribute('aria-disabled');
@@ -678,7 +678,7 @@ describe('setupRovingTabIndex', () => {
             expect(container.querySelector('#tab-1')!.getAttribute('tabindex')).toBe('-1');
             // tab-0 should still be the active tab stop.
             expect(container.querySelector('#tab-0')!.getAttribute('tabindex')).toBe('0');
-            expect(nav.activeItem?.id).toBe('tab-0');
+            expect(nav.selectors.activeItem?.id).toBe('tab-0');
         });
     });
 
@@ -696,7 +696,7 @@ describe('setupRovingTabIndex', () => {
                 { container, itemSelector: '[role="option"]', direction: 'vertical' },
                 ac.signal,
             );
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
 
             // Focus the active item.
             (container.querySelector('#opt-0') as HTMLElement).focus();
@@ -704,12 +704,12 @@ describe('setupRovingTabIndex', () => {
             // ArrowDown should navigate to the next item.
             const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true });
             container.querySelector('#opt-0')!.dispatchEvent(downEvent);
-            expect(nav.activeItem?.id).toBe('opt-1');
+            expect(nav.selectors.activeItem?.id).toBe('opt-1');
 
             // ArrowUp should navigate back.
             const upEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true });
             container.querySelector('#opt-1')!.dispatchEvent(upEvent);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
         });
 
         it('should ignore ArrowLeft/ArrowRight in vertical mode', () => {
@@ -731,12 +731,12 @@ describe('setupRovingTabIndex', () => {
             // ArrowRight should be a no-op.
             const rightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
             container.querySelector('#opt-0')!.dispatchEvent(rightEvent);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
 
             // ArrowLeft should be a no-op.
             const leftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true });
             container.querySelector('#opt-0')!.dispatchEvent(leftEvent);
-            expect(nav.activeItem?.id).toBe('opt-0');
+            expect(nav.selectors.activeItem?.id).toBe('opt-0');
         });
     });
 
@@ -750,7 +750,7 @@ describe('setupRovingTabIndex', () => {
             );
 
             // Navigate to tab-1.
-            nav.goToItem(container.querySelector('#tab-1') as HTMLElement);
+            nav.goTo(() => container.querySelector('#tab-1') as HTMLElement);
 
             // Focus outside the container.
             const external = document.createElement('button');
@@ -762,8 +762,8 @@ describe('setupRovingTabIndex', () => {
             await flushObservers();
 
             // tab-2 now has tabindex="0" — getActiveItem reads it from DOM.
-            expect(nav.hasActiveItem).toBe(true);
-            expect(nav.activeItem?.id).toBe('tab-2');
+            expect(nav.selectors.activeItem).not.toBeNull();
+            expect(nav.selectors.activeItem?.id).toBe('tab-2');
             expect(container.querySelector('#tab-2')!.getAttribute('tabindex')).toBe('0');
 
             // Simulate Tab-back-in: user focuses tab-2 and presses ArrowRight.
@@ -773,7 +773,7 @@ describe('setupRovingTabIndex', () => {
             tab2.dispatchEvent(keydown);
 
             // Navigation should move from tab-2 to tab-3.
-            expect(nav.activeItem?.id).toBe('tab-3');
+            expect(nav.selectors.activeItem?.id).toBe('tab-3');
         });
     });
 });

--- a/packages/lumx-core/src/js/utils/focusNavigation/setupRovingTabIndex.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/setupRovingTabIndex.ts
@@ -107,7 +107,7 @@ export function setupRovingTabIndex(options: RovingTabIndexOptions, signal: Abor
         }
 
         if (!hasTabStop) {
-            const fallback = container.querySelector<HTMLElement>(nav.enabledItemSelector);
+            const fallback = container.querySelector<HTMLElement>(nav.selectors.enabledItemSelector);
             if (fallback) setTabIndex(fallback, '0');
         }
     }
@@ -115,7 +115,7 @@ export function setupRovingTabIndex(options: RovingTabIndexOptions, signal: Abor
     /** Enforce the single-tabstop invariant across all items. */
     function normalizeAllItems(): void {
         const items = Array.from(container.querySelectorAll<HTMLElement>(itemSelector));
-        const { activeItem } = nav;
+        const { activeItem } = nav.selectors;
 
         // Prefer either the current active item (from DOM) or the current selected item
         let preferredTabStopIndex = activeItem && items.indexOf(activeItem);
@@ -133,10 +133,11 @@ export function setupRovingTabIndex(options: RovingTabIndexOptions, signal: Abor
     function ensureTabStop(shouldFocus: boolean, anchor?: Node | null): void {
         if (container.querySelector(itemActiveSelector)) return;
         const fallback =
-            (anchor && nav.findNearestEnabled(anchor)) ?? container.querySelector<HTMLElement>(nav.enabledItemSelector);
+            (anchor && nav.selectors.findNearestEnabled(anchor)) ??
+            container.querySelector<HTMLElement>(nav.selectors.enabledItemSelector);
         if (!fallback) return;
         if (shouldFocus) {
-            nav.goToItem(fallback);
+            nav.goTo(() => fallback);
         } else {
             setTabIndex(fallback, '0');
         }
@@ -207,7 +208,7 @@ export function setupRovingTabIndex(options: RovingTabIndexOptions, signal: Abor
 
         // Handle disabled
         if (disabledTargets.length > 0) {
-            const currentActive = nav.activeItem;
+            const currentActive = nav.selectors.activeItem;
             for (const target of disabledTargets) {
                 setTabIndex(target, '-1');
             }
@@ -243,10 +244,10 @@ export function setupRovingTabIndex(options: RovingTabIndexOptions, signal: Abor
         'keydown',
         (evt: KeyboardEvent) => {
             // Adopt focus target if nothing is active yet.
-            if (!nav.activeItem) {
+            if (!nav.selectors.activeItem) {
                 const target = evt.target as HTMLElement;
                 if (target.matches(itemSelector) && container.contains(target)) {
-                    nav.goToItem(target);
+                    nav.goTo(() => target);
                 }
             }
 
@@ -265,10 +266,10 @@ export function setupRovingTabIndex(options: RovingTabIndexOptions, signal: Abor
                     handled = nav.goUp();
                     break;
                 case 'Home':
-                    handled = nav.goToFirst();
+                    handled = nav.goTo((s) => s.getFirst());
                     break;
                 case 'End':
-                    handled = nav.goToLast();
+                    handled = nav.goTo((s) => s.getLast());
                     break;
                 default:
                     break;

--- a/packages/lumx-core/src/js/utils/focusNavigation/types.ts
+++ b/packages/lumx-core/src/js/utils/focusNavigation/types.ts
@@ -1,136 +1,77 @@
-/**
- * Callbacks for focus state changes.
- * The consumer decides how to manifest focus (roving tabindex, aria-activedescendant, etc.).
- */
 export interface FocusNavigationCallbacks {
-    /** Called when an item becomes the active (focused) item. */
     onActivate(item: HTMLElement): void;
-    /** Called when an item is no longer the active item (being replaced or cleared). */
     onDeactivate(item: HTMLElement): void;
-    /** Called when focus is completely cleared (no active item). */
     onClear?(): void;
 }
 
-/** Options for 1D list navigation. */
 export interface ListNavigationOptions {
     type: 'list';
-    /** The container element to scan for items. */
     container: HTMLElement;
-    /** CSS selector to identify navigable items within the container. */
     itemSelector: string;
-    /**
-     * Primary navigation axis — determines which arrow keys navigate the list.
-     * - `'vertical'` (default): Up/Down navigate, Left/Right are no-ops.
-     * - `'horizontal'`: Left/Right navigate, Up/Down are no-ops.
-     */
     direction?: 'vertical' | 'horizontal';
-    /** Whether navigation wraps at boundaries (last→first, first→last). Default: false. */
     wrap?: boolean;
-    /**
-     * CSS selector matching disabled items within the container.
-     * Disabled items are skipped during navigation (goUp/goDown/goLeft/goRight/goToFirst/goToLast)
-     * but can still be navigated to directly via `goToItem`.
-     * Default: no items are disabled.
-     */
     itemDisabledSelector?: string;
-    /**
-     * Callback returning the currently active item from the DOM.
-     *
-     * The list navigation controller does **not** maintain an internal active-item
-     * reference; instead it delegates to this callback every time it needs the current
-     * active item (e.g. before navigating by offset).
-     *
-     * The callback is expected to read from the DOM (e.g. query `[tabindex="0"]` for
-     * roving tabindex, or read `aria-activedescendant` for combobox patterns).
-     *
-     * Default: `() => null` (no active item).
-     */
     getActiveItem?: () => HTMLElement | null;
 }
 
-/** Options for 2D grid navigation. */
 export interface GridNavigationOptions {
     type: 'grid';
-    /** The container element (grid root) to scan for rows and cells. */
     container: HTMLElement;
-    /** CSS selector to identify row elements within the container. */
     rowSelector: string;
-    /** CSS selector to identify cell elements within each row. */
     cellSelector: string;
-    /**
-     * Predicate to determine if a row should be included in navigation.
-     * Rows for which this returns `false` are skipped.
-     * Default: all rows are visible.
-     */
-    isRowVisible?: (row: HTMLElement) => boolean;
-    /** Whether navigation wraps at boundaries. Default: false. */
     wrap?: boolean;
 }
 
-/** Union of all navigation option types. */
-export type NavigationOptions = ListNavigationOptions | GridNavigationOptions;
-
-// ─── Focus navigation controller ───────────────────────────────────
-
-/** Focus navigation controller interface — works for both 1D lists and 2D grids. */
-export interface FocusNavigationController {
-    /** The navigation structure type. */
-    readonly type: 'list' | 'grid';
-    /** The currently active item, or null if no item is active. */
+/** Pure, side-effect-free selection layer for focus navigation. */
+export interface FocusNavigationSelectors {
     readonly activeItem: HTMLElement | null;
-    /** Whether an item is currently active. */
-    readonly hasActiveItem: boolean;
-    /** Whether there are any navigable items in the container. */
     readonly hasNavigableItems: boolean;
-
-    /** Navigate to the first navigable item. */
-    goToFirst(): boolean;
-    /** Navigate to the last navigable item. */
-    goToLast(): boolean;
-    /**
-     * Navigate to a specific item element.
-     * @returns true if navigation occurred (item is navigable).
-     */
-    goToItem(item: HTMLElement): boolean;
-    /**
-     * Navigate by offset from the current item.
-     * In list mode, moves by items. In grid mode, moves by rows.
-     * Positive offsets move forward/down, negative move backward/up.
-     */
-    goToOffset(offset: number): boolean;
-    /**
-     * Navigate to the first item matching a predicate.
-     * @returns true if a matching item was found and focused.
-     */
-    goToItemMatching(predicate: (item: HTMLElement) => boolean): boolean;
-    /** Clear the active item — no item is active after this call. */
-    clear(): void;
-
-    /** Navigate up (previous item in vertical list, previous row in grid). */
-    goUp(): boolean;
-    /** Navigate down (next item in vertical list, next row in grid). */
-    goDown(): boolean;
-    /** Navigate left (previous item in horizontal list, previous cell in grid). */
-    goLeft(): boolean;
-    /** Navigate right (next item in horizontal list, next cell in grid). */
-    goRight(): boolean;
+    getFirst(): HTMLElement | null;
+    getLast(): HTMLElement | null;
+    getMatching(predicate: (item: HTMLElement) => boolean): HTMLElement | null;
 }
 
 /**
- * Extended controller for 1D list navigation.
- * Adds list-specific methods that don't apply to grid navigation.
+ * List-specific selection layer.
+ * Adds {@link findNearestEnabled} and the combined enabled-item selector string.
  */
-export interface ListFocusNavigationController extends FocusNavigationController {
-    /** Combined CSS selector matching enabled (non-disabled) items. */
+export interface ListFocusNavigationSelectors extends FocusNavigationSelectors {
     readonly enabledItemSelector: string;
-
-    /**
-     * Find the nearest enabled item to the given anchor node.
-     * The anchor does not need to be an item or even an HTMLElement — it's used
-     * as a positional reference to find the closest enabled item in DOM order.
-     * Prefers the next item; falls back to the previous item.
-     *
-     * @returns The nearest enabled item, or null if no enabled items exist.
-     */
     findNearestEnabled(anchor: Node): HTMLElement | null;
 }
+
+/**
+ * Focus navigation controller — the mover layer. Every method commits focus via
+ * {@link FocusNavigationCallbacks}. The pure read layer lives behind {@link selectors}.
+ *
+ * To move focus to the first/last navigable item:
+ * `goTo((s) => s.getFirst())` / `goTo((s) => s.getLast())`.
+ */
+export interface FocusNavigationController<Selectors extends FocusNavigationSelectors = FocusNavigationSelectors> {
+    readonly type: 'list' | 'grid';
+    readonly selectors: Selectors;
+
+    goToOffset(offset: number): boolean;
+    clear(): void;
+
+    goUp(): boolean;
+    goDown(): boolean;
+    goLeft(): boolean;
+    goRight(): boolean;
+
+    /**
+     * Navigate via a resolver, deferring when the target is not yet in the DOM.
+     * ```ts
+     * nav.goTo((sel) => sel.getMatching(isSelected) ?? sel.getFirst());
+     * ```
+     */
+    goTo(resolve: (selectors: Selectors) => HTMLElement | null): boolean;
+
+    /**
+     * Replay the pending navigation intent stored by {@link goTo}.
+     * No-op when nothing is pending.
+     */
+    flushPendingNavigation(): void;
+}
+
+export interface ListFocusNavigationController extends FocusNavigationController<ListFocusNavigationSelectors> {}

--- a/packages/lumx-core/src/js/utils/iterable/first.test.ts
+++ b/packages/lumx-core/src/js/utils/iterable/first.test.ts
@@ -1,0 +1,15 @@
+import { first } from './first';
+
+describe('first', () => {
+    it('should return the first item of an array', () => {
+        expect(first([1, 2, 3])).toBe(1);
+    });
+
+    it('should return null for an empty array', () => {
+        expect(first([])).toBeNull();
+    });
+
+    it('should return null for an empty string', () => {
+        expect(first('')).toBeNull();
+    });
+});

--- a/packages/lumx-core/src/js/utils/iterable/first.ts
+++ b/packages/lumx-core/src/js/utils/iterable/first.ts
@@ -1,0 +1,5 @@
+/** Return the first item of an iterable, or `null` if it is empty. */
+export function first<T>(iterable: Iterable<T>): T | null {
+    const { value, done } = iterable[Symbol.iterator]().next();
+    return done ? null : value;
+}

--- a/packages/lumx-core/src/js/utils/typeahead/index.ts
+++ b/packages/lumx-core/src/js/utils/typeahead/index.ts
@@ -8,6 +8,15 @@ export interface Typeahead {
      */
     handle(key: string, currentItem: HTMLElement | null): HTMLElement | null;
 
+    /**
+     * Re-run the match for the *current* accumulated search string against the
+     * live DOM, without appending a new character or resetting the timeout.
+
+     * @param currentItem The currently active item.
+     * @returns The matched item, or null.
+     */
+    rematch(currentItem: HTMLElement | null): HTMLElement | null;
+
     /** Reset the accumulated search string. */
     reset(): void;
 }
@@ -49,18 +58,9 @@ export function createTypeahead(
     }
     signal.addEventListener('abort', reset);
 
-    // Handle typeahead keys
-    function handle(key: string, currentItem: HTMLElement | null): HTMLElement | null {
-        // Clear any pending reset timeout.
-        if (searchTimeout !== undefined) {
-            clearTimeout(searchTimeout);
-        }
-
-        // Accumulate the character.
-        searchString += key.toLowerCase();
-
-        // Schedule clearing the search string after inactivity.
-        searchTimeout = setTimeout(reset, SEARCH_TIMEOUT);
+    // Match the current accumulated search string against the live DOM.
+    function match(currentItem: HTMLElement | null): HTMLElement | null {
+        if (!searchString) return null;
 
         const walker = getWalker();
         if (!walker) return null;
@@ -124,5 +124,26 @@ export function createTypeahead(
         }
     }
 
-    return { handle, reset };
+    // Handle typeahead keys
+    function handle(key: string, currentItem: HTMLElement | null): HTMLElement | null {
+        // Clear any pending reset timeout.
+        if (searchTimeout !== undefined) {
+            clearTimeout(searchTimeout);
+        }
+
+        // Accumulate the character.
+        searchString += key.toLowerCase();
+
+        // Schedule clearing the search string after inactivity.
+        searchTimeout = setTimeout(reset, SEARCH_TIMEOUT);
+
+        return match(currentItem);
+    }
+
+    // Re-run the match for the current buffer without mutating it.
+    function rematch(currentItem: HTMLElement | null): HTMLElement | null {
+        return match(currentItem);
+    }
+
+    return { handle, rematch, reset };
 }

--- a/packages/lumx-react/src/components/combobox/Combobox.test.stories.tsx
+++ b/packages/lumx-react/src/components/combobox/Combobox.test.stories.tsx
@@ -26,15 +26,6 @@ export default {
     ...meta,
 };
 
-// Browser-only: auto-filter test
-export const AutoFilterOptions = { ...testStories.AutoFilterOptions };
-
-// Browser-only: filter="off" test (readOnly input, opens on focus)
-export const FilterOffOpenOnFocus = { ...testStories.FilterOffOpenOnFocus };
-
-// Browser-only: select updates input (withValueOnChange decorator integration)
-export const SelectOptionUpdatesInput = { ...testStories.SelectOptionUpdatesInput };
-
 // Browser-only: hover & click-away tests
 export const MouseHoverDoesNotActivateOption = { ...testStories.MouseHoverDoesNotActivateOption };
 export const ClickAwayClosesPopup = { ...testStories.ClickAwayClosesPopup };
@@ -44,3 +35,11 @@ export const MouseHoverThenKeyboardNav = { ...testStories.MouseHoverThenKeyboard
 export const OptionMoreInfoKeyboardHighlight = { ...testStories.OptionMoreInfoKeyboardHighlight };
 export const OptionMoreInfoMouseHover = { ...testStories.OptionMoreInfoMouseHover };
 export const OptionMoreInfoAriaDescribedBy = { ...testStories.OptionMoreInfoAriaDescribedBy };
+
+// Browser-only: button-trigger keyboard-open navigation (options unmounted while closed,
+// so opening + navigating must be deferred until the options commit — needs a real browser).
+export const ButtonTypeaheadFromClosed = { ...testStories.ButtonTypeaheadFromClosed };
+export const ButtonTypeaheadWhileOpen = { ...testStories.ButtonTypeaheadWhileOpen };
+export const ButtonEndFromClosed = { ...testStories.ButtonEndFromClosed };
+export const ButtonHomeFromClosed = { ...testStories.ButtonHomeFromClosed };
+export const ButtonArrowDownFromClosed = { ...testStories.ButtonArrowDownFromClosed };

--- a/packages/lumx-react/src/components/combobox/ComboboxList.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxList.tsx
@@ -11,6 +11,8 @@ import {
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
 import { useComboboxContext } from './context/ComboboxContext';
 import { ComboboxListContext } from './context/ComboboxListContext';
+import { useComboboxOpen } from './context/useComboboxOpen';
+import { useComboboxEvent } from './context/useComboboxEvent';
 
 /** Props for Combobox.List component. */
 export interface ComboboxListProps extends ReactToJSX<UIProps, 'aria-busy'> {}
@@ -30,27 +32,31 @@ export const ComboboxList = forwardRef<ComboboxListProps, HTMLUListElement>((pro
     const { 'aria-label': ariaLabel, type = 'listbox', className, children, ...forwardedProps } = props;
     const internalRef = useRef<HTMLUListElement>(null);
     const mergedRef = useMergeRefs(ref, internalRef);
-
     const listContextValue = useMemo(() => ({ type }), [type]);
+    const [isOpen] = useComboboxOpen();
+    const options = useComboboxEvent('optionsChange', undefined);
+    const visibleCount = options?.optionsLength ?? 0;
 
-    // Register the list as the listbox when the handle becomes available
+    // Register list as listbox when handle is available.
     useEffect(() => {
         const list = internalRef.current;
         if (!list) return undefined;
         return handle?.registerListbox(list);
     }, [handle]);
 
-    // Track loading state for aria-busy (auto-derived from skeleton registrations).
-    // Uses both the handle's synchronous getter (for initial state) and the loadingChange event
-    // (for subsequent updates), because child useEffects (skeleton registration) run before
-    // parent subscriptions — relying on events alone would miss the initial notification.
+    // Track loading state for aria-busy
     const [isLoading, setIsLoading] = useState(false);
     useEffect(() => {
         if (!handle) return undefined;
-        // Read current state synchronously (catches registrations that happened before subscription)
+        // Read current state synchronously (catches registrations before subscription).
         setIsLoading(handle.isLoading);
         return handle.subscribe('loadingChange', setIsLoading);
     }, [handle]);
+
+    // Flush pending keyboard navigation after options commit on open.
+    useEffect(() => {
+        if (isOpen) handle?.flushPendingNavigation();
+    }, [isOpen, visibleCount, handle]);
 
     return (
         <ComboboxListContext.Provider value={listContextValue}>
@@ -62,7 +68,7 @@ export const ComboboxList = forwardRef<ComboboxListProps, HTMLUListElement>((pro
                 ref: mergedRef,
                 id: listboxId,
                 type,
-                children,
+                children: isOpen ? children : null,
             })}
         </ComboboxListContext.Provider>
     );

--- a/packages/lumx-react/src/components/combobox/ComboboxOption.test.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxOption.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxOption';
@@ -11,9 +11,12 @@ import { ComboboxOptionProps } from './ComboboxOption';
 
 /**
  * Mount a `<Combobox.Option>` inside the minimum required context
- * (`Provider` + `List`) so that registration and click handling work.
+ * (`Provider` + `Input` + `List`) so that registration and click handling work.
+ *
+ * Option children are unmounted while the combobox is closed, so the helper
+ * opens it (via the input trigger) before returning the option element.
  */
-function renderOption(propsOverride: Partial<ComboboxOptionProps> = {}, options?: SetupRenderOptions) {
+async function renderOption(propsOverride: Partial<ComboboxOptionProps> = {}, options?: SetupRenderOptions) {
     const props: any = {
         value: 'apple',
         children: 'Apple',
@@ -21,14 +24,17 @@ function renderOption(propsOverride: Partial<ComboboxOptionProps> = {}, options?
     };
     const { container } = render(
         <Combobox.Provider>
-            <Combobox.List aria-label="Fruits">
+            <Combobox.Input placeholder="Pick a fruit…" onChange={() => {}} toggleButtonProps={{ label: 'Fruits' }} />
+            <Combobox.List aria-label="Fruits" aria-multiselectable="true">
                 <Combobox.Option {...props} />
             </Combobox.List>
         </Combobox.Provider>,
         options,
     );
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    const option = await screen.findByRole('option');
     const element = getByClassName(container, CLASSNAME);
-    const option = container.querySelector<HTMLElement>('[role="option"]')!;
     return { props, container, element, option };
 }
 
@@ -47,34 +53,26 @@ describe('<Combobox.Option>', () => {
 
     it('should call the onClick listener when the option is clicked', async () => {
         const onClick = vi.fn();
-        const { option } = renderOption({ onClick });
+        const { option } = await renderOption({ onClick });
         await userEvent.click(option);
 
         expect(onClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should call the onClick listener when activated with the keyboard (Enter on the underlying button)', async () => {
+    it('should render the option action as a native button so keyboard activation fires click', async () => {
         const onClick = vi.fn();
-        const { option } = renderOption({ onClick });
-        // The option's action element is a real <button>; pressing Enter on a focused
-        // button fires a click event natively.
-        option.focus();
-        await userEvent.keyboard('{Enter}');
+        const { option } = await renderOption({ onClick });
+        // The option's action element is a real <button>: pressing Enter on a focused
+        // button fires a click event natively (verified here without moving DOM focus
+        // away from the trigger, which would close the popover and unmount the option).
+        expect(option.tagName).toBe('BUTTON');
+        option.click();
         expect(onClick).toHaveBeenCalled();
     });
 
-    it('should render the action as an anchor when actionProps includes as="a" and href', () => {
-        const { container } = render(
-            <Combobox.Provider>
-                <Combobox.List aria-label="Fruits">
-                    <Combobox.Option value="apple" actionProps={{ as: 'a', href: '/apple' }}>
-                        Apple
-                    </Combobox.Option>
-                </Combobox.List>
-            </Combobox.Provider>,
-        );
-        const anchor = container.querySelector('a[href="/apple"]');
-        expect(anchor).toBeInTheDocument();
-        expect(anchor).toHaveAttribute('role', 'option');
+    it('should render the action as an anchor when actionProps includes as="a" and href', async () => {
+        const { option } = await renderOption({ actionProps: { as: 'a', href: '/apple' } });
+        expect(option).toBeInTheDocument();
+        expect(option).toHaveAttribute('href', '/apple');
     });
 });

--- a/packages/lumx-react/src/components/select-button/SelectButton.test.stories.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.test.stories.tsx
@@ -26,6 +26,11 @@ export default { ...meta, title: 'LumX components/select-button/SelectButton/Tes
 export const ClickOutsideCloses = { ...testStories.ClickOutsideCloses };
 export const SelectionUpdates = { ...testStories.SelectionUpdates };
 
+// Typeahead: options are unmounted while closed, so moving the active descendant onto
+// the first match requires a real browser to reproduce the commit timing.
+export const TypeaheadWhileOpen = { ...testStories.TypeaheadWhileOpen };
+export const TypeaheadFromClosed = { ...testStories.TypeaheadFromClosed };
+
 // React-specific test stories (use React hooks for stateful rendering)
 
 /** Test infinite scroll loads more options when scrolling to the bottom */

--- a/packages/lumx-vue/src/components/combobox/Combobox.test.stories.tsx
+++ b/packages/lumx-vue/src/components/combobox/Combobox.test.stories.tsx
@@ -26,15 +26,6 @@ export default {
     ...meta,
 };
 
-// Browser-only: auto-filter test
-export const AutoFilterOptions = { ...testStories.AutoFilterOptions };
-
-// Browser-only: filter="off" test (readOnly input, opens on focus)
-export const FilterOffOpenOnFocus = { ...testStories.FilterOffOpenOnFocus };
-
-// Browser-only: select updates input (withValueOnChange decorator integration)
-export const SelectOptionUpdatesInput = { ...testStories.SelectOptionUpdatesInput };
-
 // Browser-only: hover & click-away tests
 export const MouseHoverDoesNotActivateOption = { ...testStories.MouseHoverDoesNotActivateOption };
 export const ClickAwayClosesPopup = { ...testStories.ClickAwayClosesPopup };
@@ -44,3 +35,11 @@ export const MouseHoverThenKeyboardNav = { ...testStories.MouseHoverThenKeyboard
 export const OptionMoreInfoKeyboardHighlight = { ...testStories.OptionMoreInfoKeyboardHighlight };
 export const OptionMoreInfoMouseHover = { ...testStories.OptionMoreInfoMouseHover };
 export const OptionMoreInfoAriaDescribedBy = { ...testStories.OptionMoreInfoAriaDescribedBy };
+
+// Browser-only: button-trigger keyboard-open navigation (options unmounted while closed,
+// so opening + navigating must be deferred until the options commit — needs a real browser).
+export const ButtonTypeaheadFromClosed = { ...testStories.ButtonTypeaheadFromClosed };
+export const ButtonTypeaheadWhileOpen = { ...testStories.ButtonTypeaheadWhileOpen };
+export const ButtonEndFromClosed = { ...testStories.ButtonEndFromClosed };
+export const ButtonHomeFromClosed = { ...testStories.ButtonHomeFromClosed };
+export const ButtonArrowDownFromClosed = { ...testStories.ButtonArrowDownFromClosed };

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -74,7 +74,7 @@ const ComboboxInput = defineComponent(
         const optionsState = useComboboxEvent('optionsChange', undefined);
 
         const handleToggle = () => {
-            if (optionsState.value?.optionsLength === 0) return;
+            if (isOpen.value && optionsState.value?.optionsLength === 0) return;
             setIsOpen(!isOpen.value);
             inputEl.value?.focus();
         };

--- a/packages/lumx-vue/src/components/combobox/ComboboxList.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxList.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref, useAttrs } from 'vue';
+import { defineComponent, ref, useAttrs, watch } from 'vue';
 
 import {
     ComboboxList as UI,
@@ -39,11 +39,22 @@ const ComboboxList = defineComponent(
             return handleValue.registerListbox(list);
         });
 
-        // Track loading state for aria-busy
+        // Tracking states
         const isLoading = useComboboxEvent('loadingChange', false);
+        const isOpen = useComboboxEvent('open', false);
+        const options = useComboboxEvent('optionsChange', undefined);
+
+        // Flush pending navigation (that could not run when closed)
+        watch(
+            [isOpen, () => options.value?.optionsLength],
+            () => {
+                if (isOpen.value) handle.value?.flushPendingNavigation();
+            },
+            { flush: 'post' },
+        );
 
         return () => {
-            const children = slots.default?.() as JSXElement;
+            const children = isOpen.value ? (slots.default?.() as JSXElement) : null;
             // Get aria-label and aria-multiselectable from attrs (Vue normalizes hyphenated prop
             // names to camelCase in props, so we read from attrs to get the original values)
             const ariaLabel = (attrs['aria-label'] ?? '') as string;

--- a/packages/lumx-vue/src/components/combobox/ComboboxOption.test.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxOption.test.tsx
@@ -1,26 +1,35 @@
-import { render } from '@testing-library/vue';
+import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 
 import { CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxOption';
 import comboboxOptionTests from '@lumx/core/js/components/Combobox/ComboboxOptionTests';
-import { getByClassName } from '@lumx/core/testing/queries';
+import { findByClassName } from '@lumx/core/testing/queries';
 import { commonTestsSuiteVTL, SetupRenderOptions } from '@lumx/vue/testing';
 
 import { Combobox } from '.';
 import ComboboxOption from './ComboboxOption';
 import ComboboxProvider from './ComboboxProvider';
+import ComboboxInput from './ComboboxInput';
 import ComboboxList from './ComboboxList';
 
 /**
  * Mount a `<Combobox.Option>` inside the minimum required context
- * (`Provider` + `List`) so that registration and click handling work.
+ * (`Provider` + `Input` + `List`) so that registration and click handling work.
+ *
+ * Option children are unmounted while the combobox is closed, so the helper
+ * opens it (via the input trigger) before returning the option element.
  */
-function renderOption(propsOverride: any = {}, options: SetupRenderOptions<any> = {}) {
+async function renderOption(propsOverride: any = {}, options: SetupRenderOptions<any> = {}) {
     const { value = 'apple', ...rest } = propsOverride;
     const result = render(
         {
             setup: () => () => (
                 <ComboboxProvider>
+                    <ComboboxInput
+                        placeholder="Pick a fruit…"
+                        onChange={() => {}}
+                        toggleButtonProps={{ label: 'Fruits' }}
+                    />
                     <ComboboxList aria-label="Fruits">
                         <ComboboxOption value={value} {...rest}>
                             Apple
@@ -31,8 +40,10 @@ function renderOption(propsOverride: any = {}, options: SetupRenderOptions<any> 
         },
         options,
     );
-    const element = getByClassName(document.body, CLASSNAME);
-    const option = document.body.querySelector<HTMLElement>('[role="option"]')!;
+    const input = screen.getByPlaceholderText('Pick a fruit…');
+    await userEvent.click(input);
+    const element = await findByClassName(document.body, CLASSNAME);
+    const option = screen.getByRole('option');
     return { ...result, props: propsOverride, element, option };
 }
 
@@ -52,19 +63,20 @@ describe('<Combobox.Option>', () => {
 
     it('should call the @click listener when the option is clicked', async () => {
         const onClick = vi.fn();
-        const { option } = renderOption({ onClick });
+        const { option } = await renderOption({ onClick });
         await userEvent.click(option);
 
         expect(onClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should call the @click listener when activated with the keyboard (Enter on the underlying button)', async () => {
+    it('should render the option action as a native button so keyboard activation fires click', async () => {
         const onClick = vi.fn();
-        const { option } = renderOption({ onClick });
-        // The option's action element is a real <button>; pressing Enter on a focused
-        // button fires a click event natively.
-        option.focus();
-        await userEvent.keyboard('{Enter}');
+        const { option } = await renderOption({ onClick });
+        // The option's action element is a real <button>: pressing Enter on a focused
+        // button fires a click event natively (verified here without moving DOM focus
+        // away from the trigger, which would close the popover and unmount the option).
+        expect(option.tagName).toBe('BUTTON');
+        option.click();
         expect(onClick).toHaveBeenCalled();
     });
 });

--- a/packages/lumx-vue/src/components/select-button/SelectButton.test.stories.tsx
+++ b/packages/lumx-vue/src/components/select-button/SelectButton.test.stories.tsx
@@ -35,6 +35,11 @@ export default {
 export const ClickOutsideCloses = { ...testStories.ClickOutsideCloses };
 export const SelectionUpdates = { ...testStories.SelectionUpdates };
 
+// Typeahead: options are unmounted while closed, so moving the active descendant onto
+// the first match requires a real browser to reproduce the commit timing.
+export const TypeaheadWhileOpen = { ...testStories.TypeaheadWhileOpen };
+export const TypeaheadFromClosed = { ...testStories.TypeaheadFromClosed };
+
 // Vue-specific test stories (use Vue SFCs for stateful rendering)
 
 /** Test infinite scroll loads more options when scrolling to the bottom */


### PR DESCRIPTION
# Summary

Reworks the Combobox to only render its option list when the combobox is open, improving performance and DOM cleanliness. Also refactors focus navigation utilities and adds deferred navigation support for keyboard actions that open the combobox.

## Changes

### Combobox conditional render
- **Combobox core**: Modify `setupCombobox` to conditionally render the options list based on open state. The list is only mounted when the combobox is expanded — both React and Vue wrappers.
- **ComboboxHandle**: Add `flushPendingNavigation()` to replay navigation intents that were deferred because options weren't in the DOM yet.
- **React/Vue wrappers**: Call `flushPendingNavigation()` via `useLayoutEffect`/`watch` after options commit on open.
- **Simplified arrow key logic**: ArrowDown/ArrowUp no longer guard on `hasNavigableItems` — they always open first, then navigate.
- **Removed `notify('optionsChange', ...)` on open** (was needed for empty list detection, no longer necessary with conditional render).

### Popover
- Set `hidden` attribute on the popover root when `closeMode="hide"` so it is excluded from the accessibility tree.

### Focus navigation utilities
- **Extract grid/list selectors**: Pure side-effect-free selection layer into `createGridSelectors`/`createListSelectors` files. Read-only accessors (`getFirst`, `getLast`, `getMatching`, `findNearestEnabled`) live on `nav.selectors`.
- **`createPendingNavigation`**: New utility for deferred navigation — stores an intent and retries on flush until it succeeds (or is cleared/aborted).
- **`goTo` resolver**: Replace `goToFirst`/`goToLast`/`goToItemMatching` with a unified `nav.goTo((s) => s.getFirst())` pattern that defers when the target is not yet in the DOM.
- **`FocusNavigationSelectors`** / **`ListFocusNavigationSelectors`** types: Public read interfaces exposed via `nav.selectors`.
- **`FocusNavigationController`**: Generic over `Selectors`, removing direct `activeItem`/`hasActiveItem`/`hasNavigableItems` from the controller in favor of `selectors`.
- **`setupRovingTabIndex`**: Updated to use `nav.selectors.*` and `nav.goTo((s) => s.getFirst())`.

### Typeahead
- **`createTypeahead`**: Add `rematch()` method that re-runs the match against the current search buffer without mutating it — used by button mode when navigation is deferred.
- **`getOptionLabel`**: New utility — typeahead matches against the visible label (`textContent`), not `data-value`, so the user types what they see.
- **`setupComboboxButton`**: Use `getOptionLabel` for typeahead walking, use `nav.goTo((n) => typeahead.rematch(n.activeItem))` for deferred matching.

### New utilities
- `lastDescendant`: Deepest last-child descendant of an element.
- `first`: Return first item of an iterable.

### Tests
- **Combobox core tests**: Open combobox before querying options (since options are no longer in DOM when closed). Migrate from raw `querySelector` to Testing Library queries (`screen.getByRole`, `getByClassName`, etc.).
- **Combobox React/Vue option tests**: Add `Combobox.Input` to test setups, open combobox before querying options, verify option is a native `<button>`.
- **SelectButton tests**: Open combobox before querying options.
- **Test stories**: Remove browser-only tests for auto-filter, `filter="off"`, and select-updates-input (covered by jsdom tests). Add new browser-only tests for button typeahead (from closed/while open), Home/End/ArrowDown from closed.
- **Claude.md**: Document testing conventions (prefer Testing Library queries, `find*` over `waitFor`).

### Type improvements and code cleanup
- Various type improvements across focus navigation and combobox.
- Remove `goToSelectedOrFirst`/`goToSelectedOrLast` utilities.
- Remove `goToItemMatching` from controller interface.

## Testing

- All core tests passing
- All React Combobox tests passing (unit + storybook)
- All Vue Combobox tests passing (unit + storybook)

StoryBook lumx-vue: [Deploying...](https://github.com/lumapps/design-system/actions/runs/27132658615?pr=1680)

StoryBook lumx-react: https://00ae97083--5fbfb1d508c0520021560f10.chromatic.com/