### PR TITLE
chore(cd-publish): remove unecessary npm update

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -211,9 +211,6 @@ jobs:
             - name: 'Setup'
               uses: ./.github/actions/setup
 
-            - name: 'Update npm' # Need npm >= v11.5 for trusted publishing
-              run: npm install -g npm@latest
-
             - name: '[prerelease] Detect release type from CHANGELOG'
               id: detect-type
               if: >-


### PR DESCRIPTION
# General summary

We no longer need to update npm on publish (our version of node supports trusted publishing)

