### PR TITLE
fix(select): stop onLoadMore firing without an actual scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `Combobox`: avoid recursive updates errors when mounting a large option list
 
+### Changed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `InfiniteScroll`: allow `undefined` callback to disable it
+
 ## [4.19.0][] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `Combobox`: avoid recursive updates errors when mounting a large option list
+    -   `SelectButton`: fix `onLoadMore` firing eagerly
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`, `@lumx/vue`:
     -   `TabList`: render a `role="navigation"` landmark instead of `role="tablist"` when used outside a `TabProvider`.
     -   `Tab`: render with WAI-ARIA `role="tab"` semantics only inside a `TabProvider`.
+    -   `InfiniteScroll`: allow `undefined` callback to disable it
 
 ### Fixed
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `Combobox`: avoid recursive updates errors when mounting a large option list
-    -   `SelectButton`: fix `onLoadMore` firing eagerly
-
-### Changed
-
--   `@lumx/react`, `@lumx/vue`:
-    -   `InfiniteScroll`: allow `undefined` callback to disable it
+    -   `SelectButton` and `SelectTextField`: fix `onLoadMore` firing eagerly
 
 ## [4.19.0][] - 2026-06-30
 

--- a/packages/lumx-core/src/js/components/SelectButton/TestStories.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/TestStories.tsx
@@ -80,8 +80,13 @@ export function setup({
 
     /**
      * Test story for WithInfiniteScroll.
-     * Opens the dropdown and verifies that the infinite scroll sentinel triggers
-     * loading additional options.
+     * Opens the dropdown and verifies that:
+     * - `onLoadMore` does NOT fire just from mounting/opening (the initial list overflows
+     *   the popover, so the sentinel isn't in view yet) — regression test for a bug where an
+     *   unstable `callback`/`options` reference caused the IntersectionObserver to be torn down
+     *   and recreated on every render, spuriously re-firing on the sentinel's current state.
+     * - Scrolling to the bottom loads more options, and triggers `onLoadMore` exactly once
+     *   (not a runaway loop from the same instability).
      *
      * The render function is framework-specific (React hooks / Vue SFC),
      * so each framework consumer overrides `render` and keeps this `play`.
@@ -109,6 +114,14 @@ export function setup({
                 initialCount = options.length;
             });
 
+            // onLoadMore should not fire just from mounting/opening: the sentinel isn't in
+            // view since the initial list overflows the popover.
+            const counter = within(canvasElement).getByTestId('load-more-count');
+            await new Promise((resolve) => {
+                setTimeout(resolve, 300);
+            });
+            expect(counter.textContent).toBe('0');
+
             // Scroll the popover to the bottom to trigger the IntersectionObserver sentinel
             const scrollContainer = listbox.closest('.lumx-combobox-popover__scroll')!;
             expect(scrollContainer).toBeTruthy();
@@ -118,6 +131,11 @@ export function setup({
             await waitFor(() => {
                 const options = within(listbox).getAllByRole('option');
                 expect(options.length).toBeGreaterThan(initialCount);
+            });
+
+            // A single scroll-to-bottom should trigger onLoadMore exactly once, not a runaway loop.
+            await waitFor(() => {
+                expect(counter.textContent).toBe('1');
             });
         },
     };

--- a/packages/lumx-core/src/js/components/SelectButton/index.tsx
+++ b/packages/lumx-core/src/js/components/SelectButton/index.tsx
@@ -122,6 +122,8 @@ export const SelectButton = <O,>(props: SelectButtonProps<O>, { Combobox, Infini
     const isLoadingMore = listStatus === 'loadingMore';
     const isError = listStatus === 'error';
     const isMultiselectable = selectionType === 'multiple';
+    // Prevent firing during loading or error states to avoid duplicate fetches.
+    const isInfiniteScrollEnabled = !listStatus || listStatus === 'idle';
 
     /*
      * Display value: castArray normalizes single/multi value to an array, then resolve
@@ -173,11 +175,7 @@ export const SelectButton = <O,>(props: SelectButtonProps<O>, { Combobox, Infini
 
                     {onLoadMore && InfiniteScroll && (
                         <InfiniteScroll
-                            callback={() => {
-                                // Guard: prevent firing during loading or error states to avoid duplicate fetches.
-                                if (listStatus && listStatus !== 'idle') return;
-                                onLoadMore();
-                            }}
+                            callback={isInfiniteScrollEnabled ? onLoadMore : undefined}
                             options={infiniteScrollOptions}
                         />
                     )}

--- a/packages/lumx-core/src/js/components/SelectTextField/index.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/index.tsx
@@ -134,6 +134,8 @@ export const SelectTextField = (props: SelectTextFieldProps, { Combobox, Infinit
     const isFullLoading = listStatus === 'loading';
     const isLoadingMore = listStatus === 'loadingMore';
     const isError = listStatus === 'error';
+    // Prevent firing during loading or error states to avoid duplicate fetches.
+    const isInfiniteScrollEnabled = !listStatus || listStatus === 'idle';
 
     return (
         <Combobox.Provider onOpen={onOpen}>
@@ -170,11 +172,7 @@ export const SelectTextField = (props: SelectTextFieldProps, { Combobox, Infinit
 
                     {onLoadMore && InfiniteScroll && (
                         <InfiniteScroll
-                            callback={() => {
-                                // Guard: prevent firing during loading or error states to avoid duplicate fetches.
-                                if (listStatus && listStatus !== 'idle') return;
-                                onLoadMore();
-                            }}
+                            callback={isInfiniteScrollEnabled ? onLoadMore : undefined}
                             options={infiniteScrollOptions}
                         />
                     )}

--- a/packages/lumx-core/src/js/utils/InfiniteScroll/index.tsx
+++ b/packages/lumx-core/src/js/utils/InfiniteScroll/index.tsx
@@ -5,9 +5,13 @@ export { setupInfiniteScrollObserver } from './setupInfiniteScrollObserver';
 export const INFINITE_SCROLL_CLASSNAME = 'lumx-infinite-scroll-anchor';
 
 export interface InfiniteScrollProps {
-    /** Callback when infinite scroll component is in view */
+    /**
+     * Callback when infinite scroll component is in view.
+     * Omit (e.g. while loading) to temporarily disable without changing the callback's
+     * identity when re-enabled — keeps the underlying observer stable.
+     */
     // eslint-disable-next-line react/no-unused-prop-types
-    callback: (evt?: Event) => void;
+    callback?(evt?: Event): void;
     /** Customize intersection observer option */
     // eslint-disable-next-line react/no-unused-prop-types
     options?: IntersectionObserverInit;

--- a/packages/lumx-react/src/components/select-button/SelectButton.test.stories.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.test.stories.tsx
@@ -37,15 +37,17 @@ export const TypeaheadFromClosed = { ...testStories.TypeaheadFromClosed };
 export const WithInfiniteScroll = {
     ...testStories.WithInfiniteScroll,
     render: () => {
-        // Start with 3 pages of items so the popover overflows and the
+        // Start with 10 pages of items so the popover overflows and the
         // IntersectionObserver sentinel doesn't fire until the user scrolls.
-        const initialItems = Array.from({ length: 3 }).flatMap((_, page) =>
+        const initialItems = Array.from({ length: 10 }).flatMap((_, page) =>
             FRUITS.map((f, i) => ({ ...f, id: `${f.id}-${page * FRUITS.length + i}` })),
         );
         const [items, setItems] = useState(initialItems);
         const [value, setValue] = useState<Fruit | undefined>();
+        const [loadMoreCount, setLoadMoreCount] = useState(0);
 
         const onLoadMore = useCallback(() => {
+            setLoadMoreCount((c) => c + 1);
             setItems((prev) => {
                 if (prev.length >= 200) return prev;
                 const offset = prev.length;
@@ -54,15 +56,18 @@ export const WithInfiniteScroll = {
         }, []);
 
         return (
-            <SelectButton
-                label="Select a fruit"
-                options={items}
-                getOptionId="id"
-                getOptionName="name"
-                value={value}
-                onChange={setValue}
-                onLoadMore={onLoadMore}
-            />
+            <>
+                <SelectButton
+                    label="Select a fruit"
+                    options={items}
+                    getOptionId="id"
+                    getOptionName="name"
+                    value={value}
+                    onChange={setValue}
+                    onLoadMore={onLoadMore}
+                />
+                <div data-testid="load-more-count">{loadMoreCount}</div>
+            </>
         );
     },
 };

--- a/packages/lumx-react/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-react/src/components/select-button/SelectButton.tsx
@@ -9,6 +9,7 @@ import {
     DEFAULT_PROPS,
 } from '@lumx/core/js/components/SelectButton';
 import { type ComboboxButtonLabelDisplayMode } from '@lumx/core/js/components/Combobox/ComboboxButton';
+import { CLASSNAME as COMBOBOX_POPOVER_CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxPopover';
 import { type SelectButtonTranslations, type SelectListStatus } from '@lumx/core/js/utils/select/types';
 import { ComponentRef } from '@lumx/react/utils/type';
 import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
@@ -180,7 +181,13 @@ export const SelectButton = (React.forwardRef as ForwardRefSelectButton)((props,
         as,
         ...buttonProps
     } = props;
-    const [listElement, setListElement] = useState<HTMLElement | null>(null);
+    // The list itself doesn't scroll — its ancestor `__scroll` wrapper does. The
+    // IntersectionObserver root must be the actual scrolling/clipping element, or the
+    // sentinel is trivially always "intersecting" its non-clipping `<ul>` parent.
+    const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(null);
+    const setListElement = useCallback((listElement: HTMLElement | null) => {
+        setScrollContainer(listElement?.closest<HTMLElement>(`.${COMBOBOX_POPOVER_CLASSNAME}__scroll`) ?? null);
+    }, []);
 
     const isMultiple = selectionType === 'multiple';
 
@@ -220,7 +227,7 @@ export const SelectButton = (React.forwardRef as ForwardRefSelectButton)((props,
             onOpen,
             translations,
             onLoadMore,
-            infiniteScrollOptions: { root: listElement, rootMargin: '100px' },
+            infiniteScrollOptions: { root: scrollContainer, rootMargin: '100px' },
         },
         { Combobox, InfiniteScroll },
     );

--- a/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-react/src/components/select-text-field/SelectTextField.tsx
@@ -5,6 +5,7 @@ import { type BaseSelectTextFieldWrapperProps } from '@lumx/core/js/utils/select
 import { getOptionDisplayName } from '@lumx/core/js/utils/select/getOptionDisplayName';
 import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
 import { SelectTextField as UI } from '@lumx/core/js/components/SelectTextField';
+import { CLASSNAME as COMBOBOX_POPOVER_CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxPopover';
 import { HasClassName } from '@lumx/react/utils/type';
 import { Combobox, type ComboboxPopoverProps } from '../combobox';
 import { wrapRenderOption } from '../combobox/wrapRenderOption';
@@ -159,7 +160,13 @@ export const SelectTextField = <O,>(props: SelectTextFieldProps<O>) => {
     // (`value`, `isSelected`, `description`, `key`) into the returned <Combobox.Option>.
     const wrappedRenderOption = wrapRenderOption(renderOption);
 
-    const [listElement, setListElement] = useState<HTMLElement | null>(null);
+    // The list itself doesn't scroll — its ancestor `__scroll` wrapper does. The
+    // IntersectionObserver root must be the actual scrolling/clipping element, or the
+    // sentinel is trivially always "intersecting" its non-clipping `<ul>` parent.
+    const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(null);
+    const setListElement = useCallback((listElement: HTMLElement | null) => {
+        setScrollContainer(listElement?.closest<HTMLElement>(`.${COMBOBOX_POPOVER_CLASSNAME}__scroll`) ?? null);
+    }, []);
     const localInputRef = useRef<HTMLInputElement>(null);
     const mergedInputRef = useMergeRefs(localInputRef, externalInputRef);
 
@@ -328,7 +335,7 @@ export const SelectTextField = <O,>(props: SelectTextFieldProps<O>) => {
             chips,
             beforeOptions,
             onLoadMore,
-            infiniteScrollOptions: { root: listElement, rootMargin: '100px' },
+            infiniteScrollOptions: { root: scrollContainer, rootMargin: '100px' },
         },
         { Combobox, InfiniteScroll },
     );

--- a/packages/lumx-react/src/utils/InfiniteScroll/InfiniteScroll.tsx
+++ b/packages/lumx-react/src/utils/InfiniteScroll/InfiniteScroll.tsx
@@ -15,13 +15,16 @@ export const InfiniteScroll: React.FC<InfiniteScrollProps> = ({ callback, option
 
     useEffect(() => {
         const { current: element } = elementRef;
-        if (!element) {
+        if (!element || !callback) {
             return undefined;
         }
 
         return setupInfiniteScrollObserver(element, callback, options);
+        // `options?.root` starts as `null` (before the scrollable list's ref attaches) and is
+        // then set to the real element — must be a dep, or the observer gets stuck watching
+        // the wrong root (falling back to the viewport) for the component's whole lifetime.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [elementRef.current, callback]);
+    }, [elementRef.current, callback, options?.root]);
 
     return UI({ ref: elementRef });
 };

--- a/packages/lumx-vue/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-vue/src/components/select-button/SelectButton.tsx
@@ -19,6 +19,7 @@ import {
     type SelectButtonProps as UIProps,
 } from '@lumx/core/js/components/SelectButton';
 import type { ComboboxButtonProps } from '@lumx/core/js/components/Combobox/ComboboxButton';
+import { CLASSNAME as COMBOBOX_POPOVER_CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxPopover';
 import { InfiniteScroll } from '@lumx/vue/utils/InfiniteScroll';
 import { JSXElement } from '@lumx/core/js/types';
 
@@ -185,6 +186,12 @@ const SelectButton = defineComponent(
         // ComboboxList is a Vue component, so the ref resolves to its instance — Vue 3 auto-sets
         // `$el` to the root DOM node (the `<ul>`).
         const listRef = ref<ComponentPublicInstance | null>(null);
+        // The list itself doesn't scroll — its ancestor `__scroll` wrapper does. The
+        // IntersectionObserver root must be the actual scrolling/clipping element, or the
+        // sentinel is trivially always "intersecting" its non-clipping `<ul>` parent.
+        const scrollContainer = computed<HTMLElement | null>(
+            () => listRef.value?.$el?.closest(`.${COMBOBOX_POPOVER_CLASSNAME}__scroll`) ?? null,
+        );
 
         // Merge `class` prop with `className` attr (React-style attr from core JSX).
         const className = useClassName(() => props.class);
@@ -270,7 +277,7 @@ const SelectButton = defineComponent(
                     onOpen: (isOpen: boolean) => emit('open', isOpen),
                     translations: props.translations,
                     onLoadMore: hasLoadMoreListener ? onLoadMore : undefined,
-                    infiniteScrollOptions: { root: listRef.value?.$el ?? null, rootMargin: '100px' },
+                    infiniteScrollOptions: { root: scrollContainer.value, rootMargin: '100px' },
                 },
                 { Combobox, InfiniteScroll },
             );

--- a/packages/lumx-vue/src/components/select-button/Stories/WithInfiniteScroll.vue
+++ b/packages/lumx-vue/src/components/select-button/Stories/WithInfiniteScroll.vue
@@ -8,6 +8,7 @@
         @change="handleChange"
         @load-more="onLoadMore"
     />
+    <div data-testid="load-more-count">{{ loadMoreCount }}</div>
 </template>
 
 <script setup lang="ts">
@@ -41,12 +42,14 @@ const initialItems: Fruit[] = Array.from({ length: 3 }).flatMap((_, page) =>
 
 const value = ref<Fruit>();
 const items = ref<Fruit[]>(initialItems);
+const loadMoreCount = ref(0);
 
 function handleChange(newValue: Fruit | undefined) {
     value.value = newValue;
 }
 
 function onLoadMore() {
+    loadMoreCount.value += 1;
     if (items.value.length >= 200) {
         return;
     }

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
@@ -13,6 +13,7 @@ import { type BaseSelectTextFieldWrapperProps } from '@lumx/core/js/utils/select
 import { getOptionDisplayName } from '@lumx/core/js/utils/select/getOptionDisplayName';
 import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
 import { SelectTextField as UI } from '@lumx/core/js/components/SelectTextField';
+import { CLASSNAME as COMBOBOX_POPOVER_CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxPopover';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { keysOf, type ClassValue, type EmitsOf } from '../../utils/VueToJSX';
@@ -156,6 +157,12 @@ const SelectTextField = defineComponent(
         // ComboboxList is a Vue component, so the ref resolves to its instance — Vue 3 auto-sets
         // `$el` to the root DOM node (the `<ul>`).
         const listRef = ref<ComponentPublicInstance | null>(null);
+        // The list itself doesn't scroll — its ancestor `__scroll` wrapper does. The
+        // IntersectionObserver root must be the actual scrolling/clipping element, or the
+        // sentinel is trivially always "intersecting" its non-clipping `<ul>` parent.
+        const scrollContainer = computed<HTMLElement | null>(
+            () => listRef.value?.$el?.closest(`.${COMBOBOX_POPOVER_CLASSNAME}__scroll`) ?? null,
+        );
 
         // Ref to the underlying <input> element (needed to link the SelectionChipGroup)
         const inputElRef = ref<HTMLInputElement | null>(null);
@@ -333,7 +340,7 @@ const SelectTextField = defineComponent(
                     chips: chips as JSXElement | undefined,
                     beforeOptions: beforeOptionsSlot,
                     onLoadMore: hasLoadMoreListener ? onLoadMore : undefined,
-                    infiniteScrollOptions: { root: listRef.value?.$el ?? null, rootMargin: '100px' },
+                    infiniteScrollOptions: { root: scrollContainer.value, rootMargin: '100px' },
                 },
                 { Combobox, InfiniteScroll },
             );

--- a/packages/lumx-vue/src/utils/InfiniteScroll/InfiniteScroll.tsx
+++ b/packages/lumx-vue/src/utils/InfiniteScroll/InfiniteScroll.tsx
@@ -17,7 +17,7 @@ export const InfiniteScroll = defineComponent(
 
         watchEffect((onCleanup) => {
             const element = elementRef.value;
-            if (!element) return;
+            if (!element || !props.callback) return;
 
             const cleanup = setupInfiniteScrollObserver(element, props.callback, props.options);
             onCleanup(cleanup);


### PR DESCRIPTION
# General summary

`onLoadMore` could fire on `SelectButton`/`SelectTextField` without the user ever scrolling to the end of the list, because of two compounding bugs in the shared infinite-scroll sentinel.

- `InfiniteScroll` (core/react/vue): an inline `callback` closure was recreated on every render, causing the `IntersectionObserver` to be torn down and recreated on every render — each recreation re-checks and can re-fire the callback outside of an actual scroll. Fixed by making `callback` a stable, optional prop instead of a per-render arrow function.
- `SelectButton` / `SelectTextField` (core/react/vue): the observer's `root` was set to the `<ul>` list element itself, which has no overflow clipping and simply grows to fit all its children — so the sentinel was trivially always "intersecting" it, firing `onLoadMore` as soon as the dropdown opened. Fixed by resolving the actual `.lumx-combobox-popover__scroll` ancestor (the real scrollable container) as the observer root.
- Added regression coverage to the existing `WithInfiniteScroll` Storybook `play` tests (React and Vue): asserts `onLoadMore` doesn't fire from mounting/opening alone, and fires exactly once per scroll-to-bottom.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review-frontend` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-storybook-react` or `need: deploy-storybook-vue` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook lumx-react: https://07e28ed64--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://07e28ed64--697a023f84e832e23544fb3c.chromatic.com/