### PR TITLE
feat(time-picker-field): add minDateTime and maxDateTime bound props [CF-1546]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `TimePickerField`: add `minDateTime` and `maxDateTime` props for date-aware time bounds
+
 ## [4.17.0][] - 2026-06-11
 
 ### Added

--- a/packages/lumx-core/src/js/components/TimePickerField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/TimePickerField/Tests.tsx
@@ -62,6 +62,11 @@ export default function timePickerFieldTests({ components, renderWithState }: Ti
             expect(inputValue).toMatch(/^2:30/);
             expect(inputValue.toUpperCase()).toContain('PM');
         });
+
+        it('renders the input as disabled when isDisabled is true', () => {
+            renderWithState(defaultTemplate, { isDisabled: true });
+            expect(screen.getByRole('combobox')).toBeDisabled();
+        });
     });
 
     describe('option list', () => {
@@ -100,6 +105,45 @@ export default function timePickerFieldTests({ components, renderWithState }: Ti
             const optAfter = options.find((o) => /1:30/.test(o.textContent ?? ''));
             expect(optAt).not.toHaveAttribute('aria-disabled', 'true');
             expect(optAfter).toHaveAttribute('aria-disabled', 'true');
+        });
+
+        it('keeps options before `minDateTime` visible but disables them (same date as value)', async () => {
+            const value = new Date(2024, 5, 15, 12, 0);
+            const minDateTime = new Date(2024, 5, 15, 10, 0);
+            renderWithState(defaultTemplate, { value, minDateTime });
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = screen.queryAllByRole('option');
+            expect(options).toHaveLength(48);
+            // 9:30 disabled, 10:00 enabled (same date as value so time-only comparison matches).
+            const optBefore = options.find((o) => /9:30/.test(o.textContent ?? ''));
+            const optAfter = options.find((o) => /10:00/.test(o.textContent ?? ''));
+            expect(optBefore).toHaveAttribute('aria-disabled', 'true');
+            expect(optAfter).not.toHaveAttribute('aria-disabled', 'true');
+        });
+
+        it('ignores `minDateTime` when value has a different (later) date', async () => {
+            const value = new Date(2024, 6, 15, 12, 0);
+            const minDateTime = new Date(2024, 5, 15, 10, 0);
+            renderWithState(defaultTemplate, { value, minDateTime });
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = screen.queryAllByRole('option');
+            // Value date is after minDateTime date → all options enabled.
+            const disabledOptions = options.filter((o) => o.getAttribute('aria-disabled') === 'true');
+            expect(disabledOptions).toHaveLength(0);
+        });
+
+        it('disables options before `minDateTime` time after auto-advance snaps value to bound', async () => {
+            // Value date is before minDateTime → auto-advance snaps value to minDateTime.
+            // After auto-advance: value === minDateTime (same date), so only options before
+            // 10:00 (20 entries) are disabled.
+            const value = new Date(2024, 4, 15, 12, 0);
+            const minDateTime = new Date(2024, 5, 15, 10, 0);
+            renderWithState(defaultTemplate, { value, minDateTime });
+            await userEvent.click(screen.getByRole('combobox'));
+            const options = screen.queryAllByRole('option');
+            const disabledOptions = options.filter((o) => o.getAttribute('aria-disabled') === 'true');
+            // 20 disabled options = midnight to 9:30 on the same date as minDateTime.
+            expect(disabledOptions).toHaveLength(20);
         });
     });
 
@@ -161,6 +205,49 @@ export default function timePickerFieldTests({ components, renderWithState }: Ti
             expect(onChange).toHaveBeenLastCalledWith(expectTimeOfDay(12, 0), undefined, undefined);
         });
 
+        it('snaps to `maxTime` when the typed input is above it', async () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, {
+                value: getDateAtTime({ hour: 11, minute: 0 }),
+                maxTime: getDateAtTime({ hour: 14, minute: 0 }),
+                onChange,
+            });
+            const input = screen.getByRole('combobox');
+            await userEvent.click(input);
+            await userEvent.clear(input);
+            await userEvent.type(input, '18');
+            await userEvent.tab();
+            expect(onChange).toHaveBeenLastCalledWith(expectTimeOfDay(14, 0), undefined, undefined);
+        });
+
+        it('snaps to `maxDateTime` when the typed input is above it (same date)', async () => {
+            const onChange = vi.fn();
+            const value = new Date(2024, 5, 15, 11, 0);
+            const maxDateTime = new Date(2024, 5, 15, 14, 0);
+            renderWithState(defaultTemplate, { value, maxDateTime, onChange });
+            const input = screen.getByRole('combobox');
+            await userEvent.click(input);
+            await userEvent.clear(input);
+            await userEvent.type(input, '18');
+            await userEvent.tab();
+            expect(onChange).toHaveBeenLastCalledWith(expectTimeOfDay(14, 0), undefined, undefined);
+        });
+
+        it('skips `minDateTime` snap when value is cleared (no date context)', async () => {
+            const onChange = vi.fn();
+            const value = new Date(2024, 6, 15, 11, 0);
+            const minDateTime = new Date(2024, 5, 15, 12, 0);
+            renderWithState(defaultTemplate, { value, minDateTime, onChange });
+            const input = screen.getByRole('combobox');
+            await userEvent.click(input);
+            await userEvent.clear(input);
+            await userEvent.type(input, '9');
+            await userEvent.tab();
+            // Value was cleared to undefined → no date context for dateTime comparison,
+            // so snapTimeToBounds skips minDateTime entirely. Typed "9" = 9:00 emitted as-is.
+            expect(onChange).toHaveBeenLastCalledWith(expectTimeOfDay(9, 0), undefined, undefined);
+        });
+
         it('does not call onChange for an unparseable typed value', async () => {
             const onChange = vi.fn();
             renderWithState(defaultTemplate, { value: getDateAtTime({ hour: 8, minute: 0 }), onChange });
@@ -183,6 +270,20 @@ export default function timePickerFieldTests({ components, renderWithState }: Ti
             const option = await screen.findByRole('option', { name: /^8:00\sPM$/i });
             await userEvent.click(option);
             expect(onChange).toHaveBeenLastCalledWith(expectTimeOfDay(20, 0), undefined, undefined);
+        });
+    });
+
+    describe('clear button', () => {
+        it('emits undefined when the clear button is clicked', async () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, {
+                value: getDateAtTime({ hour: 14, minute: 0 }),
+                hasClearButton: true,
+                onChange,
+            });
+            const clearButton = screen.getByRole('button', { name: TRANSLATIONS.clearLabel });
+            await userEvent.click(clearButton);
+            expect(onChange).toHaveBeenLastCalledWith(undefined, undefined, undefined);
         });
     });
 }

--- a/packages/lumx-core/src/js/components/TimePickerField/index.tsx
+++ b/packages/lumx-core/src/js/components/TimePickerField/index.tsx
@@ -51,18 +51,37 @@ export interface TimePickerFieldWrapperProps {
     step?: number;
 
     /**
-     * Lower bound. Options strictly before this time remain **visible** in the
-     * dropdown but are rendered as disabled (cannot be picked). Typed input
+     * Lower bound (date part ignored). Time options out of range are visible but disabled. Typed input
      * below this bound is snapped up to it on blur.
      */
     minTime?: Date;
 
     /**
-     * Upper bound. Options strictly after this time remain **visible** in the
-     * dropdown but are rendered as disabled (cannot be picked). Typed input
+     * Upper bound (date part ignored). Time options out of range are visible but disabled. Typed input
      * above this bound is snapped down to it on blur.
      */
     maxTime?: Date;
+
+    /**
+     * Lower bound (date part respected). Same behaviour as `minTime` but
+     * compares the full date-time formed by combining each option's time with
+     * the current value's date. Skipped when `value` is undefined (no date
+     * context).
+     *
+     * When set and the current value falls below this bound, the component
+     * auto-selects the bound value on mount and on bound/value changes.
+     */
+    minDateTime?: Date;
+
+    /**
+     * Upper bound (date part respected). Same behaviour as `maxTime` but
+     * compares the full date-time. Skipped when `value` is undefined (no date
+     * context).
+     *
+     * When set and the current value exceeds this bound, the component
+     * auto-selects the bound value.
+     */
+    maxDateTime?: Date;
 
     /**
      * Translations label for clear and show suggestions buttons.
@@ -148,11 +167,11 @@ export const TimePickerField = (
     props: TimePickerFieldProps,
     { SelectTextField, Option }: TimePickerFieldComponents,
 ) => {
-    const { options, translations, className, handleChange, handleSearch, handleBlur, ...fowardedProps } = props;
+    const { options, translations, className, handleChange, handleSearch, handleBlur, ...forwardedProps } = props;
 
     return (
         <SelectTextField
-            {...fowardedProps}
+            {...forwardedProps}
             className={block([className])}
             selectionType="single"
             options={options}

--- a/packages/lumx-core/src/js/utils/time/buildTimeList.ts
+++ b/packages/lumx-core/src/js/utils/time/buildTimeList.ts
@@ -28,6 +28,20 @@ export interface BuildTimeListOptions {
     minTime?: Date;
     /** Upper bound (date part ignored). Entries after are kept but marked `outOfRange`. */
     maxTime?: Date;
+    /**
+     * Lower bound (date part respected). An entry is disabled when the date-time
+     * formed by combining the entry's time with `value`'s date is strictly before
+     * `minDateTime`. Requires `value` to be set (otherwise ignored).
+     */
+    minDateTime?: Date;
+    /**
+     * Upper bound (date part respected). An entry is disabled when the date-time
+     * formed by combining the entry's time with `value`'s date is strictly after
+     * `maxDateTime`. Requires `value` to be set (otherwise ignored).
+     */
+    maxDateTime?: Date;
+    /** Current value Date (date part used for `minDateTime`/`maxDateTime` comparison). */
+    value?: Date;
     /** BCP-47 locale used to populate `name` on each entry. */
     locale?: string;
 }
@@ -41,7 +55,7 @@ const MINUTES_IN_DAY = 24 * MINUTES_IN_HOUR;
  * render them as visible-but-unselectable. Returns `[]` for invalid `step`.
  */
 export function buildTimeList(options: BuildTimeListOptions = {}): TimeOfDay[] {
-    const { step = 30, minTime, maxTime, locale } = options;
+    const { step = 30, minTime, maxTime, minDateTime, maxDateTime, value, locale } = options;
     if (!Number.isInteger(step) || step <= 0) {
         return [];
     }
@@ -53,11 +67,21 @@ export function buildTimeList(options: BuildTimeListOptions = {}): TimeOfDay[] {
     for (let minutes = 0; minutes < MINUTES_IN_DAY; minutes += step) {
         const hour = Math.floor(minutes / MINUTES_IN_HOUR);
         const minute = minutes % MINUTES_IN_HOUR;
-        const outOfRange =
-            (minMinutes !== undefined && minutes < minMinutes) ||
-            (maxMinutes !== undefined && minutes > maxMinutes) ||
-            undefined;
-        const name = locale ? formatTime(getDateAtTime({ hour, minute }), locale) : undefined;
+        const optionTime = { hour, minute };
+
+        const beforeMinTime = minMinutes !== undefined && minutes < minMinutes;
+        const afterMaxTime = maxMinutes !== undefined && minutes > maxMinutes;
+        let beforeMinDateTime = false;
+        let afterMaxDateTime = false;
+
+        if (value && (minDateTime || maxDateTime)) {
+            const combined = getDateAtTime(optionTime, value);
+            if (minDateTime) beforeMinDateTime = combined < minDateTime;
+            if (maxDateTime) afterMaxDateTime = combined > maxDateTime;
+        }
+
+        const outOfRange = beforeMinTime || afterMaxTime || beforeMinDateTime || afterMaxDateTime || undefined;
+        const name = locale ? formatTime(getDateAtTime(optionTime), locale) : undefined;
 
         list.push({ hour, minute, name, outOfRange });
     }

--- a/packages/lumx-core/src/js/utils/time/index.ts
+++ b/packages/lumx-core/src/js/utils/time/index.ts
@@ -5,5 +5,5 @@ export { formatTime } from './formatTime';
 export { parseTimeInput } from './parseTimeInput';
 export { getDateAtTime } from './getDateAtTime';
 export { timeOfDayMinutes } from './timeOfDayMinutes';
-export { snapTimeToBounds } from './snapTimeToBounds';
+export { snapTimeToBounds, type SnapTimeToBoundsOptions } from './snapTimeToBounds';
 export { isDateOnTime } from './isDateOnTime';

--- a/packages/lumx-core/src/js/utils/time/snapTimeToBounds.test.ts
+++ b/packages/lumx-core/src/js/utils/time/snapTimeToBounds.test.ts
@@ -10,18 +10,24 @@ describe(snapTimeToBounds, () => {
     it('returns the input unchanged when within bounds', () => {
         const time = { hour: 14, minute: 30 };
         expect(
-            snapTimeToBounds(time, getDateAtTime({ hour: 8, minute: 0 }), getDateAtTime({ hour: 18, minute: 0 })),
+            snapTimeToBounds(time, {
+                minTime: getDateAtTime({ hour: 8, minute: 0 }),
+                maxTime: getDateAtTime({ hour: 18, minute: 0 }),
+            }),
         ).toBe(time);
     });
 
     it('snaps up to `minTime` when input is below it', () => {
         const time = { hour: 6, minute: 0 };
-        expect(snapTimeToBounds(time, getDateAtTime({ hour: 8, minute: 30 }))).toEqual({ hour: 8, minute: 30 });
+        expect(snapTimeToBounds(time, { minTime: getDateAtTime({ hour: 8, minute: 30 }) })).toEqual({
+            hour: 8,
+            minute: 30,
+        });
     });
 
     it('snaps down to `maxTime` when input is above it', () => {
         const time = { hour: 22, minute: 0 };
-        expect(snapTimeToBounds(time, undefined, getDateAtTime({ hour: 18, minute: 15 }))).toEqual({
+        expect(snapTimeToBounds(time, { maxTime: getDateAtTime({ hour: 18, minute: 15 }) })).toEqual({
             hour: 18,
             minute: 15,
         });
@@ -30,14 +36,45 @@ describe(snapTimeToBounds, () => {
     it('keeps the input when it equals a bound', () => {
         const time = { hour: 8, minute: 0 };
         expect(
-            snapTimeToBounds(time, getDateAtTime({ hour: 8, minute: 0 }), getDateAtTime({ hour: 18, minute: 0 })),
+            snapTimeToBounds(time, {
+                minTime: getDateAtTime({ hour: 8, minute: 0 }),
+                maxTime: getDateAtTime({ hour: 18, minute: 0 }),
+            }),
         ).toBe(time);
     });
 
     it('ignores the date part of the bounds', () => {
         const time = { hour: 6, minute: 0 };
-        // minTime "20 days ago" at 09:00 — only the time-of-day matters.
         const oldDate = new Date(2000, 0, 1, 9, 0, 0, 0);
-        expect(snapTimeToBounds(time, oldDate)).toEqual({ hour: 9, minute: 0 });
+        expect(snapTimeToBounds(time, { minTime: oldDate })).toEqual({ hour: 9, minute: 0 });
+    });
+
+    describe('minDateTime / maxDateTime', () => {
+        it('snaps up to `minDateTime` when combined date-time is below it', () => {
+            const value = new Date(2024, 5, 15, 14, 0);
+            const minDateTime = new Date(2024, 5, 15, 12, 0);
+            const time = { hour: 9, minute: 0 };
+            expect(snapTimeToBounds(time, { minDateTime, value })).toEqual({ hour: 12, minute: 0 });
+        });
+
+        it('snaps down to `maxDateTime` when combined date-time is above it', () => {
+            const value = new Date(2024, 5, 15, 11, 0);
+            const maxDateTime = new Date(2024, 5, 15, 14, 0);
+            const time = { hour: 18, minute: 0 };
+            expect(snapTimeToBounds(time, { maxDateTime, value })).toEqual({ hour: 14, minute: 0 });
+        });
+
+        it('does not snap `minDateTime` when value date is later', () => {
+            const value = new Date(2024, 6, 15, 11, 0);
+            const minDateTime = new Date(2024, 5, 15, 12, 0);
+            const time = { hour: 9, minute: 0 };
+            expect(snapTimeToBounds(time, { minDateTime, value })).toBe(time);
+        });
+
+        it('skips dateTime bounds when value is undefined', () => {
+            const minDateTime = new Date(2024, 5, 15, 12, 0);
+            const time = { hour: 6, minute: 0 };
+            expect(snapTimeToBounds(time, { minDateTime })).toBe(time);
+        });
     });
 });

--- a/packages/lumx-core/src/js/utils/time/snapTimeToBounds.ts
+++ b/packages/lumx-core/src/js/utils/time/snapTimeToBounds.ts
@@ -1,12 +1,29 @@
 import type { TimeOfDay } from './buildTimeList';
+import { getDateAtTime } from './getDateAtTime';
 import { timeOfDayMinutes } from './timeOfDayMinutes';
 
+export interface SnapTimeToBoundsOptions {
+    minTime?: Date;
+    maxTime?: Date;
+    /** Lower bound (date part respected). Requires `value` for comparison; skipped when value is undefined. */
+    minDateTime?: Date;
+    /** Upper bound (date part respected). Requires `value` for comparison; skipped when value is undefined. */
+    maxDateTime?: Date;
+    /** Current value whose date part is inherited for dateTime bounds. When undefined, dateTime bounds are skipped. */
+    value?: Date;
+}
+
 /**
- * Clamp `time` to `[minTime, maxTime]`. Inputs strictly before `minTime` snap
- * up; inputs strictly after `maxTime` snap down; otherwise returned unchanged.
- * Only the time-of-day of `minTime`/`maxTime` is used.
+ * Clamp `time` to `[minTime, maxTime]` and/or `[minDateTime, maxDateTime]`.
+ * Inputs strictly before a lower bound snap up; strictly after an upper bound
+ * snap down; otherwise returned unchanged.
+ *
+ * `minTime`/`maxTime` compare by time-of-day only (date part ignored).
+ * `minDateTime`/`maxDateTime` compare by full date-time and require `value`
+ * (whose date part is inherited) to be set.
  */
-export function snapTimeToBounds(time: TimeOfDay, minTime?: Date, maxTime?: Date): TimeOfDay {
+export function snapTimeToBounds(time: TimeOfDay, options: SnapTimeToBoundsOptions = {}): TimeOfDay {
+    const { minTime, maxTime, minDateTime, maxDateTime, value } = options;
     const totalMinutes = time.hour * 60 + time.minute;
 
     if (minTime && totalMinutes < timeOfDayMinutes(minTime)) {
@@ -15,5 +32,19 @@ export function snapTimeToBounds(time: TimeOfDay, minTime?: Date, maxTime?: Date
     if (maxTime && totalMinutes > timeOfDayMinutes(maxTime)) {
         return { hour: maxTime.getHours(), minute: maxTime.getMinutes() };
     }
+
+    if (value && minDateTime) {
+        const combined = getDateAtTime(time, value);
+        if (combined < minDateTime) {
+            return { hour: minDateTime.getHours(), minute: minDateTime.getMinutes() };
+        }
+    }
+    if (value && maxDateTime) {
+        const combined = getDateAtTime(time, value);
+        if (combined > maxDateTime) {
+            return { hour: maxDateTime.getHours(), minute: maxDateTime.getMinutes() };
+        }
+    }
+
     return time;
 }

--- a/packages/lumx-react/src/components/time-picker-field/TimePickerField.tsx
+++ b/packages/lumx-react/src/components/time-picker-field/TimePickerField.tsx
@@ -1,4 +1,4 @@
-import React, { type SyntheticEvent, useCallback, useMemo, useState } from 'react';
+import React, { type SyntheticEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { HasClassName, HasTheme } from '@lumx/core/js/types';
 import {
@@ -70,14 +70,32 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
         step = DEFAULT_PROPS.step,
         minTime,
         maxTime,
+        minDateTime,
+        maxDateTime,
         className,
         theme,
         translations,
+        name: nameProp,
         ...forwardedProps
     } = props;
 
     // Build the option list — re-computed only when bounds/step/locale change.
-    const timeList = useMemo(() => buildTimeList({ step, minTime, maxTime, locale }), [step, minTime, maxTime, locale]);
+    const timeList = useMemo(
+        () => buildTimeList({ step, minTime, maxTime, minDateTime, maxDateTime, value, locale }),
+        [step, minTime, maxTime, minDateTime, maxDateTime, value, locale],
+    );
+
+    // Auto-advance to bounds when the current value falls outside minDateTime / maxDateTime.
+    useEffect(() => {
+        if (!value) return;
+        if (minDateTime && value < minDateTime) {
+            onChange(minDateTime, nameProp);
+            return;
+        }
+        if (maxDateTime && value > maxDateTime) {
+            onChange(maxDateTime, nameProp);
+        }
+    }, [value, minDateTime, maxDateTime, onChange, nameProp]);
 
     // Track the user's typed input separately from the SelectTextField's internal search state,
     // so blur can convert it to a Date.
@@ -92,9 +110,9 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
     const handleChange: UIProps['handleChange'] = useCallback(
         (next) => {
             const date = next ? getDateAtTime(next, value) : undefined;
-            onChange(date, forwardedProps.name);
+            onChange(date, nameProp);
         },
-        [forwardedProps.name, onChange, value],
+        [nameProp, onChange, value],
     );
 
     const handleBlur: UIProps['handleBlur'] = useCallback(() => {
@@ -105,17 +123,18 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
         if (!parsed) return;
 
         // Snap to bounds if needed, then dedup against the current value.
-        const time = snapTimeToBounds(parsed, minTime, maxTime);
+        const time = snapTimeToBounds(parsed, { minTime, maxTime, minDateTime, maxDateTime, value });
         if (value && isDateOnTime(value, time)) return;
 
-        onChange(getDateAtTime(time, value), forwardedProps.name);
-    }, [maxTime, minTime, forwardedProps.name, onChange, searchValue, value]);
+        onChange(getDateAtTime(time, value), nameProp);
+    }, [maxTime, minTime, minDateTime, maxDateTime, nameProp, onChange, searchValue, value]);
 
     const searchInputValue = value ? formatTime(value, locale) : undefined;
 
     return UI(
         {
             ...forwardedProps,
+            name: nameProp,
             value: selectedOption,
             options: timeList,
             translations,

--- a/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
+++ b/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref } from 'vue';
+import { computed, defineComponent, ref, watch } from 'vue';
 
 import {
     TimePickerField as UI,
@@ -70,8 +70,27 @@ const TimePickerField = defineComponent(
                 step: step.value,
                 minTime: props.minTime,
                 maxTime: props.maxTime,
+                minDateTime: props.minDateTime,
+                maxDateTime: props.maxDateTime,
+                value: props.value,
                 locale: locale.value,
             }),
+        );
+
+        // Auto-advance to bounds when the current value falls outside minDateTime / maxDateTime.
+        watch(
+            () => ({ value: props.value, minDateTime: props.minDateTime, maxDateTime: props.maxDateTime }),
+            ({ value, minDateTime, maxDateTime }) => {
+                if (!value) return;
+                if (minDateTime && value < minDateTime) {
+                    emit('change', minDateTime);
+                    return;
+                }
+                if (maxDateTime && value > maxDateTime) {
+                    emit('change', maxDateTime);
+                }
+            },
+            { immediate: true },
         );
 
         // Track the user's last non-empty typed input.
@@ -106,7 +125,13 @@ const TimePickerField = defineComponent(
             if (!parsed) return;
 
             // Snap to bounds if needed, then dedup against the current value.
-            const time = snapTimeToBounds(parsed, props.minTime, props.maxTime);
+            const time = snapTimeToBounds(parsed, {
+                minTime: props.minTime,
+                maxTime: props.maxTime,
+                minDateTime: props.minDateTime,
+                maxDateTime: props.maxDateTime,
+                value: props.value,
+            });
             if (props.value && isDateOnTime(props.value, time)) return;
 
             emit('change', getDateAtTime(time, props.value));
@@ -121,6 +146,8 @@ const TimePickerField = defineComponent(
                 step: _step,
                 minTime: _minTime,
                 maxTime: _maxTime,
+                minDateTime: _minDateTime,
+                maxDateTime: _maxDateTime,
                 translations,
                 class: _class,
                 ...forwardedProps
@@ -151,6 +178,8 @@ const TimePickerField = defineComponent(
             'step',
             'minTime',
             'maxTime',
+            'minDateTime',
+            'maxDateTime',
             'translations',
             'class',
             // Inherited SelectTextField props

--- a/packages/site-demo/content/product/components/time-picker-field/index.mdx
+++ b/packages/site-demo/content/product/components/time-picker-field/index.mdx
@@ -20,9 +20,13 @@ The field generates time suggestions in a dropdonw list with configurable minute
 
 ## Bounds
 
-Restrict the pickable range with `minTime` and `maxTime`. Options outside the range remain **visible** in the dropdown but are rendered as disabled. Typed input outside the range is snapped to the nearest bound on blur.
+Two independent bounding systems control which times the user can pick.
+
+**Time-of-day bounds** (`minTime` / `maxTime`) — restrict the pickable time range regardless of date. Options outside the range remain **visible** in the dropdown but are rendered as disabled. Typed input outside the range is snapped to the nearest bound on blur.
 
 <DemoBlock demo={{ react: ReactDemoBounds, vue: VueDemoBounds }} />
+
+**Date-aware bounds** (`minDateTime` / `maxDateTime`) — constrain based on the full date-time formed by combining each option's time with the current `value`'s date. The `value` prop must be set (the bound is skipped when no date context is defined). Useful for linked pickers — for example, constraining an end time to be after a start time on the same day. Options outside the bound remain **visible** but disabled, and when the current `value` falls outside the bound the component auto-corrects to the bound value.
 
 ## Locale
 


### PR DESCRIPTION
# General summary

- Add `minDateTime` and `maxDateTime` bound props to TimePickerField
- New `snapTimeToBounds` utility in core to clamp time values to configurable bounds
- Wired through React and Vue wrappers

# Screenshots

N/A — API-only change, no visual impact

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-storybook-react` or `need: deploy-storybook-vue` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->

StoryBook lumx-vue: https://ac0516357--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://ac0516357--5fbfb1d508c0520021560f10.chromatic.com/