### PR TITLE
refactor(react): replace MenuButton polymorphic `as` with `variant` prop

### DIFF
--- a/packages/lumx-core/src/js/components/Menu/MenuButton.tsx
+++ b/packages/lumx-core/src/js/components/Menu/MenuButton.tsx
@@ -1,6 +1,28 @@
+import { mdiDotsVertical } from '@lumx/icons';
 import type { JSXElement, LumxClassName } from '../../types';
 
+export type MenuButtonVariant = 'button' | 'icon-button' | 'chip' | 'link';
+
+/** ARIA keys set by MenuButton on the trigger — omitted from variant component props. */
+type MenuButtonAriaKeys = 'aria-haspopup' | 'aria-controls' | 'aria-expanded';
+
+/** Per-variant keys internally managed by MenuButton — omitted from variant component props. */
+type MenuButtonVariantsInternalKeys = {
+    button: MenuButtonAriaKeys;
+    'icon-button': MenuButtonAriaKeys;
+    chip: MenuButtonAriaKeys | 'isClickable';
+    link: MenuButtonAriaKeys | 'href' | 'linkAs';
+};
+
+/** Discriminated union of MenuButton props across all trigger variants. */
+export type MenuButtonVariantsProps<TBase, TVariantProps extends Record<MenuButtonVariant, any>> = {
+    [V in MenuButtonVariant]: TBase &
+        (V extends 'button' ? { variant?: V } : { variant: V }) &
+        Omit<TVariantProps[V], MenuButtonVariantsInternalKeys[V] | keyof TBase>;
+}[MenuButtonVariant];
+
 export interface MenuButtonProps {
+    variant?: MenuButtonVariant;
     label?: JSXElement;
     children?: JSXElement;
     triggerProps?: Record<string, any>;
@@ -9,22 +31,49 @@ export interface MenuButtonProps {
 }
 
 export interface MenuButtonComponents {
-    Menu: any;
+    MenuProvider: any;
+    MenuTrigger: any;
+    MenuPopover: any;
+    MenuList: any;
 }
 
 export const COMPONENT_NAME = 'MenuButton';
 export const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-menu-button';
 
 /** Menu button core template (composition of menu provider, trigger, popover and list) */
-export const MenuButton = (props: MenuButtonProps, { Menu }: MenuButtonComponents) => {
-    const { label, children, triggerProps, popoverProps, onOpen } = props;
+export const MenuButton = (
+    props: MenuButtonProps,
+    { MenuProvider, MenuTrigger, MenuPopover, MenuList }: MenuButtonComponents,
+) => {
+    const { label, children, triggerProps, popoverProps, onOpen, variant } = props;
+
+    const extraTriggerProps: Record<string, any> = {};
+    if (variant === 'chip') {
+        // Chip render as clickable (since the component cannot detect this automatically)
+        extraTriggerProps.isClickable = true;
+    }
+
+    let triggerChildren;
+    if (variant === 'icon-button') {
+        // Label as prop (renders as tooltip label)
+        extraTriggerProps.label = label;
+        // Default icon
+        if (!triggerProps?.icon) {
+            extraTriggerProps.icon = mdiDotsVertical;
+        }
+    } else {
+        // Only set the label as children when we are not displaying an icon-button
+        triggerChildren = label;
+    }
 
     return (
-        <Menu.Provider onOpen={onOpen}>
-            <Menu.Trigger {...triggerProps}>{label}</Menu.Trigger>
-            <Menu.Popover {...popoverProps}>
-                <Menu.List>{children}</Menu.List>
-            </Menu.Popover>
-        </Menu.Provider>
+        <MenuProvider onOpen={onOpen}>
+            <MenuTrigger {...triggerProps} {...extraTriggerProps}>
+                {triggerChildren}
+            </MenuTrigger>
+            <MenuPopover {...popoverProps}>
+                <MenuList>{children}</MenuList>
+            </MenuPopover>
+        </MenuProvider>
     );
 };

--- a/packages/lumx-core/src/js/components/Menu/MenuButtonStories.tsx
+++ b/packages/lumx-core/src/js/components/Menu/MenuButtonStories.tsx
@@ -1,15 +1,17 @@
 import { userEvent } from 'storybook/test';
-import { mdiAccount, mdiCog, mdiHelpCircle, mdiLogout } from '@lumx/icons';
+import { mdiAccount, mdiCog, mdiHelpCircle, mdiLogout, mdiPencil, mdiTrashCan } from '@lumx/icons';
 import type { SetupStoriesOptions } from '@lumx/core/stories/types';
 
 export function setup({
     components: { MenuButton, MenuItem, MenuDivider },
+    decorators: { withCombinations },
 }: SetupStoriesOptions<{
     components: {
         MenuButton: any;
         MenuItem: any;
         MenuDivider: any;
     };
+    decorators: 'withCombinations';
 }>) {
     const meta = {
         component: MenuButton,
@@ -25,37 +27,75 @@ export function setup({
         },
     };
 
+    /** Default menu button config */
     const Default = {
         argTypes: {
-            onProfile: { action: true },
-            onSettings: { action: true },
-            onHelp: { action: true },
-            onLogout: { action: true },
+            onItemClick: { action: true },
         },
-        args: {
-            emphasis: 'high',
-        },
-        render: ({ onProfile, onSettings, onHelp, onLogout, ...args }: any) => (
+        render: ({ onItemClick, ...args }: any) => (
             <MenuButton {...args}>
-                <MenuItem icon={mdiAccount} onClick={onProfile}>
+                <MenuItem icon={mdiAccount} onClick={onItemClick}>
                     Profile
                 </MenuItem>
-                <MenuItem icon={mdiCog} onClick={onSettings}>
+                <MenuItem icon={mdiCog} onClick={onItemClick}>
                     Settings
                 </MenuItem>
                 <MenuDivider />
-                <MenuItem icon={mdiHelpCircle} onClick={onHelp}>
+                <MenuItem icon={mdiHelpCircle} onClick={onItemClick}>
                     Help
                 </MenuItem>
-                <MenuItem icon={mdiLogout} onClick={onLogout}>
+                <MenuItem icon={mdiLogout} onClick={onItemClick}>
                     Logout
                 </MenuItem>
             </MenuButton>
         ),
     };
 
+    /** All MenuButton variants */
+    const Variants = {
+        argTypes: {
+            onItemClick: { action: true },
+        },
+        decorators: [
+            withCombinations({
+                combinations: {
+                    cols: {
+                        Button: {},
+                        'Icon button': { variant: 'icon-button', label: 'More actions', emphasis: 'low' },
+                        Chip: { variant: 'chip', label: 'Filter by' },
+                        Link: { variant: 'link', label: 'Open as link' },
+                    },
+                },
+            }),
+        ],
+        render: (args: any) => () => (
+            <MenuButton {...args}>
+                <MenuItem icon={mdiPencil} onClick={args.onItemClick}>
+                    Edit
+                </MenuItem>
+                <MenuItem onClick={args.onItemClick}>Duplicate</MenuItem>
+                <MenuDivider />
+                <MenuItem icon={mdiTrashCan} color="red" onClick={args.onItemClick}>
+                    Delete
+                </MenuItem>
+            </MenuButton>
+        ),
+    };
+
+    const WithLinkItems = {
+        argTypes: {
+            onItemClick: { action: true },
+        },
+        args: {
+            label: 'Actions',
+            emphasis: 'low',
+        },
+    };
+
     return {
         meta,
         Default,
+        Variants,
+        WithLinkItems,
     };
 }

--- a/packages/lumx-core/src/js/components/Menu/MenuButtonTests.tsx
+++ b/packages/lumx-core/src/js/components/Menu/MenuButtonTests.tsx
@@ -3,9 +3,14 @@ import { vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { waitFor, screen } from '@testing-library/dom';
 
+import { mdiAccount } from '@lumx/icons';
+
+import { getByClassName } from '../../../testing/queries';
+import { CLASSNAME as MENU_TRIGGER_CLASSNAME } from './MenuTrigger';
+
 // ─── Types ───────────────────────────────────────────────────────
 
-type RenderResult = { unmount: () => void; container: HTMLElement };
+type RenderResult = { unmount: () => void; container: Element };
 
 /**
  * Options to set up the MenuButton test suite.
@@ -17,11 +22,13 @@ export interface MenuButtonTestSetup {
         MenuItem: any;
     };
     /**
-     * Render a MenuButton template.
+     * Render a MenuButton template, forwarding optional framework-specific render options
+     * (e.g. `{ wrapper }` in React, `{ global }` in Vue).
      *
      * @param template JSX render function returning the element to render.
+     * @param options  Framework-specific render options (e.g. wrapper component).
      */
-    render: (template: () => any) => RenderResult;
+    render: (template: () => any, options?: Record<string, any>) => RenderResult;
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -31,17 +38,24 @@ export interface MenuButtonTestSetup {
 export default function menuButtonTests({ components, render }: MenuButtonTestSetup) {
     const { MenuButton, MenuItem } = components;
 
-    /** Default MenuButton template with two items. */
-    const defaultTemplate = () => (
-        <MenuButton label="Open menu">
-            <MenuItem onClick={() => undefined}>First</MenuItem>
-            <MenuItem>Second</MenuItem>
-        </MenuButton>
-    );
-
-    const setup = () => {
-        const result = render(defaultTemplate);
-        return { ...result, trigger: screen.getByRole('button', { name: 'Open menu' }) };
+    /**
+     * Renders MenuButton with a single MenuItem child (labelled "First").
+     * Returns props, container, the trigger element (for behavioral tests) and the
+     * trigger wrapper element by class name (for `commonTestsSuite*`).
+     */
+    const setup = (propsOverride: Record<string, any> = {}, options?: Record<string, any>) => {
+        const props = { label: 'Open menu', ...propsOverride };
+        const { container } = render(
+            () => (
+                <MenuButton {...props}>
+                    <MenuItem>First</MenuItem>
+                </MenuButton>
+            ),
+            options,
+        );
+        const element = getByClassName(document.body, MENU_TRIGGER_CLASSNAME);
+        const trigger = screen.queryByRole('button', { name: props.label }) as HTMLElement;
+        return { props, container, element, trigger };
     };
 
     // ─── Render ──────────────────────────────────────────────────
@@ -58,6 +72,13 @@ export default function menuButtonTests({ components, render }: MenuButtonTestSe
             expect(trigger).toHaveAttribute('aria-haspopup', 'true');
             expect(trigger).toHaveAttribute('aria-controls');
             expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+            // aria-controls must reference the menu list element's id
+            const ariaControls = trigger.getAttribute('aria-controls');
+            expect(ariaControls).toBeTruthy();
+            const menuList = document.getElementById(ariaControls!);
+            expect(menuList).not.toBeNull();
+            expect(menuList).toHaveAttribute('id', ariaControls);
         });
     });
 
@@ -107,20 +128,11 @@ export default function menuButtonTests({ components, render }: MenuButtonTestSe
     describe('onOpen', () => {
         it('fires onOpen with true when menu opens and false when it closes', async () => {
             const onOpen = vi.fn();
-            const { trigger } = (() => {
-                const result = render(() => (
-                    <MenuButton label="Open menu" onOpen={onOpen}>
-                        <MenuItem onClick={() => undefined}>First</MenuItem>
-                        <MenuItem>Second</MenuItem>
-                    </MenuButton>
-                ));
-                return { ...result, trigger: screen.getByRole('button', { name: 'Open menu' }) };
-            })();
+            const { trigger } = setup({ onOpen });
             await userEvent.click(trigger);
             expect(onOpen).toHaveBeenCalledWith(true);
             await userEvent.click(trigger);
             expect(onOpen).toHaveBeenCalledWith(false);
-            expect(onOpen).toHaveBeenCalledTimes(2);
         });
     });
 
@@ -139,4 +151,77 @@ export default function menuButtonTests({ components, render }: MenuButtonTestSe
             expect(disabled).toHaveAttribute('aria-disabled', 'true');
         });
     });
+
+    // ─── Variant-specific trigger ────────────────────────────────
+
+    describe('variant trigger', () => {
+        describe('variant="icon-button"', () => {
+            const setupIconButton = (overrides?: Record<string, any>) =>
+                setup({ variant: 'icon-button', label: 'More', ...overrides });
+
+            it('renders an icon button with default mdiDotsVertical icon', () => {
+                const { element } = setupIconButton();
+                expect(element.querySelector('svg')).toBeTruthy();
+            });
+
+            it('renders a custom icon if provided', () => {
+                const { element } = setupIconButton({ icon: mdiAccount });
+                expect(element.querySelector('svg')).toBeTruthy();
+            });
+
+            it('sets disclosure aria attributes', () => {
+                const { element } = setupIconButton();
+                expect(element).toHaveAttribute('aria-haspopup', 'true');
+                expect(element).toHaveAttribute('aria-controls');
+                expect(element).toHaveAttribute('aria-expanded', 'false');
+
+                const ariaControls = element.getAttribute('aria-controls');
+                expect(ariaControls).toBeTruthy();
+                expect(document.getElementById(ariaControls!)).not.toBeNull();
+            });
+
+            it('toggles aria-expanded and opens menu on click', async () => {
+                const { element } = setupIconButton();
+                expect(element).toHaveAttribute('aria-expanded', 'false');
+                await userEvent.click(element);
+                await screen.findByRole('button', { name: 'First' });
+                expect(element).toHaveAttribute('aria-expanded', 'true');
+            });
+        });
+
+        describe('variant="chip"', () => {
+            const setupChip = () => setup({ variant: 'chip', label: 'Filters' });
+
+            it('renders a chip', () => {
+                const { element } = setupChip();
+                expect(element).toBeInTheDocument();
+                expect(element.tagName).toBe('A');
+            });
+
+            it('sets isClickable automatically', () => {
+                const { element } = setupChip();
+                expect(element.classList.contains('lumx-chip--is-clickable')).toBe(true);
+            });
+
+            it('sets disclosure aria attributes', () => {
+                const { element } = setupChip();
+                expect(element).toHaveAttribute('aria-haspopup', 'true');
+                expect(element).toHaveAttribute('aria-controls');
+                expect(element).toHaveAttribute('aria-expanded', 'false');
+
+                const ariaControls = element.getAttribute('aria-controls');
+                expect(ariaControls).toBeTruthy();
+                expect(document.getElementById(ariaControls!)).not.toBeNull();
+            });
+
+            it('opens menu on click', async () => {
+                const { element } = setupChip();
+                await userEvent.click(element);
+                await screen.findByRole('button', { name: 'First' });
+                expect(element).toHaveAttribute('aria-expanded', 'true');
+            });
+        });
+    });
+
+    return { setup, triggerClassName: MENU_TRIGGER_CLASSNAME };
 }

--- a/packages/lumx-core/src/js/components/Menu/MenuPopover.tsx
+++ b/packages/lumx-core/src/js/components/Menu/MenuPopover.tsx
@@ -1,27 +1,14 @@
-import type { CommonRef, HasClassName, JSXElement, LumxClassName } from '../../types';
+import type { HasClassName, JSXElement, LumxClassName } from '../../types';
 import type { Placement } from '../Popover/constants';
 import { classNames } from '../../utils';
+import { PopoverProps } from '../Popover';
 
 /** MenuPopover props. */
-export interface MenuPopoverProps extends HasClassName {
+export interface MenuPopoverProps
+    extends HasClassName,
+        Pick<PopoverProps, 'placement' | 'anchorRef' | 'isOpen' | 'handleClose'> {
     /** Popover content (a `Menu`). */
     children?: JSXElement;
-    /** Whether the popover is open. */
-    isOpen?: boolean;
-    /** Placement relative to the anchor. Defaults to `'bottom-start'`. */
-    placement?: Placement;
-    /** Reference to the anchor element. */
-    anchorRef?: CommonRef;
-    /** Callback invoked when the popover requests to close (click away, escape). */
-    handleClose?(): void;
-    /** Whether the popover should close when clicking outside. Default: true. */
-    closeOnClickAway?: boolean;
-    /** Whether the popover should close on Escape. Default: true. */
-    closeOnEscape?: boolean;
-    /** Whether to render in a portal. Default: false (avoid stacking-context surprises). */
-    usePortal?: boolean;
-    /** Whether to focus the anchor on close. Default: true. */
-    focusAnchorOnClose?: boolean;
 }
 
 /** Framework components injected by wrappers. */
@@ -46,10 +33,6 @@ export const MenuPopover = (props: MenuPopoverProps, { Popover, FlexBox }: MenuP
         placement = 'bottom-start' as Placement,
         anchorRef,
         handleClose,
-        closeOnClickAway = true,
-        closeOnEscape = true,
-        usePortal = false,
-        focusAnchorOnClose = true,
         ...forwardedProps
     } = props;
 
@@ -60,10 +43,10 @@ export const MenuPopover = (props: MenuPopoverProps, { Popover, FlexBox }: MenuP
             anchorRef={anchorRef}
             isOpen={isOpen}
             onClose={handleClose}
-            closeOnClickAway={closeOnClickAway}
-            closeOnEscape={closeOnEscape}
-            usePortal={usePortal}
-            focusAnchorOnClose={focusAnchorOnClose}
+            closeOnClickAway
+            closeOnEscape
+            usePortal={false}
+            focusAnchorOnClose
             withFocusTrap={false}
             closeMode="hide"
             fitToAnchorWidth={false}

--- a/packages/lumx-core/src/js/components/Menu/MenuTrigger.tsx
+++ b/packages/lumx-core/src/js/components/Menu/MenuTrigger.tsx
@@ -5,6 +5,8 @@ import { classNames } from '../../utils';
 export interface MenuTriggerProps extends HasClassName {
     /** Content of the trigger (label / icon / etc.). */
     children?: JSXElement;
+    /** The id of the trigger element. */
+    id?: string;
     /** The id of the menu container (for `aria-controls`). */
     menuId?: string;
     /** Whether the menu is currently open. */

--- a/packages/lumx-react/src/components/menu/MenuButton.stories.tsx
+++ b/packages/lumx-react/src/components/menu/MenuButton.stories.tsx
@@ -1,14 +1,14 @@
-import { mdiDotsVertical, mdiFilter, mdiPencil, mdiStar } from '@lumx/icons';
-import { Chip, IconButton } from '@lumx/react';
+import { mdiOpenInNew } from '@lumx/icons';
 
 import { setup } from '@lumx/core/js/components/Menu/MenuButtonStories';
 import { CustomLink } from '@lumx/react/stories/utils/CustomLink';
-import { iconArgType } from '@lumx/core/stories/controls/icons';
+import { withCombinations } from '@lumx/react/stories/decorators/withCombinations';
 
 import { MenuButton, MenuItem, MenuDivider } from '.';
 
 const { meta, ...stories } = setup({
     components: { MenuButton, MenuItem, MenuDivider },
+    decorators: { withCombinations },
 });
 
 export default {
@@ -16,65 +16,28 @@ export default {
     ...meta,
 };
 
+/** Default menu button config */
 export const Default = { ...stories.Default };
 
-/** Menu button as IconButton */
-export const AsIconButton = {
-    argTypes: {
-        onEdit: { action: true },
-        onDuplicate: { action: true },
-        onDelete: { action: true },
-        icon: iconArgType,
-    },
-    args: {
-        label: 'More actions',
-        icon: mdiDotsVertical,
-        emphasis: 'low',
-    },
-    render: ({ onEdit, onDuplicate, onDelete, ...args }: any) => (
-        <MenuButton {...args} as={IconButton}>
-            <MenuItem icon={mdiPencil} onClick={onEdit}>
-                Edit
-            </MenuItem>
-            <MenuItem onClick={onDuplicate}>Duplicate</MenuItem>
-            <MenuDivider />
-            <MenuItem onClick={onDelete}>Delete</MenuItem>
-        </MenuButton>
-    ),
-};
+/** All MenuButton variants */
+export const Variants = { ...stories.Variants };
 
-/** Menu button as Chip */
-export const AsChip = {
-    argTypes: {
-        onAll: { action: true },
-        onActive: { action: true },
-        onArchived: { action: true },
-    },
-    render: ({ onAll, onActive, onArchived, ...args }: any) => (
-        <MenuButton {...args} as={Chip} isClickable>
-            <MenuItem icon={mdiFilter} onClick={onAll}>
-                All
-            </MenuItem>
-            <MenuItem icon={mdiStar} onClick={onActive}>
-                Active
-            </MenuItem>
-            <MenuItem onClick={onArchived}>Archived</MenuItem>
-        </MenuButton>
-    ),
-};
-
-/** Menu with item with custom link action */
-export const WithCustomLinkAction = {
-    args: {
-        label: 'Actions',
-        emphasis: 'low' as const,
-    },
-    render: (args: any) => (
+/** Menu with link items */
+export const WithLinkItems = {
+    ...stories.WithLinkItems,
+    render: ({ onItemClick, ...args }: any) => (
         <MenuButton {...args}>
-            <MenuItem>Default item</MenuItem>
-            <MenuItem actionProps={{ as: CustomLink, to: '/page' }}>Custom link action</MenuItem>
-            <MenuDivider />
-            <MenuItem onClick={() => {}}>Delete</MenuItem>
+            <MenuItem onClick={onItemClick} actionProps={{ as: 'a', href: '#' }}>
+                HTML link
+            </MenuItem>
+
+            <MenuItem
+                onClick={onItemClick}
+                actionProps={{ as: CustomLink, to: 'https://example.com', target: '_blank' }}
+                afterIcon={mdiOpenInNew}
+            >
+                Custom link target=_blank
+            </MenuItem>
         </MenuButton>
     ),
 };

--- a/packages/lumx-react/src/components/menu/MenuButton.test.tsx
+++ b/packages/lumx-react/src/components/menu/MenuButton.test.tsx
@@ -1,72 +1,23 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import { expectTypeOf } from 'vitest';
 
 import menuButtonTests from '@lumx/core/js/components/Menu/MenuButtonTests';
-import { commonTestsSuiteRTL, SetupRenderOptions } from '@lumx/react/testing/utils';
-import { getByClassName } from '@lumx/react/testing/utils/queries';
-import { CLASSNAME as MENU_TRIGGER_CLASSNAME } from '@lumx/core/js/components/Menu/MenuTrigger';
-import { mdiDotsVertical } from '@lumx/icons';
-
-import { IconButton } from '../button';
-import { Chip } from '../chip';
-import { Link } from '../link';
-
+import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import { MenuButton, type MenuButtonProps } from './MenuButton';
 import { MenuItem } from './MenuItem';
 
 describe('<MenuButton>', () => {
     // ── Shared behavioral suite (core) ─────────────────────────
-    menuButtonTests({
+    const { setup: setupCommon, triggerClassName } = menuButtonTests({
         components: { MenuButton, MenuItem },
-        render: (template) => render(template()),
-    });
-
-    // ── Polymorphic trigger (React-specific `as` prop) ─────────
-    describe('polymorphic trigger', () => {
-        it('renders as IconButton when as={IconButton}', () => {
-            render(
-                <MenuButton as={IconButton} icon={mdiDotsVertical} label="More">
-                    <MenuItem>First</MenuItem>
-                </MenuButton>,
-            );
-            const trigger = screen.getByRole('button', { name: 'More' });
-            expect(trigger).toHaveAttribute('aria-haspopup', 'true');
-            expect(trigger.querySelector('svg')).toBeTruthy();
-        });
-
-        it('renders as Chip and opens on click', async () => {
-            render(
-                <MenuButton as={Chip} label="Filters" isClickable>
-                    <MenuItem>All</MenuItem>
-                </MenuButton>,
-            );
-            const trigger = screen.getByText('Filters').closest('a') as HTMLElement;
-            expect(trigger).toHaveAttribute('aria-haspopup', 'true');
-            trigger.focus();
-            await userEvent.keyboard('{Enter}');
-            await screen.findByLabelText('Filters');
-        });
+        render: (template, options) => render(template(), options),
     });
 
     // ── commonTestsSuiteRTL ────────────────────────────────────
-    const setupCommon = (propsOverride: Record<string, any> = {}, options?: SetupRenderOptions) => {
-        const props: any = { label: 'Open menu', ...propsOverride };
-        const { container } = render(
-            <MenuButton {...props}>
-                <MenuItem>First</MenuItem>
-            </MenuButton>,
-            options,
-        );
-        const element = getByClassName(document.body, MENU_TRIGGER_CLASSNAME);
-        return { props, container, element };
-    };
-
     commonTestsSuiteRTL(setupCommon, {
-        baseClassName: MENU_TRIGGER_CLASSNAME,
+        baseClassName: triggerClassName,
         forwardClassName: 'element',
         forwardAttributes: 'element',
-        forwardRef: 'element',
         applyTheme: {
             affects: [{ element: 'element' }],
             viaProp: true,
@@ -78,33 +29,27 @@ describe('<MenuButton>', () => {
 
 // ── Type-level tests ──────────────────────────────────────────
 describe('Type tests', () => {
-    it('default trigger exposes Button props', () => {
-        expectTypeOf<MenuButtonProps>().toHaveProperty('emphasis');
-        expectTypeOf<MenuButtonProps>().toHaveProperty('size');
-        expectTypeOf<MenuButtonProps>().toHaveProperty('isDisabled');
-        expectTypeOf<MenuButtonProps>().toHaveProperty('leftIcon');
+    it('default variant exposes Button props', () => {
+        type ButtonVariant = Extract<MenuButtonProps, { variant?: 'button' }>;
+        expectTypeOf<ButtonVariant>().toHaveProperty('emphasis');
+        expectTypeOf<ButtonVariant>().toHaveProperty('size');
+        expectTypeOf<ButtonVariant>().toHaveProperty('isDisabled');
+        expectTypeOf<ButtonVariant>().toHaveProperty('leftIcon');
     });
 
-    it('as={IconButton} exposes icon but label comes from MenuButton', () => {
-        expectTypeOf<MenuButtonProps<typeof IconButton>>().toHaveProperty('icon');
-        // label is MenuButton's own prop (from core UIProps), not IconButton's
-        expectTypeOf<MenuButtonProps<typeof IconButton>>().toHaveProperty('label');
+    it('variant="icon-button" exposes icon but label comes from MenuButton', () => {
+        type IconVariant = Extract<MenuButtonProps, { variant: 'icon-button' }>;
+        expectTypeOf<IconVariant>().toHaveProperty('icon');
+        expectTypeOf<IconVariant>().toHaveProperty('label');
     });
 
-    it('as={Chip} exposes isClickable and size', () => {
-        expectTypeOf<MenuButtonProps<typeof Chip>>().toHaveProperty('isClickable');
-        expectTypeOf<MenuButtonProps<typeof Chip>>().toHaveProperty('size');
+    it('variant="chip" exposes size but not isClickable (set automatically)', () => {
+        type ChipVariant = Extract<MenuButtonProps, { variant: 'chip' }>;
+        expectTypeOf<ChipVariant>().toHaveProperty('size');
     });
 
-    it('as={Link} accepts href and rightIcon', () => {
-        expectTypeOf<MenuButtonProps<typeof Link>>().toHaveProperty('href');
-        expectTypeOf<MenuButtonProps<typeof Link>>().toHaveProperty('rightIcon');
-    });
-
-    it('strips GenericProps index signature', () => {
-        type HasIndexSignature<T> = string extends keyof T ? true : false;
-        expectTypeOf<HasIndexSignature<MenuButtonProps>>().toEqualTypeOf<false>();
-        expectTypeOf<HasIndexSignature<MenuButtonProps<typeof IconButton>>>().toEqualTypeOf<false>();
-        expectTypeOf<HasIndexSignature<MenuButtonProps<typeof Chip>>>().toEqualTypeOf<false>();
+    it('variant="link" accepts rightIcon', () => {
+        type LinkVariant = Extract<MenuButtonProps, { variant: 'link' }>;
+        expectTypeOf<LinkVariant>().toHaveProperty('rightIcon');
     });
 });

--- a/packages/lumx-react/src/components/menu/MenuButton.tsx
+++ b/packages/lumx-react/src/components/menu/MenuButton.tsx
@@ -1,42 +1,49 @@
-import React, { ElementType } from 'react';
+import React, { type ForwardedRef } from 'react';
+
 import {
     MenuButton as UI,
     type MenuButtonProps as UIProps,
+    type MenuButtonVariantsProps,
     COMPONENT_NAME,
 } from '@lumx/core/js/components/Menu/MenuButton';
+import { forwardRef } from '@lumx/react/utils/react/forwardRef';
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
-import { forwardRefPolymorphic } from '@lumx/react/utils/react/forwardRefPolymorphic';
-import { ComponentRef } from '@lumx/react/utils/type';
-import { NamedProps } from '@lumx/core/js/types';
+
 import { MenuProvider } from './MenuProvider';
 import { MenuTrigger } from './MenuTrigger';
 import { MenuPopover, type MenuPopoverProps } from './MenuPopover';
 import { MenuList } from './MenuList';
 
-import { Button, IconButton } from '../button';
+import { Button, IconButton, type ButtonProps, type IconButtonProps } from '../button';
+import { Chip, type ChipProps } from '../chip';
+import { Link, type LinkProps } from '../link';
 
-const Menu = {
-    Provider: MenuProvider,
-    Trigger: MenuTrigger,
-    Popover: MenuPopover,
-    List: MenuList,
+/** Props that MenuButton explicitly declares. */
+type MenuButtonBase = ReactToJSX<UIProps, 'triggerProps' | 'variant'> & {
+    children?: React.ReactNode;
+    popoverProps?: MenuPopoverProps;
+    onOpen?: (isOpen: boolean) => void;
+    label: string;
 };
 
-/** Keys managed by MenuButton — omitted from the polymorphic trigger props. */
-type OmittedTriggerKeys = 'aria-haspopup' | 'aria-controls' | 'aria-expanded' | 'label' | 'children' | 'ref';
+/** MenuButton props — discriminated union over the variant to inherit the target component's props. */
+export type MenuButtonProps = MenuButtonVariantsProps<
+    MenuButtonBase,
+    {
+        button: ButtonProps;
+        'icon-button': IconButtonProps;
+        chip: ChipProps;
+        link: LinkProps;
+    }
+>;
 
-/** Polymorphic trigger props with index signature stripped and managed keys removed. */
-type TriggerProps<E extends ElementType> = Omit<NamedProps<React.ComponentProps<E>>, OmittedTriggerKeys>;
-
-/** Menu button props */
-export type MenuButtonProps<E extends ElementType = typeof Button> = TriggerProps<E> &
-    ReactToJSX<UIProps, 'triggerProps'> & {
-        /** Customize the rendered trigger component. */
-        as?: E;
-        children?: React.ReactNode;
-        popoverProps?: MenuPopoverProps;
-        onOpen?: (isOpen: boolean) => void;
-    };
+/** Menu trigger button component by variant */
+const TRIGGER_COMPONENTS = {
+    button: Button,
+    'icon-button': IconButton,
+    chip: Chip,
+    link: Link,
+} as const;
 
 /**
  * MenuButton component.
@@ -44,24 +51,20 @@ export type MenuButtonProps<E extends ElementType = typeof Button> = TriggerProp
  * @param  props Component props.
  * @return React element.
  */
-export const MenuButton = Object.assign(
-    forwardRefPolymorphic(<E extends ElementType = typeof Button>(props: MenuButtonProps<E>, ref: ComponentRef<E>) => {
-        const { label, children, popoverProps, onOpen, as, ...triggerProps } = props as any;
+export const MenuButton = forwardRef<MenuButtonProps>((props, ref: ForwardedRef<HTMLElement>) => {
+    const { label, children, popoverProps, onOpen, variant = 'button', ...triggerProps } = props;
 
-        const isIconButton = as === IconButton;
-        const triggerLabel = isIconButton ? undefined : label;
-        const extraTriggerProps = isIconButton ? ({ label } as any) : {};
+    return UI(
+        {
+            label,
+            children,
+            popoverProps,
+            onOpen,
+            variant,
+            triggerProps: { ...triggerProps, as: TRIGGER_COMPONENTS[variant], ref },
+        },
+        { MenuProvider, MenuTrigger, MenuPopover, MenuList },
+    );
+});
 
-        return UI(
-            {
-                label: triggerLabel,
-                children,
-                popoverProps,
-                onOpen,
-                triggerProps: { ...triggerProps, ...extraTriggerProps, as, ref },
-            },
-            { Menu },
-        );
-    }),
-    { displayName: COMPONENT_NAME },
-);
+MenuButton.displayName = COMPONENT_NAME;

--- a/packages/lumx-react/src/components/menu/MenuItem.test.tsx
+++ b/packages/lumx-react/src/components/menu/MenuItem.test.tsx
@@ -40,6 +40,12 @@ describe(`<${MenuItem.displayName}>`, () => {
         forwardAttributes: 'element',
         forwardRef: 'element',
     });
+
+    // ── afterIcon ──────────────────────────────────────────────
+    it('should render afterIcon', () => {
+        renderMenuItem({ children: 'Item', afterIcon: 'test-icon' });
+        expect(getByClassName(document.body, 'lumx-icon')).toBeInTheDocument();
+    });
 });
 
 // ── Type-level tests ──────────────────────────────────────────

--- a/packages/lumx-react/src/components/menu/MenuItem.tsx
+++ b/packages/lumx-react/src/components/menu/MenuItem.tsx
@@ -32,6 +32,8 @@ export interface MenuItemProps<E extends ElementType = 'button'>
     onClick?(event: SyntheticEvent): void;
     /** MDI icon rendered as `<Icon size="xs" />` prepended to the `before` slot. */
     icon?: string;
+    /** MDI icon rendered as `<Icon size="xs" />` appended to the `after` slot. */
+    afterIcon?: string;
     /** Foreground color applied to the icon and label text. */
     color?: ColorPalette;
     /** Content rendered before the label (rendered AFTER `icon` if both are provided). */
@@ -55,7 +57,7 @@ export const MenuItem: {
     className: typeof CLASSNAME;
 } = forwardRef<MenuItemProps, HTMLLIElement>((props, ref) => {
     const { handle } = useMenuContext();
-    const { children, icon, color, before, after, isDisabled, onClick, actionProps, ...rest } = props;
+    const { children, icon, afterIcon, color, before, after, isDisabled, onClick, actionProps, ...rest } = props;
 
     const internalRef = useRef<HTMLLIElement>(null);
     const actionRef = useRef<HTMLElement>(null);
@@ -86,12 +88,22 @@ export const MenuItem: {
         before
     );
 
+    // Append the optional `afterIcon` to the `after` slot.
+    const mergedAfter = afterIcon ? (
+        <>
+            {after}
+            <Icon icon={afterIcon} size="xs" color={color} />
+        </>
+    ) : (
+        after
+    );
+
     return UI({
         ...rest,
         ref: mergedRef,
         actionRef,
         before: mergedBefore,
-        after,
+        after: mergedAfter,
         children: (
             <Text as="span" color={color}>
                 {children}

--- a/packages/lumx-react/src/components/menu/context/MenuContext.ts
+++ b/packages/lumx-react/src/components/menu/context/MenuContext.ts
@@ -12,11 +12,11 @@ export interface MenuContextValue {
 
 export const MenuContext = createContext<MenuContextValue | undefined>(undefined);
 
-/** Use Menu context. @throws if used outside `Menu.Provider`. */
+/** Use Menu context. @throws if used outside `MenuProvider`. */
 export function useMenuContext(): MenuContextValue {
     const context = useContext(MenuContext);
     if (!context) {
-        throw new Error('Menu sub-components must be used within a Menu.Provider');
+        throw new Error('Menu sub-components must be used within a MenuProvider');
     }
     return context;
 }


### PR DESCRIPTION

Simplifying how we switch the button in the MenuButton with a `variant` rather than a `as` component

Bonus:
- Deduplicate `MenuPopover` props via `Pick<PopoverProps, ...>`
- Reorganize stories into `Variants` combo story (`withCombinations`)
- Add variant-specific tests and `afterIcon` prop on `MenuItem`


StoryBook lumx-vue: https://523e66298--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://523e66298--5fbfb1d508c0520021560f10.chromatic.com/