### PR TITLE
chore(publish): make the rest of the workflow idempotent

### DIFF
--- a/.github/actions/release-note/index.js
+++ b/.github/actions/release-note/index.js
@@ -30,7 +30,8 @@ async function main({ github, context }) {
     // Release notes
     const body = `${versionChangelog}\n\n${links}`;
 
-    await github.rest.repos.createRelease({
+    // Idempotent: update the release if it already exists, create otherwise.
+    const releaseParams = {
         draft: false,
         generate_release_notes: false,
         prerelease: false,
@@ -39,7 +40,25 @@ async function main({ github, context }) {
         tag_name: versionTag,
         name: versionTag,
         body,
-    });
+    };
+    try {
+        await github.rest.repos.createRelease(releaseParams);
+    } catch (error) {
+        if (error.status === 422) {
+            const { data: existing } = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: versionTag,
+            });
+            await github.rest.repos.updateRelease({
+                ...releaseParams,
+                release_id: existing.id,
+            });
+            console.log(`Release ${versionTag} already existed, updated.`);
+        } else {
+            throw error;
+        }
+    }
 }
 
 module.exports = main;

--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -8,7 +8,8 @@ name: 'CD / Publish'
 #   any lib package (packages/lumx-*)
 # - Manual prereleases initiated via workflow_dispatch (with prereleaseName)
 # - Manual release retries via workflow_dispatch (without prereleaseName, to retry a failed release
-#   using the version already set in packages)
+#   using the version already set in packages). All steps are idempotent: NPM publish skips
+#   already-published packages, git tag skips existing tags, and release notes are upserted.
 #
 # For releases: it builds and publishes NPM packages, creates Git tags,
 # deploys the demo site, updates Chromatic, and generates GitHub release notes.
@@ -251,13 +252,16 @@ jobs:
               run: |
                   set -x
 
-                  # Create tag
                   tag="v${{ needs.check_trigger.outputs.version }}"
                   echo "tag=$tag" >> $GITHUB_OUTPUT
-                  git tag "$tag"
 
-                  # Push tag
-                  git push origin "$tag"
+                  # Idempotent: skip if tag already exists on remote
+                  if git ls-remote --tags origin "$tag" | grep -q "$tag"; then
+                      echo "Tag $tag already exists, skipping"
+                  else
+                      git tag "$tag"
+                      git push origin "$tag"
+                  fi
 
     deploy_demo_site:
         name: 'Deploy demo site'


### PR DESCRIPTION
## Summary
Ensure the publish workflow is fully idempotent (re-running does not fail on already-published packages).