### PR TITLE
fix(combobox): avoid recursive-update loop when mounting large option lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `Combobox`: avoid recursive updates errors when mounting a large option list
+
 ## [4.19.0][] - 2026-06-30
 
 ### Added

--- a/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
+++ b/packages/lumx-core/src/js/components/Combobox/setupCombobox.ts
@@ -9,6 +9,7 @@ import type {
     OptionRegistration,
     SectionRegistration,
 } from './types';
+import { debounceMicrotask } from '../../utils/function/debounceMicrotask';
 
 /** Options for configuring the shared combobox behavior. */
 interface ComboboxOptions {
@@ -101,8 +102,9 @@ export function setupCombobox(
      * or if the input value changed while the list is empty (so `emptyMessage` callbacks get
      * the updated query string).
      * Called whenever the set of visible options may have changed (option register/unregister, filter change).
+     * (debounced in a microtask)
      */
-    function notifyVisibilityChange() {
+    const notifyVisibilityChange = debounceMicrotask(() => {
         for (const [sectionElement] of sectionRegistrations) {
             notifySection(sectionElement, sectionRegistrations, optionRegistrations);
         }
@@ -121,7 +123,7 @@ export function setupCombobox(
         if (isOpenState) {
             trigger?.setAttribute('aria-expanded', String(hasVisibleContent()));
         }
-    }
+    });
 
     // ── Skeleton loading tracking ──────────────────────────────
 
@@ -537,6 +539,7 @@ export function setupCombobox(
             optionRegistrations.clear();
             sectionRegistrations.clear();
             skeletonCount = 0;
+            notifyVisibilityChange.cancel();
             clearTimeout(loadingTimer);
             announcementSent = false;
             // Clear all subscribers

--- a/packages/lumx-core/src/js/components/SelectTextField/TestStories.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/TestStories.tsx
@@ -26,6 +26,16 @@ const FRUITS = [
 ];
 
 /**
+ * Build a list of `count` fruit options by repeating the base `FRUITS` list with unique ids.
+ * Shared between React and Vue `WithManyOptions` test stories.
+ */
+export function createManyOptions(count: number) {
+    return Array.from({ length: Math.ceil(count / FRUITS.length) })
+        .flatMap((_, page) => FRUITS.map((f, i) => ({ ...f, id: `${f.id}-${page * FRUITS.length + i}` })))
+        .slice(0, count);
+}
+
+/**
  * Setup test stories
  */
 export function setup({
@@ -194,6 +204,37 @@ export function setup({
         },
     };
 
+    /**
+     * Test story for WithManyOptions.
+     * Opens the dropdown and verifies that a large static option list renders fully.
+     *
+     * The number of options is controlled via the `optionsCount` arg (Storybook control),
+     * so it can be tweaked without editing the story. The render function is
+     * framework-specific (React hooks / Vue SFC), so each framework consumer overrides
+     * `render` and keeps this `args`/`argTypes`/`play`.
+     */
+    const WithManyOptions = {
+        args: { optionsCount: 200 },
+        argTypes: {
+            optionsCount: { control: { type: 'number', min: 1 } },
+        },
+        async play({ canvas, args }: any) {
+            const input = canvas.getByRole('combobox') as HTMLInputElement;
+
+            await userEvent.click(input);
+            await waitFor(() => {
+                expect(input).toHaveAttribute('aria-expanded', 'true');
+            });
+
+            const listbox = await screen.findByRole('listbox', { name: 'Select a fruit' });
+
+            await waitFor(() => {
+                const options = within(listbox).getAllByRole('option');
+                expect(options.length).toBe(args.optionsCount);
+            });
+        },
+    };
+
     return {
         meta,
         ClickOutsideCloses,
@@ -201,5 +242,6 @@ export function setup({
         BlurResetsToEmpty,
         MultiBlurResetsSearch,
         WithInfiniteScroll,
+        WithManyOptions,
     };
 }

--- a/packages/lumx-core/src/js/utils/function/debounceMicrotask.ts
+++ b/packages/lumx-core/src/js/utils/function/debounceMicrotask.ts
@@ -1,0 +1,22 @@
+/**
+ * Wrap `fn` so that, no matter how many times the returned function is called within the same
+ * microtask cycle, `fn` only runs once at the end of that cycle.
+ */
+export function debounceMicrotask(fn: () => void) {
+    let running = false;
+    const debounced = () => {
+        if (!running) {
+            running = true;
+            queueMicrotask(() => {
+                if (running) {
+                    running = false;
+                    fn();
+                }
+            });
+        }
+    };
+    debounced.cancel = () => {
+        running = false;
+    };
+    return debounced;
+}

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.test.stories.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.test.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { useState, useCallback } from 'react';
-import { setup } from '@lumx/core/js/components/SelectTextField/TestStories';
+import { useState, useCallback, useMemo } from 'react';
+import { setup, createManyOptions } from '@lumx/core/js/components/SelectTextField/TestStories';
 import { FRUITS, type Fruit } from '@lumx/core/js/components/SelectTextField/Stories';
 import { TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
 import { SelectTextField } from '.';
@@ -51,6 +51,30 @@ export const WithInfiniteScroll = {
                 value={value}
                 onChange={setValue}
                 onLoadMore={onLoadMore}
+                translations={TRANSLATIONS}
+            />
+        );
+    },
+};
+
+/** Test that a large option list (count set via the `optionsCount` arg) renders and can be scrolled through */
+export const WithManyOptions = {
+    ...testStories.WithManyOptions,
+    render: (args: { optionsCount: number }) => {
+        const items = useMemo(() => createManyOptions(args.optionsCount), [args.optionsCount]);
+        const [value, setValue] = useState<(typeof items)[number] | undefined>();
+
+        return (
+            <SelectTextField
+                selectionType="single"
+                label="Select a fruit"
+                placeholder="Search fruits..."
+                options={items}
+                filter="auto"
+                getOptionId="id"
+                getOptionName="name"
+                value={value}
+                onChange={setValue}
                 translations={TRANSLATIONS}
             />
         );

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.test.stories.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.test.stories.tsx
@@ -3,6 +3,7 @@ import { SelectTextField } from '.';
 import { Combobox } from '../combobox';
 
 import StoryWithInfiniteScroll from './Stories/WithInfiniteScroll.vue';
+import StoryWithManyOptions from './Stories/WithManyOptions.vue';
 
 const { meta, ...testStories } = setup({
     components: { SelectTextField, Combobox },
@@ -23,5 +24,17 @@ export const WithInfiniteScroll = {
     render: () => ({
         components: { StoryWithInfiniteScroll },
         template: '<StoryWithInfiniteScroll />',
+    }),
+};
+
+/** Test that a large (200) option list renders and can be scrolled through */
+export const WithManyOptions = {
+    ...testStories.WithManyOptions,
+    render: (args: { optionsCount: number }) => ({
+        components: { StoryWithManyOptions },
+        setup() {
+            return { args };
+        },
+        template: '<StoryWithManyOptions v-bind="args" />',
     }),
 };

--- a/packages/lumx-vue/src/components/select-text-field/Stories/WithManyOptions.vue
+++ b/packages/lumx-vue/src/components/select-text-field/Stories/WithManyOptions.vue
@@ -1,0 +1,32 @@
+<template>
+    <SelectTextField
+        selection-type="single"
+        label="Select a fruit"
+        placeholder="Search fruits..."
+        :options="items"
+        filter="auto"
+        get-option-id="id"
+        get-option-name="name"
+        :value="value"
+        :translations="TRANSLATIONS"
+        @change="handleChange"
+    />
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { TRANSLATIONS } from '@lumx/core/js/components/SelectTextField/Tests';
+import { createManyOptions } from '@lumx/core/js/components/SelectTextField/TestStories';
+import { SelectTextField } from '@lumx/vue';
+
+type Fruit = ReturnType<typeof createManyOptions>[number];
+
+const props = defineProps<{ optionsCount: number }>();
+
+const value = ref<Fruit>();
+const items = computed<Fruit[]>(() => createManyOptions(props.optionsCount));
+
+function handleChange(newValue: Fruit | undefined) {
+    value.value = newValue;
+}
+</script>


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Fixes a recursive-update loop in Vue when a Combobox mounts with many options.

- `setupCombobox.ts` fired one synchronous `optionsChange` notification per option registration, which could hit Vue's recursive-update guard when mounting large option lists (e.g. 200 static options).
- Added `debounceMicrotask` (new shared core utility) to coalesce all registrations from the same synchronous burst into a single notification at the end of the microtask, so subscribers react once to the final state.
- Added a `WithManyOptions` test story (React + Vue, 200 static options) that reproduces the original bug.


StoryBook lumx-react: https://a777a1808--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://a777a1808--697a023f84e832e23544fb3c.chromatic.com/