### PR TITLE
docs: add Menu demo pages, improve PropTable, fix SelectButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/vue`:
     -   `ClickAwayProvider`: resolve anchor refs lazily at click time to correctly exclude late-mounted elements
 
+### Changed
+
+-   `@lumx/react`:
+    -   `Dropdown`: deprecate component
+
 ## [4.16.0][] - 2026-06-08
 
 ### Changed

--- a/packages/lumx-core/src/js/components/SelectButton/index.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/index.tsx
@@ -20,11 +20,8 @@ export interface SelectButtonProps<O> extends BaseSelectProps<O> {
      * The wrapper layer chooses the shape; the core just renders names.
      */
     value?: O | O[];
-    /**
-     * When `true`, sets `aria-multiselectable="true"` on the listbox so
-     * the dropdown stays open after each selection (combobox setup detects this attribute).
-     */
-    isMultiselectable?: boolean;
+    /** Single or multiple selection */
+    selectionType?: 'single' | 'multiple';
     /** Button label (used for ARIA and when no selection). */
     label: string;
     /** Controls how the label/value is displayed in the button. */
@@ -81,6 +78,13 @@ export const COMPONENT_NAME = 'SelectButton';
 export const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-select-button';
 
 /**
+ * Component default props.
+ */
+export const DEFAULT_PROPS = {
+    selectionType: 'single',
+} as const;
+
+/**
  * SelectButton core template.
  * Renders a Combobox with a button trigger and a dropdown list of options.
  *
@@ -100,7 +104,7 @@ export const SelectButton = <O,>(props: SelectButtonProps<O>, { Combobox, Infini
         getSectionId,
         renderSectionTitle,
         value,
-        isMultiselectable,
+        selectionType = DEFAULT_PROPS.selectionType,
         label,
         labelDisplayMode,
         buttonProps,
@@ -117,6 +121,7 @@ export const SelectButton = <O,>(props: SelectButtonProps<O>, { Combobox, Infini
     const isFullLoading = listStatus === 'loading';
     const isLoadingMore = listStatus === 'loadingMore';
     const isError = listStatus === 'error';
+    const isMultiselectable = selectionType === 'multiple';
 
     /*
      * Display value: castArray normalizes single/multi value to an array, then resolve

--- a/packages/lumx-react/src/components/dropdown/Dropdown.tsx
+++ b/packages/lumx-react/src/components/dropdown/Dropdown.tsx
@@ -110,6 +110,7 @@ const DEFAULT_PROPS: Partial<DropdownProps> = {
 /**
  * Dropdown component.
  *
+ * @deprecated Use `MenuButton` for action-based dropdowns, `SelectButton` for selection-based dropdowns, or `Popover` for lower-level control.
  * @param  props Component props.
  * @param  ref   Component ref.
  * @return React element.

--- a/packages/lumx-react/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.tsx
@@ -3,7 +3,11 @@ import React, { ElementType, type ForwardedRef, useCallback, useState } from 're
 import { mdiMenuDown } from '@lumx/icons';
 import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
 import type { GenericProps, NamedProps } from '@lumx/core/js/types';
-import { SelectButton as UI, type SelectButtonProps as UIProps } from '@lumx/core/js/components/SelectButton';
+import {
+    SelectButton as UI,
+    type SelectButtonProps as UIProps,
+    DEFAULT_PROPS,
+} from '@lumx/core/js/components/SelectButton';
 import { type ComboboxButtonLabelDisplayMode } from '@lumx/core/js/components/Combobox/ComboboxButton';
 import { type SelectButtonTranslations, type SelectListStatus } from '@lumx/core/js/utils/select/types';
 import { ComponentRef } from '@lumx/react/utils/type';
@@ -31,10 +35,11 @@ type OmittedKeys =
     | 'ref';
 
 /** Select-specific props common to both single and multi modes. */
-type SelectButtonSelectProps<O> = Omit<
-    ReactToJSX<UIProps<O>>,
-    'renderOption' | 'buttonProps' | 'value' | 'isMultiselectable'
-> & {
+interface SelectButtonSelectProps<O>
+    extends ReactToJSX<
+        UIProps<O>,
+        'renderOption' | 'buttonProps' | 'value' | 'handleSelect' | 'listProps' | 'infiniteScrollOptions'
+    > {
     /** Called to load more options (infinite scroll). */
     onLoadMore?: () => void;
     /** Called when the dropdown opens or closes. */
@@ -44,7 +49,7 @@ type SelectButtonSelectProps<O> = Omit<
      * Props `value`, `isSelected`, `description` and `key` are merged in automatically.
      */
     renderOption?: (option: O, index: number) => React.ReactNode;
-};
+}
 
 /**
  * Forwarded trigger props for a given element `E`, minus the keys that the
@@ -162,7 +167,7 @@ export const SelectButton = (React.forwardRef as ForwardRefSelectButton)((props,
         renderOption,
         getSectionId,
         renderSectionTitle,
-        selectionType,
+        selectionType = DEFAULT_PROPS.selectionType,
         value,
         onChange,
         onLoadMore,
@@ -204,7 +209,7 @@ export const SelectButton = (React.forwardRef as ForwardRefSelectButton)((props,
             getSectionId,
             renderSectionTitle,
             value,
-            isMultiselectable: isMultiple,
+            selectionType,
             label,
             labelDisplayMode,
             buttonProps: { ...buttonProps, as: buttonAs, ref },

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
@@ -79,6 +79,11 @@ export interface MultipleSelectTextFieldProps<O = any> extends BaseSelectTextFie
 
 /**
  * SelectTextField props — supports both single and multiple selection.
+ * Discriminated on `selectionType`:
+ * - `'single'` → `value?: O`, `onChange?: (newValue?: O) => void`.
+ * - `'multiple'` → `value?: O[]`, `onChange?: (newValue?: O[]) => void`, `renderChip`, `getChipProps`.
+ *
+ * @typeParam O - Option object type, inferred from `options` / `getOptionId`.
  */
 export type SelectTextFieldProps<O = any> = SingleSelectTextFieldProps<O> | MultipleSelectTextFieldProps<O>;
 

--- a/packages/lumx-vue/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-vue/src/components/select-button/SelectButton.tsx
@@ -12,7 +12,12 @@ import {
 import { mdiMenuDown } from '@lumx/icons';
 import { type BaseSelectButtonWrapperProps } from '@lumx/core/js/utils/select/types';
 import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
-import { SelectButton as UI, type SelectButtonProps as UIProps } from '@lumx/core/js/components/SelectButton';
+import {
+    DEFAULT_PROPS,
+    CLASSNAME,
+    SelectButton as UI,
+    type SelectButtonProps as UIProps,
+} from '@lumx/core/js/components/SelectButton';
 import type { ComboboxButtonProps } from '@lumx/core/js/components/Combobox/ComboboxButton';
 import { InfiniteScroll } from '@lumx/vue/utils/InfiniteScroll';
 import { JSXElement } from '@lumx/core/js/types';
@@ -218,15 +223,13 @@ const SelectButton = defineComponent(
                 },
         );
 
-        const isMultiple = computed(() => props.selectionType === 'multiple');
-
         const handleSelect = (selectedOption: { value: string }) => {
             const next = toggleSelection(
                 props.options,
                 props.getOptionId,
                 props.value,
                 selectedOption?.value,
-                isMultiple.value,
+                props.selectionType === 'multiple',
             );
             emit('change', next);
         };
@@ -251,7 +254,7 @@ const SelectButton = defineComponent(
                     getSectionId: props.getSectionId as any,
                     renderSectionTitle: renderSectionTitle.value as any,
                     value: props.value,
-                    isMultiselectable: isMultiple.value,
+                    selectionType: props.selectionType,
                     label: props.label,
                     labelDisplayMode: props.labelDisplayMode,
                     buttonProps: {
@@ -307,3 +310,4 @@ const SelectButton = defineComponent(
 );
 
 export default SelectButton as unknown as SelectButtonConstructor & typeof SelectButton;
+export { DEFAULT_PROPS, CLASSNAME };

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
@@ -51,7 +51,11 @@ export interface MultipleSelectTextFieldProps<O = any> extends BaseSelectTextFie
 
 /**
  * SelectTextField props — supports both single and multiple selection.
- * Discriminated on `selectionType`: when `'multiple'`, `value` is `O[]`.
+ * Discriminated on `selectionType`:
+ * - `'single'` → `value?: O`, emits `change` with `O | undefined`.
+ * - `'multiple'` → `value?: O[]`, emits `change` with `O[] | undefined`.
+ *
+ * @typeParam O - Option object type, inferred from `options` / `getOptionId`.
  */
 export type SelectTextFieldProps<O = any> = SingleSelectTextFieldProps<O> | MultipleSelectTextFieldProps<O>;
 

--- a/packages/site-demo/content/product/components/autocomplete/index.mdx
+++ b/packages/site-demo/content/product/components/autocomplete/index.mdx
@@ -18,7 +18,7 @@ import ReactAutocompleteMultiple from 'lumx-docs:@lumx/react/components/autocomp
 
 <DemoBlock withThemeSwitcher demo={{ react: DemoDefault }} />
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactAutocomplete }} />
 
@@ -26,6 +26,6 @@ import ReactAutocompleteMultiple from 'lumx-docs:@lumx/react/components/autocomp
 
 <DemoBlock withThemeSwitcher demo={{ react: DemoMultiple }} />
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactAutocompleteMultiple }} />

--- a/packages/site-demo/content/product/components/avatar/index.mdx
+++ b/packages/site-demo/content/product/components/avatar/index.mdx
@@ -39,6 +39,6 @@ Avatars can have 3 different accessibility use cases:
 
 See the [button page](../button#accessibility-concerns) for the accessibility concerns on actions button.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactAvatar, vue: VueAvatar }} />

--- a/packages/site-demo/content/product/components/badge/index.mdx
+++ b/packages/site-demo/content/product/components/badge/index.mdx
@@ -61,6 +61,6 @@ A badge can contain two types of information:
 
 Keep in mind that the color can also carry an information, it may be translated for screen-readers through alt texts.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactBadge, vue: VueBadge }} />

--- a/packages/site-demo/content/product/components/button/index.mdx
+++ b/packages/site-demo/content/product/components/button/index.mdx
@@ -82,10 +82,9 @@ Buttons may have 3 specific accessibility use cases:
 
 All concerns about the `Button` component are true for `IconButton`, but as there is no text in the button, you have to provide a `label` describing what the button does.
 
-### Button properties
+## Properties
 
 <PropTable docs={{ react: ReactButton, vue: VueButton }} />
 
-### IconButton properties
 
 <PropTable docs={{ react: ReactIconButton, vue: VueIconButton }} />

--- a/packages/site-demo/content/product/components/checkbox/index.mdx
+++ b/packages/site-demo/content/product/components/checkbox/index.mdx
@@ -27,6 +27,6 @@ Checkbox can be disabled in two ways:
 -   `aria-disabled` only disable changes on the checkbox (read only) so it's still focusable and accessible. You'll have
     to setup either a `helper`, a tooltip or an aria description to explain to the user why it is disabled.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactCheckbox, vue: VueCheckbox }} />

--- a/packages/site-demo/content/product/components/chip/index.mdx
+++ b/packages/site-demo/content/product/components/chip/index.mdx
@@ -68,10 +68,9 @@ Chips can be disabled in two ways:
 -   `aria-disabled` only disable changes on the chip (read only) so it's still focusable and accessible. You'll have
     to setup either a tooltip or an aria description (must be visible too) to explain to the user why it is disabled.
 
-### Chip properties
+## Properties
 
 <PropTable docs={{ react: ReactChip, vue: VueChip }} />
 
-### ChipGroup properties
 
 <PropTable docs={{ react: ReactChipGroup, vue: VueChipGroup }} />

--- a/packages/site-demo/content/product/components/comment-block/index.mdx
+++ b/packages/site-demo/content/product/components/comment-block/index.mdx
@@ -30,6 +30,6 @@ Comment blocks and it's default subcomponents do not use any special landmark or
 
 Avoid using the deprecated `onClick`, `onMouseEnter` & `onMouseLeave` props as they do not provide accessible interactive elements.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactCommentBlock }} />

--- a/packages/site-demo/content/product/components/date-picker/index.mdx
+++ b/packages/site-demo/content/product/components/date-picker/index.mdx
@@ -24,6 +24,6 @@ Date selection can be restricted via `minDate` and `maxDate` properties.
 
 <DemoBlock orientation="horizontal" demo={{ react: DemoRestrictedSelectionModes }} />
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactDatePicker }} />

--- a/packages/site-demo/content/product/components/dialog/index.mdx
+++ b/packages/site-demo/content/product/components/dialog/index.mdx
@@ -51,10 +51,9 @@ Use processing state when dialogs contain a form which submission takes an exten
 
 <DemoBlock orientation="horizontal" vAlign="center" demo={{ react: ReactDemoProcessingState, vue: VueDemoProcessingState }} />
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactDialog, vue: VueDialog }} />
 
-### Alert Dialog Properties
 
 <PropTable docs={{ react: ReactAlertDialog }} />

--- a/packages/site-demo/content/product/components/divider/index.mdx
+++ b/packages/site-demo/content/product/components/divider/index.mdx
@@ -17,6 +17,6 @@ import VueDivider from 'lumx-docs:@lumx/vue/components/divider/Divider';
 
 Dividers use standard `hr` HTML elements and thus inherit the [`separator` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role).
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactDivider, vue: VueDivider }} />

--- a/packages/site-demo/content/product/components/dropdown/index.mdx
+++ b/packages/site-demo/content/product/components/dropdown/index.mdx
@@ -16,6 +16,7 @@ import ReactDropdown from 'lumx-docs:@lumx/react/components/dropdown/Dropdown';
 **Dropdowns present multiple actions in a small area.**
 Dropdowns are commonly used for contextual menus and in form selects.
 
+
 <DemoBlock orientation="horizontal" demo={{ react: DemoDefault }} />
 
 ## Programmatically controlled

--- a/packages/site-demo/content/product/components/dropdown/index.mdx
+++ b/packages/site-demo/content/product/components/dropdown/index.mdx
@@ -1,5 +1,6 @@
 ---
 frameworks: ['react']
+deprecated: true
 ---
 import * as DemoDefault from './react/default.tsx';
 import * as DemoProgrammaticallyControlled from './react/programmatically-controlled.tsx';
@@ -7,6 +8,10 @@ import * as DemoActionsStates from './react/actions-states.tsx';
 import ReactDropdown from 'lumx-docs:@lumx/react/components/dropdown/Dropdown';
 
 # Dropdown
+
+<DeprecationNotice>
+    Use [MenuButton](../menu-button) for action-based dropdowns, [SelectButton](../select-button) for selection-based dropdowns, or [Popover](../popover) for lower-level control. Dropdown is kept for backwards compatibility but will be removed in a future major version.
+</DeprecationNotice>
 
 **Dropdowns present multiple actions in a small area.**
 Dropdowns are commonly used for contextual menus and in form selects.

--- a/packages/site-demo/content/product/components/dropdown/index.mdx
+++ b/packages/site-demo/content/product/components/dropdown/index.mdx
@@ -40,6 +40,6 @@ We do not yet provide a simple way to create a full accessible menu or listbox t
 
 On top of the popover, dropdowns provide an "infinite scroll" callback to load more data into the dropdown while the user scrolls. Consider adding [`aria-setsize`](https://w3c.github.io/aria/#aria-setsize) and [`aria-posinset`](https://w3c.github.io/aria/#aria-posinset) to your dropdown list items so that screen readers can know the size of the list and the position of items in the list.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactDropdown }} />

--- a/packages/site-demo/content/product/components/expansion-panel/index.mdx
+++ b/packages/site-demo/content/product/components/expansion-panel/index.mdx
@@ -35,6 +35,6 @@ Expansion panels use a `section` landmark combined with a disclosure button (see
 
 Make sure the toggle button an appropriate label (defined in the `toggleButtonProps`) so that screen readers can clearly announce what the expansion panel shows once expanded.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactExpansionPanel }} />

--- a/packages/site-demo/content/product/components/flag/index.mdx
+++ b/packages/site-demo/content/product/components/flag/index.mdx
@@ -19,6 +19,6 @@ Use flags to display short to middle length pieces of info like labels, status, 
 
 Flags are simple text elements without any particular semantic or ARIA role.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactFlag, vue: VueFlag }} />

--- a/packages/site-demo/content/product/components/flex-box/index.mdx
+++ b/packages/site-demo/content/product/components/flex-box/index.mdx
@@ -15,6 +15,6 @@ If you are new to or unfamiliar with flexbox, we encourage you to read this <a h
 
 Flex boxes are simple layout blocks without any particular semantic or ARIA role. They use `<div>` by default, but it can be customized with the `as` property.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactFlexBox, vue: VueFlexBox }} />

--- a/packages/site-demo/content/product/components/generic-block/index.mdx
+++ b/packages/site-demo/content/product/components/generic-block/index.mdx
@@ -87,6 +87,6 @@ Generic blocks are mostly layout block. They use `div` by default but you can cu
 
 You can, for example, use `<GenericBlock as="article">` so that generic blocks are considered as independent, self-contained content on a page.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactGenericBlock, vue: VueGenericBlock }} />

--- a/packages/site-demo/content/product/components/grid-column/index.mdx
+++ b/packages/site-demo/content/product/components/grid-column/index.mdx
@@ -22,6 +22,6 @@ import VueGridColumn from 'lumx-docs:@lumx/vue/components/grid-column/GridColumn
 
 GridColumn is a simple layout blocks without any particular semantic or ARIA role. It use `<div>` by default, but it can be customized with the `as` property.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactGridColumn, vue: VueGridColumn }} />

--- a/packages/site-demo/content/product/components/heading/index.mdx
+++ b/packages/site-demo/content/product/components/heading/index.mdx
@@ -40,10 +40,9 @@ Use the `HeadingLevelProvider` component to help you automatically adapt heading
 
 Heading elements use standard HTML heading elements. Make sure to properly nest heading level in pages (`HeadingLevelProvider` can help with that).
 
-### Heading Properties
+## Properties
 
 <PropTable docs={{ react: ReactHeading, vue: VueHeading }} />
 
-### HeadingLevelProvider Properties
 
 <PropTable docs={{ react: ReactHeadingLevelProvider, vue: VueHeadingLevelProvider }} />

--- a/packages/site-demo/content/product/components/icon/index.mdx
+++ b/packages/site-demo/content/product/components/icon/index.mdx
@@ -50,6 +50,6 @@ By default, icons are hidden from screen reader as they are generally decoration
 
 The `alt` property can be used make it appear as an image with alternate text in screen readers.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactIcon, vue: VueIcon }} />

--- a/packages/site-demo/content/product/components/image-block/index.mdx
+++ b/packages/site-demo/content/product/components/image-block/index.mdx
@@ -43,6 +43,6 @@ Image blocks use standard HTML figure element with the `title`, `description` an
 
 See [thumbnail accessibility concerns](/product/components/thumbnail/#accessibility-concerns) for the image.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactImageBlock, vue: VueImageBlock }} />

--- a/packages/site-demo/content/product/components/image-lightbox/index.mdx
+++ b/packages/site-demo/content/product/components/image-lightbox/index.mdx
@@ -27,6 +27,6 @@ As this component is composed of a dialog and many action button, you must provi
 
 -   Labels for the zoom buttons via `zoomInButtonProps`and `zoomOutButtonProps` (see demo code).
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactImageLightbox }} />

--- a/packages/site-demo/content/product/components/inline-list/index.mdx
+++ b/packages/site-demo/content/product/components/inline-list/index.mdx
@@ -38,6 +38,6 @@ Inversely, the use of the `wrap` property will activate line wrap on overflow.
 
 Inline lists use standard `ul` list element and are read as such by screen readers.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactInlineList, vue: VueInlineList }} />

--- a/packages/site-demo/content/product/components/lightbox/index.mdx
+++ b/packages/site-demo/content/product/components/lightbox/index.mdx
@@ -26,6 +26,6 @@ This component uses the `dialog` accessible pattern, a few specific behaviors ar
 
 -   When closing, the activating element should take focus. Make sure to fill the `parentElement` prop to make this work properly.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactLightbox, vue: VueLightbox }} />

--- a/packages/site-demo/content/product/components/link-preview/index.mdx
+++ b/packages/site-demo/content/product/components/link-preview/index.mdx
@@ -25,6 +25,6 @@ Use `big` size to give more emphasis to the displayed hyperlink, make sure to ha
 Link previews use a standard `article` HTML element making it a self-contained section in which the link preview title is the heading (use `titleHeading` to customize its level).
 The thumbnail, title and link are all clickable but on keyboard focus navigation, only one element is accessible, either the title (if present) or the full link.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactLinkPreview, vue: VueLinkPreview }} />

--- a/packages/site-demo/content/product/components/link/index.mdx
+++ b/packages/site-demo/content/product/components/link/index.mdx
@@ -39,6 +39,6 @@ Links can change its `role` depending on the situation:
 
 If the link is within some other text, please **avoid to use the same color** as the neighbouring text because users won't be able to see where the link start or ends.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactLink, vue: VueLink }} />

--- a/packages/site-demo/content/product/components/list/index.mdx
+++ b/packages/site-demo/content/product/components/list/index.mdx
@@ -133,26 +133,21 @@ Use this when sections represent grouped items/options inside a `listbox` or `me
 `ListDivider` and the automatic dividers between `ListSection` are purely visual. Only a section with label provides
 a correct split of items in a list.
 
-### List properties
+## Properties
 
 <PropTable docs={{ react: ReactList, vue: VueList }} />
 
-### ListItem properties
 
 <PropTable docs={{ react: ReactListItem, vue: VueListItem }} />
 
-### ListItem.Action properties
 
 <PropTable docs={{ react: ReactListItemAction, vue: VueListItemAction }} />
 
-### ListSection properties
 
 <PropTable docs={{ react: ReactListSection, vue: VueListSection }} />
 
-### ListSubheader properties
 
 <PropTable docs={{ react: ReactListSubheader }} />
 
-### ListDivider properties
 
 <PropTable docs={{ react: ReactListDivider, vue: VueListDivider }} />

--- a/packages/site-demo/content/product/components/menu-button/index.mdx
+++ b/packages/site-demo/content/product/components/menu-button/index.mdx
@@ -1,0 +1,49 @@
+---
+frameworks: ['react', 'vue']
+---
+
+import * as ReactDemoDefault from './react/default.tsx';
+import * as ReactDemoVariants from './react/variants.tsx';
+import * as ReactDemoMenuItems from './react/menu-items.tsx';
+import * as VueDemoDefault from './vue/default.vue';
+import * as VueDemoVariants from './vue/variants.vue';
+import * as VueDemoMenuItems from './vue/menu-items.vue';
+import ReactMenuButton from 'lumx-docs:@lumx/react/components/menu-button/MenuButton';
+
+import VueMenuButton from 'lumx-docs:@lumx/vue/components/menu-button/MenuButton';
+
+# Menu button
+
+**Menu buttons open a dropdown of actions anchored to a button trigger.**
+
+Use a `MenuButton` when the dropdown contains **actions** (edit, delete, filter). For selection-based dropdowns, use [SelectButton](/product/components/select-button) instead.
+
+## Default
+
+A menu button triggers a dropdown with a list of actions. The trigger label describes what the menu controls.
+
+<DemoBlock orientation="horizontal" demo={{ react: ReactDemoDefault, vue: VueDemoDefault }} />
+
+## Trigger variants
+
+The menu trigger is interchangeable. By default it's a [Button](/product/components/button), whose appearance can be tuned with the usual button props (`emphasis`, `size`, `color`…).
+The `variant` prop swaps the trigger for an icon button, a chip, or a link, so the menu fits naturally wherever it's placed.
+
+<DemoBlock orientation="horizontal" vAlign="space-around" demo={{ react: ReactDemoVariants, vue: VueDemoVariants }} />
+
+## Menu items
+
+Each menu item have a label, before and after slots (usually used for icons). Items can also be rendered as a different element — for example a link that navigates to another page.
+
+<DemoBlock orientation="horizontal" demo={{ react: ReactDemoMenuItems, vue: VueDemoMenuItems }} />
+
+## Accessibility concerns
+
+Menu button uses a WAI-ARIA disclosure pattern (a button that expands and collapses a dropdown). Keep these points in mind:
+
+- Always provide a meaningful **label** so screen readers understand the menu's purpose.
+- For menu actions that navigate to a different page, use a true HTML `<a>` link instead of a button to preserve native browser behaviors (right-click, open in new tab, etc.).
+
+## Properties
+
+<PropTable docs={{ react: ReactMenuButton, vue: VueMenuButton }} />

--- a/packages/site-demo/content/product/components/menu-button/react/default.tsx
+++ b/packages/site-demo/content/product/components/menu-button/react/default.tsx
@@ -1,0 +1,17 @@
+import { MenuButton, MenuItem, MenuDivider } from '@lumx/react';
+import { mdiAccount, mdiCog, mdiLogout } from '@lumx/icons';
+
+export default () => (
+    <MenuButton label="Menu button">
+        <MenuItem icon={mdiAccount} onClick={() => alert('Profile')}>
+            Profile
+        </MenuItem>
+        <MenuItem icon={mdiCog} onClick={() => alert('Settings')}>
+            Settings
+        </MenuItem>
+        <MenuDivider />
+        <MenuItem icon={mdiLogout} onClick={() => alert('Logout')}>
+            Logout
+        </MenuItem>
+    </MenuButton>
+);

--- a/packages/site-demo/content/product/components/menu-button/react/menu-items.tsx
+++ b/packages/site-demo/content/product/components/menu-button/react/menu-items.tsx
@@ -1,0 +1,21 @@
+import { MenuButton, MenuItem, MenuDivider } from '@lumx/react';
+import { mdiDelete, mdiFileDocumentOutline, mdiOpenInNew, mdiPencil } from '@lumx/icons';
+
+export default () => (
+    <MenuButton label="Item options">
+        <MenuItem icon={mdiPencil} onClick={() => alert('Edit')}>
+            Edit
+        </MenuItem>
+        <MenuItem icon={mdiDelete} color="red" onClick={() => alert('Delete')}>
+            Delete
+        </MenuItem>
+        <MenuDivider />
+        <MenuItem
+            icon={mdiFileDocumentOutline}
+            afterIcon={mdiOpenInNew}
+            actionProps={{ as: 'a', href: 'https://example.com/docs', target: '_blank' }}
+        >
+            Documentation
+        </MenuItem>
+    </MenuButton>
+);

--- a/packages/site-demo/content/product/components/menu-button/react/variants.tsx
+++ b/packages/site-demo/content/product/components/menu-button/react/variants.tsx
@@ -1,0 +1,33 @@
+import { MenuButton, MenuItem, MenuDivider } from '@lumx/react';
+
+export default () => (
+    <>
+        <MenuButton label="Actions" emphasis="medium" size="s">
+            <MenuItem onClick={() => alert('Edit')}>Edit</MenuItem>
+            <MenuItem onClick={() => alert('Duplicate')}>Duplicate</MenuItem>
+            <MenuDivider />
+            <MenuItem onClick={() => alert('Delete')}>Delete</MenuItem>
+        </MenuButton>
+
+        <MenuButton variant="icon-button" emphasis="low" label="Actions">
+            <MenuItem onClick={() => alert('Edit')}>Edit</MenuItem>
+            <MenuItem onClick={() => alert('Duplicate')}>Duplicate</MenuItem>
+            <MenuDivider />
+            <MenuItem onClick={() => alert('Delete')}>Delete</MenuItem>
+        </MenuButton>
+
+        <MenuButton variant="chip" label="Actions">
+            <MenuItem onClick={() => alert('Edit')}>Edit</MenuItem>
+            <MenuItem onClick={() => alert('Duplicate')}>Duplicate</MenuItem>
+            <MenuDivider />
+            <MenuItem onClick={() => alert('Delete')}>Delete</MenuItem>
+        </MenuButton>
+
+        <MenuButton variant="link" label="Actions">
+            <MenuItem onClick={() => alert('Edit')}>Edit</MenuItem>
+            <MenuItem onClick={() => alert('Duplicate')}>Duplicate</MenuItem>
+            <MenuDivider />
+            <MenuItem onClick={() => alert('Delete')}>Delete</MenuItem>
+        </MenuButton>
+    </>
+);

--- a/packages/site-demo/content/product/components/menu-button/vue/default.vue
+++ b/packages/site-demo/content/product/components/menu-button/vue/default.vue
@@ -1,0 +1,15 @@
+<template>
+    <MenuButton label="Menu button">
+        <MenuItem :icon="mdiAccount" @click="() => alert('Profile')">Profile</MenuItem>
+        <MenuItem :icon="mdiCog" @click="() => alert('Settings')">Settings</MenuItem>
+        <MenuDivider />
+        <MenuItem :icon="mdiLogout" @click="() => alert('Logout')">Logout</MenuItem>
+    </MenuButton>
+</template>
+
+<script setup lang="ts">
+import { MenuButton, MenuItem, MenuDivider } from '@lumx/vue';
+import { mdiAccount, mdiCog, mdiLogout } from '@lumx/icons';
+
+const alert = window.alert;
+</script>

--- a/packages/site-demo/content/product/components/menu-button/vue/menu-items.vue
+++ b/packages/site-demo/content/product/components/menu-button/vue/menu-items.vue
@@ -1,0 +1,26 @@
+<template>
+    <MenuButton label="Item options">
+        <MenuItem :icon="mdiPencil" @click="() => alert('Edit')">Edit</MenuItem>
+        <MenuItem :icon="mdiDelete" color="red" @click="() => alert('Delete')">Delete</MenuItem>
+        <MenuDivider />
+        <MenuItem :icon="mdiFileDocumentOutline" :after-icon="mdiOpenInNew">
+            <template #action="{ actionProps }">
+                <a v-bind="actionProps" href="https://example.com/docs" target="_blank">Documentation</a>
+            </template>
+        </MenuItem>
+    </MenuButton>
+</template>
+
+<script setup lang="ts">
+import { MenuButton, MenuItem, MenuDivider } from '@lumx/vue';
+import {
+    mdiBookOpenOutline,
+    mdiContentCopy,
+    mdiDelete,
+    mdiFileDocumentOutline,
+    mdiOpenInNew,
+    mdiPencil,
+} from '@lumx/icons';
+
+const alert = window.alert;
+</script>

--- a/packages/site-demo/content/product/components/menu-button/vue/variants.vue
+++ b/packages/site-demo/content/product/components/menu-button/vue/variants.vue
@@ -1,0 +1,39 @@
+<template>
+    <!-- Default trigger, medium emphasis, small size -->
+    <MenuButton label="Actions" emphasis="medium" size="s">
+        <MenuItem @click="() => alert('Edit')">Edit</MenuItem>
+        <MenuItem @click="() => alert('Duplicate')">Duplicate</MenuItem>
+        <MenuDivider />
+        <MenuItem @click="() => alert('Delete')">Delete</MenuItem>
+    </MenuButton>
+
+    <!-- Icon button trigger -->
+    <MenuButton label="Actions" variant="icon-button" emphasis="low">
+        <MenuItem @click="() => alert('Edit')">Edit</MenuItem>
+        <MenuItem @click="() => alert('Duplicate')">Duplicate</MenuItem>
+        <MenuDivider />
+        <MenuItem @click="() => alert('Delete')">Delete</MenuItem>
+    </MenuButton>
+
+    <!-- Chip trigger -->
+    <MenuButton label="Actions" variant="chip">
+        <MenuItem @click="() => alert('Edit')">Edit</MenuItem>
+        <MenuItem @click="() => alert('Duplicate')">Duplicate</MenuItem>
+        <MenuDivider />
+        <MenuItem @click="() => alert('Delete')">Delete</MenuItem>
+    </MenuButton>
+
+    <!-- Link trigger -->
+    <MenuButton label="Actions" variant="link">
+        <MenuItem @click="() => alert('Edit')">Edit</MenuItem>
+        <MenuItem @click="() => alert('Duplicate')">Duplicate</MenuItem>
+        <MenuDivider />
+        <MenuItem @click="() => alert('Delete')">Delete</MenuItem>
+    </MenuButton>
+</template>
+
+<script setup lang="ts">
+import { MenuButton, MenuItem, MenuDivider } from '@lumx/vue';
+
+const alert = window.alert;
+</script>

--- a/packages/site-demo/content/product/components/message/index.mdx
+++ b/packages/site-demo/content/product/components/message/index.mdx
@@ -65,6 +65,6 @@ Messages do not use any special semantic or ARIA role by default.
 
 For important or time-sensitive messages, the [WAI-ARIA alert role](https://www.w3.org/WAI/ARIA/apg/patterns/alert/) can be added (use it wisely).
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactMessage, vue: VueMessage }} />

--- a/packages/site-demo/content/product/components/mosaic/index.mdx
+++ b/packages/site-demo/content/product/components/mosaic/index.mdx
@@ -52,6 +52,6 @@ Mosaic's thumbnails can be clickable to attach an [image lightbox](/product/comp
 
 See [thumbnail accessibility concerns](/product/components/thumbnail/#accessibility-concerns). Consider adding an explicit label on clickable thumbnails to make sure users know what action they do (open a lightbox, download image, etc.).
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactMosaic, vue: VueMosaic }} />

--- a/packages/site-demo/content/product/components/notification/index.mdx
+++ b/packages/site-demo/content/product/components/notification/index.mdx
@@ -16,6 +16,6 @@ Notifications use the ARIA `alert` role which will announce itself when it appea
 
 Clickable notifications (or containing clickable action button) are not easily accessible with the keyboard. Consider moving the focus to the clickable elements and restore the focus to the previous place when the notification is closed.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactNotification }} />

--- a/packages/site-demo/content/product/components/popover-dialog/index.mdx
+++ b/packages/site-demo/content/product/components/popover-dialog/index.mdx
@@ -24,6 +24,6 @@ As this component uses the `dialog` accessible pattern, a few specific behaviors
 
 -   The activating element should take focus on popover close (`focusAnchorOnClose` property, activated by default)
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactPopoverDialog }} />

--- a/packages/site-demo/content/product/components/popover/index.mdx
+++ b/packages/site-demo/content/product/components/popover/index.mdx
@@ -96,6 +96,6 @@ In this case, the following concerns should be handled:
 -   Follow the sames rules as described in the [popup section](/product/components/popover#popup)
 -   Use the [PopoverDialog](/product/component/popover-dialog) component to apply the correct role and pattern to the popover
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactPopover, vue: VuePopover }} />

--- a/packages/site-demo/content/product/components/progress-tracker/index.mdx
+++ b/packages/site-demo/content/product/components/progress-tracker/index.mdx
@@ -33,10 +33,9 @@ Step can be inactive or active but can't be completed while in error.
 
 <DemoBlock orientation="horizontal" demo={{ react: DemoError }} />
 
-### ProgressTracker properties
+## Properties
 
 <PropTable docs={{ react: ReactProgressTracker }} />
 
-### ProgressTrackerStep properties
 
 <PropTable docs={{ react: ReactProgressTrackerStep }} />

--- a/packages/site-demo/content/product/components/progress/index.mdx
+++ b/packages/site-demo/content/product/components/progress/index.mdx
@@ -29,10 +29,9 @@ Progress elements are purely visual and do not use any special accessibility or 
 
 Please look into ARIA live regions to announce the loading state and changes to the user.
 
-### Progress circular properties
+## Properties
 
 <PropTable docs={{ react: ReactProgressCircular, vue: VueProgressCircular }} />
 
-### Progress linear properties
 
 <PropTable docs={{ react: ReactProgressLinear, vue: VueProgressLinear }} />

--- a/packages/site-demo/content/product/components/radio-button/index.mdx
+++ b/packages/site-demo/content/product/components/radio-button/index.mdx
@@ -27,6 +27,6 @@ Radio button can disabled in two ways:
 -   `aria-disabled` only disable changes on the radio button (read only) so it's still focusable and accessible. You'll
     have to setup either a `helper`, a tooltip or an aria description to explain to the user why it is disabled.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactRadioButton, vue: VueRadioButton }} />

--- a/packages/site-demo/content/product/components/select-button/index.mdx
+++ b/packages/site-demo/content/product/components/select-button/index.mdx
@@ -19,6 +19,8 @@ import VueSelectButton from 'lumx-docs:@lumx/vue/components/select-button/Select
 
 **Select buttons let users pick one or more options from a dropdown anchored to a button trigger.**
 
+Use a `SelectButton` when the dropdown offers a **selection** (choose one or more options from a list). For action-based dropdowns (edit, delete, filter), use [MenuButton](/product/components/menu-button) instead.
+
 For a full text input with built-in search and filtering, use [Select text field](/product/components/select-text-field) instead.
 
 ## Default

--- a/packages/site-demo/content/product/components/select/index.mdx
+++ b/packages/site-demo/content/product/components/select/index.mdx
@@ -20,10 +20,9 @@ Use it when users need to select one or more options.
 
 <DemoBlock withThemeSwitcher demo={{ react: DemoSingleSelection }} />
 
-### Select properties
+## Properties
 
 <PropTable docs={{ react: ReactSelect }} />
 
-### SelectMultiple properties
 
 <PropTable docs={{ react: ReactSelectMultiple }} />

--- a/packages/site-demo/content/product/components/side-navigation/index.mdx
+++ b/packages/site-demo/content/product/components/side-navigation/index.mdx
@@ -47,10 +47,9 @@ Side navigation items default to a list item with a button inside. Adding a `lin
 
 Side navigation items with children use the [ARIA disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/) using the `isOpen` prop to control the expand/close state that should be toggled when the `onClick` is called. Combining `linkProps.href` and `onActionClick` will split the toggle button and the link.
 
-### SideNavigation properties
+## Properties
 
 <PropTable docs={{ react: ReactSideNavigation }} />
 
-### SideNavigationItem properties
 
 <PropTable docs={{ react: ReactSideNavigationItem }} />

--- a/packages/site-demo/content/product/components/skeleton/index.mdx
+++ b/packages/site-demo/content/product/components/skeleton/index.mdx
@@ -53,14 +53,12 @@ Skeletons are purely visual and do not use any special accessibility or landmark
 
 Please look into ARIA live regions to announce the loading state and changes to the user.
 
-### Skeleton circle properties
+## Properties
 
 <PropTable docs={{ react: ReactSkeletonCircle, vue: VueSkeletonCircle }} />
 
-### Skeleton rectangle properties
 
 <PropTable docs={{ react: ReactSkeletonRectangle, vue: VueSkeletonRectangle }} />
 
-### Skeleton typography properties
 
 <PropTable docs={{ react: ReactSkeletonTypography, vue: VueSkeletonTypography }} />

--- a/packages/site-demo/content/product/components/slider/index.mdx
+++ b/packages/site-demo/content/product/components/slider/index.mdx
@@ -31,6 +31,6 @@ Use to limit the choice between value propositions.
 
 <DemoBlock withThemeSwitcher demo={{ react: DemoStep }} />
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactSlider }} />

--- a/packages/site-demo/content/product/components/slideshow/index.mdx
+++ b/packages/site-demo/content/product/components/slideshow/index.mdx
@@ -24,6 +24,6 @@ Slideshows can play automatically.
 
 <DemoBlock orientation="horizontal" withThemeSwitcher vAlign="center" demo={{ react: DemoAutoplay }} />
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactSlideshow }} />

--- a/packages/site-demo/content/product/components/switch/index.mdx
+++ b/packages/site-demo/content/product/components/switch/index.mdx
@@ -27,6 +27,6 @@ Switches can be disabled in two ways:
 -   `aria-disabled` only disable changes on the switch (read only) so it's still focusable and accessible. You'll have
     to setup either a `helper`, a tooltip or an aria description to explain to the user why it is disabled.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactSwitch, vue: VueSwitch }} />

--- a/packages/site-demo/content/product/components/table/index.mdx
+++ b/packages/site-demo/content/product/components/table/index.mdx
@@ -29,14 +29,12 @@ Clickable table rows can be disabled or selected.
 
 Table components use standard HTML elements for semantic and structure. Consider adding a caption to describe the content of the table to the user.
 
-### Table properties
+## Properties
 
 <PropTable docs={{ react: ReactTable, vue: VueTable }} />
 
-### TableRow properties
 
 <PropTable docs={{ react: ReactTableRow, vue: VueTableRow }} />
 
-### TableCell properties
 
 <PropTable docs={{ react: ReactTableCell, vue: VueTableCell }} />

--- a/packages/site-demo/content/product/components/tabs/index.mdx
+++ b/packages/site-demo/content/product/components/tabs/index.mdx
@@ -34,18 +34,15 @@ import VueTabPanel from 'lumx-docs:@lumx/vue/components/tabs/TabPanel';
 
 `Tab`, `TabList` and `TabPanel` use the [WAI-ARIA tab pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) with no need for configuration.
 
-#### TabProvider properties
+## Properties
 
 <PropTable docs={{ react: ReactTabProvider, vue: VueTabProvider }} />
 
-#### TabList properties
 
 <PropTable docs={{ react: ReactTabList, vue: VueTabList }} />
 
-#### Tab properties
 
 <PropTable docs={{ react: ReactTab, vue: VueTab }} />
 
-#### TabPanel properties
 
 <PropTable docs={{ react: ReactTabPanel, vue: VueTabPanel }} />

--- a/packages/site-demo/content/product/components/text-field/index.mdx
+++ b/packages/site-demo/content/product/components/text-field/index.mdx
@@ -144,6 +144,6 @@ Text fields can be disabled in two ways:
 -   `aria-disabled` only disable editing the text field (read only) so it's still focusable and accessible. You'll have
     to setup either a `helper`, a tooltip or an aria description to explain to the user why this field is disabled.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactTextField, vue: VueTextField }} />

--- a/packages/site-demo/content/product/components/text/index.mdx
+++ b/packages/site-demo/content/product/components/text/index.mdx
@@ -49,6 +49,6 @@ Particularly, on titles, consider using HTML heading tags (`h1`, `h2`, `h3`, etc
 
 When cutting text overflow (with `noWrap` or `truncate`), screen readers will still read everything in text elements so **make sure content is not too long** or cut it beforehand.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactText, vue: VueText }} />

--- a/packages/site-demo/content/product/components/thumbnail/index.mdx
+++ b/packages/site-demo/content/product/components/thumbnail/index.mdx
@@ -106,6 +106,6 @@ Thumbnails may have 5 different accessibility use cases:
 
 If you have some troubles to define how to fill the `alt` attribute, you can use the [Alt decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/).
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactThumbnail, vue: VueThumbnail }} />

--- a/packages/site-demo/content/product/components/toolbar/index.mdx
+++ b/packages/site-demo/content/product/components/toolbar/index.mdx
@@ -48,6 +48,6 @@ A toolbar has three sections. An optional contextual icon button and a title on 
 
 Toolbars are simple layout blocks without any particular semantic or ARIA role.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactToolbar, vue: VueToolbar }} />

--- a/packages/site-demo/content/product/components/tooltip/index.mdx
+++ b/packages/site-demo/content/product/components/tooltip/index.mdx
@@ -36,6 +36,6 @@ Use `closeMode="hide"` to render the tooltip hidden when not activated and keep 
 
 Consider using the [Popover](/product/components/popover/#accessibility-concerns) as a disclosure element to show longer or richer messages.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactTooltip, vue: VueTooltip }} />

--- a/packages/site-demo/content/product/components/uploader/index.mdx
+++ b/packages/site-demo/content/product/components/uploader/index.mdx
@@ -42,6 +42,6 @@ Uploaders can be disabled in two ways:
 -   `aria-disabled` only disable click and on change (read only) so it's still focusable and accessible. You'll have
     to set up either a tooltip or an aria description to explain to the user why this field is disabled.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactUploader, vue: VueUploader }} />

--- a/packages/site-demo/content/product/components/user-block/index.mdx
+++ b/packages/site-demo/content/product/components/user-block/index.mdx
@@ -71,6 +71,6 @@ describe the button action or the link target.
 
 See the [button page](../button#accessibility-concerns) for the accessibility concerns on actions button.
 
-### Properties
+## Properties
 
 <PropTable docs={{ react: ReactUserBlock, vue: VueUserBlock }} />

--- a/packages/site-demo/plugins/lumx-prop-table/docgen.js
+++ b/packages/site-demo/plugins/lumx-prop-table/docgen.js
@@ -72,13 +72,25 @@ function getTypeNameFromNode(typeNode) {
         return names.length > 0 ? names : null;
     }
 
-    // Handle type references (named types like React.Ref<T>)
+    // Handle type references (named types like React.Ref<T>, ComboboxPopoverProps, etc.)
     if (kind === 'TypeReference') {
+        // Prefer the written type name from the node directly (getTypeName()) because resolving
+        // through the symbol/alias can yield the underlying type (e.g. ComboboxPopoverProps → Partial).
+        const writtenName = typeNode.getTypeName?.()?.getText();
+        if (writtenName) {
+            // Append explicit type arguments if present in the written code
+            const typeArgs = typeNode.getTypeArguments?.();
+            if (typeArgs && typeArgs.length > 0) {
+                const argTexts = typeArgs.map((a) => a.getText());
+                return `${writtenName}<${argTexts.join(', ')}>`;
+            }
+            return writtenName;
+        }
+
+        // Fallback: resolve through the symbol
         const symbol = type.getAliasSymbol() || type.getSymbol();
         const fqn = getCleanFQN(symbol);
-
         if (fqn) {
-            // Append explicit type arguments if present in the written code
             const typeArgs = typeNode.getTypeArguments?.();
             if (typeArgs && typeArgs.length > 0) {
                 const argTexts = typeArgs.map((a) => a.getText());
@@ -90,6 +102,21 @@ function getTypeNameFromNode(typeNode) {
 
     // Fallback to node text for other types (function types, etc.)
     return typeNode.getText();
+}
+
+/**
+ * Format a type alias FQN with its type arguments, if any.
+ * E.g. alias="Selector", args=["O"] → "Selector<O>"
+ *
+ * @param {string} fqn - The clean fully-qualified name
+ * @param {Type[]} aliasTypeArgs - The alias type arguments array
+ * @param {SourceFile} [sourceFile] - Source file for scoped text
+ * @returns {string}
+ */
+function formatFQNWithArgs(fqn, aliasTypeArgs, sourceFile) {
+    if (!aliasTypeArgs || aliasTypeArgs.length === 0) return fqn;
+    const argTexts = aliasTypeArgs.map((a) => sanitizeTypeText(sourceFile ? a.getText(sourceFile) : a.getText()));
+    return `${fqn}<${argTexts.join(', ')}>`;
 }
 
 /**
@@ -114,17 +141,28 @@ function extractUnionLiteralValues(unionTypes, sourceFile) {
             // Wrap strings in quotes for display, keep numbers/booleans as-is
             values.push(typeof literalValue === 'string' ? JSON.stringify(literalValue) : literalValue);
         } else if (t.getCallSignatures().length > 0) {
-            // Function types: use text representation (FQN would be the property name, not the type)
-            values.push(sourceFile ? t.getText(sourceFile) : t.getText());
+            // Function types: use sanitized text representation
+            values.push(sanitizeTypeText(sourceFile ? t.getText(sourceFile) : t.getText()));
         } else {
-            // For non-literal types in a union, use the symbol's FQN
+            // Array types (T[]) — use sanitized text directly rather than losing the element type
+            if (t.isArray?.()) {
+                values.push(sanitizeTypeText(sourceFile ? t.getText(sourceFile) : t.getText()));
+                continue;
+            }
+            // For non-literal types in a union, use the symbol's FQN (with type args)
             const symbol = t.getAliasSymbol() || t.getSymbol();
             const fqn = getCleanFQN(symbol);
             if (fqn) {
-                values.push(fqn);
+                // For generic utility types (Partial, Record, etc.) prefer sanitized text to preserve args
+                const aliasArgs = t.getAliasTypeArguments();
+                if (aliasArgs.length > 0) {
+                    values.push(formatFQNWithArgs(fqn, aliasArgs, sourceFile));
+                } else {
+                    values.push(fqn);
+                }
             } else {
-                // Fallback to text representation
-                values.push(t.getText());
+                // Fallback to sanitized text representation
+                values.push(sanitizeTypeText(sourceFile ? t.getText(sourceFile) : t.getText()));
             }
         }
     }
@@ -183,6 +221,38 @@ function isExpandableEnum(type) {
 }
 
 /**
+ * Sanitize a raw type text string, removing leaked absolute import paths.
+ * TypeScript sometimes emits `import("/abs/path/to/file").TypeName` in type text;
+ * this strips the import wrapper and keeps only the type name.
+ *
+ * @param {string} text - The raw type text
+ * @returns {string} - Cleaned type text
+ */
+function sanitizeTypeText(text) {
+    // Replace `import("...").Name` with just `Name`
+    return text.replace(/import\("[^"]*"\)\./g, '');
+}
+
+/**
+ * Check if a union type contains "complex" members (mapped types, conditionals, generics)
+ * that would produce unreadable output if we try to enumerate individual members.
+ * When true, prefer falling back to a sanitized whole-type text instead.
+ *
+ * @param {Type[]} unionTypes - The union member types (undefined/null already excluded)
+ * @returns {boolean}
+ */
+function hasComplexUnionMembers(unionTypes) {
+    return unionTypes.some((t) => {
+        if (t.isLiteral() || t.isBooleanLiteral() || t.isBoolean() || t.isString() || t.isNumber()) return false;
+        if (t.getCallSignatures().length > 0) return false;
+        // If the type has no alias and no clean symbol (e.g. mapped types, conditional types)
+        const symbol = t.getAliasSymbol() || t.getSymbol();
+        if (!getCleanFQN(symbol)) return true;
+        return false;
+    });
+}
+
+/**
  * Get the type text representation, handling unions and complex types.
  * Uses ts-morph symbol APIs to get clean fully qualified names where possible.
  *
@@ -202,6 +272,7 @@ function getTypeText(type, valueDecl, sourceFile) {
     // Handle union types
     if (type.isUnion()) {
         const unionTypes = type.getUnionTypes();
+        const meaningfulTypes = unionTypes.filter((t) => !t.isUndefined() && !t.isNull());
 
         // Check if this is an expandable enum (simple literal union from design system)
         // If so, expand it to show the actual values instead of the type name
@@ -222,7 +293,13 @@ function getTypeText(type, valueDecl, sourceFile) {
         const aliasSymbol = type.getAliasSymbol();
         if (aliasSymbol) {
             const fqn = getCleanFQN(aliasSymbol);
-            if (fqn) return fqn;
+            if (fqn) return formatFQNWithArgs(fqn, type.getAliasTypeArguments(), sourceFile);
+        }
+
+        // If the union has complex members (mapped/conditional types), fall back to
+        // sanitized whole-type text rather than dumping unreadable member representations.
+        if (hasComplexUnionMembers(meaningfulTypes)) {
+            return sanitizeTypeText(sourceFile ? type.getText(sourceFile) : type.getText());
         }
 
         // Fallback: extract values from the resolved union
@@ -251,13 +328,14 @@ function getTypeText(type, valueDecl, sourceFile) {
 
     // Function types: use text representation (FQN would be the property name, not the type)
     if (type.getCallSignatures().length > 0) {
-        return sourceFile ? type.getText(sourceFile) : type.getText();
+        return sanitizeTypeText(sourceFile ? type.getText(sourceFile) : type.getText());
     }
 
-    // Fallback: use symbol FQN or type text
+    // Fallback: use symbol FQN (with type args) or sanitized type text
     const symbol = type.getAliasSymbol() || type.getSymbol();
     const fqn = getCleanFQN(symbol);
-    return fqn || type.getText();
+    if (fqn) return formatFQNWithArgs(fqn, type.getAliasTypeArguments(), sourceFile);
+    return sanitizeTypeText(sourceFile ? type.getText(sourceFile) : type.getText());
 }
 
 /**
@@ -356,6 +434,35 @@ function getJsDocDeprecated(propSymbol) {
 }
 
 /**
+ * Check whether a declaration has an @internal JSDoc tag.
+ * @param {Node} decl - The declaration node
+ * @returns {boolean}
+ */
+function isJsDocInternalFromDeclaration(decl) {
+    if (!decl) return false;
+    const jsDocs = decl.getJsDocs?.();
+    if (jsDocs) {
+        for (const jsDoc of jsDocs) {
+            const tags = jsDoc.getTags?.();
+            if (!tags) continue;
+            for (const tag of tags) {
+                if (tag.getTagName() === 'internal') return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Check whether a property symbol is marked @internal in any of its declarations.
+ * @param {Symbol} propSymbol
+ * @returns {boolean}
+ */
+function isJsDocInternal(propSymbol) {
+    return findInDeclarations(propSymbol, (decl) => (isJsDocInternalFromDeclaration(decl) ? true : undefined), false);
+}
+
+/**
  * Get @alias tag value from a declaration node's JSDoc.
  */
 function getJsDocAliasFromDeclaration(decl) {
@@ -422,28 +529,156 @@ function getDeclarations(prop, rootPath) {
 function extractDefaultValues(sourceFile) {
     const defaults = {};
 
-    // Look for DEFAULT_PROPS constant
-    for (const varDecl of sourceFile.getVariableDeclarations()) {
-        if (varDecl.getName() !== 'DEFAULT_PROPS') continue;
+    /** Try to extract from a given source file. Returns true if DEFAULT_PROPS was found. */
+    function tryExtract(file) {
+        for (const varDecl of file.getVariableDeclarations()) {
+            if (varDecl.getName() !== 'DEFAULT_PROPS') continue;
 
-        const initializer = varDecl.getInitializer();
-        if (!initializer || initializer.getKindName() !== 'ObjectLiteralExpression') continue;
+            let initializer = varDecl.getInitializer();
+            if (!initializer) continue;
 
-        for (const prop of initializer.getProperties()) {
-            if (prop.getKindName() === 'PropertyAssignment') {
-                const name = prop.getName();
-                const value = prop.getInitializer()?.getText();
-                if (name && value) {
-                    // Remove quotes from string literals
-                    defaults[name] = value.replace(/^["']|["']$/g, '');
+            // Handle `as const` — unwrap AsExpression to get the ObjectLiteralExpression inside.
+            if (initializer.getKindName() === 'AsExpression') {
+                initializer = initializer.getExpression();
+            }
+
+            if (initializer.getKindName() !== 'ObjectLiteralExpression') continue;
+
+            for (const prop of initializer.getProperties()) {
+                if (prop.getKindName() === 'PropertyAssignment') {
+                    const name = prop.getName();
+                    const value = prop.getInitializer()?.getText();
+                    if (name && value) {
+                        defaults[name] = value.replace(/^["']|["']$/g, '');
+                    }
                 }
             }
+            return true;
         }
-        // Found DEFAULT_PROPS, no need to continue
-        break;
+        return false;
+    }
+
+    // First try the current file.
+    if (tryExtract(sourceFile)) return defaults;
+
+    // Follow re-exported DEFAULT_PROPS to its original source (e.g. from @lumx/core).
+    for (const importDecl of sourceFile.getImportDeclarations()) {
+        const namedImports = importDecl.getNamedImports();
+        const hasDefaultProps = namedImports.some((ni) => {
+            const name = ni.getAliasNode()?.getText() || ni.getName();
+            return name === 'DEFAULT_PROPS';
+        });
+        if (!hasDefaultProps) continue;
+
+        const resolvedModule = importDecl.getModuleSpecifierSourceFile();
+        if (resolvedModule && resolvedModule !== sourceFile) {
+            tryExtract(resolvedModule);
+            if (Object.keys(defaults).length > 0) break;
+        }
     }
 
     return defaults;
+}
+
+/**
+ * Collect all property symbols from a type, resolving Omit/Pick/Partial/Required utility types
+ * that ts-morph would otherwise return 0 properties for.
+ * Returns a Map of prop name -> symbol.
+ *
+ * @param {Type} t - The TypeScript type to collect properties from
+ * @returns {Map<string, Symbol>} - Map of prop name to symbol
+ */
+function collectPropsFromType(t) {
+    const propMap = new Map();
+
+    if (t.isIntersection()) {
+        for (const part of t.getIntersectionTypes()) {
+            for (const [name, sym] of collectPropsFromType(part)) {
+                if (!propMap.has(name)) propMap.set(name, sym);
+            }
+        }
+        return propMap;
+    }
+
+    // Resolve Omit<Base, Keys> — ts-morph often returns 0 properties for these
+    const aliasName = t.getAliasSymbol()?.getName();
+    const aliasArgs = t.getAliasTypeArguments();
+
+    if (aliasName === 'Omit' && aliasArgs.length >= 2) {
+        const baseType = aliasArgs[0];
+        const keysType = aliasArgs[1];
+        const excludedKeys = new Set();
+        const keyTypes = keysType.isUnion() ? keysType.getUnionTypes() : [keysType];
+        for (const k of keyTypes) {
+            if (k.isStringLiteral()) excludedKeys.add(k.getLiteralValue());
+        }
+        for (const sym of baseType.getProperties()) {
+            if (!excludedKeys.has(sym.getName())) propMap.set(sym.getName(), sym);
+        }
+        return propMap;
+    }
+
+    if (aliasName === 'Pick' && aliasArgs.length >= 2) {
+        const baseType = aliasArgs[0];
+        const keysType = aliasArgs[1];
+        const includedKeys = new Set();
+        const keyTypes = keysType.isUnion() ? keysType.getUnionTypes() : [keysType];
+        for (const k of keyTypes) {
+            if (k.isStringLiteral()) includedKeys.add(k.getLiteralValue());
+        }
+        for (const sym of baseType.getProperties()) {
+            if (includedKeys.has(sym.getName())) propMap.set(sym.getName(), sym);
+        }
+        return propMap;
+    }
+
+    if ((aliasName === 'Partial' || aliasName === 'Required') && aliasArgs.length >= 1) {
+        for (const sym of aliasArgs[0].getProperties()) {
+            propMap.set(sym.getName(), sym);
+        }
+        return propMap;
+    }
+
+    // Normal: direct properties
+    for (const sym of t.getProperties()) {
+        propMap.set(sym.getName(), sym);
+    }
+    return propMap;
+}
+
+/**
+ * Convert a property symbol to a prop info object.
+ *
+ * @param {Symbol} prop - The property symbol
+ * @param {SourceFile} sourceFile - The source file (for type resolution location)
+ * @param {string} rootPath - The project root path for relative file names
+ * @param {Object} defaultValues - Default values map (prop name -> default value string)
+ * @returns {Object} - The prop info object
+ */
+function propSymbolToInfo(prop, sourceFile, rootPath, defaultValues) {
+    const name = prop.getName();
+    const valueDecl = prop.getValueDeclaration();
+    const propType = prop.getTypeAtLocation(sourceFile);
+    const optional = prop.isOptional();
+    const defaultValue = defaultValues[name] || null;
+    const deprecatedReason = getJsDocDeprecated(prop);
+    const deprecated = deprecatedReason !== undefined;
+
+    let description = getJsDocDescription(prop);
+    if (deprecated && deprecatedReason) {
+        const deprecatedText = `@deprecated ${deprecatedReason}`;
+        description = description ? `${description}\n${deprecatedText}` : deprecatedText;
+    }
+
+    return {
+        name,
+        description,
+        required: !optional,
+        deprecated,
+        type: getTypeText(propType, valueDecl, sourceFile),
+        declarations: getDeclarations(prop, rootPath),
+        defaultValue,
+    };
 }
 
 /**
@@ -452,18 +687,16 @@ function extractDefaultValues(sourceFile) {
  * @param {SourceFile} sourceFile
  * @param {string} rootPath - The project root path for relative file names
  * @param {Object} [defaultValues] - Default values map (prop name -> default value string)
+ * @param {Map<string,Symbol>} [propMap] - Optional pre-collected prop map (skips re-collection if provided)
  */
-function extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, defaultValues = {}) {
+function extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, defaultValues = {}, propMap = null) {
     const properties = [];
     const seenProps = new Set();
     // Track alias relationships: alias prop name -> target prop name
     const aliasMap = new Map();
 
-    // Get the type of the interface
-    const interfaceType = interfaceDecl.getType();
-
-    // Get all properties including inherited ones
-    const typeProperties = interfaceType.getProperties();
+    // Get all properties — use provided map or collect from interface type
+    const typeProperties = propMap ? [...propMap.values()] : interfaceDecl.getType().getProperties();
 
     for (const prop of typeProperties) {
         const name = prop.getName();
@@ -472,6 +705,9 @@ function extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, def
         if (seenProps.has(name)) continue;
         seenProps.add(name);
 
+        // Skip @internal props (framework-internal, not part of the public API)
+        if (isJsDocInternal(prop)) continue;
+
         // Check for @alias tag
         const aliasTarget = getJsDocAlias(prop);
         if (aliasTarget) {
@@ -479,37 +715,7 @@ function extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, def
             continue;
         }
 
-        // Get the value declaration for this property (may be undefined for Pick<> types)
-        const valueDecl = prop.getValueDeclaration();
-
-        // Get the type at the location
-        const propType = prop.getTypeAtLocation(sourceFile);
-        const optional = prop.isOptional();
-
-        // Get default value if any
-        let defaultValue = defaultValues[name] || null;
-
-        const deprecatedReason = getJsDocDeprecated(prop);
-        const deprecated = deprecatedReason !== undefined;
-
-        // Build description, appending @deprecated reason if present
-        let description = getJsDocDescription(prop);
-        if (deprecated && deprecatedReason) {
-            const deprecatedText = `@deprecated ${deprecatedReason}`;
-            description = description ? `${description}\n${deprecatedText}` : deprecatedText;
-        }
-
-        const propInfo = {
-            name,
-            description,
-            required: !optional,
-            deprecated,
-            type: getTypeText(propType, valueDecl, sourceFile),
-            declarations: getDeclarations(prop, rootPath),
-            defaultValue,
-        };
-
-        properties.push(propInfo);
+        properties.push(propSymbolToInfo(prop, sourceFile, rootPath, defaultValues));
     }
 
     // Merge aliases into their target properties
@@ -522,6 +728,421 @@ function extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, def
     }
 
     return properties;
+}
+
+/**
+ * Detect if a type is a discriminated union of object types (not a simple literal union).
+ * Returns the discriminant property name and the union members if detected, else null.
+ *
+ * A discriminant is a property that:
+ *  - exists in all union members
+ *  - has a unique string-literal type (ignoring `undefined`) in each member
+ *
+ * @param {Type} type - The resolved type of the Props declaration
+ * @param {SourceFile} sourceFile - The source file for type resolution location
+ * @returns {{ discriminant: string, members: Type[] } | null}
+ */
+function detectDiscriminatedUnion(type, sourceFile) {
+    if (!type.isUnion()) return null;
+
+    const members = type.getUnionTypes();
+
+    // Must have 2+ members
+    if (members.length < 2) return null;
+
+    // All members must be object-like (not simple literals)
+    if (members.some((m) => m.isLiteral() || m.isUndefined() || m.isNull())) return null;
+
+    // Search for a discriminant prop in the first member's properties
+    const firstMemberProps = members[0].getProperties();
+    for (const prop of firstMemberProps) {
+        const propName = prop.getName();
+        const discriminantValues = [];
+        let valid = true;
+
+        for (const member of members) {
+            const memberProp = member.getProperty(propName);
+            if (!memberProp) {
+                valid = false;
+                break;
+            }
+            const pt = memberProp.getTypeAtLocation(sourceFile);
+            // Allow `"value" | undefined` — strip undefined
+            const nonUndef = pt.isUnion() ? pt.getUnionTypes().filter((u) => !u.isUndefined()) : [pt];
+            if (nonUndef.length === 1 && nonUndef[0].isStringLiteral()) {
+                discriminantValues.push(nonUndef[0].getLiteralValue());
+            } else {
+                valid = false;
+                break;
+            }
+        }
+
+        if (valid && new Set(discriminantValues).size === members.length) {
+            return { discriminant: propName, members };
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Extract @typeParam tags from a declaration's JSDoc.
+ *
+ * ts-morph's JSDocTypeParameterTag may not expose the parameter name via getNameNode()
+ * (it returns undefined). In that case, the comment text itself starts with the name:
+ * e.g. `O - Option object type...` → name="O", description="Option object type...".
+ *
+ * @param {InterfaceDeclaration|TypeAliasDeclaration} decl
+ * @returns {Array<{name: string, description: string}>}
+ */
+function extractTypeParams(decl) {
+    const result = [];
+    const jsDocs = decl.getJsDocs?.() ?? [];
+    for (const jsDoc of jsDocs) {
+        for (const tag of jsDoc.getTags?.() ?? []) {
+            const tagName = tag.getTagName();
+            if (tagName !== 'typeParam' && tagName !== 'template') continue;
+
+            const rawComment = getCommentText(tag.getComment());
+
+            // Try getNameNode() first (works for some ts-morph versions)
+            const nameFromNode = tag.getNameNode?.()?.getText();
+            if (nameFromNode) {
+                result.push({ name: nameFromNode, description: rawComment });
+                continue;
+            }
+
+            // Fallback: parse "Name - description" or "Name description" from the comment
+            // The name is the first word (type param names are single uppercase letters or PascalCase)
+            const match = rawComment.match(/^(\w+)\s*[-–]?\s*(.*)/s);
+            if (match) {
+                result.push({ name: match[1], description: match[2].trim() });
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Extract props for a discriminated-union Props type, returning common props and per-variant groups.
+ *
+ * @param {InterfaceDeclaration|TypeAliasDeclaration} interfaceDecl
+ * @param {SourceFile} sourceFile
+ * @param {string} rootPath
+ * @param {Object} defaultValues
+ * @returns {{ commonProps: Object[], variants: { discriminant: string, items: Array<{ value: string, props: Object[] }> } } | null}
+ *   Returns null if not a discriminated union.
+ */
+function extractDiscriminatedUnionProps(interfaceDecl, sourceFile, rootPath, defaultValues) {
+    const type = interfaceDecl.getType();
+    const unionInfo = detectDiscriminatedUnion(type, sourceFile);
+    if (!unionInfo) return null;
+
+    const { discriminant, members } = unionInfo;
+
+    // Collect all props per member using Omit/Pick-aware resolution
+    const memberPropMaps = members.map((m) => collectPropsFromType(m));
+
+    // Determine common props: present in ALL members with:
+    // 1. The same name
+    // 2. A non-never type in every member (never = intentionally excluded from that variant)
+    // 3. The same type text across all members (variant-specific types like O vs O[] stay in variants)
+    const commonPropNames = new Set(
+        [...memberPropMaps[0].keys()].filter((name) => {
+            if (!memberPropMaps.every((m) => m.has(name))) return false;
+
+            // Exclude discriminant — handled separately as the variant key
+            if (name === discriminant) return false;
+
+            // Collect type text per member using the prop map (supports deep intersection props)
+            const typeTexts = memberPropMaps.map((memberMap) => {
+                const sym = memberMap.get(name);
+                if (!sym) return null;
+                const t = sym.getTypeAtLocation(sourceFile);
+                const resolvedText = t.getText();
+                // If resolved type is `never` or `undefined` (from `prop?: never`), check typeNode
+                if (resolvedText === 'never') return null;
+                // Also check typeNode for `never` annotation
+                const valDecl = sym.getValueDeclaration?.();
+                if (valDecl?.getTypeNode?.()?.getText() === 'never') return null;
+                return resolvedText;
+            });
+
+            // Prop is common only if all members have the same non-null type text
+            if (typeTexts.some((t) => t === null)) return false;
+            const firstText = typeTexts[0];
+            return typeTexts.every((t) => t === firstText);
+        }),
+    );
+
+    // Gather common prop symbols from the first member (they share the same symbol for inherited props)
+    const commonPropMap = new Map();
+    for (const name of commonPropNames) {
+        commonPropMap.set(name, memberPropMaps[0].get(name));
+    }
+
+    // Build common props list (exclude the discriminant itself — shown in variant headers)
+    const commonPropMapWithoutDiscriminant = new Map(commonPropMap);
+    commonPropMapWithoutDiscriminant.delete(discriminant);
+    const commonProps = extractPropertiesFromInterface(
+        interfaceDecl,
+        sourceFile,
+        rootPath,
+        defaultValues,
+        commonPropMapWithoutDiscriminant,
+    );
+
+    // Build per-variant groups: only props unique to each member (not in common, and not `never`)
+    const variantItems = members.map((member, idx) => {
+        const memberMap = memberPropMaps[idx];
+        const variantPropMap = new Map();
+        for (const [name, sym] of memberMap) {
+            if (commonPropNames.has(name)) continue;
+            if (name === discriminant) continue;
+            // Skip `never`-typed props (they're "explicitly blocked" markers, not real props).
+            // `prop?: never` resolves to `undefined` in the type system, so check both the
+            // resolved type text AND the value declaration's typeNode text.
+            const propType = sym.getTypeAtLocation(sourceFile);
+            if (propType.getText() === 'never') continue;
+            const propValueDecl = sym.getValueDeclaration?.();
+            if (propValueDecl?.getTypeNode?.()?.getText() === 'never') continue;
+            variantPropMap.set(name, sym);
+        }
+
+        // Get the discriminant value for this member
+        const discriminantProp = member.getProperty(discriminant);
+        const discriminantType = discriminantProp?.getTypeAtLocation(sourceFile);
+        const nonUndef = discriminantType?.isUnion()
+            ? discriminantType.getUnionTypes().filter((u) => !u.isUndefined())
+            : [discriminantType];
+        const value = nonUndef[0]?.isStringLiteral() ? nonUndef[0].getLiteralValue() : String(idx);
+
+        const props = [...variantPropMap.values()].map((sym) =>
+            propSymbolToInfo(sym, sourceFile, rootPath, defaultValues),
+        );
+
+        // Mark the variant as default using DEFAULT_PROPS constant if available, otherwise
+        // fall back to detecting an optional literal discriminant (e.g. `selectionType?: 'single'`
+        // is optional only in the single-member, meaning 'single' is the implicit default).
+        let isDefault = false;
+        if (defaultValues[discriminant] !== undefined) {
+            isDefault = value === defaultValues[discriminant];
+        } else {
+            const discriminantPropSym = member.getProperty(discriminant);
+            isDefault = discriminantPropSym?.isOptional() === true;
+        }
+
+        return { value, props, ...(isDefault ? { isDefault: true } : {}) };
+    });
+
+    // Only emit variants if at least one variant has props worth showing
+    const hasVariantProps = variantItems.some((item) => item.props.length > 0);
+    if (!hasVariantProps) return null;
+
+    return {
+        commonProps,
+        variants: { discriminant, items: variantItems },
+    };
+}
+
+/**
+ * Detect and extract props for a generic Props type that uses a selection-mode type parameter
+ * (e.g. `S extends 'single' | 'multiple'`) with conditional `value` / `onChange` types.
+ *
+ * This handles the React `SelectButtonProps<O, E, S>` pattern where the type is NOT a union
+ * at the TypeScript level (because S is unbound), but semantically behaves like one.
+ *
+ * Strategy:
+ *  1. Check whether the Props type alias has a type param constrained to a union of string literals
+ *     AND the type has a `selectionType` property typed as that param.
+ *  2. Find all props whose typeNode text contains `S extends '...' ? A : B` conditionals.
+ *  3. Produce two variant prop groups by text-substituting the resolved branch for each value of S.
+ *  4. Common props are all props that DON'T have conditional types (i.e., the same across all modes).
+ *
+ * @param {TypeAliasDeclaration} interfaceDecl - Must be a TypeAliasDeclaration with type params
+ * @param {SourceFile} sourceFile
+ * @param {string} rootPath
+ * @param {Object} defaultValues
+ * @returns {{ commonProps: Object[], variants: { discriminant: string, items: Array<{ value: string, props: Object[] }> } } | null}
+ */
+function extractConditionalSelectionVariants(interfaceDecl, sourceFile, rootPath, defaultValues) {
+    // Only applies to type aliases (not plain interfaces)
+    const typeParams = interfaceDecl.getTypeParameters?.();
+    if (!typeParams || typeParams.length === 0) return null;
+
+    // Find a type param with a string-literal-union constraint (e.g. `S extends 'single' | 'multiple'`)
+    let selectionParam = null;
+    let selectionValues = [];
+    let selectionDefaultValue = null;
+
+    for (const tp of typeParams) {
+        const constraint = tp.getConstraint();
+        if (!constraint) continue;
+        const constraintType = constraint.getType();
+        if (!constraintType.isUnion()) continue;
+        const members = constraintType.getUnionTypes();
+        if (!members.every((m) => m.isStringLiteral())) continue;
+        const values = members.map((m) => m.getLiteralValue());
+        if (values.length < 2) continue;
+        selectionParam = tp.getName();
+        selectionValues = values;
+        // Capture the default value if present (e.g. `= 'single'`)
+        const defaultNode = tp.getDefault();
+        if (defaultNode) {
+            const defaultType = defaultNode.getType();
+            if (defaultType.isStringLiteral()) {
+                selectionDefaultValue = defaultType.getLiteralValue();
+            }
+        }
+        break;
+    }
+
+    if (!selectionParam) return null;
+
+    // Verify the Props type has a `selectionType` prop typed as `S` (or `S | undefined`)
+    const type = interfaceDecl.getType();
+    const selTypeProp = type.getProperty('selectionType');
+    if (!selTypeProp) return null;
+    const selTypeDecl = selTypeProp.getValueDeclaration?.();
+    const selTypeNode = selTypeDecl?.getTypeNode?.();
+    if (!selTypeNode || selTypeNode.getText() !== selectionParam) return null;
+
+    // Collect all props from the type
+    const allProps = type.getProperties();
+
+    // For each prop, check if its typeNode contains a conditional involving `S`
+    // Pattern: `S extends 'X' ? TrueType : FalseType`
+    const conditionalPattern = new RegExp(
+        `\\b${selectionParam}\\s+extends\\s+`,
+    );
+
+    // Split props into common (no conditional) and conditional (per-variant)
+    const commonPropSymbols = [];
+    const conditionalPropSymbols = []; // [{name, sym, typeNodeText}]
+
+    for (const sym of allProps) {
+        if (sym.getName() === 'selectionType') continue; // shown in variant header, skip
+
+        const decl = sym.getValueDeclaration?.();
+        const typeNodeText = decl?.getTypeNode?.()?.getText() ?? '';
+
+        if (conditionalPattern.test(typeNodeText)) {
+            conditionalPropSymbols.push({ name: sym.getName(), sym, typeNodeText });
+        } else {
+            commonPropSymbols.push(sym);
+        }
+    }
+
+    // If no conditional props found, this isn't a selection-mode generic
+    if (conditionalPropSymbols.length === 0) return null;
+
+    // Build common props list
+    const commonPropMap = new Map();
+    for (const sym of commonPropSymbols) {
+        commonPropMap.set(sym.getName(), sym);
+    }
+    const commonProps = extractPropertiesFromInterface(
+        interfaceDecl,
+        sourceFile,
+        rootPath,
+        defaultValues,
+        commonPropMap,
+    );
+
+    // For each selection value, resolve each conditional prop's type by text substitution.
+    // `S extends 'multiple' ? O[] : O` with S='multiple' → 'O[]'; with S='single' → 'O'
+    // This is pure text manipulation — we don't need full TS resolution since O remains generic.
+    function resolveConditional(typeNodeText, paramName, paramValue) {
+        // Parse the outermost conditional: `P extends 'V' ? TrueType : FalseType`
+        // We can't use a simple regex for TrueType because it may contain `:` (e.g. function types).
+        // Instead, find the `?` after the extends clause, then scan for the balancing `:` at depth 0.
+        const extendsRegex = new RegExp(`\\b${paramName}\\s+extends\\s+'([^']+)'\\s*\\?\\s*`);
+        const extendsMatch = typeNodeText.match(extendsRegex);
+        if (!extendsMatch) return typeNodeText;
+
+        const condValue = extendsMatch[1];
+        const afterQuestion = typeNodeText.slice(extendsMatch.index + extendsMatch[0].length);
+
+        // Scan afterQuestion for the `:` that splits true/false branches at depth 0.
+        // Depth increases on `<`, `(`, `{` and decreases on `>`, `)`, `}`.
+        // BUT `=>` is an arrow function — the `>` there must NOT decrease depth.
+        // We track whether the previous non-space char was `=` to skip those `>`.
+        let depth = 0;
+        let splitIdx = -1;
+        let prevNonSpace = '';
+        for (let i = 0; i < afterQuestion.length; i++) {
+            const ch = afterQuestion[i];
+            if (ch === '<' || ch === '(' || ch === '{') {
+                depth++;
+            } else if (ch === ')' || ch === '}') {
+                depth--;
+            } else if (ch === '>') {
+                // Only count as closing bracket if not part of `=>`
+                if (prevNonSpace !== '=') depth--;
+            } else if (ch === ':' && depth === 0) {
+                splitIdx = i;
+                break;
+            }
+            if (ch !== ' ') prevNonSpace = ch;
+        }
+
+        if (splitIdx === -1) return typeNodeText;
+
+        const trueType = afterQuestion.slice(0, splitIdx).trim();
+        const falseType = afterQuestion.slice(splitIdx + 1).trim();
+        const result = paramValue === condValue ? trueType : falseType;
+        // Recursively resolve any remaining conditionals in the result
+        return conditionalPattern.test(result) ? resolveConditional(result, paramName, paramValue) : result;
+    }
+
+    const variantItems = selectionValues.map((value) => {
+        const props = conditionalPropSymbols.map(({ name, sym, typeNodeText }) => {
+            const resolvedType = resolveConditional(typeNodeText, selectionParam, value);
+
+            // Build the prop info, overriding the type with the resolved conditional
+            const decl = sym.getValueDeclaration?.();
+            const optional = sym.isOptional();
+            const defaultValue = defaultValues[name] || null;
+            const deprecatedReason = getJsDocDeprecated(sym);
+            const deprecated = deprecatedReason !== undefined;
+            let description = getJsDocDescription(sym);
+            if (deprecated && deprecatedReason) {
+                const deprecatedText = `@deprecated ${deprecatedReason}`;
+                description = description ? `${description}\n${deprecatedText}` : deprecatedText;
+            }
+
+            return {
+                name,
+                description,
+                required: !optional,
+                deprecated,
+                type: sanitizeTypeText(resolvedType),
+                declarations: getDeclarations(sym, rootPath),
+                defaultValue,
+            };
+        });
+
+        // Mark the variant as default using the type param default if present, otherwise
+        // fall back to the DEFAULT_PROPS constant.
+        let isDefault = false;
+        if (selectionDefaultValue !== null) {
+            isDefault = value === selectionDefaultValue;
+        } else if (defaultValues['selectionType'] !== undefined) {
+            isDefault = value === defaultValues['selectionType'];
+        }
+        return { value, props, ...(isDefault ? { isDefault: true } : {}) };
+    });
+
+    // Only emit if at least one variant has non-trivial props (e.g. single=O, multiple=O[] differ)
+    const allSame = variantItems.every((item) =>
+        item.props.every((p, i) => p.type === variantItems[0].props[i]?.type),
+    );
+    if (allSame) return null;
+
+    return {
+        commonProps,
+        variants: { discriminant: 'selectionType', items: variantItems },
+    };
 }
 
 /**
@@ -617,6 +1238,9 @@ exports.getSourceFile = getSourceFile;
 exports.findComponentInterface = findComponentInterface;
 exports.findTypeByName = findTypeByName;
 exports.extractPropertiesFromInterface = extractPropertiesFromInterface;
+exports.extractDiscriminatedUnionProps = extractDiscriminatedUnionProps;
+exports.extractConditionalSelectionVariants = extractConditionalSelectionVariants;
+exports.extractTypeParams = extractTypeParams;
 exports.extractDefaultValues = extractDefaultValues;
 exports.getJsDocFromDeclaration = getJsDocFromDeclaration;
 exports.getJsDocDeprecatedFromDeclaration = getJsDocDeprecatedFromDeclaration;

--- a/packages/site-demo/plugins/lumx-prop-table/props-loader.js
+++ b/packages/site-demo/plugins/lumx-prop-table/props-loader.js
@@ -37,8 +37,11 @@ function lumxDocsWebpackLoader() {
             projectConf.project = createProject(path.resolve(ROOT_PATH, packagePath));
         }
 
-        // Add dependency so webpack watches the component file
+        // Add dependency so webpack watches the component file and the docgen scripts themselves
         this.addDependency(filePath);
+        this.addDependency(require.resolve('./docgen.js'));
+        this.addDependency(require.resolve('./react-docgen.js'));
+        this.addDependency(require.resolve('./vue-docgen.js'));
 
         // Parse with the appropriate framework docgen
         const result = projectConf.parse(projectConf.project, filePath);

--- a/packages/site-demo/plugins/lumx-prop-table/react-docgen.js
+++ b/packages/site-demo/plugins/lumx-prop-table/react-docgen.js
@@ -5,6 +5,9 @@ const {
     getRootPath,
     findComponentInterface,
     extractPropertiesFromInterface,
+    extractDiscriminatedUnionProps,
+    extractConditionalSelectionVariants,
+    extractTypeParams,
     extractDefaultValues,
     getJsDocDeprecatedFromDeclaration,
 } = require('./docgen.js');
@@ -89,14 +92,30 @@ function parseReactComponent(project, filePath) {
 
     const rootPath = getRootPath(project);
     const defaultValues = extractDefaultValues(sourceFile);
-    const props = extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, defaultValues);
     const displayName = getComponentName(sourceFile);
     const deprecated = getComponentDeprecated(sourceFile, displayName);
 
-    const result = { displayName, props };
+    // Detect discriminated union Props (e.g. MenuButton variants) — true TS union
+    const unionResult = extractDiscriminatedUnionProps(interfaceDecl, sourceFile, rootPath, defaultValues);
+    // Detect generic selection-mode Props with conditional types (e.g. SelectButton<O,E,S>)
+    const conditionalResult =
+        !unionResult && extractConditionalSelectionVariants(interfaceDecl, sourceFile, rootPath, defaultValues);
+
+    const splitResult = unionResult || conditionalResult;
+    const result = splitResult
+        ? { displayName, props: splitResult.commonProps, variants: splitResult.variants }
+        : { displayName, props: extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, defaultValues) };
+
     if (deprecated !== undefined) {
         result.deprecated = deprecated;
     }
+
+    // Extract @typeParam documentation
+    const typeParams = extractTypeParams(interfaceDecl);
+    if (typeParams.length > 0) {
+        result.typeParams = typeParams;
+    }
+
     return result;
 }
 

--- a/packages/site-demo/plugins/lumx-prop-table/vue-docgen.js
+++ b/packages/site-demo/plugins/lumx-prop-table/vue-docgen.js
@@ -5,6 +5,9 @@ const {
     getRootPath,
     findComponentInterface,
     extractPropertiesFromInterface,
+    extractDiscriminatedUnionProps,
+    extractConditionalSelectionVariants,
+    extractTypeParams,
     extractDefaultValues,
     getJsDocFromDeclaration,
     getJsDocDeprecatedFromDeclaration,
@@ -12,37 +15,13 @@ const {
 
 /**
  * Extract default values for a Vue component.
- * Vue components re-export DEFAULT_PROPS from @lumx/core, so we need to
- * follow the import chain to find the original definition.
+ * Delegates to the shared extractDefaultValues which now follows re-exports.
  *
  * @param {SourceFile} sourceFile - The Vue component source file
  * @returns {Object} - Map of prop name to default value string
  */
 function extractVueDefaultValues(sourceFile) {
-    // First try local definition (same as React)
-    const localDefaults = extractDefaultValues(sourceFile);
-    if (Object.keys(localDefaults).length > 0) {
-        return localDefaults;
-    }
-
-    // Follow re-exported DEFAULT_PROPS to its original source
-    for (const importDecl of sourceFile.getImportDeclarations()) {
-        const namedImports = importDecl.getNamedImports();
-        const defaultPropsImport = namedImports.find((ni) => {
-            // Handle both `import { DEFAULT_PROPS }` and `import { X as DEFAULT_PROPS }`
-            const name = ni.getAliasNode()?.getText() || ni.getName();
-            return name === 'DEFAULT_PROPS';
-        });
-
-        if (defaultPropsImport) {
-            const resolvedModule = importDecl.getModuleSpecifierSourceFile();
-            if (resolvedModule) {
-                return extractDefaultValues(resolvedModule);
-            }
-        }
-    }
-
-    return {};
+    return extractDefaultValues(sourceFile);
 }
 
 /**
@@ -250,16 +229,32 @@ function parseVueComponent(project, filePath) {
 
     const rootPath = getRootPath(project);
     const defaultValues = extractVueDefaultValues(sourceFile);
-    const props = extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, defaultValues);
     const displayName = getVueComponentName(sourceFile);
     const events = extractEmits(sourceFile);
     const slots = extractSlots(sourceFile);
     const deprecated = getVueComponentDeprecated(sourceFile);
 
-    const result = { displayName, props, events, slots };
+    // Detect discriminated union Props (e.g. MenuButton variants) — true TS union
+    const unionResult = extractDiscriminatedUnionProps(interfaceDecl, sourceFile, rootPath, defaultValues);
+    // Detect generic selection-mode Props with conditional types
+    const conditionalResult =
+        !unionResult && extractConditionalSelectionVariants(interfaceDecl, sourceFile, rootPath, defaultValues);
+
+    const splitResult = unionResult || conditionalResult;
+    const result = splitResult
+        ? { displayName, props: splitResult.commonProps, variants: splitResult.variants, events, slots }
+        : { displayName, props: extractPropertiesFromInterface(interfaceDecl, sourceFile, rootPath, defaultValues), events, slots };
+
     if (deprecated !== undefined) {
         result.deprecated = deprecated;
     }
+
+    // Extract @typeParam documentation
+    const typeParams = extractTypeParams(interfaceDecl);
+    if (typeParams.length > 0) {
+        result.typeParams = typeParams;
+    }
+
     return result;
 }
 

--- a/packages/site-demo/src/components/content/PropTable/PropTable.scss
+++ b/packages/site-demo/src/components/content/PropTable/PropTable.scss
@@ -16,55 +16,26 @@
 }
 
 /* ==========================================================================
-   Variant sections (discriminated-union props)
+   Details animation
    ========================================================================== */
 
-.prop-table__variants {
-    margin-top: $lumx-spacing-unit * 4;
-}
+.prop-table__details {
+    interpolate-size: allow-keywords;
 
-.prop-table__variant {
-    margin-top: $lumx-spacing-unit * 2;
-    border: 1px solid lumx-color-variant("dark", "L4");
-    border-radius: var(--lumx-border-radius);
-    overflow: hidden;
-
-    &-summary {
-        display: flex;
-        align-items: center;
-        padding: $lumx-spacing-unit * 2 $lumx-spacing-unit * 3;
-        background-color: lumx-color-variant("dark", "L5");
+    & > summary {
         margin-top: $lumx-spacing-unit;
         cursor: pointer;
-        list-style: none;
-        user-select: none;
-
-        &::-webkit-details-marker {
-            display: none;
-        }
-
-        &::before {
-            content: "▶";
-            display: inline-block;
-            margin-right: $lumx-spacing-unit * 2;
-            font-size: 0.65em;
-            transition: transform 0.15s ease;
-        }
     }
 
-    &[open] > &-summary::before {
-        transform: rotate(90deg);
+    &::details-content {
+        overflow: clip;
+        height: 0;
+        transition: height 0.3s ease,
+                    content-visibility 0.3s allow-discrete;
     }
 
-    &-label {
-        code {
-            font-family: monospace;
-            font-size: 0.9em;
-        }
-    }
-
-    &-body {
-        padding-top: $lumx-spacing-unit * 2;
+    &[open]::details-content {
+        height: auto;
         padding: $lumx-spacing-unit *2;
     }
 }

--- a/packages/site-demo/src/components/content/PropTable/PropTable.scss
+++ b/packages/site-demo/src/components/content/PropTable/PropTable.scss
@@ -14,3 +14,77 @@
         word-break: break-all;
     }
 }
+
+/* ==========================================================================
+   Variant sections (discriminated-union props)
+   ========================================================================== */
+
+.prop-table__variants {
+    margin-top: $lumx-spacing-unit * 4;
+}
+
+.prop-table__variant {
+    margin-top: $lumx-spacing-unit * 2;
+    border: 1px solid lumx-color-variant("dark", "L4");
+    border-radius: var(--lumx-border-radius);
+    overflow: hidden;
+
+    &-summary {
+        display: flex;
+        align-items: center;
+        padding: $lumx-spacing-unit * 2 $lumx-spacing-unit * 3;
+        background-color: lumx-color-variant("dark", "L5");
+        margin-top: $lumx-spacing-unit;
+        cursor: pointer;
+        list-style: none;
+        user-select: none;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+
+        &::before {
+            content: "▶";
+            display: inline-block;
+            margin-right: $lumx-spacing-unit * 2;
+            font-size: 0.65em;
+            transition: transform 0.15s ease;
+        }
+    }
+
+    &[open] > &-summary::before {
+        transform: rotate(90deg);
+    }
+
+    &-label {
+        code {
+            font-family: monospace;
+            font-size: 0.9em;
+        }
+    }
+
+    &-body {
+        padding-top: $lumx-spacing-unit * 2;
+        padding: $lumx-spacing-unit *2;
+    }
+}
+
+/* ==========================================================================
+   Type-param legend
+   ========================================================================== */
+
+.prop-table__type-params {
+    margin-bottom: $lumx-spacing-unit * 4;
+    padding: $lumx-spacing-unit * 2 $lumx-spacing-unit * 3;
+    background-color: lumx-color-variant("blue", "L6");
+    border-left: 3px solid lumx-color-variant("blue", "N");
+    border-radius: var(--lumx-border-radius);
+
+    &-list {
+        margin-top: $lumx-spacing-unit;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: $lumx-spacing-unit $lumx-spacing-unit * 3;
+        align-items: baseline;
+    }
+}

--- a/packages/site-demo/src/components/content/PropTable/PropTable.tsx
+++ b/packages/site-demo/src/components/content/PropTable/PropTable.tsx
@@ -29,6 +29,32 @@ export interface Property {
     aliases?: string[];
 }
 
+/** A single variant entry in a discriminated-union Props type. */
+export interface VariantItem {
+    /** The discriminant value (e.g. "button", "chip"). */
+    value: string;
+    /** Props that are specific to this variant. */
+    props: Property[];
+    /** Whether this variant is the default (open by default in the UI). */
+    isDefault?: boolean;
+}
+
+/** Discriminated-union variant metadata emitted by docgen. */
+export interface VariantDoc {
+    /** The discriminant prop name (e.g. "variant", "selectionType"). */
+    discriminant: string;
+    /** One entry per union branch. */
+    items: VariantItem[];
+}
+
+/** A type parameter with its documentation. */
+export interface TypeParamDoc {
+    /** Type parameter name (e.g. "O", "E", "S"). */
+    name: string;
+    /** Description from @typeParam JSDoc. */
+    description: string;
+}
+
 const renderTypeTableRow = ({ type, defaultValue }: Property) => (
     <Text as="span" typography="body1" className="prop-table__type">
         {castArray(type).reduce((acc, typeName, index, arr) => {
@@ -178,6 +204,52 @@ const SlotsTable: React.FC<{ slots: SlotDoc[] }> = ({ slots }) => (
     </div>
 );
 
+/**
+ * Collapsible section for a single discriminated-union variant.
+ */
+const VariantSection: React.FC<{ discriminant: string; item: VariantItem; componentName: string }> = ({
+    discriminant,
+    item,
+    componentName,
+}) => {
+    if (item.props.length === 0) {
+        return null;
+    }
+
+    return (
+        <details open={item.isDefault} name={componentName} className="prop-table__details">
+            <summary>
+                <Heading as="h4" style={{ display: 'inline-block' }}>
+                    <code>
+                        {discriminant} = &quot;{item.value}&quot;
+                    </code>
+                    {item.isDefault && ' (default)'}
+                </Heading>
+            </summary>
+            <Table properties={item.props} />
+        </details>
+    );
+};
+
+/**
+ * Type parameter legend block.
+ */
+const TypeParamsLegend: React.FC<{ typeParams: TypeParamDoc[] }> = ({ typeParams }) => (
+    <div className="prop-table__type-params">
+        <Text as="p">Generic type parameters:</Text>
+        <dl className="prop-table__type-params-list">
+            {typeParams.map(({ name, description }) => (
+                <Fragment key={name}>
+                    <dt>
+                        <code>{name}</code>
+                    </dt>
+                    <dd>{description || <em>No description</em>}</dd>
+                </Fragment>
+            ))}
+        </dl>
+    </div>
+);
+
 export interface ComponentDoc {
     displayName: string;
     props: Property[];
@@ -185,6 +257,10 @@ export interface ComponentDoc {
     slots?: SlotDoc[];
     /** Component-level deprecation message from @deprecated JSDoc tag. */
     deprecated?: string;
+    /** Discriminated-union variant groups (e.g. for MenuButton variants). */
+    variants?: VariantDoc;
+    /** Generic type parameter documentation (from @typeParam JSDoc). */
+    typeParams?: TypeParamDoc[];
 }
 
 export interface PropTableProps {
@@ -200,6 +276,8 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
     const events = componentDoc?.events;
     const slots = componentDoc?.slots;
     const deprecated = componentDoc?.deprecated;
+    const variants = componentDoc?.variants;
+    const typeParams = componentDoc?.typeParams;
 
     if (!properties || !componentName) {
         return (
@@ -209,7 +287,29 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
         );
     }
 
-    const [forwardedProps, others] = partition(properties, (prop) =>
+    // Synthesise a discriminant prop row for the main table (e.g. `selectionType`, `variant`).
+    // Its type lists the accepted literal values; required-ness is inherited from the original.
+    const existingDiscriminant = variants && properties.find((p) => p.name === variants.discriminant);
+    const discriminantProp: Property | null = variants
+        ? {
+              name: variants.discriminant,
+              description: existingDiscriminant?.description ?? '',
+              required: existingDiscriminant?.required ?? true,
+              deprecated: existingDiscriminant?.deprecated ?? false,
+              type: variants.items.map((item) => `"${item.value}"`),
+              defaultValue: variants.items.find((item) => item.isDefault)?.value ?? '',
+              declarations: existingDiscriminant?.declarations ?? [],
+          }
+        : null;
+
+    // Remove original discriminant from properties to avoid duplicate.
+    const filteredProperties = discriminantProp
+        ? properties.filter((p) => p.name !== variants!.discriminant)
+        : properties;
+
+    const allProperties = discriminantProp ? [...filteredProperties, discriminantProp] : properties;
+
+    const [forwardedProps, others] = partition(allProperties, (prop) =>
         prop.declarations?.some(({ fileName }) => fileName.match(/@types\/react/)),
     );
 
@@ -222,7 +322,27 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
                     </Text>
                 </Message>
             )}
-            <Table properties={others} />
+
+            {typeParams && typeParams.length > 0 && <TypeParamsLegend typeParams={typeParams} />}
+
+            {others.length > 0 && <Table properties={others} />}
+
+            {variants && variants.items.some((item) => item.props.length > 0) && (
+                <div className="prop-table__variants">
+                    <Heading as="h4" typography="subtitle2" className="lumx-spacing-margin-bottom-regular">
+                        Variant-specific props
+                    </Heading>
+                    {variants.items.map((item) => (
+                        <VariantSection
+                            componentName={componentName}
+                            key={item.value}
+                            discriminant={variants.discriminant}
+                            item={item}
+                        />
+                    ))}
+                </div>
+            )}
+
             {forwardedProps.length ? (
                 <details>
                     <summary>

--- a/packages/site-demo/src/components/content/PropTable/PropTable.tsx
+++ b/packages/site-demo/src/components/content/PropTable/PropTable.tsx
@@ -315,8 +315,10 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
 
     return (
         <>
+            <Heading as="h3">{componentName}</Heading>
+
             {deprecated !== undefined && (
-                <Message kind="warning" hasBackground className="lumx-spacing-margin-bottom-big">
+                <Message kind="warning" hasBackground>
                     <Text as="p" typography="body1">
                         <strong>Deprecated:</strong> {deprecated || 'This component is deprecated.'}
                     </Text>
@@ -329,9 +331,7 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
 
             {variants && variants.items.some((item) => item.props.length > 0) && (
                 <div className="prop-table__variants">
-                    <Heading as="h4" typography="subtitle2" className="lumx-spacing-margin-bottom-regular">
-                        Variant-specific props
-                    </Heading>
+                    <Heading as="h4">Variant-specific props</Heading>
                     {variants.items.map((item) => (
                         <VariantSection
                             componentName={componentName}
@@ -344,9 +344,9 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
             )}
 
             {forwardedProps.length ? (
-                <details>
+                <details className="prop-table__details">
                     <summary>
-                        <Heading as="h4" typography="subtitle2" style={{ display: 'inline-block' }}>
+                        <Heading as="h4" style={{ display: 'inline-block' }}>
                             Forwarded props
                         </Heading>
                     </summary>
@@ -356,18 +356,14 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
 
             {events && events.length > 0 && (
                 <>
-                    <Heading as="h4" typography="subtitle2">
-                        Events
-                    </Heading>
+                    <Heading as="h4">Events</Heading>
                     <EventsTable events={events} />
                 </>
             )}
 
             {slots && slots.length > 0 && (
                 <>
-                    <Heading as="h4" typography="subtitle2">
-                        Slots
-                    </Heading>
+                    <Heading as="h4">Slots</Heading>
                     <SlotsTable slots={slots} />
                 </>
             )}

--- a/packages/site-demo/src/components/layout/MainContent/MainContent.scss
+++ b/packages/site-demo/src/components/layout/MainContent/MainContent.scss
@@ -17,6 +17,7 @@
         display: flex;
         flex-direction: column;
         view-transition-name: main-content-wrapper;
+        padding-bottom: 10vh;
 
         & > h1 {
             @include lumx-typography(display1);


### PR DESCRIPTION
# General summary

- Add Menu component demo pages (React + Vue) with variants and menu-items examples
- Improve PropTable to support discriminated unions and generic type parameter documentation
- Uniformize PropTable section headings across all component doc pages
- Fix SelectButton default props and internal props (core, React, Vue)
- Document SelectTextField generic type parameters
- Deprecate Dropdown component with notice
- Add deprecation badges on docs for deprecated components

# Screenshots
<img width="768" height="3294" alt="gcornut-nzxt-h1 tailc8ba1 ts net_8000_product_components_menu-button__framework=react" src="https://github.com/user-attachments/assets/698bf929-5de0-4563-9ab3-015873698d0b" />



StoryBook lumx-react: https://a3f8a412a--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://a3f8a412a--697a023f84e832e23544fb3c.chromatic.com/