### PR TITLE
chore(publish): remove deprecated publishConfig.directory

### DIFF
--- a/packages/lumx-core/package.json
+++ b/packages/lumx-core/package.json
@@ -53,9 +53,6 @@
         "./css/*": "./css/*",
         "./scss/*": "./scss/*"
     },
-    "publishConfig": {
-        "directory": "dist"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"

--- a/packages/lumx-core/rollup.config.mjs
+++ b/packages/lumx-core/rollup.config.mjs
@@ -16,7 +16,7 @@ const importUrl = new URL(import.meta.url);
 const __dirname = path.dirname(importUrl.pathname);
 
 const ROOT_PATH = path.resolve(__dirname, '..', '..');
-const DIST_PATH = path.resolve(__dirname, pkg.publishConfig.directory);
+const DIST_PATH = path.resolve(__dirname, 'dist');
 const SRC_PATH = path.resolve(__dirname, 'src');
 
 // Move internal modules to hash named files

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -26,9 +26,6 @@
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"
     },
-    "publishConfig": {
-        "directory": "dist"
-    },
     "scripts": {
         "generate:icons": "./override/generate/run-all.cjs",
         "test:css-font": "./override/test-css-font/run.cjs",

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -82,9 +82,6 @@
             "default": "./utils/index.js"
         }
     },
-    "publishConfig": {
-        "directory": "dist"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"

--- a/packages/lumx-react/rollup.config.mjs
+++ b/packages/lumx-react/rollup.config.mjs
@@ -18,7 +18,7 @@ const importUrl = new URL(import.meta.url);
 const __dirname = path.dirname(importUrl.pathname);
 
 const ROOT_PATH = path.resolve(__dirname, '..', '..');
-const DIST_PATH = path.resolve(__dirname, pkg.publishConfig.directory);
+const DIST_PATH = path.resolve(__dirname, 'dist');
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
 /**

--- a/packages/lumx-vue/package.json
+++ b/packages/lumx-vue/package.json
@@ -1,9 +1,6 @@
 {
     "license": "MIT",
     "name": "@lumx/vue",
-    "publishConfig": {
-        "directory": "dist"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"

--- a/packages/lumx-vue/vite.config.mts
+++ b/packages/lumx-vue/vite.config.mts
@@ -17,7 +17,7 @@ import fixEsmImports from 'rollup-plugin-lumx-fix-esm-imports';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT_PATH = path.resolve(__dirname, '../..');
-const DIST_PATH = path.resolve(__dirname, pkg.publishConfig.directory);
+const DIST_PATH = path.resolve(__dirname, 'dist');
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
 /** Set of lumx core exports */


### PR DESCRIPTION

# General summary

npm v11+ warns about unknown publishConfig keys and will error in the next major version. The directory config was redundant since the CI publish workflow already cds into /dist before running npm publish. Build configs updated to hardcode 'dist' instead.

To test that we'll publish an alpha version from this branch



StoryBook lumx-react: https://fc8eb6eb7--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://fc8eb6eb7--697a023f84e832e23544fb3c.chromatic.com/