### PR TITLE
feat(time-picker-field): add getOptionProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `TimePickerField`: add `getOptionProps` prop to customize individual option props
+
 ## [4.18.0][] - 2026-06-23
 
 ### Added

--- a/packages/lumx-core/src/js/components/TimePickerField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/TimePickerField/Tests.tsx
@@ -90,6 +90,46 @@ export default function timePickerFieldTests({ components, renderWithState }: Ti
             expect(optAfter).not.toHaveAttribute('aria-disabled', 'true');
         });
 
+        describe('getOptionProps', () => {
+            it('is called for each option with the entry and index', async () => {
+                const getOptionProps = vi.fn(() => ({}));
+                renderWithState(defaultTemplate, { getOptionProps });
+                await userEvent.click(screen.getByRole('combobox'));
+                expect(getOptionProps).toHaveBeenCalledWith({ hour: 0, minute: 0 });
+                expect(getOptionProps).toHaveBeenCalledWith({ hour: 23, minute: 30 });
+            });
+
+            it('forwards returned props to the option element', async () => {
+                renderWithState(defaultTemplate, {
+                    getOptionProps: () => ({ className: 'custom-option' }),
+                });
+                await userEvent.click(screen.getByRole('combobox'));
+                const options = screen.queryAllByRole('option');
+                // The role="option" element is inside a <li> that receives the className.
+                expect(options[0]?.closest('.custom-option')).toBeInTheDocument();
+            });
+
+            it('merges isDisabled with outOfRange via ||', async () => {
+                renderWithState(defaultTemplate, {
+                    minTime: getDateAtTime({ hour: 10, minute: 0 }),
+                    getOptionProps: (entry: any) => ({
+                        // out-of-range entries (before 10:00) already disabled by outOfRange;
+                        // also disable 10:00 and 10:30 manually.
+                        isDisabled: entry.hour === 10,
+                    }),
+                });
+                await userEvent.click(screen.getByRole('combobox'));
+                // 9:30 — disabled by outOfRange
+                expect(screen.getByRole('option', { name: '9:30 AM' })).toHaveAttribute('aria-disabled', 'true');
+                // 10:00 — disabled by getOptionProps (outOfRange is falsy, but || merges)
+                expect(screen.getByRole('option', { name: '10:00 AM' })).toHaveAttribute('aria-disabled', 'true');
+                // 10:30 — disabled by getOptionProps
+                expect(screen.getByRole('option', { name: '10:30 AM' })).toHaveAttribute('aria-disabled', 'true');
+                // 11:00 — NOT disabled
+                expect(screen.getByRole('option', { name: '11:00 AM' })).not.toHaveAttribute('aria-disabled', 'true');
+            });
+        });
+
         it('keeps options after `maxTime` visible but disables them', async () => {
             renderWithState(defaultTemplate, { maxTime: getDateAtTime({ hour: 1, minute: 0 }) });
             await userEvent.click(screen.getByRole('combobox'));

--- a/packages/lumx-core/src/js/components/TimePickerField/index.tsx
+++ b/packages/lumx-core/src/js/components/TimePickerField/index.tsx
@@ -2,6 +2,7 @@ import { classNames } from '../../utils';
 import type { GenericProps, HasClassName, HasTheme, LumxClassName } from '../../types';
 import type { TimeOfDay } from '../../utils/time';
 import type { SelectTextFieldTranslations } from '../../utils/select/types';
+import type { ComboboxOptionProps } from '../Combobox/ComboboxOption';
 
 /**
  * Component display name.
@@ -79,6 +80,15 @@ export interface TimePickerFieldWrapperProps {
      * Translation labels for clear and show suggestions buttons.
      */
     translations: TimePickerFieldTranslations;
+
+    /**
+     * Callback to customize individual option props.
+     * Called for each time option with the hour and minute.
+     * Return partial `ComboboxOptionProps` to override default option rendering
+     * (e.g. `before`, `after`, `children`, `tooltipProps`, `actionProps`).
+     * `isDisabled` is merged with the out-of-range state using `||`.
+     */
+    getOptionProps?: ({ hour, minute }: { hour: number; minute: number }) => Partial<ComboboxOptionProps>;
 }
 
 /**
@@ -129,6 +139,12 @@ export interface TimePickerFieldProps extends HasTheme, HasClassName, GenericPro
 
     /** Called when the input loses focus — wrappers commit the typed value. */
     handleBlur(): void;
+
+    /**
+     * Callback to customize individual option props.
+     * See `TimePickerFieldWrapperProps.getOptionProps`.
+     */
+    getOptionProps?: ({ hour, minute }: { hour: number; minute: number }) => Partial<ComboboxOptionProps>;
 }
 
 /**
@@ -159,7 +175,16 @@ export const TimePickerField = (
     props: TimePickerFieldProps,
     { SelectTextField, Option }: TimePickerFieldComponents,
 ) => {
-    const { options, translations, className, handleChange, handleSearch, handleBlur, ...fowardedProps } = props;
+    const {
+        options,
+        translations,
+        className,
+        handleChange,
+        handleSearch,
+        handleBlur,
+        getOptionProps,
+        ...fowardedProps
+    } = props;
 
     return (
         <SelectTextField
@@ -168,7 +193,10 @@ export const TimePickerField = (
             selectionType="single"
             options={options}
             getOptionId="name"
-            renderOption={(entry: TimeOfDay) => <Option isDisabled={entry.outOfRange} />}
+            renderOption={({ hour, minute, outOfRange }: TimeOfDay) => {
+                const { isDisabled, ...extraProps } = getOptionProps?.({ hour, minute }) || {};
+                return <Option isDisabled={outOfRange || isDisabled} {...extraProps} />;
+            }}
             onChange={handleChange}
             onSearch={handleSearch}
             onBlur={handleBlur}

--- a/packages/lumx-react/src/components/time-picker-field/TimePickerField.tsx
+++ b/packages/lumx-react/src/components/time-picker-field/TimePickerField.tsx
@@ -75,6 +75,7 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
         theme,
         translations,
         name,
+        getOptionProps,
         ...forwardedProps
     } = props;
 
@@ -142,6 +143,7 @@ export const TimePickerField: React.FC<TimePickerFieldProps> = (props) => {
             handleSearch,
             handleBlur,
             searchInputValue,
+            getOptionProps,
         },
         { SelectTextField, Option: SelectTextField.Option },
     );

--- a/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
+++ b/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
@@ -143,6 +143,7 @@ const TimePickerField = defineComponent(
                 maxTime: _maxTime,
                 translations,
                 class: _class,
+                getOptionProps,
                 ...forwardedProps
             } = props;
 
@@ -157,6 +158,7 @@ const TimePickerField = defineComponent(
                     handleSearch,
                     handleBlur,
                     searchInputValue,
+                    getOptionProps,
                 },
                 { SelectTextField, Option: SelectTextFieldOption },
             );
@@ -173,6 +175,7 @@ const TimePickerField = defineComponent(
             'maxTime',
             'boundsMode',
             'translations',
+            'getOptionProps',
             'class',
             // Inherited SelectTextField props
             'label',


### PR DESCRIPTION
Add `getOptionProps` callback prop allowing consumers to customize individual dropdown option props (e.g. `before`, `after`, `children`, `tooltipProps`, `actionProps`).

```ts
getOptionProps?: ({ hour, minute }) => Partial<ComboboxOptionProps>
```

`isDisabled` returned from the callback is merged with the out-of-range state via `||`, so out-of-range entries remain disabled.

StoryBook lumx-vue: [Deploying...](https://github.com/lumapps/design-system/actions/runs/28376282374?pr=1716)

StoryBook lumx-react: https://0134a14fc--5fbfb1d508c0520021560f10.chromatic.com/