### PR TITLE
fix(text-field): improve char counter a11y [CF-1571]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `TimePickerField`: add `getOptionProps` prop to customize individual option props
 
+### Fixed
+
+-   `@lumx/core`, `@lumx/react`, `@lumx/vue`:
+    -   `TextField`: improve char counter a11y (with `role="status"` inside `<label>` and `charCounterMessage` prop)
+
 ## [4.18.0][] - 2026-06-23
 
 ### Added

--- a/packages/lumx-core/src/js/components/TextField/Stories.tsx
+++ b/packages/lumx-core/src/js/components/TextField/Stories.tsx
@@ -97,6 +97,7 @@ export function setup({
             ...LabelAndHelper.args,
             value: 'Textfield value',
             maxLength: 195,
+            charCounterMessage: (n: number) => `${n} characters`,
         },
     };
 

--- a/packages/lumx-core/src/js/components/TextField/Tests.ts
+++ b/packages/lumx-core/src/js/components/TextField/Tests.ts
@@ -181,7 +181,15 @@ export default (renderOptions: SetupOptions<any>) => {
                 const { element } = setup({ maxLength: 100, value: 'test' }, renderOptions);
                 const counter = element.querySelector(`.${CLASSNAME}__char-counter`);
                 expect(counter).toBeInTheDocument();
+                expect(counter).toHaveAttribute('role', 'status');
                 expect(counter).toHaveTextContent('96');
+            });
+
+            it('should render character counter with custom message', () => {
+                const charCounterMessage = (n: number) => `Plus que ${n} caractères`;
+                const { element } = setup({ maxLength: 100, value: 'test', charCounterMessage }, renderOptions);
+                const counter = element.querySelector(`.${CLASSNAME}__char-counter`);
+                expect(counter).toHaveTextContent('Plus que 96 caractères');
             });
 
             it('should not forward "className" to the native input element', () => {

--- a/packages/lumx-core/src/js/components/TextField/TextField.tsx
+++ b/packages/lumx-core/src/js/components/TextField/TextField.tsx
@@ -48,6 +48,8 @@ export interface TextFieldProps extends HasClassName, HasTheme, HasAriaDisabled,
     labelProps?: InputLabelProps;
     /** Max string length the input accepts (constrains the input and displays a character counter). */
     maxLength?: number;
+    /** Character counter message formatter. Receives remaining character count, returns accessible label (e.g. \"{n} characters remaining\"). */
+    charCounterMessage?: (charCount: number) => string | JSXElement;
     /** Whether the text field is a textarea or an input. */
     multiline?: boolean;
     /** Placeholder text. */
@@ -74,6 +76,7 @@ export type TextFieldPropsToOverride =
     | 'labelProps'
     | 'textFieldRef'
     | 'clearButtonProps'
+    | 'charCounterMessage'
     | 'helperId'
     | 'errorId'
     | 'labelId'
@@ -133,6 +136,7 @@ export const TextField = (props: TextFieldProps) => {
         multiline,
         placeholder,
         textFieldRef,
+        charCounterMessage,
         helperId,
         errorId,
         labelId,
@@ -147,6 +151,13 @@ export const TextField = (props: TextFieldProps) => {
 
     const valueLength = (value || '').length;
     const isNotEmpty = valueLength > 0;
+    const remaining = maxLength ? maxLength - valueLength : 0;
+    const charCounter = maxLength ? (
+        <span className={element('char-counter')} role="status">
+            {charCounterMessage ? charCounterMessage(remaining) : remaining}
+            {remaining === 0 && Icon({ icon: mdiAlertCircle, size: Size.xxs })}
+        </span>
+    ) : undefined;
 
     return (
         <div
@@ -172,23 +183,15 @@ export const TextField = (props: TextFieldProps) => {
         >
             {(label || maxLength) && (
                 <div className={element('header')}>
-                    {label &&
-                        InputLabel({
-                            ...labelProps,
-                            id: labelId,
-                            htmlFor: textFieldId as string,
-                            className: element('label'),
-                            isRequired,
-                            theme,
-                            children: label,
-                        })}
-
-                    {maxLength && (
-                        <div className={element('char-counter')}>
-                            <span>{maxLength - valueLength}</span>
-                            {maxLength - valueLength === 0 && Icon({ icon: mdiAlertCircle, size: Size.xxs })}
-                        </div>
-                    )}
+                    {InputLabel({
+                        ...labelProps,
+                        id: labelId,
+                        htmlFor: textFieldId as string,
+                        className: element('label'),
+                        isRequired,
+                        theme,
+                        children: [label, charCounter] as any,
+                    })}
                 </div>
             )}
 

--- a/packages/lumx-core/src/scss/components/text-field/_index.scss
+++ b/packages/lumx-core/src/scss/components/text-field/_index.scss
@@ -42,20 +42,19 @@
         display: flex;
         flex-shrink: 0;
         align-items: center;
-        margin-left: auto;
+        margin-left: $lumx-spacing-unit-big;
+        float: right;
 
-        span {
-            font-size: var(--lumx-material-text-field-header-label-font-size);
-            font-weight: var(--lumx-material-text-field-header-label-font-weight);
-            line-height: var(--lumx-material-text-field-header-label-line-height);
+        font-size: var(--lumx-material-text-field-header-label-font-size);
+        font-weight: var(--lumx-material-text-field-header-label-font-weight);
+        line-height: var(--lumx-material-text-field-header-label-line-height);
 
-            #{$self}--theme-light & {
-                color: lumx-color-variant("dark", "L2");
-            }
+        #{$self}--theme-light & {
+            color: lumx-color-variant("dark", "L2");
+        }
 
-            #{$self}--theme-dark & {
-                color: lumx-color-variant("light", "L2");
-            }
+        #{$self}--theme-dark & {
+            color: lumx-color-variant("light", "L2");
         }
 
         i {

--- a/packages/lumx-react/src/components/text-field/TextField.tsx
+++ b/packages/lumx-react/src/components/text-field/TextField.tsx
@@ -1,4 +1,4 @@
-import { Ref, RefObject, SyntheticEvent, useRef, useState } from 'react';
+import { Ref, RefObject, ReactNode, SyntheticEvent, useRef, useState } from 'react';
 
 import { Theme } from '@lumx/core/js/constants';
 import { GenericProps } from '@lumx/react/utils/type';
@@ -26,6 +26,8 @@ import { RawInputTextarea } from './RawInputTextarea';
  * Defines the props of the component.
  */
 export interface TextFieldProps extends GenericProps, ReactToJSX<UIProps, TextFieldPropsToOverride> {
+    /** Character counter message formatter. Receives remaining character count, returns accessible label (e.g. \"{n} characters remaining\"). */
+    charCounterMessage?: (charCount: number) => string | ReactNode;
     /** Props to pass to the clear button (minus those already set by the TextField props). If not specified, the button won't be displayed. */
     clearButtonProps?: Pick<IconButtonProps, 'label'> &
         Omit<IconButtonProps, 'label' | 'onClick' | 'icon' | 'emphasis'>;
@@ -84,6 +86,7 @@ export const TextField = forwardRef<TextFieldProps, HTMLDivElement>((props, ref)
         label,
         labelProps,
         maxLength,
+        charCounterMessage,
         minimumRows,
         multiline,
         name,
@@ -189,6 +192,7 @@ export const TextField = forwardRef<TextFieldProps, HTMLDivElement>((props, ref)
         labelId,
         multiline,
         maxLength,
+        charCounterMessage,
         isRequired,
         errorId,
         placeholder,

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -151,6 +151,7 @@ const ComboboxInput = defineComponent(
             'label',
             'labelProps',
             'maxLength',
+            'charCounterMessage',
             'isDisabled',
             'disabled',
             'aria-disabled',

--- a/packages/lumx-vue/src/components/text-field/TextField.tsx
+++ b/packages/lumx-vue/src/components/text-field/TextField.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, type ComponentPublicInstance, ref, useAttrs, watch } from 'vue';
+import { computed, defineComponent, type ComponentPublicInstance, ref, useAttrs, watch, type VNode } from 'vue';
 
 import {
     TextField as TextFieldUI,
@@ -20,6 +20,8 @@ import RawInputText from './RawInputText';
 import RawInputTextarea from './RawInputTextarea';
 
 export type TextFieldProps = VueToJSXProps<UIProps, TextFieldPropsToOverride | 'chips'> & {
+    /** Character counter message formatter. Receives remaining character count, returns accessible label (e.g. \"{n} characters remaining\"). */
+    charCounterMessage?: (charCount: number) => string | VNode;
     /** Native input id property (generated if not provided). */
     id?: string;
     /** Props to pass to the clear button. If not specified, the button won't be displayed. */
@@ -177,6 +179,7 @@ const TextField = defineComponent(
                     label={props.label}
                     labelProps={props.labelProps}
                     maxLength={props.maxLength}
+                    charCounterMessage={props.charCounterMessage as any}
                     multiline={props.multiline}
                     placeholder={props.placeholder}
                     value={props.value}
@@ -216,6 +219,7 @@ const TextField = defineComponent(
             'label',
             'labelProps',
             'maxLength',
+            'charCounterMessage',
             'isDisabled',
             'disabled',
             'multiline',

--- a/packages/site-demo/content/product/components/text-field/index.mdx
+++ b/packages/site-demo/content/product/components/text-field/index.mdx
@@ -137,6 +137,8 @@ external HTML `label` with `for`).
 
 Showing a text field with only a placeholder is not sufficient, visual and accessible labels must also be in place.
 
+When using `maxLength`, provide `charCounterMessage` with a localized message (e.g. ``(n) => `${n} caractères restants` ``) for proper accessibility.
+
 Text fields can be disabled in two ways:
 
 -   `disabled`/`isDisabled` which completely disables the text field. It's not focusable and pointer events (hover, click, etc.) are

--- a/packages/site-demo/content/product/components/text-field/react/max-length.tsx
+++ b/packages/site-demo/content/product/components/text-field/react/max-length.tsx
@@ -3,5 +3,15 @@ import { TextField, type Theme } from '@lumx/react';
 
 export default ({ theme }: { theme?: Theme }) => {
     const [value, setValue] = useState('');
-    return <TextField label="Text field label" value={value} onChange={setValue} maxLength={50} theme={theme} />;
+    return (
+        <TextField
+            label="Text field label"
+            value={value}
+            onChange={setValue}
+            maxLength={50}
+            theme={theme}
+            charCounterMessage={(n) => `${n} characters remaining`}
+        />
+    );
+
 };

--- a/packages/site-demo/content/product/components/text-field/vue/max-length.vue
+++ b/packages/site-demo/content/product/components/text-field/vue/max-length.vue
@@ -1,5 +1,12 @@
 <template>
-    <TextField label="Text field label" :value="value" :max-length="50" :theme="theme" @change="value = $event" />
+    <TextField
+        label="Text field label"
+        :value="value"
+        :max-length="50"
+        :theme="theme"
+        :char-counter-message="charCounterMessage"
+        @change="value = $event"
+    />
 </template>
 
 <script setup lang="ts">
@@ -9,4 +16,6 @@ import { TextField, type Theme } from '@lumx/vue';
 defineProps<{ theme?: Theme }>();
 
 const value = ref('');
+
+const charCounterMessage = (n: number) => `${n} characters remaining`;
 </script>


### PR DESCRIPTION

# General summary

Improve text field character counter a11y

- Replace `<div>` with `<span role='status'>`
- Move counter inside `<label>`
- Add charCounterMessage prop for localized text


StoryBook lumx-react: https://cd1a62294--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://cd1a62294--697a023f84e832e23544fb3c.chromatic.com/