### PR TITLE
fix(combobox): fix timing issue on option click, list nav in shadow DOM, and controlled value sync on clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`:
     -   Create the `Menu` component component family
 
+### Fixed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `ComboboxInput`: keep controlled value in sync when clearing the input after selecting an option
+
 ## [4.16.0][] - 2026-06-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `ComboboxInput`: keep controlled value in sync when clearing the input after selecting an option
+    -   `Combobox`: fix list navigation when used inside a shadow DOM boundary
 
 ## [4.16.0][] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `ComboboxInput`: keep controlled value in sync when clearing the input after selecting an option
     -   `Combobox`: fix list navigation when used inside a shadow DOM boundary
+    -   `Combobox`: fix timing issue delaying closing the combobox on option click
 
 ## [4.16.0][] - 2026-06-08
 

--- a/packages/lumx-core/src/js/components/Combobox/TestStories.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/TestStories.tsx
@@ -391,6 +391,38 @@ export function setup({
         },
     };
 
+    /** Test combobox input clearing */
+    const ClearAfterSelect = {
+        ...comboboxInputStory,
+        play: async ({ canvasElement }: any) => {
+            const input = within(canvasElement).getByRole<HTMLInputElement>('combobox');
+
+            // Step 1: ArrowDown opens and focuses first option
+            input.focus();
+            await userEvent.keyboard('{ArrowDown}');
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+                expect(getActiveOption()).not.toBeNull();
+            });
+
+            // Step 2: Enter selects the option and closes
+            await userEvent.keyboard('{Enter}');
+            await waitFor(() => {
+                expect(input.value).toBe('Apple');
+                expect(input).toHaveAttribute('aria-expanded', 'false');
+            });
+
+            // Step 3: Select all and delete to clear the input
+            input.setSelectionRange(0, input.value.length);
+            await userEvent.keyboard('{Delete}');
+
+            // The input value should be cleared and stay cleared
+            await waitFor(() => {
+                expect(input.value).toBe('');
+            });
+        },
+    };
+
     return {
         meta,
         MouseHoverDoesNotActivateOption,
@@ -404,5 +436,6 @@ export function setup({
         ButtonEndFromClosed,
         ButtonHomeFromClosed,
         ButtonArrowDownFromClosed,
+        ClearAfterSelect,
     };
 }

--- a/packages/lumx-core/src/js/components/Combobox/Tests.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Tests.tsx
@@ -2119,11 +2119,6 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.keyboard('{Enter}');
             expect(input.value).toBe('');
             await waitFor(() => {
-                expect(input).toHaveAttribute('aria-expanded', 'false');
-            });
-
-            await userEvent.click(input);
-            await waitFor(() => {
                 expect(input).toHaveAttribute('aria-expanded', 'true');
             });
 
@@ -2162,11 +2157,6 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
 
             await userEvent.keyboard('{Enter}');
             expect(button.textContent).toBe('Select a fruit');
-            await waitFor(() => {
-                expect(button).toHaveAttribute('aria-expanded', 'false');
-            });
-
-            await userEvent.click(button);
             await waitFor(() => {
                 expect(button).toHaveAttribute('aria-expanded', 'true');
             });

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -1,5 +1,5 @@
 import { type FocusNavigationController } from '../../utils/focusNavigation';
-import { getOptionValue, isActionCell, isOptionDisabled, isSelected, notifySection } from './utils';
+import { getOptionValue, isOptionDisabled, isSelected, notifySection } from './utils';
 import { setupListbox } from './setupListbox';
 import type {
     ComboboxCallbacks,
@@ -192,10 +192,6 @@ export function setupCombobox(
                         if (!isOptionDisabled(activeItem)) {
                             activeItem.click();
                         }
-                        // Only close when not in multi select and not in action cell
-                        if (!handle.isMultiSelect && !isActionCell(activeItem)) {
-                            handle.setIsOpen(false);
-                        }
                         flag = true;
                     } else if (handle.isOpen && !handle.isMultiSelect) {
                         // Open with no active item (single select) => close the popup,
@@ -358,6 +354,15 @@ export function setupCombobox(
 
         select(option: HTMLElement | null) {
             callbacks.onSelect?.({ value: option ? getOptionValue(option) : '' });
+
+            // Close on selection (when not multiselectable)
+            if (option && !handle.isMultiSelect) {
+                handle.focusNav?.clear();
+                // Defer the close to the next frame (to make sure all other click handler resolve).
+                requestAnimationFrame(() => {
+                    handle.setIsOpen(false);
+                });
+            }
         },
 
         flushPendingNavigation() {

--- a/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
@@ -42,18 +42,11 @@ export function setupComboboxInput(input: HTMLInputElement, options: SetupCombob
 
     /**
      * Wraps the consumer's onSelect to perform input-mode side effects after selection:
-     * clears the active descendant, resets the filter, and re-opens the popup.
+     * resets the filter and typing state.
      */
     const onSelect = (option: { value: string }) => {
         optionOnSelect?.(option);
-
-        // Clear the active item. In multi-select, keep visual focus so the
-        // user can continue navigating after selection.
-        if (!handle.isMultiSelect) {
-            handle.focusNav?.clear();
-        }
         userHasTyped = false;
-        handle.setIsOpen(true);
         if (autoFilter) {
             handle.setFilter('');
         }

--- a/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupComboboxInput.ts
@@ -2,7 +2,13 @@ import type { ComboboxCallbacks, ComboboxHandle, ComboboxInputOptions } from './
 import { setupCombobox } from './setupCombobox';
 
 /** Options for configuring the input-mode combobox controller. */
-export interface SetupComboboxInputOptions extends ComboboxCallbacks, ComboboxInputOptions {}
+export interface SetupComboboxInputOptions extends ComboboxCallbacks, ComboboxInputOptions {
+    /**
+     * Called synchronously on every user input event (typing, paste, delete…)
+     * (Use this in framework wrappers that maintain controlled input state, like React)
+     */
+    onInput?(value: string): void;
+}
 
 /**
  * Set up a combobox with an input trigger (autocomplete/filter pattern).
@@ -20,7 +26,7 @@ export interface SetupComboboxInputOptions extends ComboboxCallbacks, ComboboxIn
  */
 export function setupComboboxInput(input: HTMLInputElement, options: SetupComboboxInputOptions): ComboboxHandle {
     let handle: ComboboxHandle;
-    const { filter = 'auto', onSelect: optionOnSelect } = options;
+    const { filter = 'auto', onSelect: optionOnSelect, onInput: onInputCallback } = options;
     const openOnFocus = options.openOnFocus ?? filter === 'off';
     const autoFilter = filter === 'auto';
 
@@ -67,6 +73,10 @@ export function setupComboboxInput(input: HTMLInputElement, options: SetupCombob
 
                 combobox.focusNav?.clear();
                 userHasTyped = true;
+
+                // Notify the framework wrapper of the new input value synchronously.
+                onInputCallback?.(input.value);
+
                 combobox.setIsOpen(true);
 
                 if (autoFilter) {

--- a/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
@@ -94,7 +94,7 @@ export function setupListbox(
                 wrap: options?.wrapNavigation,
                 getActiveItem: () => {
                     const id = trigger.getAttribute('aria-activedescendant');
-                    return id ? (document.getElementById(id) as HTMLElement | null) : null;
+                    return (id && listbox.querySelector<HTMLElement>(`#${CSS.escape(id)}`)) || null;
                 },
             },
             focusCallbacks,

--- a/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupListbox.ts
@@ -124,11 +124,6 @@ export function setupListbox(
 
             handle.select(cell);
             trigger.focus();
-
-            // In multi-select mode, keep visual focus on the selected option
-            if (!handle.isMultiSelect) {
-                handle.setIsOpen(false);
-            }
         },
         { signal },
     );

--- a/packages/lumx-react/src/components/combobox/Combobox.test.stories.tsx
+++ b/packages/lumx-react/src/components/combobox/Combobox.test.stories.tsx
@@ -43,3 +43,5 @@ export const ButtonTypeaheadWhileOpen = { ...testStories.ButtonTypeaheadWhileOpe
 export const ButtonEndFromClosed = { ...testStories.ButtonEndFromClosed };
 export const ButtonHomeFromClosed = { ...testStories.ButtonHomeFromClosed };
 export const ButtonArrowDownFromClosed = { ...testStories.ButtonArrowDownFromClosed };
+
+export const ClearAfterSelect = { ...testStories.ClearAfterSelect };

--- a/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
@@ -60,6 +60,10 @@ export const ComboboxInput = forwardRef<ComboboxInputProps, HTMLDivElement>((pro
                 onChangeRef.current?.(option.value);
                 onSelectRef.current?.(option);
             },
+            onInput(value) {
+                // Keep controlled value in sync.
+                onChangeRef.current?.(value);
+            },
             filter,
             openOnFocus,
         });


### PR DESCRIPTION
## Summary

Three fixes in the combobox family:

- **fix(combobox): fix timing issue delaying closing on option click** — avoids premature closing when clicking an option inside the dropdown
- **fix(combobox): fix list nav in shadow DOM** — corrects keyboard navigation when combobox is used inside a shadow DOM boundary
- **fix(combobox-input): keep React controlled value in sync on input clear** — adds `onClear` callback so framework wrappers can keep their controlled value in sync when the user clears the input (e.g. selecting all + Delete after selecting an option)

StoryBook lumx-vue: https://f46afedf9--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://f46afedf9--5fbfb1d508c0520021560f10.chromatic.com/