### PR TITLE
chore(test): lower test:all parallelism to improve perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "test:storybook": "nx run-many --target=test:storybook",
         "test:storybook:react": "nx run @lumx/react:test:storybook",
         "test:storybook:vue": "nx run @lumx/vue:test:storybook",
-        "test:all": "nx run-many --target=test,test:storybook",
+        "test:all": "nx run-many --target=test,test:storybook --parallel 2",
         "visual-diffs": "nx run @lumx/visual-diffs:visual-diffs",
         "type-check": "nx run-many --target=type-check",
         "storybook:react": "yarn workspace @lumx/react start:storybook",


### PR DESCRIPTION
# General summary

Limit `test:all` to `--parallel 2` in Nx to avoid spawning too many concurrent processes when running both unit and Storybook test targets together.


StoryBook lumx-vue: https://837e55e07--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://837e55e07--5fbfb1d508c0520021560f10.chromatic.com/