### PR TITLE
chore(ci): optimize CI with affected package detection and checkout and setup tunning

### DIFF
--- a/.github/actions/check-affected/action.yml
+++ b/.github/actions/check-affected/action.yml
@@ -6,6 +6,8 @@ outputs:
         description: 'JSON array of affected project names'
     modified:
         description: 'JSON array of directly modified project names (without dependents)'
+    affected-test-storybook:
+        description: 'JSON array of affected project names with test:storybook target'
 
 runs:
     using: node24

--- a/.github/actions/check-affected/index.mjs
+++ b/.github/actions/check-affected/index.mjs
@@ -15,12 +15,12 @@ async function main() {
     const { files: changedFiles } = parseFiles(nxArgs);
     const touchedFiles = changedFiles.length > 0 ? calculateFileChanges(changedFiles, nxArgs) : [];
 
-    const affectedGraph =
-        changedFiles.length > 0 ? await filterAffected(graph, touchedFiles) : graph;
+    const affectedGraph = changedFiles.length > 0 ? await filterAffected(graph, touchedFiles) : graph;
     const affectedNames = Object.keys(affectedGraph.nodes);
 
     // projects with at least one modified file
     const modified = [];
+    const affectedByTarget = { test: [] };
     for (const [name, node] of Object.entries(graph.nodes)) {
         const root = node.data.root;
         const prefix = root + '/';
@@ -28,12 +28,17 @@ async function main() {
         if (changedFiles.some((f) => f === root || f.startsWith(prefix))) {
             modified.push(name);
         }
+        if (node?.data?.targets?.['test']) affectedByTarget.test.push(name);
     }
 
     console.log('affected', affectedNames);
     core.setOutput('affected', JSON.stringify(affectedNames));
+
     console.log('modified', modified);
     core.setOutput('modified', JSON.stringify(modified));
+
+    console.log('affected-test', affectedByTarget.test);
+    core.setOutput('affected-test', JSON.stringify(affectedByTarget.test));
 }
 
 main().catch((err) => {

--- a/.github/actions/check-affected/index.mjs
+++ b/.github/actions/check-affected/index.mjs
@@ -16,19 +16,34 @@ async function main() {
     const touchedFiles = changedFiles.length > 0 ? calculateFileChanges(changedFiles, nxArgs) : [];
 
     const affectedGraph = changedFiles.length > 0 ? await filterAffected(graph, touchedFiles) : graph;
-    const affectedNames = Object.keys(affectedGraph.nodes);
 
-    // projects with at least one modified file
+    // Affected projects
+    const affectedNames = Object.keys(affectedGraph.nodes);
+    // Projects with at least one modified file
     const modified = [];
-    const affectedByTarget = { test: [] };
+    // Affected projects filtered by targets
+    const affectedByTarget = {
+        test: [],
+        'test:storybook': [],
+    };
+
+    // Collect modified projects and projects with targets in affectedByTarget
     for (const [name, node] of Object.entries(graph.nodes)) {
         const root = node.data.root;
         const prefix = root + '/';
-        // collect projects listed in `changedFiles`
+        // Collect projects listed in `changedFiles`
         if (changedFiles.some((f) => f === root || f.startsWith(prefix))) {
             modified.push(name);
         }
-        if (node?.data?.targets?.['test']) affectedByTarget.test.push(name);
+
+        // Collect affected projects per target, skipping projects that don't define it
+        if (affectedNames.includes(name)) {
+            for (const target of Object.keys(affectedByTarget)) {
+                if (node?.data?.targets?.[target]) {
+                    affectedByTarget[target].push(name);
+                }
+            }
+        }
     }
 
     console.log('affected', affectedNames);
@@ -39,6 +54,9 @@ async function main() {
 
     console.log('affected-test', affectedByTarget.test);
     core.setOutput('affected-test', JSON.stringify(affectedByTarget.test));
+
+    console.log('affected-test-storybook', affectedByTarget['test:storybook']);
+    core.setOutput('affected-test-storybook', JSON.stringify(affectedByTarget['test:storybook']));
 }
 
 main().catch((err) => {

--- a/.github/actions/check-affected/index.mjs
+++ b/.github/actions/check-affected/index.mjs
@@ -1,31 +1,30 @@
 import { execSync } from 'node:child_process';
 import { createProjectGraphAsync } from 'nx/src/project-graph/project-graph.js';
 import { filterAffected } from 'nx/src/project-graph/affected/affected-project-graph.js';
-import { WholeFileChange } from 'nx/src/project-graph/file-utils.js';
+import { calculateFileChanges } from 'nx/src/project-graph/file-utils.js';
+import { parseFiles } from 'nx/src/utils/command-line-utils.js';
 import * as core from '@actions/core';
 
 async function main() {
-    const changedFiles = execSync('git diff --name-only origin/master...HEAD --diff-filter=AM')
-        .toString()
-        .trim()
-        .split('\n')
-        .filter(Boolean);
-
+    // Full Nx project dependency graph
     const graph = await createProjectGraphAsync();
 
-    const touchedFiles = changedFiles.map((file) => ({
-        file,
-        getChanges: () => [new WholeFileChange()],
-    }));
+    // Diff range: common ancestor of master..HEAD
+    const base = execSync('git merge-base origin/master HEAD').toString().trim();
+    const nxArgs = { base, head: 'HEAD' };
+    const { files: changedFiles } = parseFiles(nxArgs);
+    const touchedFiles = changedFiles.length > 0 ? calculateFileChanges(changedFiles, nxArgs) : [];
 
     const affectedGraph =
         changedFiles.length > 0 ? await filterAffected(graph, touchedFiles) : graph;
     const affectedNames = Object.keys(affectedGraph.nodes);
 
+    // projects with at least one modified file
     const modified = [];
     for (const [name, node] of Object.entries(graph.nodes)) {
         const root = node.data.root;
         const prefix = root + '/';
+        // collect projects listed in `changedFiles`
         if (changedFiles.some((f) => f === root || f.startsWith(prefix))) {
             modified.push(name);
         }

--- a/.github/actions/package.json
+++ b/.github/actions/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "devDependencies": {
         "@actions/core": "^3.0.0",
-        "@actions/github": "^9.0.0"
+        "@actions/github": "^9.0.0",
+        "nx": "^23.0.1"
     }
 }

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,10 @@ inputs:
         description: 'Install Playwright Chromium browser'
         required: false
         default: 'false'
+    focus:
+        description: 'Package name to focus install (skips cache and runs yarn workspaces focus <pkg>)'
+        required: false
+        default: ''
 
 runs:
     using: composite
@@ -15,20 +19,26 @@ runs:
             with:
                 registry-url: 'https://registry.npmjs.org'
                 node-version-file: '.nvmrc'
+                cache: yarn
 
         -   name: "Cache dependencies"
+            if: inputs.focus == ''
             id: cache
             uses: actions/cache@v5
             with:
-                path: |
-                  **/node_modules
-                  .yarn/cache
+                path: '**/node_modules'
                 key: ${{ runner.os }}-node-v${{ inputs.node_version }}-dependency-hash-${{ hashFiles('yarn.lock') }}
                 restore-keys: |
                     ${{ runner.os }}-node-v${{ inputs.node_version }}-dependency-hash-
 
         -   name: "Install dependencies"
+            if: inputs.focus == ''
             run: yarn install
+            shell: bash
+
+        -   name: "Install only one workspace"
+            if: inputs.focus != ''
+            run: yarn workspaces focus ${{ inputs.focus }}
             shell: bash
 
         - name: 'Cache Playwright browsers'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,10 @@ jobs:
         if: github.event.pull_request.draft == false
         uses: ./.github/workflows/workflow-check-affected.yml
 
-    lint:
-        if: github.event.pull_request.draft == false
+    # Run static code check (lint and type-check)
+    code-check:
+        needs: [check-affected]
+        if: github.event.pull_request.draft == false && needs.check-affected.outputs.affected != '[]'
         timeout-minutes: 30
         runs-on: ubuntu-latest
         steps:
@@ -24,8 +26,8 @@ jobs:
             - name: 'Setup'
               uses: ./.github/actions/setup
 
-            - name: 'Run packages lint'
-              run: yarn lint:code
+            - name: 'Run packages code check'
+              run: yarn nx run-many -t type-check,lint --projects='${{ needs.check-affected.outputs.affected }}'
 
     tests:
         needs: [check-affected]
@@ -56,20 +58,6 @@ jobs:
               run: |
                   sudo timedatectl set-timezone Europe/Paris
                   yarn workspace ${{ matrix.package }} test
-
-    type-check:
-        if: github.event.pull_request.draft == false
-        timeout-minutes: 30
-        runs-on: ubuntu-latest
-        steps:
-            - name: 'Checkout repository'
-              uses: actions/checkout@v6
-
-            - name: 'Setup'
-              uses: ./.github/actions/setup
-
-            - name: 'Run code type check'
-              run: yarn type-check
 
     test-storybook:
         needs: [check-affected]
@@ -134,7 +122,7 @@ jobs:
     required-checks:
         if: '!cancelled() && github.event.pull_request.draft == false'
         runs-on: ubuntu-latest
-        needs: [lint, test-storybook, tests, type-check, Commit-message-validation, release-freeze-check, check-affected, check-build-site]
+        needs: [code-check, test-storybook, tests, Commit-message-validation, release-freeze-check, check-affected, check-build-site]
         steps:
             - name: Success
               if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,11 @@ jobs:
               run: yarn type-check
 
     test-storybook:
-        if: github.event.pull_request.draft == false
+        needs: [check-affected]
+        if: github.event.pull_request.draft == false && needs.check-affected.outputs.affected-test-storybook != '[]'
         uses: ./.github/workflows/workflow-test-storybook.yml
+        with:
+            packages: ${{ needs.check-affected.outputs.affected-test-storybook }}
         permissions:
             pull-requests: write
         secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,13 @@ jobs:
               run: yarn lint:code
 
     tests:
-        if: github.event.pull_request.draft == false
+        needs: [check-affected]
+        if: github.event.pull_request.draft == false && needs.check-affected.outputs.affected-test != '[]'
         timeout-minutes: 30
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                package: ['@lumx/core', '@lumx/react', '@lumx/vue']
+                package: ${{ fromJSON(needs.check-affected.outputs.affected-test) }}
                 packageOverrides: ['']
                 include:
                     - package: '@lumx/react'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
               uses: ./.github/actions/setup
 
             - name: 'Build site'
-              run: yarn build:site
+              run: yarn workspace lumx-site-demo build
 
     # Fails when the release PR is frozen (marked "Ready for review"),
     # blocking merges to master during release preparation.

--- a/.github/workflows/workflow-check-affected.yml
+++ b/.github/workflows/workflow-check-affected.yml
@@ -22,9 +22,14 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+                  filter: 'blob:none'
+                  show-progress: false
+                  persist-credentials: false
 
             - name: 'Setup'
               uses: ./.github/actions/setup
+              with:
+                  focus: '@lumx/actions'
 
             - name: 'Check affected and modified packages'
               id: check-affected

--- a/.github/workflows/workflow-check-affected.yml
+++ b/.github/workflows/workflow-check-affected.yml
@@ -12,6 +12,9 @@ on:
             affected-test:
                 description: 'JSON array of affected project names with tests'
                 value: ${{ jobs.check-affected.outputs.affected-test }}
+            affected-test-storybook:
+                description: 'JSON array of affected project names with test:storybook target'
+                value: ${{ jobs.check-affected.outputs.affected-test-storybook }}
 
 jobs:
     check-affected:
@@ -21,6 +24,7 @@ jobs:
             affected: ${{ steps.check-affected.outputs.affected }}
             modified: ${{ steps.check-affected.outputs.modified }}
             affected-test: ${{ steps.check-affected.outputs.affected-test }}
+            affected-test-storybook: ${{ steps.check-affected.outputs.affected-test-storybook }}
         steps:
             - name: 'Checkout repository'
               uses: actions/checkout@v6

--- a/.github/workflows/workflow-check-affected.yml
+++ b/.github/workflows/workflow-check-affected.yml
@@ -9,6 +9,9 @@ on:
             modified:
                 description: 'JSON array of directly modified project names (without dependents)'
                 value: ${{ jobs.check-affected.outputs.modified }}
+            affected-test:
+                description: 'JSON array of affected project names with tests'
+                value: ${{ jobs.check-affected.outputs.affected-test }}
 
 jobs:
     check-affected:
@@ -17,6 +20,7 @@ jobs:
         outputs:
             affected: ${{ steps.check-affected.outputs.affected }}
             modified: ${{ steps.check-affected.outputs.modified }}
+            affected-test: ${{ steps.check-affected.outputs.affected-test }}
         steps:
             - name: 'Checkout repository'
               uses: actions/checkout@v6

--- a/.github/workflows/workflow-test-storybook.yml
+++ b/.github/workflows/workflow-test-storybook.yml
@@ -8,6 +8,10 @@ on:
                 description: 'Update all snapshots without checking for differences'
                 type: boolean
                 default: false
+            packages:
+                description: 'JSON array of storybook packages to test'
+                type: string
+                default: '["@lumx/react","@lumx/vue"]'
         secrets:
             GITBOT_TOKEN:
                 description: 'Token with write access to the wiki repo'
@@ -54,6 +58,7 @@ jobs:
                     | sort > ${{ matrix.visDir }}/cached-baselines.txt
 
             - name: 'Run ${{ matrix.project }} tests'
+              if: ${{ contains(fromJSON(inputs.packages), format('@lumx/{0}', matrix.label)) }}
               id: test-storybook
               run: yarn workspace "@lumx/${{ matrix.label }}" test:storybook ${{ inputs.update && '--update' || '' }}
               env:

--- a/dev-packages/visual-diffs/generate-report.js
+++ b/dev-packages/visual-diffs/generate-report.js
@@ -84,6 +84,19 @@ async function scanPackage(artifactRoot) {
         findFiles(artifactRoot, (f) => f.includes('__baselines__') && isPng(f)),
     ]);
 
+    // If no results and no diffs but baselines exist, the framework was not tested
+    // (baseline-only run to support cross-framework diffing).
+    if (resultPngs.length === 0 && diffPngs.length === 0 && baselinePngs.length > 0) {
+        return {
+            notRun: true,
+            hasBaselines: true,
+            diffs: [],
+            newScreenshots: [],
+            unchangedScreenshots: [],
+            deletedScreenshots: [],
+        };
+    }
+
     const cachedBaselines = await readBaselineManifest(artifactRoot);
 
     const baselineEntries = toEntries(baselinePngs, '__baselines__');
@@ -239,6 +252,7 @@ function renderImageEntry(entry, columns) {
  * @returns {string} e.g. "3 difference(s), 1 new" or "No changes"
  */
 function summarizeChanges(pkg) {
+    if (pkg.notRun) return 'Not tested (baseline only)';
     const parts = [
         pkg.diffs.length > 0 && `${pkg.diffs.length} difference(s)`,
         pkg.newScreenshots.length > 0 && `${pkg.newScreenshots.length} new`,
@@ -274,6 +288,9 @@ function buildReportPreamble(packages) {
  * @returns {string[]}
  */
 function buildPackageHeading(pkg, { headingLevel = 2 } = {}) {
+    if (pkg.notRun) {
+        return [md.heading(headingLevel, `@lumx/${pkg.label} — Not tested (baseline only)`), ''];
+    }
     if (!pkg.hasBaselines) {
         return [
             md.heading(headingLevel, `@lumx/${pkg.label} — No baseline snapshots found`),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2803,6 +2803,7 @@ __metadata:
   dependencies:
     "@actions/core": "npm:^3.0.0"
     "@actions/github": "npm:^9.0.0"
+    nx: "npm:^23.0.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Changes

### 1. Optimize check-affected checkout and setup
- Use `filter: blob:none`, `show-progress: false`, `persist-credentials: false` for faster checkout
- Use `focus: '@lumx/actions'` to install only the actions workspace (nx + @actions/core) instead of full install
- Use Nx `parseFiles` + `calculateFileChanges` instead of raw `git diff` for more accurate change detection
- New outputs: `affected-test` (projects with `test` target), `affected-test-storybook` (projects with `test:storybook` target)

### 2. Only run affected package tests
- `tests` job matrix now reads from `needs.check-affected.outputs.affected-test` instead of hardcoded `["'@lumx/core', '@lumx/react', '@lumx/vue']`
- Job is skipped when no affected packages have a `test` target

### 3. Only run affected package storybook tests
- `test-storybook` now reads `packages` input from `needs.check-affected.outputs.affected-test-storybook`
- Each matrix step conditionally runs based on `contains(fromJSON(inputs.packages), ...)`
- Visual diff report handles "not tested" packages gracefully

### 4. Regroup lint + type-check into single code-check job
- Merged separate `lint` and `type-check` jobs into one `code-check` job
- Runs `nx run-many -t type-check,lint --projects=$AFFECTED` targeting only affected packages
- Removes ~2min of duplicate checkout+setup overhead

### 5. Fix: remove focus install for code-check
`focus: '@lumx/lumx'` skipped installing `eslint-config-lumapps` (dev-packages), causing ESLint to fail with missing `"lumapps"` config. Code-check now does a full install — the main perf win is the targeted `nx run-many`.

### 6. Fix: bypass nx task graph in check-build-site
`nx run lumx-site-demo:build` hit a circular dependency (`@lumx/react` imports from site-demo via `.storybook/main.ts`). Changed to `yarn workspace lumx-site-demo build` directly.

## Test Results

All scenarios verified via temp commits pushed to this PR branch:

| Scenario | code-check | tests | test-storybook | check-build-site |
|---|---|---|---|---|
| **CI-only change** (no source) | ✅ Pass | ⏭️ Skip | ⏭️ Skip | ⏭️ Skip |
| **Core change** (`packages/lumx-core/src/`) | ✅ Pass | ✅ core+react+vue | ✅ react+vue | ⏭️ Skip |
| **Icons change** (`packages/lumx-icons/`) | ✅ Pass | ✅ core+react+vue | ✅ react+vue | ⏭️ Skip |
| **Site-demo change** (`packages/site-demo/src/`) | ✅ Pass | ⏭️ Skip | ⏭️ Skip | ✅ Pass |

affected-test correctly filters packages without `test` target (e.g., `@lumx/actions`, `@lumx/visual-diffs`, `lumx-site-demo`).<br>
required-checks correctly aggregations all jobs — failure in any required job cascades properly.
