### PR TITLE
feat(tabs): add nav-link mode rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `Tab`: support rendering as a custom element — `as` prop in React, `action` slot in Vue — e.g. to render navigation links.
+
+### Changed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `TabList`: render a `role="navigation"` landmark instead of `role="tablist"` when used outside a `TabProvider`.
+    -   `Tab`: render with WAI-ARIA `role="tab"` semantics only inside a `TabProvider`.
+
 ### Fixed
 
 -   `@lumx/react`, `@lumx/vue`:

--- a/packages/lumx-core/src/js/components/Tabs/Tab.tsx
+++ b/packages/lumx-core/src/js/components/Tabs/Tab.tsx
@@ -1,14 +1,21 @@
 import { Size } from '../../constants';
-import { CommonRef, HasClassName, JSXElement } from '../../types';
+import { CommonRef, ElementType, HasClassName, HasRequiredLinkHref, JSXElement } from '../../types';
 import { classNames } from '../../utils';
 import { IconProps } from '../Icon';
+import { RawClickable } from '../RawClickable';
 
 import { TABS_CLASSNAME } from './constants';
 
 /**
- * Defines the props of the component.
+ * Element a `Tab` can render as: `'button'` (default, classic tab), `'a'` (nav-link, `href`
+ * required via {@link HasRequiredLinkHref}), or any `ElementType` (nav-link, e.g. a router `Link`).
  */
-export interface TabProps extends HasClassName {
+export type TabElement = 'a' | 'button' | ElementType;
+
+/**
+ * Defines the props of the component (independent of the `as` element).
+ */
+export interface CommonTabProps extends HasClassName {
     /** Children are not supported. */
     children?: never;
     /** Icon (SVG path). */
@@ -19,6 +26,11 @@ export interface TabProps extends HasClassName {
     id?: string;
     /** Whether the tab is active or not. */
     isActive?: boolean;
+    /**
+     * WAI-ARIA `tab` role, resolved by the framework wrapper from `TabProvider` presence:
+     * `'tab'` inside a provider (classic tab mode), `undefined` outside (nav-link mode).
+     */
+    role?: 'tab';
     /** Whether the component is disabled or not. */
     isDisabled?: boolean;
     /** Label content. */
@@ -39,26 +51,42 @@ export interface TabProps extends HasClassName {
     tabIndexProp?: string;
     /** Name of the prop used to attach the keypress event (framework-dependent). */
     keyPressProp?: string;
-    /** ID applied to the tab button element (for aria-labelledby on the panel). */
-    tabId?: string;
     /** ID of the associated tab panel (for aria-controls). */
     tabPanelId?: string;
     /** Icon component injected by the framework wrapper. */
     Icon: any;
     /** Text component injected by the framework wrapper. */
     Text: any;
-    /** Forward ref to the underlying button element. */
+    /** Forward ref to the underlying element. */
     ref?: CommonRef;
 }
 
+/**
+ * Polymorphic `as` surface for `Tab`. Not `HasPolymorphicAs<E>`: core JSX is type-checked under
+ * both the React and Vue namespaces, so spreading React DOM prop types would break the Vue
+ * cross-check. `href` is required at compile time when `as === 'a'` (via {@link HasRequiredLinkHref}).
+ */
+export type TabAsProps<E extends TabElement = 'button'> = { as?: E } & (E extends 'a'
+    ? HasRequiredLinkHref<'a'>
+    : unknown);
+
+/**
+ * Props of the `Tab` component. Polymorphic on `as` (element selection only): `as` picks the
+ * rendered element, while **mode is driven by `TabProvider` presence** (via the wrapper-resolved
+ * `role`), not by `as`. The `href` conditional's false branch is `unknown` (not a record) to avoid
+ * widening `keyof TabProps`.
+ */
+export type TabProps<E extends TabElement = 'button'> = CommonTabProps & TabAsProps<E>;
+
 export type TabPropsToOverride =
+    | 'as'
+    | 'role'
     | 'isAnyDisabled'
     | 'shouldActivateOnFocus'
     | 'changeToTab'
     | 'tabIndex'
     | 'tabIndexProp'
     | 'keyPressProp'
-    | 'tabId'
     | 'tabPanelId'
     | 'Icon'
     | 'Text';
@@ -80,16 +108,19 @@ export const CLASSNAME = `${TABS_CLASSNAME}__link`;
 const { block } = classNames.bem(CLASSNAME);
 
 /**
- * Tab component.
- *
- * Implements WAI-ARIA `tab` role {@see https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html#rps_label}
+ * Tab component. Two modes keyed on `TabProvider` presence (via the wrapper-resolved `role`):
+ * tab mode (`role === 'tab'`, inside a provider) implements the WAI-ARIA `tab` role
+ * {@see https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html#rps_label};
+ * nav-link mode (no provider) renders plain link semantics (`aria-current`, no tab role/aria).
+ * `as` only selects the rendered element and applies in both modes.
  *
  * @param  props Component props.
  * @param  ref   Component ref.
  * @return React element.
  */
-export const Tab = (props: TabProps) => {
+export const Tab = <E extends TabElement = 'button'>(props: TabProps<E>) => {
     const {
+        as = 'button',
         className,
         icon,
         iconProps = {},
@@ -97,6 +128,7 @@ export const Tab = (props: TabProps) => {
         isDisabled,
         id,
         isActive,
+        role,
         label,
         handleFocus,
         handleKeyPress,
@@ -106,63 +138,71 @@ export const Tab = (props: TabProps) => {
         changeToTab,
         tabPanelId,
         shouldActivateOnFocus,
-        tabId,
         Icon,
         Text,
         ref,
         ...forwardedProps
     } = props;
+    let rawClickableProps: Record<string, unknown>;
 
-    const changeToCurrentTab = () => {
-        if (isAnyDisabled) {
-            return;
-        }
-        changeToTab?.();
-    };
-
-    const onFocus = (event: any) => {
-        handleFocus?.(event);
-        if (shouldActivateOnFocus) {
+    if (role === 'tab') {
+        // Mode: WAI-ARIA `tab` role (inside a TabProvider)
+        const changeToCurrentTab = () => {
+            if (isAnyDisabled) {
+                return;
+            }
+            changeToTab?.();
+        };
+        const onFocus = (event: any) => {
+            handleFocus?.(event);
+            if (shouldActivateOnFocus) {
+                changeToCurrentTab();
+            }
+        };
+        const onKeyPress = (event: any) => {
+            handleKeyPress?.(event);
+            if (event.key !== 'Enter' || isAnyDisabled) {
+                return;
+            }
             changeToCurrentTab();
-        }
-    };
+        };
+        rawClickableProps = {
+            ...forwardedProps,
+            'aria-disabled': isAnyDisabled ? 'true' : 'false',
+            handleClick: changeToCurrentTab,
+            onFocus,
+            role: 'tab',
+            'aria-selected': isActive,
+            'aria-controls': tabPanelId,
+            [keyPressProp]: onKeyPress,
+            [tabIndexProp]: isActive ? 0 : tabIndex,
+        };
+    } else {
+        // Mode: nav link
+        const { onClick, ...rest } = forwardedProps as any;
+        rawClickableProps = {
+            ...rest,
+            isDisabled,
+            handleClick: onClick,
+            'aria-current': isActive ? 'page' : undefined,
+        };
+    }
 
-    const onKeyPress = (event: any) => {
-        handleKeyPress?.(event);
-        if (event.key !== 'Enter' || isAnyDisabled) {
-            return;
-        }
-        changeToCurrentTab();
-    };
-
-    return (
-        <button
-            ref={ref}
-            {...forwardedProps}
-            type="button"
-            id={tabId}
-            className={classNames.join(
-                className,
-                block({
-                    'is-active': isActive,
-                    'is-disabled': isAnyDisabled,
-                }),
-            )}
-            onClick={changeToCurrentTab}
-            {...{ [keyPressProp]: onKeyPress }}
-            onFocus={onFocus}
-            role="tab"
-            {...{ [tabIndexProp]: isActive ? 0 : tabIndex }}
-            aria-disabled={isAnyDisabled}
-            aria-selected={isActive}
-            aria-controls={tabPanelId}
-        >
-            {icon && <Icon icon={icon} size={Size.xs} {...iconProps} />}
-            {label && (
-                <Text as="span" truncate>
-                    {label}
-                </Text>
-            )}
-        </button>
-    );
+    return RawClickable({
+        ...rawClickableProps,
+        as,
+        id,
+        className: classNames.join(className, block({ 'is-active': isActive, 'is-disabled': isAnyDisabled })),
+        ref: ref as CommonRef,
+        children: (
+            <>
+                {icon && <Icon icon={icon} size={Size.xs} {...iconProps} />}
+                {label && (
+                    <Text as="span" truncate>
+                        {label}
+                    </Text>
+                )}
+            </>
+        ),
+    } as any);
 };

--- a/packages/lumx-core/src/js/components/Tabs/TabList.tsx
+++ b/packages/lumx-core/src/js/components/Tabs/TabList.tsx
@@ -23,9 +23,15 @@ export interface TabListProps extends HasClassName, HasTheme {
     layout?: TabListLayout;
     /** Position of the tabs in the list (requires 'clustered' layout). */
     position?: Alignment;
+    /** `role` applied to the inner `__links` container */
+    role?: 'navigation' | 'tablist';
     /** ref to the wrapper element */
     ref?: CommonRef;
 }
+
+export type TabListPropsToOverride =
+    // `role` must be resolved by each framework wrapper
+    'role';
 
 /**
  * Component display name.
@@ -56,10 +62,12 @@ export const TabList = (props: TabListProps) => {
         className,
         layout = DEFAULT_PROPS.layout,
         position = DEFAULT_PROPS.position,
+        role = 'tablist',
         theme,
         ref,
         ...forwardedProps
     } = props;
+    const LinkWrapper = role === 'navigation' ? 'nav' : 'div';
 
     return (
         <div
@@ -74,9 +82,9 @@ export const TabList = (props: TabListProps) => {
                 }),
             )}
         >
-            <div className={element('links')} role="tablist" aria-label={ariaLabel}>
+            <LinkWrapper className={element('links')} role={role} aria-label={ariaLabel}>
                 {children}
-            </div>
+            </LinkWrapper>
         </div>
     );
 };

--- a/packages/lumx-core/src/js/components/Tabs/TabListTests.ts
+++ b/packages/lumx-core/src/js/components/Tabs/TabListTests.ts
@@ -23,10 +23,10 @@ export default (renderOptions: SetupOptions<any>) => {
 
     describe('TabList core tests', () => {
         describe('Props', () => {
-            it('should render default', () => {
+            it('should render default (navigation landmark, no TabProvider)', () => {
                 const name = 'Tab list';
                 const { links } = setup({ 'aria-label': name }, renderOptions);
-                expect(links).toBe(screen.queryByRole('tablist', { name }));
+                expect(links).toBe(screen.queryByRole('navigation', { name }));
             });
 
             it('should render layout', () => {

--- a/packages/lumx-core/src/js/components/Tabs/Tests.ts
+++ b/packages/lumx-core/src/js/components/Tabs/Tests.ts
@@ -21,13 +21,22 @@ export default (renderOptions: SetupOptions<any>) => {
 
     describe('Tab core tests', () => {
         describe('Props', () => {
-            it('should render default', () => {
+            // Without a TabProvider, Tab renders in nav-link mode: the default element is still a
+            // button, but it carries no WAI-ARIA `tab` semantics (mirrors TabList's navigation role).
+            it('should render default (nav-link mode, no TabProvider)', () => {
                 const label = 'Label';
                 const { tab } = setup({ label }, renderOptions);
-                expect(tab).toBe(screen.queryByRole('tab', { name: label }));
                 expect(tab.tagName).toBe('BUTTON');
-                expect(tab).toHaveAttribute('type', 'button');
+                expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+                expect(tab).not.toHaveAttribute('role', 'tab');
+                expect(tab).not.toHaveAttribute('aria-selected');
                 expect(queryByClassName(tab, ICON_CLASSNAME)).not.toBeInTheDocument();
+            });
+
+            it('should mark the active tab with aria-current in nav-link mode', () => {
+                const { tab } = setup({ isActive: true }, renderOptions);
+                expect(tab).toHaveAttribute('aria-current', 'page');
+                expect(tab).toHaveClass(`${CLASSNAME}--is-active`);
             });
 
             it('should render icon', () => {

--- a/packages/lumx-core/src/scss/components/tabs/_index.scss
+++ b/packages/lumx-core/src/scss/components/tabs/_index.scss
@@ -16,7 +16,9 @@
     }
 
     &__link {
-        &:not(&--is-active):not(&--is-disabled) {
+        text-decoration: none;
+
+        &:not(&--is-active):not([aria-current="page"]):not(&--is-disabled) {
             @include lumx-tabs-link(lumx-base-const("emphasis", "LOW"));
 
             #{$self}--theme-light & {
@@ -28,7 +30,8 @@
             }
         }
 
-        &--is-active {
+        &--is-active,
+        &[aria-current="page"] {
             @include lumx-tabs-link(lumx-base-const("emphasis", "SELECTED"));
 
             #{$self}--theme-light & {

--- a/packages/lumx-react/src/components/tabs/Tab.test.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.test.tsx
@@ -1,9 +1,14 @@
+import React, { createRef, forwardRef } from 'react';
 import { commonTestsSuiteRTL } from '@lumx/react/testing/utils';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { getByClassName } from '@lumx/react/testing/utils/queries';
 import BaseTabTests from '@lumx/core/js/components/Tabs/Tests';
+import { vi } from 'vitest';
 
 import { Tab, TabProps } from './Tab';
+import { TabList } from './TabList';
+import { TabProvider } from './TabProvider';
 
 const CLASSNAME = Tab.className as string;
 
@@ -18,6 +23,134 @@ describe(`<${Tab.displayName}>`, () => {
     BaseTabTests({
         render: (props: TabProps) => render(<Tab {...props} />),
         screen,
+    });
+
+    describe('nav-link mode', () => {
+        it('should render as an anchor with plain link semantics (no tab role/aria)', () => {
+            render(<Tab as="a" href="/page" label="Home" />);
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link.tagName).toBe('A');
+            expect(link).toHaveClass(CLASSNAME);
+            expect(link).toHaveAttribute('href', '/page');
+            expect(link).not.toHaveAttribute('role');
+            expect(link).not.toHaveAttribute('aria-selected');
+            expect(link).not.toHaveAttribute('aria-controls');
+            expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+        });
+
+        it('should set aria-current="page" only when active', () => {
+            const { rerender } = render(<Tab as="a" href="#" label="Home" />);
+            expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current');
+
+            rerender(<Tab as="a" href="#" label="Home" isActive />);
+            expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
+        });
+
+        it('should preserve the caller onClick when enabled', async () => {
+            const onClick = vi.fn();
+            render(<Tab as="a" href="#" label="Home" onClick={onClick} />);
+
+            await userEvent.click(screen.getByRole('link', { name: 'Home' }));
+            expect(onClick).toHaveBeenCalledTimes(1);
+        });
+
+        it('should block interaction when disabled', async () => {
+            const onClick = vi.fn();
+            render(<Tab as="a" href="#" label="Home" isDisabled onClick={onClick} />);
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link).toHaveAttribute('aria-disabled', 'true');
+            expect(link).toHaveAttribute('tabindex', '-1');
+
+            await userEvent.click(link);
+            expect(onClick).not.toHaveBeenCalled();
+        });
+
+        it('should preserve aria-current set by a custom `as` component managing it internally (e.g. router NavLink)', () => {
+            // Simulates a router `NavLink`: ignores whatever `aria-current` it receives and decides
+            // its own value internally (e.g. based on route matching), like react-router's NavLink.
+            const FakeNavLink = forwardRef<HTMLAnchorElement, React.ComponentPropsWithoutRef<'a'>>(
+                ({ 'aria-current': _ignoredAriaCurrent, children, ...props }, r) => (
+                    <a ref={r} {...props} aria-current="page">
+                        {children}
+                    </a>
+                ),
+            );
+            FakeNavLink.displayName = 'FakeNavLink';
+
+            render(<Tab as={FakeNavLink} href="/home" label="Home" />);
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link).toHaveAttribute('aria-current', 'page');
+        });
+
+        it('should render a custom component and forward the ref (ref type follows `as`)', () => {
+            const ref = createRef<HTMLAnchorElement>();
+            const RouterLink = forwardRef<HTMLAnchorElement, React.ComponentPropsWithoutRef<'a'>>(
+                ({ children, ...props }, r) => (
+                    <a ref={r} {...props}>
+                        {children}
+                    </a>
+                ),
+            );
+            RouterLink.displayName = 'RouterLink';
+
+            render(<Tab as={RouterLink} href="#" label="Home" ref={ref} />);
+            expect(ref.current).toBe(screen.getByRole('link', { name: 'Home' }));
+        });
+    });
+
+    describe('mode gating (provider presence)', () => {
+        it('renders role="tab" inside a TabProvider (cell 1: provider + button)', () => {
+            render(
+                <TabProvider>
+                    <TabList aria-label="Tabs">
+                        <Tab label="Tab 1" />
+                    </TabList>
+                </TabProvider>,
+            );
+
+            expect(screen.getByRole('tablist', { name: 'Tabs' })).toBeInTheDocument();
+            const tab = screen.getByRole('tab', { name: 'Tab 1' });
+            expect(tab.tagName).toBe('BUTTON');
+            expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+        });
+
+        it('honors `as` in tab mode: role="tab" on an anchor inside a provider (cell 2: provider + as="a")', () => {
+            render(
+                <TabProvider>
+                    <TabList aria-label="Tabs">
+                        <Tab as="a" href="/home" label="Home" />
+                    </TabList>
+                </TabProvider>,
+            );
+
+            const tab = screen.getByRole('tab', { name: 'Home' });
+            expect(tab.tagName).toBe('A');
+            expect(tab).toHaveAttribute('href', '/home');
+            // The explicit `tab` role wins over the anchor's implicit `link` role.
+            expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        });
+
+        it('drops tab semantics without a provider: navigation landmark + plain buttons (cell 3: no provider + button)', () => {
+            render(
+                <TabList aria-label="Site nav">
+                    <Tab label="Home" isActive />
+                    <Tab label="About" />
+                </TabList>,
+            );
+
+            expect(screen.getByRole('navigation', { name: 'Site nav' })).toBeInTheDocument();
+            expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+            expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+
+            const home = screen.getByRole('button', { name: 'Home' });
+            expect(home).not.toHaveAttribute('role', 'tab');
+            expect(home).not.toHaveAttribute('aria-selected');
+            expect(home).toHaveAttribute('aria-current', 'page');
+            expect(screen.getByRole('button', { name: 'About' })).not.toHaveAttribute('aria-current');
+        });
     });
 
     commonTestsSuiteRTL(setup, {

--- a/packages/lumx-react/src/components/tabs/Tab.tsx
+++ b/packages/lumx-react/src/components/tabs/Tab.tsx
@@ -1,8 +1,8 @@
-import { ReactNode } from 'react';
+import { ElementType, ReactNode } from 'react';
 
 import { Icon, IconProps, Text } from '@lumx/react';
-import { GenericProps } from '@lumx/react/utils/type';
-import { forwardRef } from '@lumx/react/utils/react/forwardRef';
+import { ComponentRef, GenericProps, HasPolymorphicAs, HasRequiredLinkHref } from '@lumx/react/utils/type';
+import { forwardRefPolymorphic } from '@lumx/react/utils/react/forwardRefPolymorphic';
 import { useDisableStateProps } from '@lumx/react/utils/disabled/useDisableStateProps';
 import {
     Tab as UI,
@@ -14,58 +14,76 @@ import {
 } from '@lumx/core/js/components/Tabs/Tab';
 
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
-import { useTabProviderContext } from './state';
+import { type TabState, useTabProviderContext } from './state';
 
 /**
- * Defines the props of the component.
+ * Defines the props of the component. Polymorphic on `as` (element selection only): `as` picks the
+ * rendered element (`as="a"` with required `href`, or `as={RouterLink}`), while the mode
+ * (`role="tab"` vs nav-link) is driven by `TabProvider` presence. The forwarded ref type follows `as`.
  */
-export interface TabProps extends GenericProps, ReactToJSX<UIProps, TabPropsToOverride> {
-    /** Children are not supported. */
-    children?: never;
-    /** Icon (SVG path). */
-    icon?: IconProps['icon'];
-    /** Icon component properties. */
-    iconProps?: Omit<IconProps, 'icon'>;
-    /** Native id property. */
-    id?: string;
-    /** Whether the tab is active or not. */
-    isActive?: boolean;
-    /** Whether the component is disabled or not. */
-    isDisabled?: boolean;
-    /** Label content. */
-    label: string | ReactNode;
-}
+export type TabProps<E extends ElementType = 'button'> = GenericProps &
+    HasPolymorphicAs<E> &
+    HasRequiredLinkHref<E> &
+    ReactToJSX<UIProps, TabPropsToOverride> & {
+        /** Children are not supported. */
+        children?: never;
+        /** Icon (SVG path). */
+        icon?: IconProps['icon'];
+        /** Icon component properties. */
+        iconProps?: Omit<IconProps, 'icon'>;
+        /** Native id property. */
+        id?: string;
+        /** Whether the tab is active or not. */
+        isActive?: boolean;
+        /** Whether the component is disabled or not. */
+        isDisabled?: boolean;
+        /** Label content. */
+        label: string | ReactNode;
+    };
 
 /**
  * Tab component.
  *
  * Implements WAI-ARIA `tab` role {@see https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html#rps_label}
+ * when rendered inside a `TabProvider`.
+ *
+ * Outside a `TabProvider` (nav-link mode): plain link, no `role="tab"`/roving tabindex/`changeToTab`
+ * dispatch — only `aria-current` marks the active item.
  *
  * @param  props Component props.
- * @param  ref   Component ref.
+ * @param  ref   Component ref (type follows `as`).
  * @return React element.
  */
-export const Tab = forwardRef<TabProps, HTMLButtonElement>((props, ref) => {
-    const { isAnyDisabled, otherProps } = useDisableStateProps(props);
-    const { isActive: propIsActive, id, onFocus, onKeyPress, ...forwardedProps } = otherProps;
-    const tabState = useTabProviderContext('tab', id);
-    const { isLazy: _isLazy, ...state } = tabState ?? ({} as Partial<NonNullable<typeof tabState>>);
-    const isActive = propIsActive || state?.isActive;
+export const Tab = Object.assign(
+    forwardRefPolymorphic(<E extends ElementType = 'button'>(props: TabProps<E>, ref: ComponentRef<E>) => {
+        const { isAnyDisabled, otherProps } = useDisableStateProps(props);
+        const { as = 'button', isActive: propIsActive, id, onFocus, onKeyPress, ...forwardedProps } = otherProps;
 
-    return UI({
-        id,
-        ...state,
-        Icon,
-        Text,
-        ref,
-        isActive,
-        isAnyDisabled,
-        handleFocus: onFocus,
-        handleKeyPress: onKeyPress,
-        ...forwardedProps,
-    });
-});
+        // Register into the provider (if any) so it can track this tab's index / active state.
+        const tabState = useTabProviderContext('tab', id);
+        // In a provider => tab mode (role="tab"); outside => nav-link mode. Mirrors TabList's role.
+        const inProvider = tabState !== undefined;
 
-Tab.displayName = COMPONENT_NAME;
-Tab.className = CLASSNAME;
-Tab.defaultProps = DEFAULT_PROPS;
+        const { isLazy: _isLazy, tabId, ...state } = tabState ?? ({} as Partial<TabState>);
+        // Without a provider there's no active index, so this collapses to the caller-provided value.
+        const isActive = propIsActive || state?.isActive;
+
+        return UI({
+            ...forwardedProps,
+            ...state,
+            as,
+            role: inProvider ? 'tab' : undefined,
+            Icon,
+            Text,
+            ref,
+            // Falls back to the caller-provided `id` when there's no TabProvider to generate one.
+            id: tabId || id,
+            isActive,
+            isAnyDisabled,
+            isDisabled: isAnyDisabled,
+            handleFocus: onFocus,
+            handleKeyPress: onKeyPress,
+        } as UIProps<E>);
+    }),
+    { displayName: COMPONENT_NAME, className: CLASSNAME, defaultProps: DEFAULT_PROPS },
+);

--- a/packages/lumx-react/src/components/tabs/TabList.test.tsx
+++ b/packages/lumx-react/src/components/tabs/TabList.test.tsx
@@ -1,4 +1,4 @@
-import { Tab } from '@lumx/react';
+import { Tab, TabProvider } from '@lumx/react';
 import { commonTestsSuiteRTL, SetupRenderOptions } from '@lumx/react/testing/utils';
 import { render, screen } from '@testing-library/react';
 import { getByClassName, queryByClassName } from '@lumx/react/testing/utils/queries';
@@ -31,6 +31,39 @@ describe(`<${TabList.displayName}>`, () => {
     BaseTabListTests({
         render: (props: any) => render(<TabList aria-label="Tab list" {...props} />),
         screen,
+    });
+
+    describe('role', () => {
+        it('should render a navigation landmark when used outside a TabProvider', () => {
+            render(
+                <TabList aria-label="Site nav">
+                    <Tab as="a" href="/a" label="A" />
+                    <Tab as="a" href="/b" label="B" />
+                </TabList>,
+            );
+
+            const nav = screen.getByRole('navigation', { name: 'Site nav' });
+            expect(nav).toHaveClass(`${CLASSNAME}__links`);
+            expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+
+            // Outer wrapper element + its classes stay unchanged and contain the landmark.
+            const tabList = getByClassName(document.body, CLASSNAME);
+            expect(tabList).toContainElement(nav);
+        });
+
+        it('should render a tablist when used inside a TabProvider', () => {
+            render(
+                <TabProvider>
+                    <TabList aria-label="Tab list">
+                        <Tab label="A" />
+                        <Tab label="B" />
+                    </TabList>
+                </TabProvider>,
+            );
+
+            expect(screen.getByRole('tablist', { name: 'Tab list' })).toBeInTheDocument();
+            expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+        });
     });
 
     // Common tests suite.

--- a/packages/lumx-react/src/components/tabs/TabList.tsx
+++ b/packages/lumx-react/src/components/tabs/TabList.tsx
@@ -11,16 +11,18 @@ import {
     DEFAULT_PROPS,
     TabList as UI,
     TabListProps as UIProps,
+    TabListPropsToOverride,
     TabListLayout,
 } from '@lumx/core/js/components/Tabs/TabList';
 
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
 import { useRovingTabIndexContainer } from '../../hooks/useRovingTabIndexContainer';
+import { useTabProviderContextState } from './state';
 
 /**
  * Defines the props of the component.
  */
-export interface TabListProps extends GenericProps, ReactToJSX<UIProps> {}
+export interface TabListProps extends GenericProps, ReactToJSX<UIProps, TabListPropsToOverride> {}
 
 export { TabListLayout };
 
@@ -29,6 +31,8 @@ export { TabListLayout };
  *
  * Implements WAI-ARIA `tablist` role {@see https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html#rps_label}
  *
+ * Renders a `role="navigation"` landmark instead when used outside a `TabProvider` (nav-link mode).
+ *
  * @param  props Component props.
  * @param  ref   Component ref.
  * @return React element.
@@ -36,16 +40,21 @@ export { TabListLayout };
 export const TabList = forwardRef<TabListProps, HTMLDivElement>((props, ref) => {
     const defaultTheme = useTheme() || Theme.light;
     const { theme = defaultTheme, ...forwardedProps } = props;
-    const tabListRef = React.useRef(null);
+    const tabListRef = React.useRef<HTMLDivElement>(null);
+    const role = useTabProviderContextState() === undefined ? 'navigation' : 'tablist';
+
+    // Classic roving tabindex (role="tab"). Disabled in nav-link mode: nav links keep their
+    // native per-link Tab stops, so this path is never engaged there.
     useRovingTabIndexContainer({
-        containerRef: tabListRef,
+        containerRef: role === 'navigation' ? null : tabListRef,
         itemSelector: '[role="tab"]',
     });
 
     return UI({
-        theme,
-        ref: mergeRefs(ref, tabListRef),
         ...forwardedProps,
+        theme,
+        role,
+        ref: mergeRefs(ref, tabListRef),
     });
 });
 

--- a/packages/lumx-react/src/components/tabs/TabProvider.test.tsx
+++ b/packages/lumx-react/src/components/tabs/TabProvider.test.tsx
@@ -1,5 +1,5 @@
 import { Tab, TabList, TabPanel, TabProvider, TabProviderProps } from '@lumx/react';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { checkTabActive, query } from '@lumx/react/components/tabs/test-utils';
 import { vi } from 'vitest';
@@ -206,6 +206,43 @@ describe('TabProvider', () => {
             setup({ isLazy: false });
             // Check the first tab is active and all panel are loaded
             checkTabActive('Tab 1', { isLazy: false });
+        });
+    });
+
+    describe('polymorphic `as` in tab mode', () => {
+        // Decision (ii): `as` selects the element, but mode follows the provider — so an `as="a"`
+        // Tab inside a TabProvider is a real tab (`role="tab"`), not a nav-link.
+        const setupAsAnchor = (props: Partial<TabProviderProps> = {}) =>
+            render(
+                <TabProvider {...props}>
+                    <TabList aria-label="Tabs">
+                        <Tab as="a" href="#a" label="Home" />
+                        <Tab as="a" href="#b" label="Profile" />
+                    </TabList>
+                </TabProvider>,
+            );
+
+        it('renders `as="a"` tabs with role="tab" (element honored, mode from provider)', () => {
+            setupAsAnchor();
+
+            expect(screen.getByRole('tablist', { name: 'Tabs' })).toBeInTheDocument();
+            expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+
+            const tabs = screen.getAllByRole('tab');
+            expect(tabs).toHaveLength(2);
+            expect(tabs[0].tagName).toBe('A');
+            expect(tabs[0]).toHaveAttribute('href', '#a');
+            // The explicit `tab` role wins over the anchors' implicit `link` role.
+            expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        });
+
+        it('fires onChange when an `as="a"` tab is activated (wired like a classic tab)', async () => {
+            const onChange = vi.fn();
+            // Controlled at index 0 so the provider does not emit onChange on mount.
+            setupAsAnchor({ onChange, activeTabIndex: 0 });
+
+            await userEvent.click(screen.getByRole('tab', { name: 'Profile' }));
+            await waitFor(() => expect(onChange).toHaveBeenCalledWith(1));
         });
     });
 

--- a/packages/lumx-vue/src/components/tabs/Tab.test.ts
+++ b/packages/lumx-vue/src/components/tabs/Tab.test.ts
@@ -1,9 +1,23 @@
 import { fireEvent, render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import { defineComponent, h, ref } from 'vue';
+import { vi } from 'vitest';
+import { mdiPlay } from '@lumx/icons';
 import BaseTabTests, { setup } from '@lumx/core/js/components/Tabs/Tests';
 import { CLASSNAME } from '@lumx/core/js/components/Tabs/Tab';
+import { queryByClassName } from '@lumx/core/testing/queries';
 import { commonTestsSuiteVTL, SetupRenderOptions } from '@lumx/vue/testing';
 
 import { Tab } from '.';
+import { INIT_STATE, TAB_PROVIDER_INJECT_KEY } from './state';
+
+/**
+ * Render options that inject a `TabProvider` context so `Tab` renders in tab mode (`role="tab"`),
+ * while keeping `Tab` as the root component so `emitted()` still captures its events.
+ */
+const inProviderOptions = () => ({
+    global: { provide: { [TAB_PROVIDER_INJECT_KEY]: { state: ref(INIT_STATE), dispatch: () => undefined } } },
+});
 
 describe('<Tab />', () => {
     const renderTab = (props: any, options?: SetupRenderOptions<any>) => render(Tab, { ...options, props });
@@ -27,15 +41,166 @@ describe('<Tab />', () => {
 
     describe('Vue', () => {
         it('should emit focus event when the tab is focused', async () => {
-            const { emitted } = render(Tab, { props: { label: 'Tab' } });
+            const { emitted } = render(Tab, { props: { label: 'Tab' }, ...inProviderOptions() });
             await fireEvent.focus(screen.getByRole('tab'));
             expect(emitted('focus')).toHaveLength(1);
         });
 
         it('should emit keypress event when a key is pressed on the tab', async () => {
-            const { emitted } = render(Tab, { props: { label: 'Tab' } });
+            const { emitted } = render(Tab, { props: { label: 'Tab' }, ...inProviderOptions() });
             await fireEvent.keyPress(screen.getByRole('tab'));
             expect(emitted('keypress')).toHaveLength(1);
+        });
+    });
+
+    describe('mode gating (provider presence)', () => {
+        it('renders role="tab" in a provider (cell 1: provider + button)', () => {
+            render(Tab, { props: { label: 'Tab 1' }, ...inProviderOptions() });
+
+            const tab = screen.getByRole('tab', { name: 'Tab 1' });
+            expect(tab.tagName).toBe('BUTTON');
+            expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        });
+
+        it('honors the action slot in tab mode: role="tab" on an anchor (cell 2: provider + action slot)', () => {
+            render(Tab, {
+                props: { label: 'Home' },
+                slots: { action: () => h('a', { href: '/home' }) },
+                ...inProviderOptions(),
+            });
+
+            const tab = screen.getByRole('tab', { name: 'Home' });
+            expect(tab.tagName).toBe('A');
+            expect(tab).toHaveAttribute('href', '/home');
+            // The explicit `tab` role wins over the anchor's implicit `link` role.
+            expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        });
+
+        it('drops tab semantics without a provider (cell 3: no provider + button)', () => {
+            render(Tab, { props: { label: 'Home', isActive: true } });
+
+            expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+            const button = screen.getByRole('button', { name: 'Home' });
+            expect(button).not.toHaveAttribute('role', 'tab');
+            expect(button).not.toHaveAttribute('aria-selected');
+            expect(button).toHaveAttribute('aria-current', 'page');
+        });
+    });
+
+    describe('nav-link mode (action slot)', () => {
+        it('should render the action element as a link with core semantics and inner icon+label', () => {
+            render(Tab, {
+                props: { label: 'Home', icon: mdiPlay },
+                slots: {
+                    action: () => h('a', { href: '/home' }),
+                },
+            });
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link.tagName).toBe('A');
+            expect(link).toHaveClass(CLASSNAME);
+            expect(link).toHaveAttribute('href', '/home');
+            // No classic tab semantics.
+            expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+            expect(link).not.toHaveAttribute('role', 'tab');
+            // Icon + label rendered inside the link by core.
+            expect(queryByClassName(link, 'lumx-icon')).toBeInTheDocument();
+        });
+
+        it('should set aria-current="page" only when isActive', () => {
+            const { unmount } = render(Tab, {
+                props: { label: 'Home', isActive: true },
+                slots: { action: () => h('a', { href: '/home' }) },
+            });
+            expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
+            unmount();
+
+            render(Tab, {
+                props: { label: 'Home' },
+                slots: { action: () => h('a', { href: '/home' }) },
+            });
+            expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current');
+        });
+
+        it('should render disabled nav-link with aria-disabled, tabindex -1 and block click', async () => {
+            const onClick = vi.fn();
+            render(Tab, {
+                props: { label: 'Home', isDisabled: true },
+                slots: { action: () => h('a', { href: '/home', onClick }) },
+            });
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link).toHaveAttribute('aria-disabled', 'true');
+            expect(link).toHaveAttribute('tabindex', '-1');
+
+            await userEvent.click(link);
+            expect(onClick).not.toHaveBeenCalled();
+        });
+
+        it('should preserve the caller onClick when not disabled', async () => {
+            const onClick = vi.fn();
+            render(Tab, {
+                props: { label: 'Home' },
+                slots: { action: () => h('a', { href: '/home', onClick }) },
+            });
+
+            await userEvent.click(screen.getByRole('link', { name: 'Home' }));
+            expect(onClick).toHaveBeenCalledTimes(1);
+        });
+
+        it('should preserve aria-current set by a custom link component managing it internally (e.g. router NavLink)', () => {
+            // Simulates a router `NavLink`: ignores whatever `aria-current` it receives via attrs
+            // and decides its own value internally (e.g. based on route matching).
+            const FakeNavLink = defineComponent({
+                inheritAttrs: false,
+                props: { to: { type: String, required: true } },
+                setup(componentProps, { attrs, slots }) {
+                    return () => {
+                        const { 'aria-current': _ignoredAriaCurrent, ...rest } = attrs;
+                        return h('a', { href: componentProps.to, ...rest, 'aria-current': 'page' }, slots.default?.());
+                    };
+                },
+            });
+
+            render(Tab, {
+                props: { label: 'Home' },
+                slots: { action: () => h(FakeNavLink, { to: '/home' }) },
+            });
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link).toHaveAttribute('aria-current', 'page');
+        });
+
+        it('should merge a custom class on the action slot element with the core classes', () => {
+            render(Tab, {
+                props: { label: 'Home' },
+                slots: { action: () => h('a', { href: '/home', class: 'custom-link-class' }) },
+            });
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link).toHaveClass('custom-link-class');
+            expect(link).toHaveClass(CLASSNAME);
+        });
+
+        it('should render as a custom link component (e.g. RouterLink)', () => {
+            const RouterLink = defineComponent({
+                inheritAttrs: false,
+                props: { to: { type: String, required: true } },
+                setup(componentProps, { attrs, slots }) {
+                    return () => h('a', { href: componentProps.to, ...attrs }, slots.default?.());
+                },
+            });
+
+            render(Tab, {
+                props: { label: 'Home' },
+                slots: { action: () => h(RouterLink, { to: '/home' }) },
+            });
+
+            const link = screen.getByRole('link', { name: 'Home' });
+            expect(link.tagName).toBe('A');
+            expect(link).toHaveClass(CLASSNAME);
+            expect(link).toHaveAttribute('href', '/home');
+            expect(screen.queryByRole('tab')).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/lumx-vue/src/components/tabs/Tab.tsx
+++ b/packages/lumx-vue/src/components/tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, useAttrs } from 'vue';
+import { type SlotsType, computed, defineComponent, useAttrs } from 'vue';
 
 import {
     Tab as TabUI,
@@ -8,22 +8,24 @@ import {
     COMPONENT_NAME,
     DEFAULT_PROPS,
 } from '@lumx/core/js/components/Tabs/Tab';
+import { classNames } from '@lumx/core/js/utils';
 
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { type HyphenatedAriaProps, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Icon } from '../icon';
 import { Text } from '../text';
 import { useTabProviderContext } from './state';
 
-export type TabProps = VueToJSXProps<UIProps, TabPropsToOverride>;
+export type TabProps = Omit<VueToJSXProps<UIProps, TabPropsToOverride>, HyphenatedAriaProps>;
 
 export { CLASSNAME, COMPONENT_NAME, DEFAULT_PROPS };
 
 /**
  * Tab component.
  *
- * Implements WAI-ARIA `tab` role.
+ * Implements the WAI-ARIA `tab` role inside a `TabProvider`; renders a plain nav-link
+ * (`aria-current`, no tab role) outside one.
  *
  * @param  props Component props.
  * @return Vue element.
@@ -36,7 +38,7 @@ export const emitSchema = {
 };
 
 const Tab = defineComponent(
-    (props: TabProps, { emit }) => {
+    (props: TabProps, { emit, slots }) => {
         const attrs = useAttrs();
         const className = useClassName(() => props.class);
         const { isAnyDisabled } = useDisableStateProps(computed(() => ({ ...props, ...attrs })));
@@ -47,29 +49,45 @@ const Tab = defineComponent(
         const handleKeyPress = (event: KeyboardEvent) => emit('keypress', event);
 
         return () => {
-            return (
-                <TabUI
-                    {...attrs}
-                    id={props.id}
-                    className={className.value}
-                    icon={props.icon}
-                    iconProps={props.iconProps}
-                    label={props.label}
-                    isActive={isActive.value}
-                    isAnyDisabled={isAnyDisabled.value}
-                    isDisabled={props.isDisabled}
-                    shouldActivateOnFocus={tabState.value?.shouldActivateOnFocus}
-                    changeToTab={tabState.value?.changeToTab}
-                    tabId={tabState.value?.tabId}
-                    tabPanelId={tabState.value?.tabPanelId}
-                    handleFocus={handleFocus}
-                    handleKeyPress={handleKeyPress}
-                    keyPressProp="onKeypress"
-                    tabIndexProp="tabindex"
-                    Icon={Icon}
-                    Text={Text}
-                />
-            );
+            const { tabId, ...state } = tabState.value || {};
+            // Element props
+            let elementProps: Record<string, any> = {
+                className: className.value,
+            };
+
+            // Custom render
+            const rendered = slots.action?.();
+            const action = Array.isArray(rendered) ? rendered[0] : rendered;
+            if (action) {
+                const { class: actionClass, ...rest } = action.props || {};
+                Object.assign(elementProps, rest);
+                elementProps = rest;
+                elementProps.as = action.type;
+                // merge `class`
+                elementProps.className = classNames.join(elementProps.className, actionClass);
+            }
+
+            // Invoke core as a function (not JSX) so Vue doesn't also forward `onClick` to the root.
+            return TabUI({
+                ...attrs,
+                ...state,
+                ...elementProps,
+                // role=tab driven by presence of the TabProvider
+                role: tabState.value ? 'tab' : undefined,
+                id: tabId || props.id,
+                icon: props.icon,
+                iconProps: props.iconProps,
+                label: props.label,
+                isActive: isActive.value,
+                isAnyDisabled: isAnyDisabled.value,
+                isDisabled: props.isDisabled,
+                handleFocus,
+                handleKeyPress,
+                keyPressProp: 'onKeypress',
+                tabIndexProp: 'tabindex',
+                Icon,
+                Text,
+            });
         };
     },
     {
@@ -77,6 +95,9 @@ const Tab = defineComponent(
         inheritAttrs: false,
         props: keysOf<TabProps>()('icon', 'iconProps', 'id', 'isActive', 'isDisabled', 'label', 'class'),
         emits: emitSchema,
+        slots: Object as SlotsType<{
+            action: void;
+        }>,
     },
 );
 

--- a/packages/lumx-vue/src/components/tabs/TabList.test.ts
+++ b/packages/lumx-vue/src/components/tabs/TabList.test.ts
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/vue';
+import { defineComponent } from 'vue';
 import BaseTabListTests, { setup } from '@lumx/core/js/components/Tabs/TabListTests';
 import { TABS_CLASSNAME as CLASSNAME } from '@lumx/core/js/components/Tabs/constants';
 import { commonTestsSuiteVTL, SetupRenderOptions } from '@lumx/vue/testing';
 
-import { TabList } from '.';
+import { Tab, TabList, TabProvider } from '.';
 
 describe('<TabList />', () => {
     const renderTabList = (props: any, options?: SetupRenderOptions<any>) => render(TabList, { ...options, props });
@@ -16,6 +17,49 @@ describe('<TabList />', () => {
 
     const setupTabList = (props: any = {}, options: SetupRenderOptions<any> = {}) =>
         setup(props, { ...options, render: renderTabList, screen });
+
+    describe('role', () => {
+        it('should render a navigation landmark when used outside a TabProvider', () => {
+            render(
+                defineComponent({
+                    components: { TabList, Tab },
+                    template: `
+                        <TabList aria-label="Main navigation">
+                            <Tab label="Home">
+                                <template #action><a href="/home" /></template>
+                            </Tab>
+                            <Tab label="Profile">
+                                <template #action><a href="/profile" /></template>
+                            </Tab>
+                        </TabList>
+                    `,
+                }),
+            );
+
+            expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeInTheDocument();
+            expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+            expect(screen.getAllByRole('link')).toHaveLength(2);
+        });
+
+        it('should render a tablist when used inside a TabProvider', () => {
+            render(
+                defineComponent({
+                    components: { TabList, Tab, TabProvider },
+                    template: `
+                        <TabProvider>
+                            <TabList aria-label="Classic tabs">
+                                <Tab label="Tab 1" />
+                                <Tab label="Tab 2" />
+                            </TabList>
+                        </TabProvider>
+                    `,
+                }),
+            );
+
+            expect(screen.getByRole('tablist', { name: 'Classic tabs' })).toBeInTheDocument();
+            expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+        });
+    });
 
     // Common tests suite
     commonTestsSuiteVTL(setupTabList, {

--- a/packages/lumx-vue/src/components/tabs/TabList.tsx
+++ b/packages/lumx-vue/src/components/tabs/TabList.tsx
@@ -1,8 +1,9 @@
-import { defineComponent, ref, useAttrs, useSlots } from 'vue';
+import { defineComponent, inject, ref, useAttrs, useSlots } from 'vue';
 
 import {
     TabList as TabListUI,
     type TabListProps as UIProps,
+    type TabListPropsToOverride,
     TabListLayout,
     COMPONENT_NAME,
     DEFAULT_PROPS,
@@ -14,10 +15,11 @@ import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useRovingTabIndexContainer } from '../../composables/useRovingTabIndexContainer';
 import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { TAB_PROVIDER_INJECT_KEY } from './state';
 
 // aria-label is excluded from declared Vue props — Vue treats aria-* as attrs,
 // so it flows through the {..attrs} spread to the core component.
-type InternalProps = VueToJSXProps<UIProps, 'aria-label'>;
+type InternalProps = VueToJSXProps<UIProps, 'aria-label' | TabListPropsToOverride>;
 
 /** Public props type (includes aria-label for TypeScript consumers). */
 export type TabListProps = InternalProps & { 'aria-label': string };
@@ -27,7 +29,8 @@ export { TabListLayout, CLASSNAME, COMPONENT_NAME, DEFAULT_PROPS };
 /**
  * TabList component.
  *
- * Implements WAI-ARIA `tablist` role.
+ * Implements WAI-ARIA `tablist` role, or a `role="navigation"` landmark when used outside a
+ * `TabProvider` (nav-link mode).
  *
  * @param  props Component props.
  * @return Vue element.
@@ -39,24 +42,32 @@ const TabList = defineComponent(
         const defaultTheme = useTheme();
         const className = useClassName(() => props.class);
         const containerRef = ref<HTMLElement | null>(null);
+        const role = inject(TAB_PROVIDER_INJECT_KEY, undefined) === undefined ? 'navigation' : 'tablist';
 
+        // Classic mode: roving tabindex over `role="tab"` items — naturally inert in nav-link mode
+        // since nav links carry no `role="tab"` and keep their native per-link Tab stops.
         useRovingTabIndexContainer({
-            containerRef,
+            containerRef: role === 'navigation' ? ref<HTMLElement | null>(null) : containerRef,
             itemSelector: '[role="tab"]',
         });
 
-        return () => (
-            <TabListUI
-                {...attrs}
-                ref={containerRef}
-                aria-label={attrs['aria-label'] as string}
-                className={className.value}
-                theme={props.theme || defaultTheme.value}
-                layout={props.layout}
-                position={props.position}
-                children={slots.default?.() as JSXElement}
-            />
-        );
+        return () => {
+            const children = slots.default?.();
+
+            return (
+                <TabListUI
+                    {...attrs}
+                    ref={containerRef}
+                    aria-label={attrs['aria-label'] as string}
+                    className={className.value}
+                    theme={props.theme || defaultTheme.value}
+                    layout={props.layout}
+                    position={props.position}
+                    role={role}
+                    children={children as JSXElement}
+                />
+            );
+        };
     },
     {
         name: 'LumxTabList',

--- a/packages/lumx-vue/src/components/tabs/TabProvider.test.tsx
+++ b/packages/lumx-vue/src/components/tabs/TabProvider.test.tsx
@@ -204,6 +204,49 @@ describe('TabProvider', () => {
         });
     });
 
+    describe('polymorphic element in tab mode', () => {
+        // Decision (ii): the `action` slot selects the element, but mode follows the provider — so an
+        // action-slot Tab inside a TabProvider is a real tab (`role="tab"`), not a nav-link.
+        const setupAsAnchor = async ({ onChange }: { onChange?: (index: number) => void } = {}) => {
+            const result = render({
+                setup() {
+                    return () => (
+                        <TabProvider onChange={onChange} activeTabIndex={0}>
+                            <TabList aria-label="Tabs">
+                                <Tab label="Home">{{ action: () => <a href="/home" /> }}</Tab>
+                                <Tab label="Profile">{{ action: () => <a href="/profile" /> }}</Tab>
+                            </TabList>
+                        </TabProvider>
+                    );
+                },
+            });
+            await flushPromises();
+            return result;
+        };
+
+        it('renders action-slot tabs with role="tab" (element honored, mode from provider)', async () => {
+            await setupAsAnchor();
+
+            expect(screen.getByRole('tablist', { name: 'Tabs' })).toBeInTheDocument();
+            expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+
+            const tabs = screen.getAllByRole('tab');
+            expect(tabs).toHaveLength(2);
+            expect(tabs[0].tagName).toBe('A');
+            expect(tabs[0]).toHaveAttribute('href', '/home');
+            // The explicit `tab` role wins over the anchors' implicit `link` role.
+            expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        });
+
+        it('dispatches a tab change when an action-slot tab is activated (wired like a classic tab)', async () => {
+            const onChange = vi.fn();
+            await setupAsAnchor({ onChange });
+
+            await userEvent.click(screen.getByRole('tab', { name: 'Profile' }));
+            await waitFor(() => expect(onChange).toHaveBeenCalledWith(1));
+        });
+    });
+
     describe('activate on focus', () => {
         it('should activate tab on focus', async () => {
             await setup({ shouldActivateOnFocus: true });

--- a/packages/lumx-vue/src/components/tabs/state.ts
+++ b/packages/lumx-vue/src/components/tabs/state.ts
@@ -46,7 +46,6 @@ export const useTabProviderContext = (type: TabType, originalId?: string): Compu
 
     return computed((): TabState | undefined => {
         const index = state.value.ids[type].indexOf(id);
-        if (index === -1) return undefined;
         return {
             isLazy: state.value.isLazy,
             shouldActivateOnFocus: state.value.shouldActivateOnFocus,
@@ -56,11 +55,4 @@ export const useTabProviderContext = (type: TabType, originalId?: string): Compu
             changeToTab: () => dispatch({ type: 'setActiveTabIndex', payload: index }),
         };
     });
-};
-
-/**
- * Returns the raw tab provider state ref, or undefined if no provider is present.
- */
-export const useTabProviderContextState = (): Ref<State> | undefined => {
-    return inject(TAB_PROVIDER_INJECT_KEY, undefined)?.state;
 };

--- a/packages/lumx-vue/src/utils/VueToJSX.ts
+++ b/packages/lumx-vue/src/utils/VueToJSX.ts
@@ -27,7 +27,7 @@ export type VueToJSXProps<Props, OmitProps extends keyof Props = never> = Omit<
  * which breaks hyphenated key destructuring in core component templates.
  * By excluding them from props, they flow through `attrs` with their original hyphenated keys.
  */
-export type HyphenatedAriaProps = 'aria-expanded' | 'aria-haspopup' | 'aria-label' | 'aria-pressed';
+export type HyphenatedAriaProps = 'aria-current' | 'aria-expanded' | 'aria-haspopup' | 'aria-label' | 'aria-pressed';
 
 export const keysOf = <T>() => {
     return <K extends readonly (keyof T)[]>(

--- a/packages/site-demo/content/product/components/tabs/index.mdx
+++ b/packages/site-demo/content/product/components/tabs/index.mdx
@@ -4,9 +4,11 @@ frameworks: ['react', 'vue']
 import * as ReactDemoDefault from './react/default.tsx';
 import * as ReactDemoJustifyLeft from './react/justify-left.tsx';
 import * as ReactDemoIcon from './react/icon.tsx';
+import * as ReactDemoNavigation from './react/navigation.tsx';
 import * as VueDemoDefault from './vue/default.vue';
 import * as VueDemoJustifyLeft from './vue/justify-left.vue';
 import * as VueDemoIcon from './vue/icon.vue';
+import * as VueDemoNavigation from './vue/navigation.vue';
 import ReactTabProvider from 'lumx-docs:@lumx/react/components/tabs/TabProvider';
 import ReactTabList from 'lumx-docs:@lumx/react/components/tabs/TabList';
 import ReactTab from 'lumx-docs:@lumx/react/components/tabs/Tab';
@@ -30,9 +32,24 @@ import VueTabPanel from 'lumx-docs:@lumx/vue/components/tabs/TabPanel';
 
 <DemoBlock withThemeSwitcher demo={{ react: ReactDemoIcon, vue: VueDemoIcon }} />
 
+## Navigation
+
+Tabs can also be rendered as classic navigation links if not used in a `TabProvider`.
+
+<DemoBlock withThemeSwitcher demo={{ react: ReactDemoNavigation, vue: VueDemoNavigation }} />
+
+Make sure to provide a proper link and update either the `isActive` or `aria-current` prop (in this demo `HashNavLink` updates its `aria-current` internally).
+
 ### Accessibility concerns
 
-`Tab`, `TabList` and `TabPanel` use the [WAI-ARIA tab pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) with no need for configuration.
+Tabs support two distinct interaction modes, each with its own accessibility contract. Which mode applies is decided by whether `TabList` and `Tab` are used inside a `TabProvider`:
+
+-   **Tabbed panel mode**: wrapping `TabList` and `Tab` in a `TabProvider` activates the [WAI-ARIA tab pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) with no further configuration — `TabList` renders `role="tablist"`, each `Tab` renders `role="tab"` with `aria-selected`, and a `TabPanel` shows/hides the associated content.
+-   **Nav-link mode** : using `TabList` and `Tab` **without** a `TabProvider` activates plain navigation-link semantics instead. `TabList` renders a `<nav>` landmark, and each `Tab` should render as a link (via `as` / the `action` slot) with `aria-current`.
+
+The rendered element and the interaction mode are independent: `as` (React) and the `action` slot (Vue) only choose which element a `Tab` renders as — the mode always follows `TabProvider` presence. A `Tab` rendered as a link inside a `TabProvider` is therefore still a real tab (`role="tab"`), not a navigation link.
+
+Use tabbed panels to switch between sections of content on the same page; use navigation tabs to link to different pages or routes.
 
 ## Properties
 

--- a/packages/site-demo/content/product/components/tabs/react/navigation.tsx
+++ b/packages/site-demo/content/product/components/tabs/react/navigation.tsx
@@ -1,0 +1,11 @@
+import { Tab, TabList, type Theme } from '@lumx/react';
+import { HashNavLink } from '@lumx/demo/components/content/HashNavLink';
+
+/** TabList used as a <nav> with tab links (using URL #hash) */
+export default ({ theme }: { theme?: Theme }) => (
+    <TabList theme={theme} aria-label="Tab list">
+        <Tab as={HashNavLink} hash="#" label="Tab 1" />
+        <Tab as={HashNavLink} hash="#tab-2" label="Tab 2" />
+        <Tab as={HashNavLink} hash="#tab-3" label="Tab 3" />
+    </TabList>
+);

--- a/packages/site-demo/content/product/components/tabs/vue/navigation.vue
+++ b/packages/site-demo/content/product/components/tabs/vue/navigation.vue
@@ -1,0 +1,27 @@
+<!-- TabList used as a <nav> with tab links (using URL #hash) -->
+<template>
+    <TabList :theme="theme" aria-label="Tab list">
+        <Tab label="Tab 1">
+            <template #action>
+                <HashNavLink hash="#" />
+            </template>
+        </Tab>
+        <Tab label="Tab 2">
+            <template #action>
+                <HashNavLink hash="#tab-2" />
+            </template>
+        </Tab>
+        <Tab label="Tab 3">
+            <template #action>
+                <HashNavLink hash="#tab-3" />
+            </template>
+        </Tab>
+    </TabList>
+</template>
+
+<script setup lang="ts">
+import { Tab, TabList, type Theme } from '@lumx/vue';
+import HashNavLink from '@lumx/demo/components/content/HashNavLink/index.vue';
+
+defineProps<{ theme?: Theme }>();
+</script>

--- a/packages/site-demo/src/components/content/HashNavLink/index.tsx
+++ b/packages/site-demo/src/components/content/HashNavLink/index.tsx
@@ -1,0 +1,20 @@
+import { WINDOW } from '@lumx/core/js/constants/browser';
+import { useSyncExternalStore } from 'react';
+
+// Demo "hash" nav link displaying a <a> with aria-current
+export const HashNavLink = ({ className, hash, children }: any) => {
+    const getSnapshot = () => (WINDOW?.location.hash || '#') === hash;
+    const isActive = useSyncExternalStore(
+        (listener) => {
+            WINDOW?.addEventListener('hashchange', listener);
+            return () => WINDOW?.removeEventListener('hashchange', listener);
+        },
+        getSnapshot,
+        getSnapshot,
+    );
+    return (
+        <a className={className} href={hash} aria-current={isActive ? 'page' : undefined}>
+            {children}
+        </a>
+    );
+};

--- a/packages/site-demo/src/components/content/HashNavLink/index.vue
+++ b/packages/site-demo/src/components/content/HashNavLink/index.vue
@@ -1,0 +1,21 @@
+<!-- Demo "hash" nav link displaying a <a> with aria-current -->
+<template>
+    <a v-bind="attrs" :href="hash" :aria-current="isActive ? 'page' : undefined">
+        <slot />
+    </a>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, useAttrs } from 'vue';
+
+defineOptions({ inheritAttrs: false });
+const { hash } = defineProps<{ hash: string }>();
+const attrs = useAttrs();
+
+const matchesHash = () => (window.location.hash || '#') === hash;
+const isActive = ref(matchesHash());
+const onHashChange = () => isActive.value = matchesHash();
+
+onMounted(() => window.addEventListener('hashchange', onHashChange));
+onUnmounted(() => window.removeEventListener('hashchange', onHashChange));
+</script>


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Adds a nav-link rendering mode to `Tab`/`TabList` (React + Vue), so a `TabList` can be used as a navigation menu (links to pages/routes) instead of an in-page tab panel switcher.

-   **Mode is driven by `TabProvider` presence, not by `as`**: inside a provider → classic WAI-ARIA `tab` mode (`role="tab"`, roving tabindex, `aria-selected`); outside a provider → nav-link mode (plain link, `role="navigation"` on the list, `aria-current`, no tab roles/roving tabindex).
-   `Tab` becomes polymorphic on `as` — this only selects the rendered element and applies in both modes. React: `as="a"` (with `href` required at compile time via `HasRequiredLinkHref`) or `as={RouterLink}`, ref type follows `as` (`forwardRefPolymorphic`). Vue: an `action` scoped slot supplies the element.
-   `TabList` resolves its container role from provider presence directly (`navigation` vs `tablist`) rather than scanning children; roving-tabindex hook is left inert in nav-link mode since nav links keep native per-link tab stops.
-   Active state in nav-link mode is the caller's responsibility (e.g. a router `NavLink` setting `aria-current="page"`); the demo `HashNavLink` shows this via URL hash.
-   Removed the earlier nav-link context/registration mechanism and the now-unused `tabId`/`useTabProviderContextState` plumbing in favor of the provider-presence check.
-   Docs: new "Navigation" demo (React + Vue) + accessibility notes on the Tabs page.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-storybook-react` or `need: deploy-storybook-vue` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->

StoryBook lumx-react: https://27eef50a8--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://27eef50a8--697a023f84e832e23544fb3c.chromatic.com/
