### PR TITLE
fix(combobox): avoid aria-expanded=true when list is empty [CF-1596]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `SelectButton`, `SelectTextfield`: change default maxHeight to `80vh` instead of `50vh`
 
+### Fixed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `Combobox`: avoid setting `aria-expanded="true"` when the list has no visible options (empty or error state)
+
 ## [4.17.0][] - 2026-06-11
 
 ### Added

--- a/packages/lumx-core/src/js/components/Combobox/Tests.tsx
+++ b/packages/lumx-core/src/js/components/Combobox/Tests.tsx
@@ -2776,7 +2776,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.click(input);
 
             await waitFor(() => {
-                expect(input).toHaveAttribute('aria-expanded', 'true');
+                expect(input).toHaveAttribute('aria-expanded', 'false');
             });
 
             // Content is deferred after open to allow the aria-live region
@@ -2795,7 +2795,7 @@ export default function comboboxTests({ components: { Combobox, IconButton }, re
             await userEvent.click(input);
 
             await waitFor(() => {
-                expect(input).toHaveAttribute('aria-expanded', 'true');
+                expect(input).toHaveAttribute('aria-expanded', 'false');
             });
 
             await waitFor(() => {

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -62,6 +62,12 @@ export function setupCombobox(
     /** Last notified input value, to re-fire `optionsChange` when the user keeps typing while empty. */
     let lastInputValue = '';
 
+    /** Last notified loading state, used to replay current state to late subscribers. */
+    let lastLoadingState = false;
+
+    /** Number of currently mounted skeleton placeholders. */
+    let skeletonCount = 0;
+
     /** Event subscribers managed by the handle. */
     const subscribers: { [K in keyof ComboboxEventMap]: Set<(value: ComboboxEventMap[K]) => void> } = {
         open: new Set(),
@@ -76,6 +82,20 @@ export function setupCombobox(
         subscribers[event].forEach((cb) => cb(value));
     }
 
+    /** Count visible (non-filtered) options. */
+    function getVisibleOptionCount(): number {
+        let count = 0;
+        for (const reg of optionRegistrations.values()) {
+            if (!reg.lastFiltered) count += 1;
+        }
+        return count;
+    }
+
+    /** True when the popup has visible content (options or skeletons). */
+    function hasVisibleContent(): boolean {
+        return getVisibleOptionCount() > 0 || skeletonCount > 0;
+    }
+
     /**
      * Notify all registered sections and fire `optionsChange` if the visible option count changed
      * or if the input value changed while the list is empty (so `emptyMessage` callbacks get
@@ -87,10 +107,7 @@ export function setupCombobox(
             notifySection(sectionElement, sectionRegistrations, optionRegistrations);
         }
 
-        let visibleCount = 0;
-        for (const reg of optionRegistrations.values()) {
-            if (!reg.lastFiltered) visibleCount += 1;
-        }
+        const visibleCount = getVisibleOptionCount();
         const inputValue = trigger?.value ?? '';
         const isEmpty = visibleCount === 0;
         if (visibleCount !== lastOptionsLength || (isEmpty && inputValue !== lastInputValue)) {
@@ -98,15 +115,18 @@ export function setupCombobox(
             lastInputValue = inputValue;
             notify('optionsChange', { optionsLength: visibleCount, inputValue });
         }
+
+        // Re-evaluate aria-expanded when the combobox is open — visible content may have
+        // changed due to filtering, option register/unregister, or skeleton transitions.
+        if (isOpenState) {
+            trigger?.setAttribute('aria-expanded', String(hasVisibleContent()));
+        }
     }
 
     // ── Skeleton loading tracking ──────────────────────────────
 
     /** Delay before announcing loading in the live region (ms). */
     const LOADING_ANNOUNCEMENT_DELAY = 500;
-
-    /** Number of currently mounted skeleton placeholders. */
-    let skeletonCount = 0;
 
     /** Timer for debounced loading announcement. */
     let loadingTimer: ReturnType<typeof setTimeout> | undefined;
@@ -133,6 +153,7 @@ export function setupCombobox(
      */
     function onSkeletonCountChange() {
         const isLoading = skeletonCount > 0;
+        lastLoadingState = isLoading;
         notify('loadingChange', isLoading);
 
         if (isLoading) {
@@ -347,8 +368,8 @@ export function setupCombobox(
                 startLoadingAnnouncementTimer();
             }
 
-            // Update aria-expanded on trigger
-            trigger?.setAttribute('aria-expanded', String(isOpen));
+            // Update aria-expanded on trigger (false when no visible options or skeletons)
+            trigger?.setAttribute('aria-expanded', String(isOpen && hasVisibleContent()));
             notify('open', isOpen);
         },
 
@@ -489,6 +510,17 @@ export function setupCombobox(
             callback: (value: ComboboxEventMap[K]) => void,
         ): () => void {
             subscribers[event].add(callback);
+            // Replay current loading state to late subscribers so that framework wrappers
+            // that subscribe after initial mount (e.g. async Vue watchers) don't miss the
+            // initial events fired during mount.
+            if (event === 'open' && isOpenState) {
+                (callback as (value: boolean) => void)(true);
+            }
+            if (event === 'loadingChange' && lastLoadingState) {
+                (callback as (value: boolean) => void)(true);
+            }
+
+            // Cleanup function
             return () => {
                 subscribers[event].delete(callback);
             };
@@ -501,6 +533,7 @@ export function setupCombobox(
             filterValue = '';
             lastOptionsLength = 0;
             lastInputValue = '';
+            lastLoadingState = false;
             optionRegistrations.clear();
             sectionRegistrations.clear();
             skeletonCount = 0;

--- a/packages/lumx-core/src/js/components/SelectButton/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/Tests.tsx
@@ -433,7 +433,8 @@ export default function selectButtonTests({ components, renderWithState }: Selec
 
             await userEvent.click(button);
             await waitFor(() => {
-                expect(button.getAttribute('aria-expanded')).toBe('true');
+                // aria-expanded is false: error state has no selectable options
+                expect(button.getAttribute('aria-expanded')).toBe('false');
             });
 
             await waitFor(() => {

--- a/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
@@ -1403,7 +1403,8 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
             await userEvent.click(input);
             await waitFor(() => {
-                expect(input.getAttribute('aria-expanded')).toBe('true');
+                // aria-expanded is false: error state has no selectable options
+                expect(input.getAttribute('aria-expanded')).toBe('false');
             });
 
             // Wait a tick to let InfiniteScroll potentially fire
@@ -1424,7 +1425,8 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
             await userEvent.click(input);
             await waitFor(() => {
-                expect(input.getAttribute('aria-expanded')).toBe('true');
+                // aria-expanded is false: error state has no selectable options
+                expect(input.getAttribute('aria-expanded')).toBe('false');
             });
 
             await waitFor(() => {
@@ -1445,7 +1447,8 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
 
             await userEvent.click(input);
             await waitFor(() => {
-                expect(input.getAttribute('aria-expanded')).toBe('true');
+                // aria-expanded is false: error state has no selectable options
+                expect(input.getAttribute('aria-expanded')).toBe('false');
             });
 
             expect(getSkeletons()).toHaveLength(0);

--- a/packages/lumx-react/src/components/combobox/ComboboxButton.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxButton.tsx
@@ -13,6 +13,7 @@ import { useMergeRefs } from '@lumx/react/utils/react/mergeRefs';
 import { ComponentRef, HasPolymorphicAs, HasRequiredLinkHref } from '@lumx/react/utils/type';
 import { Tooltip } from '../tooltip';
 import { Button } from '../button';
+import { useComboboxEvent } from './context/useComboboxEvent';
 import { useComboboxContext } from './context/ComboboxContext';
 import { useComboboxOpen } from './context/useComboboxOpen';
 
@@ -45,6 +46,8 @@ export const ComboboxButton = Object.assign(
         <E extends ElementType = typeof Button>(props: ComboboxButtonProps<E>, ref: ComponentRef<E>) => {
             const { listboxId, anchorRef, setHandle } = useComboboxContext();
             const [isOpen] = useComboboxOpen();
+            const state = useComboboxEvent('optionsChange', { optionsLength: 0 });
+            const isLoading = useComboboxEvent('loadingChange', false);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const { as, label, value, labelDisplayMode = 'show-selection', onSelect, ...buttonProps } = props as any;
 
@@ -81,7 +84,7 @@ export const ComboboxButton = Object.assign(
                     value,
                     labelDisplayMode,
                     listboxId,
-                    isOpen,
+                    isOpen: isOpen && (!!state?.optionsLength || isLoading),
                     ref: mergedRef,
                 },
                 { Button: ButtonComp, Tooltip },

--- a/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-react/src/components/combobox/ComboboxInput.tsx
@@ -13,6 +13,7 @@ import { useMergeRefs } from '@lumx/react/utils/react/mergeRefs';
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
 import { IconButton, IconButtonProps } from '../button';
 import { TextField, TextFieldProps } from '../text-field';
+import { useComboboxEvent } from './context/useComboboxEvent';
 import { useComboboxContext } from './context/ComboboxContext';
 import { useComboboxOpen } from './context/useComboboxOpen';
 
@@ -40,6 +41,8 @@ export interface ComboboxInputProps extends TextFieldProps, ReactToJSX<UIProps, 
 export const ComboboxInput = forwardRef<ComboboxInputProps, HTMLDivElement>((props, ref) => {
     const { listboxId, anchorRef, setHandle } = useComboboxContext();
     const [isOpen, setIsOpen] = useComboboxOpen();
+    const state = useComboboxEvent('optionsChange', { optionsLength: 0 });
+    const isLoading = useComboboxEvent('loadingChange', false);
     const { inputRef: externalInputRef, toggleButtonProps, onSelect, filter, openOnFocus, ...otherProps } = props;
     const internalInputRef = useRef<HTMLInputElement>(null);
     const mergedInputRef = useMergeRefs(externalInputRef, internalInputRef);
@@ -84,7 +87,7 @@ export const ComboboxInput = forwardRef<ComboboxInputProps, HTMLDivElement>((pro
             ...otherProps,
             ref,
             listboxId,
-            isOpen,
+            isOpen: isOpen && (!!state?.optionsLength || isLoading),
             filter,
             inputRef: mergedInputRef,
             textFieldRef: anchorRef as Ref<HTMLDivElement>,

--- a/packages/lumx-vue/src/components/combobox/ComboboxButton.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxButton.tsx
@@ -14,6 +14,7 @@ import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Button } from '../button';
 import { Tooltip } from '../tooltip';
 import { useComboboxContext } from './context/ComboboxContext';
+import { useComboboxEvent } from './context/useComboboxEvent';
 import { useComboboxOpen } from './context/useComboboxOpen';
 
 export type ComboboxButtonProps = VueToJSXProps<UIProps, 'label' | 'renderButton'> & {
@@ -41,6 +42,8 @@ const ComboboxButton = defineComponent(
         const className = useClassName(() => props.class);
         const { listboxId, anchorRef, setHandle, handle } = useComboboxContext();
         const { isOpen } = useComboboxOpen();
+        const optionsState = useComboboxEvent('optionsChange', { optionsLength: 0 });
+        const isLoading = useComboboxEvent('loadingChange', false);
 
         const buttonRef = ref<HTMLElement | null>(null);
 
@@ -86,7 +89,7 @@ const ComboboxButton = defineComponent(
                     labelDisplayMode,
                     renderButton,
                     listboxId,
-                    isOpen: isOpen.value,
+                    isOpen: isOpen.value && (!!optionsState.value?.optionsLength || isLoading.value),
                     ref: (el: any) => {
                         // Handle both component instances and raw elements
                         buttonRef.value = el?.$el ?? el;

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -70,11 +70,13 @@ const ComboboxInput = defineComponent(
             setHandle(null);
         });
 
-        // Track whether the option list is empty to disable the toggle button.
-        const optionsState = useComboboxEvent('optionsChange', undefined);
+        // Track options and loading state to compute aria-expanded correctly.
+        const optionsState = useComboboxEvent('optionsChange', { optionsLength: 0 });
+        const isLoading = useComboboxEvent('loadingChange', false);
 
         const handleToggle = () => {
-            if (isOpen.value && optionsState.value?.optionsLength === 0) return;
+            // Don't toggle when error/empty state (no options and not loading)
+            if (isOpen.value && !optionsState.value?.optionsLength && !isLoading.value) return;
             setIsOpen(!isOpen.value);
             inputEl.value?.focus();
         };
@@ -110,7 +112,7 @@ const ComboboxInput = defineComponent(
                     'aria-disabled': fwdAriaDisabled ?? (attrs as any).ariaDisabled,
                     ...eventHandlers,
                     listboxId,
-                    isOpen: isOpen.value,
+                    isOpen: isOpen.value && (!!optionsState.value?.optionsLength || isLoading.value),
                     filter,
                     textFieldRef: (el: HTMLElement | null) => {
                         anchorRef.value = el;


### PR DESCRIPTION
Only set `aria-expanded=true` when the combobox opens with visible options or loading skeletons. Keep it false when the list is empty so screen readers don't announce 'expanded' for a popover with no selectable content.

**Changes:**
- Core: `setIsOpen()` now checks visible option count + skeleton count before setting `aria-expanded`
- Core: `notifyVisibilityChange()` re-evaluates `aria-expanded` when open (handles filter-to-empty then back)
- React/Vue wrappers: subscribe to `optionsChange` and pass `optionsLength` to core templates
- Tests: error state tests updated to expect `aria-expanded=false` (empty list template)
- Loading state preserved: skeletons count as visible content

StoryBook lumx-react: https://ce411f0bd--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://ce411f0bd--697a023f84e832e23544fb3c.chromatic.com/