### PR TITLE
feat(time-picker-field): add boundsMode prop [CF-1546]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `TimePickerField`: add `boundsMode="enforce"` prop mode to proactively clamp the `value` to `minTime` and `maxTime` on mount and when bounds change
+
 ## [4.17.0][] - 2026-06-11
 
 ### Added

--- a/packages/lumx-core/src/js/components/TimePickerField/Stories.tsx
+++ b/packages/lumx-core/src/js/components/TimePickerField/Stories.tsx
@@ -69,6 +69,15 @@ export function setup({
         },
     };
 
+    /** Enforce (clamp out-of-bounds) maxTime. */
+    const WithBoundsMode = {
+        args: {
+            value: getDateAtTime({ hour: 20, minute: 0 }),
+            maxTime: getDateAtTime({ hour: 18, minute: 0 }),
+            boundsMode: 'enforce',
+        },
+    };
+
     /** Disabled states (matrix). */
     const Disabled = {
         args: WithValue.args,
@@ -84,5 +93,5 @@ export function setup({
         ],
     };
 
-    return { meta, Default, WithValue, Step15, WithMinTime, WithMaxTime, French, Disabled };
+    return { meta, Default, WithValue, Step15, WithMinTime, WithMaxTime, French, WithBoundsMode, Disabled };
 }

--- a/packages/lumx-core/src/js/components/TimePickerField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/TimePickerField/Tests.tsx
@@ -174,6 +174,63 @@ export default function timePickerFieldTests({ components, renderWithState }: Ti
         });
     });
 
+    describe('boundsMode', () => {
+        it('clamps value to minTime on mount when boundsMode is "enforce"', () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, {
+                value: getDateAtTime({ hour: 8, minute: 0 }),
+                minTime: getDateAtTime({ hour: 10, minute: 0 }),
+                boundsMode: 'enforce' as const,
+                onChange,
+            });
+            expect(onChange).toHaveBeenCalledWith(expectTimeOfDay(10, 0), undefined, undefined);
+        });
+
+        it('clamps value to maxTime on mount when boundsMode is "enforce"', () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, {
+                value: getDateAtTime({ hour: 22, minute: 0 }),
+                maxTime: getDateAtTime({ hour: 18, minute: 0 }),
+                boundsMode: 'enforce' as const,
+                onChange,
+            });
+            expect(onChange).toHaveBeenCalledWith(expectTimeOfDay(18, 0), undefined, undefined);
+        });
+
+        it('does not clamp when boundsMode is not set', () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, {
+                value: getDateAtTime({ hour: 22, minute: 0 }),
+                maxTime: getDateAtTime({ hour: 18, minute: 0 }),
+                onChange,
+            });
+            expect(onChange).not.toHaveBeenCalled();
+        });
+
+        it('does not clamp when boundsMode is "on-blur"', () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, {
+                value: getDateAtTime({ hour: 22, minute: 0 }),
+                maxTime: getDateAtTime({ hour: 18, minute: 0 }),
+                boundsMode: 'on-blur' as const,
+                onChange,
+            });
+            expect(onChange).not.toHaveBeenCalled();
+        });
+
+        it('does not clamp when value is already in bounds', () => {
+            const onChange = vi.fn();
+            renderWithState(defaultTemplate, {
+                value: getDateAtTime({ hour: 12, minute: 0 }),
+                minTime: getDateAtTime({ hour: 9, minute: 0 }),
+                maxTime: getDateAtTime({ hour: 18, minute: 0 }),
+                boundsMode: 'enforce' as const,
+                onChange,
+            });
+            expect(onChange).not.toHaveBeenCalled();
+        });
+    });
+
     describe('selection via click', () => {
         it('emits a Date matching the picked option time-of-day', async () => {
             const onChange = vi.fn();

--- a/packages/lumx-core/src/js/components/TimePickerField/index.tsx
+++ b/packages/lumx-core/src/js/components/TimePickerField/index.tsx
@@ -19,6 +19,7 @@ const { block } = classNames.bem(CLASSNAME);
  */
 export const DEFAULT_PROPS: Partial<TimePickerFieldWrapperProps> = {
     step: 30,
+    boundsMode: 'on-blur',
 };
 
 /**
@@ -65,7 +66,17 @@ export interface TimePickerFieldWrapperProps {
     maxTime?: Date;
 
     /**
-     * Translations label for clear and show suggestions buttons.
+     * Controls how the time value interacts with `[minTime, maxTime]` bounds.
+     * Typed input is always snapped to bounds on blur.
+     * - `'enforce'`: additionally, the controlled `value` prop is proactively
+     *   clamped to bounds on mount and whenever bounds change, calling
+     *   `onChange` when adjusted.
+     * - `'on-blur'` (default): only blur snapping applies.
+     */
+    boundsMode?: 'on-blur' | 'enforce';
+
+    /**
+     * Translation labels for clear and show suggestions buttons.
      */
     translations: TimePickerFieldTranslations;
 }

--- a/packages/lumx-react/src/components/time-picker-field/TimePickerField.stories.tsx
+++ b/packages/lumx-react/src/components/time-picker-field/TimePickerField.stories.tsx
@@ -19,4 +19,5 @@ export const Step15 = { ...stories.Step15 };
 export const WithMinTime = { ...stories.WithMinTime };
 export const WithMaxTime = { ...stories.WithMaxTime };
 export const French = { ...stories.French };
+export const WithBoundsMode = { ...stories.WithBoundsMode };
 export const Disabled = { ...stories.Disabled };

--- a/packages/lumx-react/src/components/time-picker-field/TimePickerField.tsx
+++ b/packages/lumx-react/src/components/time-picker-field/TimePickerField.tsx
@@ -1,4 +1,4 @@
-import React, { type SyntheticEvent, useCallback, useMemo, useState } from 'react';
+import React, { type SyntheticEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { HasClassName, HasTheme } from '@lumx/core/js/types';
 import {
@@ -70,9 +70,11 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
         step = DEFAULT_PROPS.step,
         minTime,
         maxTime,
+        boundsMode = DEFAULT_PROPS.boundsMode,
         className,
         theme,
         translations,
+        name,
         ...forwardedProps
     } = props;
 
@@ -89,12 +91,27 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
         return { hour: value.getHours(), minute: value.getMinutes(), name: formatTime(value, locale) };
     }, [value, locale]);
 
+    // Clamp the current value to bounds whenever enforce mode is set and value/bounds change.
+    useEffect(() => {
+        if (boundsMode !== 'enforce' || !value) return;
+
+        const timeOfDay = {
+            hour: value.getHours(),
+            minute: value.getMinutes(),
+        };
+        const clamped = snapTimeToBounds(timeOfDay, minTime, maxTime);
+
+        if (clamped.hour !== value.getHours() || clamped.minute !== value.getMinutes()) {
+            onChange(getDateAtTime(clamped, value), name);
+        }
+    }, [boundsMode, value, minTime, maxTime, onChange, name]);
+
     const handleChange: UIProps['handleChange'] = useCallback(
         (next) => {
             const date = next ? getDateAtTime(next, value) : undefined;
-            onChange(date, forwardedProps.name);
+            onChange(date, name);
         },
-        [forwardedProps.name, onChange, value],
+        [name, onChange, value],
     );
 
     const handleBlur: UIProps['handleBlur'] = useCallback(() => {
@@ -108,8 +125,8 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
         const time = snapTimeToBounds(parsed, minTime, maxTime);
         if (value && isDateOnTime(value, time)) return;
 
-        onChange(getDateAtTime(time, value), forwardedProps.name);
-    }, [maxTime, minTime, forwardedProps.name, onChange, searchValue, value]);
+        onChange(getDateAtTime(time, value), name);
+    }, [maxTime, minTime, name, onChange, searchValue, value]);
 
     const searchInputValue = value ? formatTime(value, locale) : undefined;
 

--- a/packages/lumx-vue/src/components/time-picker-field/TimePickerField.stories.tsx
+++ b/packages/lumx-vue/src/components/time-picker-field/TimePickerField.stories.tsx
@@ -20,4 +20,5 @@ export const Step15 = { ...stories.Step15 };
 export const WithMinTime = { ...stories.WithMinTime };
 export const WithMaxTime = { ...stories.WithMaxTime };
 export const French = { ...stories.French };
+export const WithBoundsMode = { ...stories.WithBoundsMode };
 export const Disabled = { ...stories.Disabled };

--- a/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
+++ b/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref } from 'vue';
+import { computed, defineComponent, ref, watch } from 'vue';
 
 import {
     TimePickerField as UI,
@@ -63,6 +63,7 @@ const TimePickerField = defineComponent(
         const className = useClassName(() => props.class);
         const locale = computed(() => props.locale ?? getCurrentLocale());
         const step = computed(() => props.step ?? DEFAULT_PROPS.step);
+        const boundsMode = computed(() => props.boundsMode ?? DEFAULT_PROPS.boundsMode);
 
         // Build the option list — re-computed only when bounds/step/locale change.
         const timeList = computed(() =>
@@ -87,6 +88,25 @@ const TimePickerField = defineComponent(
                 name: formatTime(value, locale.value),
             };
         });
+
+        // Clamp the current value to bounds whenever enforce mode is set and value/bounds change.
+        watch(
+            () => [boundsMode.value, props.value, props.minTime, props.maxTime],
+            () => {
+                if (boundsMode.value !== 'enforce' || !props.value) return;
+
+                const timeOfDay = {
+                    hour: props.value.getHours(),
+                    minute: props.value.getMinutes(),
+                };
+                const clamped = snapTimeToBounds(timeOfDay, props.minTime, props.maxTime);
+
+                if (clamped.hour !== props.value.getHours() || clamped.minute !== props.value.getMinutes()) {
+                    emit('change', getDateAtTime(clamped, props.value));
+                }
+            },
+            { immediate: true },
+        );
 
         const handleChange: UIProps['handleChange'] = (next) => {
             const date = next ? getDateAtTime(next, props.value) : undefined;
@@ -151,6 +171,7 @@ const TimePickerField = defineComponent(
             'step',
             'minTime',
             'maxTime',
+            'boundsMode',
             'translations',
             'class',
             // Inherited SelectTextField props

--- a/packages/site-demo/content/product/components/time-picker-field/index.mdx
+++ b/packages/site-demo/content/product/components/time-picker-field/index.mdx
@@ -4,9 +4,11 @@ frameworks: ['react', 'vue']
 
 import * as ReactDemoDefault from './react/default.tsx';
 import * as ReactDemoBounds from './react/bounds.tsx';
+import * as ReactDemoBoundsEnforce from './react/bounds-enforce.tsx';
 import * as ReactDemoLocale from './react/locale.tsx';
 import * as VueDemoDefault from './vue/default.vue';
 import * as VueDemoBounds from './vue/bounds.vue';
+import * as VueDemoBoundsEnforce from './vue/bounds-enforce.vue';
 import * as VueDemoLocale from './vue/locale.vue';
 import ReactTimePickerField from 'lumx-docs:@lumx/react/components/time-picker-field/TimePickerField';
 import VueTimePickerField from 'lumx-docs:@lumx/vue/components/time-picker-field/TimePickerField';
@@ -23,6 +25,11 @@ The field generates time suggestions in a dropdonw list with configurable minute
 Restrict the pickable range with `minTime` and `maxTime`. Options outside the range remain **visible** in the dropdown but are rendered as disabled. Typed input outside the range is snapped to the nearest bound on blur.
 
 <DemoBlock demo={{ react: ReactDemoBounds, vue: VueDemoBounds }} />
+
+The `boundsMode` prop controls when the value is adjusted to the bounds:
+
+- `"on-blur"` (default) — typed input is snapped to the nearest bound on blur only.
+- `"enforce"` — in addition to blur snapping, the controlled value is proactively clamped to the bounds on mount and whenever bounds change. The value stays in sync with `minTime` and `maxTime` automatically, calling `onChange` when adjusted.
 
 ## Locale
 


### PR DESCRIPTION
Adds a `boundsMode` prop on `TimePickerField` with two string modes:

- `boundsMode=enforce`: proactively clamps the controlled `value` prop to `[minTime, maxTime]` on mount and whenever bounds change, calling `onChange`/`change` when adjusted
- `boundsMode=on-blur` (default): typed input is snapped to bounds on blur, no proactive clamping

### Changes

- **Core**: Added `boundsMode?: 'on-blur' | 'enforce'` to `DEFAULT_PROPS` (defaults to `'on-blur'`)
- **React**: `useEffect` clamping when `boundsMode === 'enforce'`, calls `onChange` when adjusted
- **Vue**: `watch` with `{ immediate: true }` doing same logic, emits `change`
- **Stories**: New `WithBoundsMode` story (`boundsMode=enforce`)
- **Tests**: 5 mount-time scenarios (enforce to minTime, enforce to maxTime, no-op without prop, no-op with `on-blur`, no-op when already in bounds)

StoryBook lumx-react: https://04e41b3ab--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://04e41b3ab--697a023f84e832e23544fb3c.chromatic.com/