### PR TITLE
chore(release): skip already-published packages on NPM publish

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -190,10 +190,8 @@ jobs:
             - name: '[prerelease] Detect release type from CHANGELOG'
               id: detect-type
               if: >-
-                  !needs.check_trigger.outputs.version && (
-                      (github.event_name == 'workflow_dispatch' && inputs.prereleaseName) ||
-                      needs.check_trigger.outputs.affected == 'true'
-                  )
+                  !needs.check_trigger.outputs.version &&
+                  needs.check_trigger.outputs.affected == 'true'
               uses: ./.github/actions/detect-release-type
 
             - name: '[prerelease] Increment package versions'

--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -214,10 +214,22 @@ jobs:
             - name: 'Publish version to NPM'
               env:
                   DIST_TAG: ${{ steps.version.outputs.distTag || 'latest' }}
+              # Idempotent publish: skip packages already published at the target version on the
+              # registry. This allows safely retrying a release that partially published (e.g. when
+              # one package failed after others succeeded) without aborting on "cannot publish over
+              # the previously published versions".
               run: |
                   for package in $(echo packages/lumx-*);
                   do
-                      (echo "Publishing $package"; cd $package/dist; npm publish --tag $DIST_TAG)
+                      dist="$package/dist"
+                      name=$(node -p "require('./$dist/package.json').name")
+                      version=$(node -p "require('./$dist/package.json').version")
+                      if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
+                          echo "Skipping $name@$version (already published)"
+                          continue
+                      fi
+                      echo "Publishing $name@$version"
+                      (cd "$dist" && npm publish --tag "$DIST_TAG")
                   done
 
     git_tag:

--- a/packages/lumx-core/package.json
+++ b/packages/lumx-core/package.json
@@ -53,9 +53,6 @@
         "./css/*": "./css/*",
         "./scss/*": "./scss/*"
     },
-    "publishConfig": {
-        "directory": "dist"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"

--- a/packages/lumx-core/rollup.config.mjs
+++ b/packages/lumx-core/rollup.config.mjs
@@ -16,7 +16,7 @@ const importUrl = new URL(import.meta.url);
 const __dirname = path.dirname(importUrl.pathname);
 
 const ROOT_PATH = path.resolve(__dirname, '..', '..');
-const DIST_PATH = path.resolve(__dirname, pkg.publishConfig.directory);
+const DIST_PATH = path.resolve(__dirname, 'dist');
 const SRC_PATH = path.resolve(__dirname, 'src');
 
 // Move internal modules to hash named files

--- a/packages/lumx-icons/package.json
+++ b/packages/lumx-icons/package.json
@@ -26,9 +26,6 @@
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"
     },
-    "publishConfig": {
-        "directory": "dist"
-    },
     "scripts": {
         "generate:icons": "./override/generate/run-all.cjs",
         "test:css-font": "./override/test-css-font/run.cjs",

--- a/packages/lumx-react/package.json
+++ b/packages/lumx-react/package.json
@@ -82,9 +82,6 @@
             "default": "./utils/index.js"
         }
     },
-    "publishConfig": {
-        "directory": "dist"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"

--- a/packages/lumx-react/rollup.config.mjs
+++ b/packages/lumx-react/rollup.config.mjs
@@ -18,7 +18,7 @@ const importUrl = new URL(import.meta.url);
 const __dirname = path.dirname(importUrl.pathname);
 
 const ROOT_PATH = path.resolve(__dirname, '..', '..');
-const DIST_PATH = path.resolve(__dirname, pkg.publishConfig.directory);
+const DIST_PATH = path.resolve(__dirname, 'dist');
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
 /**

--- a/packages/lumx-vue/package.json
+++ b/packages/lumx-vue/package.json
@@ -1,9 +1,6 @@
 {
     "license": "MIT",
     "name": "@lumx/vue",
-    "publishConfig": {
-        "directory": "dist"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/lumapps/design-system.git"

--- a/packages/lumx-vue/vite.config.mts
+++ b/packages/lumx-vue/vite.config.mts
@@ -17,7 +17,7 @@ import fixEsmImports from 'rollup-plugin-lumx-fix-esm-imports';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT_PATH = path.resolve(__dirname, '../..');
-const DIST_PATH = path.resolve(__dirname, pkg.publishConfig.directory);
+const DIST_PATH = path.resolve(__dirname, 'dist');
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 
 /** Set of lumx core exports */


### PR DESCRIPTION
## Summary

Three changes to make NPM publish more robust:

1. **Idempotent publish** — Check the registry before publishing each `@lumx/*` package; skip
   any that already exist at the target version. Allows safely retrying a partially-failed
   release without `npm error You cannot publish over the previously published versions`.

2. **Remove deprecated `publishConfig.directory`** — Packages always publish from `dist/`.
   Removes `publishConfig.directory` from `package.json`; rollup/vite configs hardcode `dist`
   instead of reading `pkg.publishConfig.directory`.

3. **Skip CHANGELOG detect step for prereleases** — The `[prerelease] Detect release type from
   CHANGELOG` step no longer runs on `workflow_dispatch` with a `prereleaseName`. The release
   type defaults to `prepatch` instead. Prereleases don't update the CHANGELOG, so this check
   is irrelevant and was blocking alpha/beta releases when the `[Unreleased]` section was empty.

## Context

Release run [27189530212](https://github.com/lumapps/design-system/actions/runs/27189530212)
failed: `@lumx/core` and `@lumx/icons` were already published at `4.16.0` (from a first attempt),
so the retry aborted before publishing `@lumx/react` and `@lumx/vue`.

After merge, the release can be retried via `workflow_dispatch` (empty `prereleaseName`) from
`master`: it will skip core/icons and publish react/vue.

StoryBook lumx-vue: https://e1344295b--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://e1344295b--5fbfb1d508c0520021560f10.chromatic.com/