### PR TITLE
refactor(vue): standardize defineComponent name via getName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `TabList`: render a `role="navigation"` landmark instead of `role="tablist"` when used outside a `TabProvider`.
     -   `Tab`: render with WAI-ARIA `role="tab"` semantics only inside a `TabProvider`.
     -   `InfiniteScroll`: allow `undefined` callback to disable it
+-   `@lumx/vue`:
+    -   Standardize vue internal component `name` with `Lumx` prefix (was partially already in use). Newly-prefixed components: `AlertDialog`, `ButtonGroup`, `Checkbox`, `Flag`, `FlexBox`, `Heading`, `HeadingLevelProvider`, `Icon`, `IconButton`, `InputHelper`, `InputLabel`, `Message`, `RadioButton`, `RadioGroup`, `SkeletonRectangle`.
 
 ### Fixed
 

--- a/packages/lumx-core/src/js/components/Combobox/constants.ts
+++ b/packages/lumx-core/src/js/components/Combobox/constants.ts
@@ -1,3 +1,5 @@
 import { VHSize } from '../../utils/browser/css/types';
 
 export const DEFAULT_COMBOBOX_POPOVER_MAX_HEIGHT: VHSize = '80vh';
+
+export const COMBOBOX_PROVIDER_COMPONENT_NAME = 'ComboboxProvider';

--- a/packages/lumx-core/src/js/components/Menu/constants.ts
+++ b/packages/lumx-core/src/js/components/Menu/constants.ts
@@ -1,0 +1,1 @@
+export const MENU_PROVIDER_COMPONENT_NAME = 'MenuProvider';

--- a/packages/lumx-core/src/js/components/Tabs/constants.ts
+++ b/packages/lumx-core/src/js/components/Tabs/constants.ts
@@ -2,3 +2,5 @@
  * Component default class name and class prefix.
  */
 export const TABS_CLASSNAME = `lumx-tabs`;
+
+export const TAB_PROVIDER_COMPONENT_NAME = 'TabProvider';

--- a/packages/lumx-core/src/js/components/Toolbar/index.tsx
+++ b/packages/lumx-core/src/js/components/Toolbar/index.tsx
@@ -18,12 +18,12 @@ export interface ToolbarProps extends HasClassName {
 /**
  * Component display name.
  */
-export const TOOLBAR_NAME = 'Toolbar';
+export const COMPONENT_NAME = 'Toolbar';
 
 /**
  * Component default class name and class prefix.
  */
-export const CLASSNAME: LumxClassName<typeof TOOLBAR_NAME> = 'lumx-toolbar';
+export const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-toolbar';
 const { block, element } = classNames.bem(CLASSNAME);
 
 /**

--- a/packages/lumx-react/src/components/toolbar/Toolbar.tsx
+++ b/packages/lumx-react/src/components/toolbar/Toolbar.tsx
@@ -5,7 +5,7 @@ import {
     Toolbar as UI,
     ToolbarProps as UIProps,
     CLASSNAME,
-    TOOLBAR_NAME,
+    COMPONENT_NAME,
     DEFAULT_PROPS,
 } from '@lumx/core/js/components/Toolbar';
 import { forwardRef } from '@lumx/react/utils/react/forwardRef';
@@ -36,6 +36,6 @@ export const Toolbar = forwardRef<ToolbarProps, HTMLDivElement>((props, ref) => 
         ...props,
     });
 });
-Toolbar.displayName = TOOLBAR_NAME;
+Toolbar.displayName = COMPONENT_NAME;
 Toolbar.className = CLASSNAME;
 Toolbar.defaultProps = DEFAULT_PROPS;

--- a/packages/lumx-vue/CLAUDE.md
+++ b/packages/lumx-vue/CLAUDE.md
@@ -39,6 +39,10 @@ Each component directory follows this structure:
 
 Multi-component families (Button, Chip, List, Tabs…) add siblings in the same dir: `ButtonGroup.tsx`, `IconButton.tsx`, etc.
 
+### Component `name`
+
+Every `defineComponent` sets `name: getName(COMPONENT_NAME)` (from `utils/VueToJSX`), producing a `Lumx`-prefixed name (e.g. `LumxButton`). The prefix prevents collisions with native HTML/SVG tags (`button`, `dialog`, `link`, `table`, `text`…) and namespaces components in devtools
+
 ## COMPOSABLES
 
 `src/composables/` — the Vue equivalent of lumx-react hooks (theme, disabled state, focus, keyboard, slots, etc.), each with a co-located `.test.ts`.

--- a/packages/lumx-vue/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/lumx-vue/src/components/alert-dialog/AlertDialog.tsx
@@ -5,7 +5,7 @@ import type { GenericProps, JSXElement } from '@lumx/core/js/types';
 
 import { useId } from '../../composables/useId';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, type ClassValue } from '../../utils/VueToJSX';
+import { getName, keysOf, type ClassValue } from '../../utils/VueToJSX';
 
 import Dialog from '../dialog/Dialog';
 import Button from '../button/Button';
@@ -117,7 +117,7 @@ const AlertDialog = defineComponent(
         };
     },
     {
-        name: COMPONENT_NAME,
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<AlertDialogProps>()(
             'class',

--- a/packages/lumx-vue/src/components/avatar/Avatar.tsx
+++ b/packages/lumx-vue/src/components/avatar/Avatar.tsx
@@ -3,6 +3,7 @@ import { defineComponent, useAttrs } from 'vue';
 import {
     Avatar as AvatarUI,
     type AvatarProps as UIProps,
+    COMPONENT_NAME,
     DEFAULT_PROPS,
     element,
     type AvatarSize,
@@ -12,7 +13,7 @@ import type { GenericProps, JSXElement } from '@lumx/core/js/types';
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Thumbnail, type ThumbnailProps } from '../thumbnail';
 
 export type { AvatarSize };
@@ -81,7 +82,7 @@ const Avatar = defineComponent(
         };
     },
     {
-        name: 'LumxAvatar',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<AvatarProps>()('image', 'alt', 'size', 'theme', 'linkProps', 'linkAs', 'thumbnailProps', 'class'),
         emits: emitSchema,

--- a/packages/lumx-vue/src/components/badge/Badge.tsx
+++ b/packages/lumx-vue/src/components/badge/Badge.tsx
@@ -1,10 +1,10 @@
 import { defineComponent, useAttrs } from 'vue';
 
-import { Badge as BadgeUI, type BadgeProps as UIProps } from '@lumx/core/js/components/Badge';
+import { Badge as BadgeUI, type BadgeProps as UIProps, COMPONENT_NAME } from '@lumx/core/js/components/Badge';
 import { type JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type BadgeProps = VueToJSXProps<UIProps>;
 
@@ -24,7 +24,7 @@ const Badge = defineComponent(
         );
     },
     {
-        name: 'LumxBadge',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<BadgeProps>()('color', 'class'),

--- a/packages/lumx-vue/src/components/badge/BadgeWrapper.tsx
+++ b/packages/lumx-vue/src/components/badge/BadgeWrapper.tsx
@@ -7,7 +7,7 @@ import {
     DEFAULT_PROPS,
 } from '@lumx/core/js/components/Badge/BadgeWrapper';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import type { JSXElement } from '@lumx/core/js/types';
 
 export type BadgeWrapperProps = VueToJSXProps<UIProps>;
@@ -32,7 +32,7 @@ const BadgeWrapper = defineComponent(
         };
     },
     {
-        name: 'LumxBadgeWrapper',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<BadgeWrapperProps>()('badge', 'class'),
     },

--- a/packages/lumx-vue/src/components/button/Button.tsx
+++ b/packages/lumx-vue/src/components/button/Button.tsx
@@ -12,7 +12,7 @@ import {
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
-import { type HyphenatedAriaProps, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, type HyphenatedAriaProps, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { ResetTheme } from '../../utils/theme';
 import { Icon } from '../icon';
 import Text from '../text/Text';
@@ -105,7 +105,7 @@ const Button = defineComponent(
         };
     },
     {
-        name: 'LumxButton',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<ButtonProps>()(

--- a/packages/lumx-vue/src/components/button/ButtonGroup.tsx
+++ b/packages/lumx-vue/src/components/button/ButtonGroup.tsx
@@ -3,11 +3,12 @@ import { defineComponent, useAttrs } from 'vue';
 import {
     ButtonGroup as ButtonGroupUI,
     type ButtonGroupProps as UIProps,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/Button/ButtonGroup';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ButtonGroupProps = VueToJSXProps<UIProps>;
 
@@ -32,7 +33,7 @@ const ButtonGroup = defineComponent(
         );
     },
     {
-        name: 'ButtonGroup',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<ButtonGroupProps>()('class'),

--- a/packages/lumx-vue/src/components/button/IconButton.tsx
+++ b/packages/lumx-vue/src/components/button/IconButton.tsx
@@ -3,6 +3,7 @@ import { computed, defineComponent, ref, toRaw, useAttrs } from 'vue';
 import {
     IconButton as IconButtonUI,
     type IconButtonProps as UIProps,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/Button/IconButton';
 
 import { Tooltip, type TooltipProps } from '../tooltip/Tooltip';
@@ -10,7 +11,7 @@ import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useAttrFallback } from '../../composables/useAttrFallback';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
-import { type HyphenatedAriaProps, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, type HyphenatedAriaProps, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type IconButtonProps = Omit<VueToJSXProps<UIProps>, HyphenatedAriaProps> & {
     /**
@@ -84,7 +85,7 @@ const IconButton = defineComponent(
         };
     },
     {
-        name: 'IconButton',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<IconButtonProps>()(

--- a/packages/lumx-vue/src/components/checkbox/Checkbox.tsx
+++ b/packages/lumx-vue/src/components/checkbox/Checkbox.tsx
@@ -12,7 +12,7 @@ import {
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useId } from '../../composables/useId';
 
 export type CheckboxProps = VueToJSXProps<UIProps, 'inputId' | 'inputRef'>;
@@ -85,7 +85,7 @@ const Checkbox = defineComponent(
         };
     },
     {
-        name: 'Checkbox',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<CheckboxProps>()(

--- a/packages/lumx-vue/src/components/chip/Chip.tsx
+++ b/packages/lumx-vue/src/components/chip/Chip.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useHasEventListener } from '../../composables/useHasEventListener';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ChipProps = VueToJSXProps<UIProps, ChipPropsToOverride>;
 
@@ -105,7 +105,7 @@ const Chip = defineComponent(
         );
     },
     {
-        name: 'LumxChip',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ChipProps>()(
             'color',

--- a/packages/lumx-vue/src/components/chip/ChipGroup.tsx
+++ b/packages/lumx-vue/src/components/chip/ChipGroup.tsx
@@ -1,7 +1,11 @@
 import { defineComponent, useAttrs } from 'vue';
-import { ChipGroup as ChipGroupUI, type ChipGroupProps as UIProps } from '@lumx/core/js/components/Chip/ChipGroup';
+import {
+    ChipGroup as ChipGroupUI,
+    type ChipGroupProps as UIProps,
+    COMPONENT_NAME,
+} from '@lumx/core/js/components/Chip/ChipGroup';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { JSXElement } from '@lumx/core/js/types';
 
 export type ChipGroupProps = VueToJSXProps<UIProps, never>;
@@ -16,7 +20,7 @@ const ChipGroup = defineComponent(
         );
     },
     {
-        name: 'LumxChipGroup',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ChipGroupProps>()('align', 'class'),
     },

--- a/packages/lumx-vue/src/components/chip/SelectionChipGroup.tsx
+++ b/packages/lumx-vue/src/components/chip/SelectionChipGroup.tsx
@@ -13,6 +13,7 @@ import {
 import {
     SelectionChipGroup as UI,
     type SelectionChipGroupProps as UIProps,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/Chip/SelectionChipGroup';
 import { CLASSNAME as CHIP_CLASSNAME } from '@lumx/core/js/components/Chip';
 import { setupSelectionChipGroupEvents } from '@lumx/core/js/components/Chip/setupSelectionChipGroupEvents';
@@ -20,7 +21,7 @@ import { setupSelectionChipGroupEvents } from '@lumx/core/js/components/Chip/set
 import { useClassName } from '../../composables/useClassName';
 import { useTheme } from '../../composables/useTheme';
 import { useRovingTabIndexContainer } from '../../composables/useRovingTabIndexContainer';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { isComponentType } from '../../utils/isComponentType';
 import { Icon } from '../icon';
 import { Tooltip } from '../tooltip';
@@ -148,7 +149,7 @@ const SelectionChipGroup = defineComponent(
         };
     },
     {
-        name: 'LumxSelectionChipGroup',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<SelectionChipGroupProps>()(
             'getChipProps',

--- a/packages/lumx-vue/src/components/combobox/ComboboxButton.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxButton.tsx
@@ -10,7 +10,7 @@ import {
 import { setupComboboxButton } from '@lumx/core/js/components/Combobox/setupComboboxButton';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Button } from '../button';
 import { Tooltip } from '../tooltip';
 import { useComboboxContext } from './context/ComboboxContext';
@@ -102,7 +102,7 @@ const ComboboxButton = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxButton',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxButtonProps>()(
             'class',

--- a/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxInput.tsx
@@ -10,7 +10,7 @@ import {
 import { setupComboboxInput } from '@lumx/core/js/components/Combobox/setupComboboxInput';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import type { TextFieldProps } from '../text-field/TextField';
 import { TextField } from '../text-field';
 import { IconButton } from '../button';
@@ -134,7 +134,7 @@ const ComboboxInput = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxInput',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxInputProps>()(
             'class',

--- a/packages/lumx-vue/src/components/combobox/ComboboxList.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxList.tsx
@@ -9,7 +9,7 @@ import {
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useWatchDisposable } from '../../composables/useWatchDisposable';
 import { useComboboxContext } from './context/ComboboxContext';
 import { useComboboxEvent } from './context/useComboboxEvent';
@@ -72,7 +72,7 @@ const ComboboxList = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxList',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Note: 'aria-label' is intentionally NOT declared as a prop because Vue normalizes
         // hyphenated prop names to camelCase (ariaLabel) internally, making it inaccessible

--- a/packages/lumx-vue/src/components/combobox/ComboboxOption.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxOption.tsx
@@ -12,7 +12,7 @@ import type { JSXElement } from '@lumx/core/js/types';
 import { useId } from '../../composables/useId';
 import { useClassName } from '../../composables/useClassName';
 import { useWatchDisposable } from '../../composables/useWatchDisposable';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Tooltip } from '../tooltip';
 import type { TooltipProps } from '../tooltip/Tooltip';
 import { useComboboxContext } from './context/ComboboxContext';
@@ -118,7 +118,7 @@ const ComboboxOption = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxOption',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxOptionProps>()(
             'value',

--- a/packages/lumx-vue/src/components/combobox/ComboboxOptionAction.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxOptionAction.tsx
@@ -11,7 +11,7 @@ import type { JSXElement } from '@lumx/core/js/types';
 import { useId } from '../../composables/useId';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ComboboxOptionActionProps = Pick<VueToJSXProps<UIProps>, 'isDisabled' | 'class'> & {
     /** On click callback. */
@@ -48,7 +48,7 @@ const ComboboxOptionAction = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxOptionAction',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxOptionActionProps>()('isDisabled', 'onClick', 'class'),
     },

--- a/packages/lumx-vue/src/components/combobox/ComboboxOptionMoreInfo.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxOptionMoreInfo.tsx
@@ -11,7 +11,7 @@ import {
 } from '@lumx/core/js/components/Combobox/ComboboxOptionMoreInfo';
 import type { JSXElement } from '@lumx/core/js/types';
 
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { IconButton } from '../button';
 import { Popover } from '../popover';
 import { useComboboxOptionContext } from './context/ComboboxOptionContext';
@@ -113,7 +113,7 @@ const ComboboxOptionMoreInfo = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxOptionMoreInfo',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxOptionMoreInfoProps>()('class', 'onToggle'),
         emits: {

--- a/packages/lumx-vue/src/components/combobox/ComboboxOptionSkeleton.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxOptionSkeleton.tsx
@@ -9,7 +9,7 @@ import {
 } from '@lumx/core/js/components/Combobox/ComboboxOptionSkeleton';
 import type { JSXElement } from '@lumx/core/js/types';
 
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useClassName } from '../../composables/useClassName';
 import { useWatchDisposable } from '../../composables/useWatchDisposable';
 import { useComboboxContext } from './context/ComboboxContext';
@@ -46,7 +46,7 @@ const ComboboxOptionSkeleton = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxOptionSkeleton',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxOptionSkeletonProps>()('hasDescription', 'count', 'class'),
     },

--- a/packages/lumx-vue/src/components/combobox/ComboboxPopover.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxPopover.tsx
@@ -10,7 +10,7 @@ import {
 } from '@lumx/core/js/components/Combobox/ComboboxPopover';
 import type { JSXElement } from '@lumx/core/js/types';
 
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Popover } from '../popover';
 import type { PopoverProps } from '../popover/Popover';
 import { useComboboxContext } from './context/ComboboxContext';
@@ -57,7 +57,7 @@ const ComboboxPopover = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxPopover',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxPopoverProps>()(
             'as',

--- a/packages/lumx-vue/src/components/combobox/ComboboxProvider.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxProvider.tsx
@@ -1,8 +1,10 @@
 import { defineComponent, onWatcherCleanup, ref, shallowRef, useAttrs, watch } from 'vue';
 
+import { COMBOBOX_PROVIDER_COMPONENT_NAME } from '@lumx/core/js/components/Combobox/constants';
 import type { ComboboxHandle } from '@lumx/core/js/components/Combobox/types';
 
 import { useId } from '../../composables/useId';
+import { getName } from '../../utils/VueToJSX';
 import { provideComboboxContext } from './context/ComboboxContext';
 
 /**
@@ -44,7 +46,7 @@ const ComboboxProvider = defineComponent(
         return () => slots.default?.();
     },
     {
-        name: 'LumxComboboxProvider',
+        name: getName(COMBOBOX_PROVIDER_COMPONENT_NAME),
         inheritAttrs: false,
         props: {},
         emits: {

--- a/packages/lumx-vue/src/components/combobox/ComboboxSection.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxSection.tsx
@@ -11,7 +11,7 @@ import {
 } from '@lumx/core/js/components/Combobox/ComboboxSection';
 import type { JSXElement } from '@lumx/core/js/types';
 
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useWatchDisposable } from '../../composables/useWatchDisposable';
 import { ListSection } from '../list';
 import { useComboboxContext } from './context/ComboboxContext';
@@ -71,7 +71,7 @@ const ComboboxSection = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxSection',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxSectionProps>()('label', 'icon', 'class'),
     },

--- a/packages/lumx-vue/src/components/combobox/ComboboxState.tsx
+++ b/packages/lumx-vue/src/components/combobox/ComboboxState.tsx
@@ -8,7 +8,7 @@ import {
 } from '@lumx/core/js/components/Combobox/ComboboxState';
 import { subscribeComboboxState } from '@lumx/core/js/components/Combobox/subscribeComboboxState';
 
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useWatchDisposable } from '../../composables/useWatchDisposable';
 import { GenericBlock } from '../generic-block';
 import { Text } from '../text';
@@ -66,7 +66,7 @@ const ComboboxState = defineComponent(
         };
     },
     {
-        name: 'LumxComboboxState',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ComboboxStateProps>()(
             'emptyMessage',

--- a/packages/lumx-vue/src/components/dialog/Dialog.tsx
+++ b/packages/lumx-vue/src/components/dialog/Dialog.tsx
@@ -1,7 +1,13 @@
 import { Comment, computed, defineComponent, ref, type Ref } from 'vue';
 import { useIntersectionObserver } from '@vueuse/core';
 
-import { Dialog as UI, type BaseDialogProps, type DialogSizes, DEFAULT_PROPS } from '@lumx/core/js/components/Dialog';
+import {
+    Dialog as UI,
+    type BaseDialogProps,
+    type DialogSizes,
+    COMPONENT_NAME,
+    DEFAULT_PROPS,
+} from '@lumx/core/js/components/Dialog';
 import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
 import type { GenericProps, HasCloseMode, JSXElement } from '@lumx/core/js/types';
 
@@ -17,7 +23,7 @@ import { useFocusTrap } from '../../composables/useFocusTrap';
 import { useRestoreFocusOnClose } from '../../composables/useRestoreFocusOnClose';
 import { useTransitionVisibility } from '../../composables/useTransitionVisibility';
 import { useDisableBodyScroll } from '../../composables/useDisableBodyScroll';
-import { keysOf, type ClassValue } from '../../utils/VueToJSX';
+import { getName, keysOf, type ClassValue } from '../../utils/VueToJSX';
 
 export type DialogProps = Pick<BaseDialogProps, 'forceFooterDivider' | 'forceHeaderDivider' | 'isLoading'> &
     HasCloseMode & {
@@ -185,7 +191,7 @@ const Dialog = defineComponent(
         };
     },
     {
-        name: 'LumxDialog',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<DialogProps>()(
             'class',

--- a/packages/lumx-vue/src/components/divider/Divider.tsx
+++ b/packages/lumx-vue/src/components/divider/Divider.tsx
@@ -10,7 +10,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type DividerProps = VueToJSXProps<UIProps>;
 
@@ -40,7 +40,7 @@ const Divider = defineComponent(
         };
     },
     {
-        name: 'LumxDivider',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<DividerProps>()('class', 'theme'),

--- a/packages/lumx-vue/src/components/drag-handle/DragHandle.tsx
+++ b/packages/lumx-vue/src/components/drag-handle/DragHandle.tsx
@@ -10,7 +10,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type DragHandleProps = VueToJSXProps<UIProps>;
 
@@ -40,7 +40,7 @@ const DragHandle = defineComponent(
         };
     },
     {
-        name: 'LumxDragHandle',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<DragHandleProps>()('class', 'theme'),
     },

--- a/packages/lumx-vue/src/components/expansion-panel/ExpansionPanel.tsx
+++ b/packages/lumx-vue/src/components/expansion-panel/ExpansionPanel.tsx
@@ -15,7 +15,7 @@ import type { JSXElement } from '@lumx/core/js/types';
 import IconButton from '../button/IconButton';
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ExpansionPanelProps = VueToJSXProps<UIProps, ExpansionPanelPropsToOverride> & {
     /** Props to pass to the toggle button (minus those already set by the ExpansionPanel). */
@@ -121,7 +121,7 @@ const ExpansionPanel = defineComponent(
         };
     },
     {
-        name: 'LumxExpansionPanel',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ExpansionPanelProps>()(
             'class',

--- a/packages/lumx-vue/src/components/flag/Flag.tsx
+++ b/packages/lumx-vue/src/components/flag/Flag.tsx
@@ -1,11 +1,11 @@
 import { defineComponent, useAttrs } from 'vue';
 
-import { Flag as FlagUI, type FlagProps as UIProps } from '@lumx/core/js/components/Flag';
+import { Flag as FlagUI, type FlagProps as UIProps, COMPONENT_NAME } from '@lumx/core/js/components/Flag';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Text } from '../text';
 
 export type FlagProps = VueToJSXProps<UIProps, 'Text'>;
@@ -34,7 +34,7 @@ const Flag = defineComponent(
         );
     },
     {
-        name: 'Flag',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<FlagProps>()('color', 'icon', 'truncate', 'theme', 'class'),

--- a/packages/lumx-vue/src/components/flex-box/FlexBox.tsx
+++ b/packages/lumx-vue/src/components/flex-box/FlexBox.tsx
@@ -9,7 +9,7 @@ import {
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type FlexBoxProps = VueToJSXProps<UIProps, 'vAlign' | 'hAlign'> & {
     /** Customize the root element. */
@@ -50,7 +50,7 @@ const FlexBox = defineComponent(
         };
     },
     {
-        name: 'FlexBox',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<FlexBoxProps>()(

--- a/packages/lumx-vue/src/components/generic-block/GenericBlock.tsx
+++ b/packages/lumx-vue/src/components/generic-block/GenericBlock.tsx
@@ -4,12 +4,13 @@ import {
     GenericBlock as GenericBlockUI,
     type GenericBlockProps as UIProps,
     GenericBlockPropsToOverride,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/GenericBlock';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { FlexBox as FlexBoxVue, FlexBoxProps } from '../flex-box';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 /** FlexBox section props extended with standard HTML style. */
 type SectionProps = FlexBoxProps & { style?: CSSProperties };
@@ -97,7 +98,7 @@ const GenericBlock = defineComponent(
         };
     },
     {
-        name: 'LumxGenericBlock',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<GenericBlockProps>()(
             'as',

--- a/packages/lumx-vue/src/components/grid-column/GridColumn.tsx
+++ b/packages/lumx-vue/src/components/grid-column/GridColumn.tsx
@@ -9,7 +9,7 @@ import {
 } from '@lumx/core/js/components/GridColumn';
 import { type JSXElement } from '@lumx/core/js/types';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type GridColumnProps = VueToJSXProps<UIProps>;
 
@@ -31,7 +31,7 @@ const GridColumn = defineComponent(
         );
     },
     {
-        name: 'LumxGridColumn',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<GridColumnProps>()('as', 'class', 'gap', 'itemMinWidth', 'maxColumns', 'style'),
     },

--- a/packages/lumx-vue/src/components/heading/Heading.tsx
+++ b/packages/lumx-vue/src/components/heading/Heading.tsx
@@ -1,9 +1,9 @@
 import { computed, defineComponent, useAttrs } from 'vue';
 
-import { getHeadingProps, type HeadingProps } from '@lumx/core/js/components/Heading';
+import { COMPONENT_NAME, getHeadingProps, type HeadingProps } from '@lumx/core/js/components/Heading';
 import { useClassName } from '@lumx/vue/composables/useClassName';
 
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Text } from '../text';
 import { useHeadingLevel } from './useHeadingLevel';
 
@@ -40,7 +40,7 @@ const Heading = defineComponent(
         return () => <Text {...uiProps.value}>{slots.default?.()}</Text>;
     },
     {
-        name: 'Heading',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<HeadingVueProps>()(

--- a/packages/lumx-vue/src/components/heading/HeadingLevelProvider.tsx
+++ b/packages/lumx-vue/src/components/heading/HeadingLevelProvider.tsx
@@ -4,7 +4,7 @@ import type { HeadingElement } from '@lumx/core/js/types';
 import type { HeadingLevelContext } from '@lumx/core/js/components/Heading/constants';
 import { computeHeadingLevel } from '@lumx/core/js/components/Heading/utils';
 
-import { keysOf } from '../../utils/VueToJSX';
+import { getName, keysOf } from '../../utils/VueToJSX';
 import { HeadingLevelContextKey } from './context';
 import { useHeadingLevel } from './useHeadingLevel';
 
@@ -40,7 +40,7 @@ const HeadingLevelProvider = defineComponent(
         return () => slots.default?.();
     },
     {
-        name: 'HeadingLevelProvider',
+        name: getName('HeadingLevelProvider'),
         props: keysOf<HeadingLevelProviderProps>()('level'),
     },
 );

--- a/packages/lumx-vue/src/components/icon/Icon.tsx
+++ b/packages/lumx-vue/src/components/icon/Icon.tsx
@@ -1,10 +1,10 @@
 import { defineComponent, useAttrs } from 'vue';
 
-import { Icon as IconUI, type IconProps as UIProps } from '@lumx/core/js/components/Icon';
+import { Icon as IconUI, type IconProps as UIProps, COMPONENT_NAME } from '@lumx/core/js/components/Icon';
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type IconProps = VueToJSXProps<UIProps>;
 
@@ -25,7 +25,7 @@ const Icon = defineComponent(
         );
     },
     {
-        name: 'Icon',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<IconProps>()(

--- a/packages/lumx-vue/src/components/image-block/ImageBlock.tsx
+++ b/packages/lumx-vue/src/components/image-block/ImageBlock.tsx
@@ -12,7 +12,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Thumbnail, ThumbnailProps } from '../thumbnail';
 import ImageCaption from './ImageCaption';
 
@@ -55,7 +55,7 @@ const ImageBlock = defineComponent(
         };
     },
     {
-        name: 'LumxImageBlock',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ImageBlockProps>()(
             'actions',

--- a/packages/lumx-vue/src/components/image-block/ImageCaption.tsx
+++ b/packages/lumx-vue/src/components/image-block/ImageCaption.tsx
@@ -4,7 +4,7 @@ import { ImageCaption as UI } from '@lumx/core/js/components/ImageBlock/ImageCap
 import { type HorizontalAlignment, type Theme } from '@lumx/core/js/constants';
 
 import { useTheme } from '../../composables/useTheme';
-import { keysOf, type ClassValue } from '../../utils/VueToJSX';
+import { getName, keysOf, type ClassValue } from '../../utils/VueToJSX';
 import { FlexBox } from '../flex-box';
 import { Text } from '../text';
 
@@ -43,7 +43,7 @@ const ImageCaption = defineComponent(
         };
     },
     {
-        name: 'LumxImageCaption',
+        name: getName('ImageCaption'),
         inheritAttrs: false,
         props: keysOf<ImageCaptionProps>()(
             'align',

--- a/packages/lumx-vue/src/components/inline-list/InlineList.tsx
+++ b/packages/lumx-vue/src/components/inline-list/InlineList.tsx
@@ -1,10 +1,14 @@
 import { defineComponent, useAttrs } from 'vue';
 
-import { InlineList as InlineListUI, type InlineListProps as UIProps } from '@lumx/core/js/components/InlineList';
+import {
+    InlineList as InlineListUI,
+    type InlineListProps as UIProps,
+    COMPONENT_NAME,
+} from '@lumx/core/js/components/InlineList';
 import { type JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type InlineListProps = VueToJSXProps<UIProps, 'items'>;
 
@@ -24,7 +28,7 @@ const InlineList = defineComponent(
         );
     },
     {
-        name: 'LumxInlineList',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<InlineListProps>()('color', 'colorVariant', 'typography', 'wrap', 'class'),
     },

--- a/packages/lumx-vue/src/components/input-helper/InputHelper.tsx
+++ b/packages/lumx-vue/src/components/input-helper/InputHelper.tsx
@@ -1,11 +1,15 @@
 import { defineComponent, useAttrs } from 'vue';
 
-import { InputHelper as InputHelperUI, type InputHelperProps as UIProps } from '@lumx/core/js/components/InputHelper';
+import {
+    InputHelper as InputHelperUI,
+    type InputHelperProps as UIProps,
+    COMPONENT_NAME,
+} from '@lumx/core/js/components/InputHelper';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type InputHelperProps = VueToJSXProps<UIProps>;
 
@@ -32,7 +36,7 @@ const InputHelper = defineComponent(
         );
     },
     {
-        name: 'InputHelper',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<InputHelperProps>()('kind', 'theme', 'class', 'id'),

--- a/packages/lumx-vue/src/components/input-label/InputLabel.tsx
+++ b/packages/lumx-vue/src/components/input-label/InputLabel.tsx
@@ -1,11 +1,15 @@
 import { defineComponent, useAttrs } from 'vue';
 
-import { InputLabel as InputLabelUI, type InputLabelProps as UIProps } from '@lumx/core/js/components/InputLabel';
+import {
+    InputLabel as InputLabelUI,
+    type InputLabelProps as UIProps,
+    COMPONENT_NAME,
+} from '@lumx/core/js/components/InputLabel';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type InputLabelProps = VueToJSXProps<UIProps>;
 
@@ -32,7 +36,7 @@ const InputLabel = defineComponent(
         );
     },
     {
-        name: 'InputLabel',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<InputLabelProps>()('htmlFor', 'id', 'isRequired', 'typography', 'theme', 'class', 'as'),

--- a/packages/lumx-vue/src/components/lightbox/Lightbox.tsx
+++ b/packages/lumx-vue/src/components/lightbox/Lightbox.tsx
@@ -1,6 +1,6 @@
 import { computed, defineComponent, ref, type Ref } from 'vue';
 
-import { Lightbox as UI, type BaseLightboxProps } from '@lumx/core/js/components/Lightbox';
+import { Lightbox as UI, type BaseLightboxProps, COMPONENT_NAME } from '@lumx/core/js/components/Lightbox';
 import { DIALOG_TRANSITION_DURATION } from '@lumx/core/js/constants';
 import type { JSXElement } from '@lumx/core/js/types';
 
@@ -16,7 +16,7 @@ import { useFocusTrap } from '../../composables/useFocusTrap';
 import { useRestoreFocusOnClose } from '../../composables/useRestoreFocusOnClose';
 import { useTransitionVisibility } from '../../composables/useTransitionVisibility';
 import { useDisableBodyScroll } from '../../composables/useDisableBodyScroll';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type LightboxProps = VueToJSXProps<BaseLightboxProps, 'theme' | 'aria-label' | 'aria-labelledby'> & {
     /** Reference to the element that triggered lightbox opening (gets focus back on close). */
@@ -113,7 +113,7 @@ const Lightbox = defineComponent(
         };
     },
     {
-        name: 'LumxLightbox',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<LightboxProps>()(
             'class',

--- a/packages/lumx-vue/src/components/link-preview/LinkPreview.tsx
+++ b/packages/lumx-vue/src/components/link-preview/LinkPreview.tsx
@@ -11,7 +11,7 @@ import { Link } from '../link';
 import { Thumbnail } from '../thumbnail';
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type LinkPreviewProps = VueToJSXProps<UIProps, 'TitleHeading' | 'Link' | 'Thumbnail'> & {
     /** Customize the title heading tag. */
@@ -50,7 +50,7 @@ const LinkPreview = defineComponent(
         };
     },
     {
-        name: 'LumxLinkPreview',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<LinkPreviewProps>()(
             'class',

--- a/packages/lumx-vue/src/components/link/Link.tsx
+++ b/packages/lumx-vue/src/components/link/Link.tsx
@@ -1,10 +1,10 @@
 import { computed, defineComponent, toRaw, useAttrs, useSlots } from 'vue';
 
-import { Link as LinkUI, type LinkProps as UIProps, CLASSNAME } from '@lumx/core/js/components/Link';
+import { Link as LinkUI, type LinkProps as UIProps, CLASSNAME, COMPONENT_NAME } from '@lumx/core/js/components/Link';
 
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { JSXElement } from '@lumx/core/js/types';
 import { classNames } from '@lumx/core/js/utils';
 
@@ -55,7 +55,7 @@ const Link = defineComponent(
         };
     },
     {
-        name: 'LumxLink',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<LinkProps>()(
             'color',

--- a/packages/lumx-vue/src/components/list/List.tsx
+++ b/packages/lumx-vue/src/components/list/List.tsx
@@ -1,10 +1,10 @@
 import { defineComponent, useAttrs } from 'vue';
 
-import { List as ListUI, type ListProps as UIProps } from '@lumx/core/js/components/List';
+import { List as ListUI, type ListProps as UIProps, COMPONENT_NAME } from '@lumx/core/js/components/List';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ListProps = VueToJSXProps<UIProps>;
 
@@ -24,7 +24,7 @@ const List = defineComponent(
         );
     },
     {
-        name: 'LumxList',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ListProps>()('itemPadding', 'class'),
     },

--- a/packages/lumx-vue/src/components/list/ListDivider.tsx
+++ b/packages/lumx-vue/src/components/list/ListDivider.tsx
@@ -3,10 +3,11 @@ import { defineComponent, useAttrs } from 'vue';
 import {
     ListDivider as ListDividerUI,
     type ListDividerProps as UIProps,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/List/ListDivider';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ListDividerProps = VueToJSXProps<UIProps>;
 
@@ -24,7 +25,7 @@ const ListDivider = defineComponent(
         return () => <ListDividerUI {...attrs} className={className.value} />;
     },
     {
-        name: 'LumxListDivider',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ListDividerProps>()('class'),
     },

--- a/packages/lumx-vue/src/components/list/ListItem.tsx
+++ b/packages/lumx-vue/src/components/list/ListItem.tsx
@@ -4,13 +4,14 @@ import {
     ListItem as ListItemUI,
     type ListItemProps as UIProps,
     type ListItemSize,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/List/ListItem';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useClassName } from '../../composables/useClassName';
 import { useHasEventListener } from '../../composables/useHasEventListener';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import ListItemAction from './ListItemAction';
 
 export type { ListItemSize };
@@ -64,7 +65,7 @@ const ListItem = defineComponent(
         };
     },
     {
-        name: 'LumxListItem',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ListItemProps>()(
             'isHighlighted',

--- a/packages/lumx-vue/src/components/list/ListItemAction.tsx
+++ b/packages/lumx-vue/src/components/list/ListItemAction.tsx
@@ -1,13 +1,13 @@
 import { computed, defineComponent, useAttrs } from 'vue';
 
-import { ListItemAction as ListItemActionUI } from '@lumx/core/js/components/List/ListItemAction';
+import { ListItemAction as ListItemActionUI, COMPONENT_NAME } from '@lumx/core/js/components/List/ListItemAction';
 import type { BaseClickableProps, ClickableElement } from '@lumx/core/js/components/RawClickable';
 import type { HasClassName, JSXElement } from '@lumx/core/js/types';
 
 import { classNames } from '@lumx/core/js/utils';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ListItemActionProps = VueToJSXProps<BaseClickableProps & HasClassName> & {
     /** Customize the rendered element. */
@@ -57,7 +57,7 @@ const ListItemAction = defineComponent(
         };
     },
     {
-        name: 'LumxListItemAction',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ListItemActionProps>()('as', 'href', 'class', 'isDisabled', 'disabled', 'aria-disabled'),
         emits: emitSchema,

--- a/packages/lumx-vue/src/components/list/ListSection.tsx
+++ b/packages/lumx-vue/src/components/list/ListSection.tsx
@@ -3,12 +3,13 @@ import { defineComponent, useAttrs } from 'vue';
 import {
     ListSection as ListSectionUI,
     type ListSectionProps as UIProps,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/List/ListSection';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useId } from '../../composables/useId';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Text } from '../text';
 
 export type ListSectionProps = VueToJSXProps<UIProps, 'id' | 'Text'>;
@@ -37,7 +38,7 @@ const ListSection = defineComponent(
         );
     },
     {
-        name: 'LumxListSection',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ListSectionProps>()('label', 'icon', 'itemsWrapperProps', 'class'),
     },

--- a/packages/lumx-vue/src/components/menu-button/MenuButton.tsx
+++ b/packages/lumx-vue/src/components/menu-button/MenuButton.tsx
@@ -12,7 +12,7 @@ import {
 } from '@lumx/core/js/components/Menu/MenuButton';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 import Button, { type ButtonProps } from '../button/Button';
 import IconButton, { type IconButtonProps } from '../button/IconButton';
@@ -81,7 +81,7 @@ const MenuButton = defineComponent(
         };
     },
     {
-        name: 'LumxMenuButton',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<MenuButtonBaseProps>()('label', 'popoverProps', 'class', 'variant'),
         emits: ['open'],

--- a/packages/lumx-vue/src/components/menu-button/MenuItem.tsx
+++ b/packages/lumx-vue/src/components/menu-button/MenuItem.tsx
@@ -11,7 +11,7 @@ import {
 } from '@lumx/core/js/components/Menu/MenuItem';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Icon } from '../icon';
 import Text from '../text/Text';
 
@@ -119,7 +119,7 @@ const MenuItem = defineComponent(
         };
     },
     {
-        name: 'LumxMenuItem',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<MenuItemProps>()('icon', 'afterIcon', 'color', 'isDisabled', 'class'),
         emits: ['click'],

--- a/packages/lumx-vue/src/components/menu-button/MenuList.tsx
+++ b/packages/lumx-vue/src/components/menu-button/MenuList.tsx
@@ -9,7 +9,7 @@ import {
 } from '@lumx/core/js/components/Menu/MenuList';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 import { useMenuContext } from './context';
 import { useMenuOpen } from './useMenuOpen';
@@ -52,7 +52,7 @@ const MenuList = defineComponent(
             });
     },
     {
-        name: 'LumxMenuList',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<MenuListProps>()('class'),
     },

--- a/packages/lumx-vue/src/components/menu-button/MenuPopover.tsx
+++ b/packages/lumx-vue/src/components/menu-button/MenuPopover.tsx
@@ -8,7 +8,7 @@ import {
     COMPONENT_NAME as MENU_POPOVER_COMPONENT_NAME,
 } from '@lumx/core/js/components/Menu/MenuPopover';
 
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { FlexBox } from '../flex-box';
 import { Popover } from '../popover';
 
@@ -43,7 +43,7 @@ const MenuPopover = defineComponent(
             );
     },
     {
-        name: 'LumxMenuPopover',
+        name: getName(MENU_POPOVER_COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<MenuPopoverProps>()('placement', 'class'),
     },

--- a/packages/lumx-vue/src/components/menu-button/MenuProvider.tsx
+++ b/packages/lumx-vue/src/components/menu-button/MenuProvider.tsx
@@ -1,8 +1,10 @@
 import { defineComponent, onMounted, onUnmounted, ref, useSlots } from 'vue';
 
+import { MENU_PROVIDER_COMPONENT_NAME } from '@lumx/core/js/components/Menu/constants';
 import { setupMenu } from '@lumx/core/js/components/Menu/setupMenu';
 
 import { useId } from '../../composables/useId';
+import { getName } from '../../utils/VueToJSX';
 
 import { provideMenuContext } from './context';
 
@@ -39,7 +41,7 @@ const MenuProvider = defineComponent(
         return () => slots.default?.();
     },
     {
-        name: 'LumxMenuProvider',
+        name: getName(MENU_PROVIDER_COMPONENT_NAME),
         inheritAttrs: false,
         props: {
             onOpen: { type: Function as any, default: undefined },

--- a/packages/lumx-vue/src/components/menu-button/MenuTrigger.tsx
+++ b/packages/lumx-vue/src/components/menu-button/MenuTrigger.tsx
@@ -10,7 +10,7 @@ import {
 } from '@lumx/core/js/components/Menu/MenuTrigger';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Button } from '../button';
 
 import { useMenuContext } from './context';
@@ -71,7 +71,7 @@ const MenuTrigger = defineComponent(
         };
     },
     {
-        name: 'LumxMenuTrigger',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<MenuTriggerProps>()('class', 'id'),
     },

--- a/packages/lumx-vue/src/components/message/Message.tsx
+++ b/packages/lumx-vue/src/components/message/Message.tsx
@@ -1,9 +1,9 @@
 import { defineComponent, useAttrs } from 'vue';
-import { Message as MessageUI, type MessageProps as UIProps } from '@lumx/core/js/components/Message';
+import { Message as MessageUI, type MessageProps as UIProps, COMPONENT_NAME } from '@lumx/core/js/components/Message';
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type MessageProps = VueToJSXProps<Omit<UIProps, 'closeButtonProps'>> & {
     /** label to be used for the close button */
@@ -45,7 +45,7 @@ const Message = defineComponent(
         );
     },
     {
-        name: 'Message',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<MessageProps>()('hasBackground', 'icon', 'kind', 'class', 'closeButtonLabel'),

--- a/packages/lumx-vue/src/components/mosaic/Mosaic.tsx
+++ b/packages/lumx-vue/src/components/mosaic/Mosaic.tsx
@@ -4,12 +4,13 @@ import {
     Mosaic as MosaicUI,
     type MosaicProps as UIProps,
     MosaicPropsToOverride,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/Mosaic';
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useHasEventListener } from '../../composables/useHasEventListener';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import Thumbnail, { type ThumbnailProps } from '../thumbnail/Thumbnail';
 
 export type MosaicThumbnailItem = Omit<ThumbnailProps, 'class'> & { onClick?: (event: Event) => void };
@@ -52,7 +53,7 @@ const Mosaic = defineComponent(
         );
     },
     {
-        name: 'LumxMosaic',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<MosaicProps>()('thumbnails', 'theme', 'class'),
         emits: emitSchema,

--- a/packages/lumx-vue/src/components/popover-dialog/PopoverDialog.tsx
+++ b/packages/lumx-vue/src/components/popover-dialog/PopoverDialog.tsx
@@ -10,7 +10,7 @@ import type { PopoverProps as CorePopoverProps } from '@lumx/core/js/components/
 import { classNames } from '@lumx/core/js/utils';
 import { useClassName } from '@lumx/vue/composables/useClassName';
 
-import { keysOf } from '../../utils/VueToJSX';
+import { getName, keysOf } from '../../utils/VueToJSX';
 import Popover, { type PopoverProps } from '../popover/Popover';
 import HeadingLevelProvider from '../heading/HeadingLevelProvider';
 
@@ -54,7 +54,7 @@ const PopoverDialog = defineComponent(
         };
     },
     {
-        name: `Lumx${COMPONENT_NAME}`,
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<PopoverDialogProps>()(
             'anchorRef',

--- a/packages/lumx-vue/src/components/popover/Popover.tsx
+++ b/packages/lumx-vue/src/components/popover/Popover.tsx
@@ -3,6 +3,7 @@ import { computed, defineComponent, type Ref, unref, toRef } from 'vue';
 import {
     Popover as PopoverUI,
     type PopoverProps as CorePopoverProps,
+    COMPONENT_NAME,
     DEFAULT_PROPS,
 } from '@lumx/core/js/components/Popover';
 import { type Placement, POPOVER_ZINDEX } from '@lumx/core/js/components/Popover/constants';
@@ -14,7 +15,7 @@ import { useCallbackOnEscape } from '../../composables/useCallbackOnEscape';
 import { useClassName } from '../../composables/useClassName';
 import { Portal } from '../../utils/Portal/Portal';
 import { ClickAwayProvider } from '../../utils/ClickAway/ClickAwayProvider';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 import { usePopoverStyle } from './usePopoverStyle';
 import { useFocusTrap } from '../../composables/useFocusTrap';
@@ -135,7 +136,7 @@ const Popover = defineComponent(
             );
     },
     {
-        name: 'LumxPopover',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<PopoverProps>()(
             'anchorRef',

--- a/packages/lumx-vue/src/components/progress/ProgressCircular.tsx
+++ b/packages/lumx-vue/src/components/progress/ProgressCircular.tsx
@@ -10,7 +10,7 @@ import {
 } from '@lumx/core/js/components/ProgressCircular';
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, type VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, type VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ProgressCircularProps = VueToJSXProps<UIProps, 'ref' | 'svgProps' | 'circleProps'>;
 
@@ -42,7 +42,7 @@ const ProgressCircular = defineComponent(
         };
     },
     {
-        name: 'LumxProgressCircular',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ProgressCircularProps>()('class', 'size', 'display', 'theme'),
     },

--- a/packages/lumx-vue/src/components/progress/ProgressLinear.tsx
+++ b/packages/lumx-vue/src/components/progress/ProgressLinear.tsx
@@ -8,7 +8,7 @@ import {
 } from '@lumx/core/js/components/ProgressLinear';
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, type VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, type VueToJSXProps } from '../../utils/VueToJSX';
 
 export type ProgressLinearProps = VueToJSXProps<UIProps, 'ref'>;
 
@@ -32,7 +32,7 @@ const ProgressLinear = defineComponent(
         };
     },
     {
-        name: 'LumxProgressLinear',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ProgressLinearProps>()('class', 'theme'),
     },

--- a/packages/lumx-vue/src/components/radio-button/RadioButton.tsx
+++ b/packages/lumx-vue/src/components/radio-button/RadioButton.tsx
@@ -11,7 +11,7 @@ import {
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useId } from '../../composables/useId';
 
 export type RadioButtonProps = VueToJSXProps<UIProps, 'inputId' | 'inputRef'>;
@@ -68,7 +68,7 @@ const RadioButton = defineComponent(
         };
     },
     {
-        name: 'RadioButton',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<RadioButtonProps>()(

--- a/packages/lumx-vue/src/components/radio-button/RadioGroup.tsx
+++ b/packages/lumx-vue/src/components/radio-button/RadioGroup.tsx
@@ -4,7 +4,7 @@ import { RadioGroup as RadioGroupUI, CLASSNAME, COMPONENT_NAME } from '@lumx/cor
 import type { JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, type ClassValue } from '../../utils/VueToJSX';
+import { getName, keysOf, type ClassValue } from '../../utils/VueToJSX';
 
 export interface RadioGroupProps {
     /** CSS class name */
@@ -34,7 +34,7 @@ const RadioGroup = defineComponent(
         );
     },
     {
-        name: 'RadioGroup',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<RadioGroupProps>()('class'),
     },

--- a/packages/lumx-vue/src/components/select-button/SelectButton.tsx
+++ b/packages/lumx-vue/src/components/select-button/SelectButton.tsx
@@ -15,6 +15,7 @@ import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
 import {
     DEFAULT_PROPS,
     CLASSNAME,
+    COMPONENT_NAME,
     SelectButton as UI,
     type SelectButtonProps as UIProps,
 } from '@lumx/core/js/components/SelectButton';
@@ -23,7 +24,7 @@ import { CLASSNAME as COMBOBOX_POPOVER_CLASSNAME } from '@lumx/core/js/component
 import { InfiniteScroll } from '@lumx/vue/utils/InfiniteScroll';
 import { JSXElement } from '@lumx/core/js/types';
 
-import { keysOf, type EmitsOf } from '../../utils/VueToJSX';
+import { getName, keysOf, type EmitsOf } from '../../utils/VueToJSX';
 import { Combobox } from '../combobox';
 import { Button } from '../button';
 import { useWrappedRenderOptionSlot } from '../combobox/useWrappedRenderOptionSlot';
@@ -284,7 +285,7 @@ const SelectButton = defineComponent(
         };
     },
     {
-        name: 'LumxSelectButton',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         slots: Object as SlotsType<{
             /**

--- a/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
+++ b/packages/lumx-vue/src/components/select-text-field/SelectTextField.tsx
@@ -12,11 +12,11 @@ import {
 import { type BaseSelectTextFieldWrapperProps } from '@lumx/core/js/utils/select/types';
 import { getOptionDisplayName } from '@lumx/core/js/utils/select/getOptionDisplayName';
 import { toggleSelection } from '@lumx/core/js/utils/select/toggleSelection';
-import { SelectTextField as UI } from '@lumx/core/js/components/SelectTextField';
+import { SelectTextField as UI, COMPONENT_NAME } from '@lumx/core/js/components/SelectTextField';
 import { CLASSNAME as COMBOBOX_POPOVER_CLASSNAME } from '@lumx/core/js/components/Combobox/ComboboxPopover';
 import type { JSXElement } from '@lumx/core/js/types';
 
-import { keysOf, type ClassValue, type EmitsOf } from '../../utils/VueToJSX';
+import { getName, keysOf, type ClassValue, type EmitsOf } from '../../utils/VueToJSX';
 import { Combobox } from '../combobox';
 import { useWrappedRenderOptionSlot } from '../combobox/useWrappedRenderOptionSlot';
 import { useWrappedRenderSectionTitleSlot } from '../combobox/useWrappedRenderSectionTitleSlot';
@@ -347,7 +347,7 @@ const SelectTextField = defineComponent(
         };
     },
     {
-        name: 'LumxSelectTextField',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<SelectTextFieldProps<unknown>>()(
             'options',

--- a/packages/lumx-vue/src/components/skeleton/SkeletonCircle.tsx
+++ b/packages/lumx-vue/src/components/skeleton/SkeletonCircle.tsx
@@ -10,7 +10,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type SkeletonCircleProps = VueToJSXProps<UIProps>;
 
@@ -40,7 +40,7 @@ const SkeletonCircle = defineComponent(
         };
     },
     {
-        name: 'LumxSkeletonCircle',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<SkeletonCircleProps>()('class', 'size', 'color', 'theme'),
     },

--- a/packages/lumx-vue/src/components/skeleton/SkeletonRectangle.tsx
+++ b/packages/lumx-vue/src/components/skeleton/SkeletonRectangle.tsx
@@ -11,7 +11,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type SkeletonRectangleProps = VueToJSXProps<UIProps>;
 
@@ -41,7 +41,7 @@ const SkeletonRectangle = defineComponent(
         };
     },
     {
-        name: 'SkeletonRectangle',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<SkeletonRectangleProps>()('class', 'aspectRatio', 'height', 'variant', 'width', 'color', 'theme'),
     },

--- a/packages/lumx-vue/src/components/skeleton/SkeletonTypography.tsx
+++ b/packages/lumx-vue/src/components/skeleton/SkeletonTypography.tsx
@@ -10,7 +10,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type SkeletonTypographyProps = VueToJSXProps<UIProps>;
 
@@ -40,7 +40,7 @@ const SkeletonTypography = defineComponent(
         };
     },
     {
-        name: 'LumxSkeletonTypography',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<SkeletonTypographyProps>()('class', 'typography', 'width', 'color', 'theme', 'style'),
     },

--- a/packages/lumx-vue/src/components/switch/Switch.tsx
+++ b/packages/lumx-vue/src/components/switch/Switch.tsx
@@ -11,7 +11,7 @@ import {
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useId } from '../../composables/useId';
 import { JSXElement } from '@lumx/core/js/types';
 
@@ -70,7 +70,7 @@ const Switch = defineComponent(
         };
     },
     {
-        name: 'LumxSwitch',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<SwitchProps>()(

--- a/packages/lumx-vue/src/components/table/Table.tsx
+++ b/packages/lumx-vue/src/components/table/Table.tsx
@@ -1,8 +1,9 @@
 import { defineComponent, useAttrs } from 'vue';
 import { Table as UI, type TableProps as UIProps } from '@lumx/core/js/components/Table';
+import { COMPONENT_NAME } from '@lumx/core/js/components/Table/constants';
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { JSXElement } from '@lumx/core/js/types';
 
 export type TableProps = VueToJSXProps<UIProps>;
@@ -26,7 +27,7 @@ const Table = defineComponent(
         };
     },
     {
-        name: 'LumxTable',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TableProps>()('class', 'hasBefore', 'hasDividers', 'theme'),
     },

--- a/packages/lumx-vue/src/components/table/TableBody.tsx
+++ b/packages/lumx-vue/src/components/table/TableBody.tsx
@@ -1,7 +1,11 @@
 import { defineComponent, useAttrs } from 'vue';
-import { TableBody as UI, type TableBodyProps as UIProps } from '@lumx/core/js/components/Table/TableBody';
+import {
+    TableBody as UI,
+    type TableBodyProps as UIProps,
+    COMPONENT_NAME,
+} from '@lumx/core/js/components/Table/TableBody';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { JSXElement } from '@lumx/core/js/types';
 
 export type TableBodyProps = VueToJSXProps<UIProps>;
@@ -16,7 +20,7 @@ const TableBody = defineComponent(
         };
     },
     {
-        name: 'LumxTableBody',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TableBodyProps>()('class'),
     },

--- a/packages/lumx-vue/src/components/table/TableCell.tsx
+++ b/packages/lumx-vue/src/components/table/TableCell.tsx
@@ -4,9 +4,10 @@ import {
     type TableCellProps as UIProps,
     ThOrder,
     TableCellVariant,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/Table/TableCell';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { JSXElement } from '@lumx/core/js/types';
 import { useHasEventListener } from '@lumx/vue/composables/useHasEventListener';
 
@@ -46,7 +47,7 @@ const TableCell = defineComponent(
         };
     },
     {
-        name: 'LumxTableCell',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TableCellProps>()('class', 'icon', 'isSortable', 'sortOrder', 'variant'),
         emits: emitSchema,

--- a/packages/lumx-vue/src/components/table/TableHeader.tsx
+++ b/packages/lumx-vue/src/components/table/TableHeader.tsx
@@ -1,7 +1,11 @@
 import { defineComponent, useAttrs } from 'vue';
-import { TableHeader as UI, type TableHeaderProps as UIProps } from '@lumx/core/js/components/Table/TableHeader';
+import {
+    TableHeader as UI,
+    type TableHeaderProps as UIProps,
+    COMPONENT_NAME,
+} from '@lumx/core/js/components/Table/TableHeader';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { JSXElement } from '@lumx/core/js/types';
 
 export type TableHeaderProps = VueToJSXProps<UIProps>;
@@ -16,7 +20,7 @@ const TableHeader = defineComponent(
         };
     },
     {
-        name: 'LumxTableHeader',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TableHeaderProps>()('class'),
     },

--- a/packages/lumx-vue/src/components/table/TableRow.tsx
+++ b/packages/lumx-vue/src/components/table/TableRow.tsx
@@ -1,8 +1,8 @@
 import { computed, defineComponent, useAttrs } from 'vue';
-import { TableRow as UI, type TableRowProps as UIProps } from '@lumx/core/js/components/Table/TableRow';
+import { TableRow as UI, type TableRowProps as UIProps, COMPONENT_NAME } from '@lumx/core/js/components/Table/TableRow';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { JSXElement } from '@lumx/core/js/types';
 
 export type TableRowProps = VueToJSXProps<UIProps, 'tabIndex' | 'aria-disabled'> & {
@@ -30,7 +30,7 @@ const TableRow = defineComponent(
         };
     },
     {
-        name: 'LumxTableRow',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TableRowProps>()('class', 'isClickable', 'isDisabled', 'isSelected'),
     },

--- a/packages/lumx-vue/src/components/tabs/Tab.tsx
+++ b/packages/lumx-vue/src/components/tabs/Tab.tsx
@@ -12,7 +12,7 @@ import { classNames } from '@lumx/core/js/utils';
 
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useClassName } from '../../composables/useClassName';
-import { type HyphenatedAriaProps, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, type HyphenatedAriaProps, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { Icon } from '../icon';
 import { Text } from '../text';
 import { useTabProviderContext } from './state';
@@ -91,7 +91,7 @@ const Tab = defineComponent(
         };
     },
     {
-        name: 'LumxTab',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TabProps>()('icon', 'iconProps', 'id', 'isActive', 'isDisabled', 'label', 'class'),
         emits: emitSchema,

--- a/packages/lumx-vue/src/components/tabs/TabList.tsx
+++ b/packages/lumx-vue/src/components/tabs/TabList.tsx
@@ -14,7 +14,7 @@ import { type JSXElement } from '@lumx/core/js/types';
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useRovingTabIndexContainer } from '../../composables/useRovingTabIndexContainer';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { TAB_PROVIDER_INJECT_KEY } from './state';
 
 // aria-label is excluded from declared Vue props — Vue treats aria-* as attrs,
@@ -70,7 +70,7 @@ const TabList = defineComponent(
         };
     },
     {
-        name: 'LumxTabList',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<InternalProps>()('layout', 'position', 'theme', 'class'),
     },

--- a/packages/lumx-vue/src/components/tabs/TabPanel.tsx
+++ b/packages/lumx-vue/src/components/tabs/TabPanel.tsx
@@ -11,7 +11,7 @@ import {
 import { type JSXElement } from '@lumx/core/js/types';
 
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useTabProviderContext } from './state';
 
 export type TabPanelProps = VueToJSXProps<UIProps, TabPanelPropsToOverride>;
@@ -48,7 +48,7 @@ const TabPanel = defineComponent(
         );
     },
     {
-        name: 'LumxTabPanel',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TabPanelProps>()('isActive', 'id', 'class'),
     },

--- a/packages/lumx-vue/src/components/tabs/TabProvider.tsx
+++ b/packages/lumx-vue/src/components/tabs/TabProvider.tsx
@@ -1,7 +1,9 @@
 import { defineComponent, provide, ref, watch } from 'vue';
 
+import { TAB_PROVIDER_COMPONENT_NAME } from '@lumx/core/js/components/Tabs/constants';
 import { INIT_STATE, reducer, type Action, type State } from '@lumx/core/js/components/Tabs/state';
 
+import { getName } from '../../utils/VueToJSX';
 import { TAB_PROVIDER_INJECT_KEY } from './state';
 
 export interface TabProviderProps {
@@ -71,7 +73,7 @@ const TabProvider = defineComponent(
         return () => slots.default?.();
     },
     {
-        name: 'LumxTabProvider',
+        name: getName(TAB_PROVIDER_COMPONENT_NAME),
         props: {
             activeTabIndex: { required: false },
             isLazy: { required: false },

--- a/packages/lumx-vue/src/components/text-field/RawInputText.tsx
+++ b/packages/lumx-vue/src/components/text-field/RawInputText.tsx
@@ -7,7 +7,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 export type RawInputTextProps = VueToJSXProps<UIProps>;
 
@@ -70,7 +70,7 @@ const RawInputText = defineComponent(
         };
     },
     {
-        name: 'LumxRawInputText',
+        name: getName('RawInputText'),
         inheritAttrs: false,
         props: keysOf<RawInputTextProps>()('class', 'theme', 'value', 'type', 'name'),
         emits: emitSchema,

--- a/packages/lumx-vue/src/components/text-field/RawInputTextarea.tsx
+++ b/packages/lumx-vue/src/components/text-field/RawInputTextarea.tsx
@@ -8,7 +8,7 @@ import {
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useFitRowsToContent } from './useFitRowsToContent';
 
 export type RawInputTextareaProps = VueToJSXProps<UIProps>;
@@ -80,7 +80,7 @@ const RawInputTextarea = defineComponent(
         };
     },
     {
-        name: 'LumxRawInputTextarea',
+        name: getName('RawInputTextarea'),
         inheritAttrs: false,
         props: keysOf<RawInputTextareaProps>()('class', 'theme', 'value', 'rows', 'name'),
         emits: emitSchema,

--- a/packages/lumx-vue/src/components/text-field/TextField.tsx
+++ b/packages/lumx-vue/src/components/text-field/TextField.tsx
@@ -14,7 +14,7 @@ import { useClassName } from '../../composables/useClassName';
 import { useId } from '../../composables/useId';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useSlot } from '../../composables/useSlot';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { IconButton } from '../button';
 import RawInputText from './RawInputText';
 import RawInputTextarea from './RawInputTextarea';
@@ -202,7 +202,7 @@ const TextField = defineComponent(
         };
     },
     {
-        name: 'LumxTextField',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TextFieldProps>()(
             'class',

--- a/packages/lumx-vue/src/components/text/Text.tsx
+++ b/packages/lumx-vue/src/components/text/Text.tsx
@@ -1,11 +1,11 @@
 import { computed, defineComponent, useAttrs, useTemplateRef, type VNodeArrayChildren } from 'vue';
 
-import { getTextProps, type TextProps as UIProps } from '@lumx/core/js/components/Text';
+import { getTextProps, type TextProps as UIProps, COMPONENT_NAME } from '@lumx/core/js/components/Text';
 import { useClassName } from '@lumx/vue/composables/useClassName';
 
 import { useOverflowTooltipLabel } from '../../composables/useOverflowTooltipLabel';
 import { useSlot } from '../../composables/useSlot';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { wrapChildrenIconWithSpaces } from '../../utils/wrapChildrenIconWithSpaces';
 
 export type TextProps = VueToJSXProps<UIProps>;
@@ -57,7 +57,7 @@ const Text = defineComponent(
         };
     },
     {
-        name: 'LumxText',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         // Redefine properties so that they come in as `props` on the `defineComponent` function
         props: keysOf<TextProps>()(

--- a/packages/lumx-vue/src/components/thumbnail/Thumbnail.tsx
+++ b/packages/lumx-vue/src/components/thumbnail/Thumbnail.tsx
@@ -16,7 +16,7 @@ import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useHasEventListener } from '../../composables/useHasEventListener';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { useImageLoad } from './useImageLoad';
 import { useFocusPointStyle } from './useFocusPointStyle';
 
@@ -136,7 +136,7 @@ const Thumbnail = defineComponent(
         };
     },
     {
-        name: 'LumxThumbnail',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ThumbnailProps>()(
             'align',

--- a/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
+++ b/packages/lumx-vue/src/components/time-picker-field/TimePickerField.tsx
@@ -6,6 +6,7 @@ import {
     type TimePickerFieldWrapperProps,
     type TimePickerFieldOwnedSelectProps,
     DEFAULT_PROPS,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/TimePickerField';
 import {
     buildTimeList,
@@ -17,7 +18,7 @@ import {
 } from '@lumx/core/js/utils/time';
 import { getCurrentLocale } from '@lumx/core/js/utils/locale/getCurrentLocale';
 
-import { keysOf, type ClassValue } from '../../utils/VueToJSX';
+import { getName, keysOf, type ClassValue } from '../../utils/VueToJSX';
 import { useClassName } from '../../composables/useClassName';
 import { SelectTextField, SelectTextFieldOption } from '../select-text-field';
 
@@ -165,7 +166,7 @@ const TimePickerField = defineComponent(
         };
     },
     {
-        name: 'LumxTimePickerField',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TimePickerFieldProps>()(
             'value',

--- a/packages/lumx-vue/src/components/toolbar/Toolbar.tsx
+++ b/packages/lumx-vue/src/components/toolbar/Toolbar.tsx
@@ -3,16 +3,16 @@ import {
     Toolbar as ToolbarUI,
     type ToolbarProps as UIProps,
     CLASSNAME,
-    TOOLBAR_NAME,
+    COMPONENT_NAME,
     DEFAULT_PROPS,
 } from '@lumx/core/js/components/Toolbar';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import type { JSXElement } from '@lumx/core/js/types';
 
 export type ToolbarProps = VueToJSXProps<UIProps, 'label' | 'after' | 'before'>;
 
-export { CLASSNAME, TOOLBAR_NAME, DEFAULT_PROPS };
+export { CLASSNAME, COMPONENT_NAME as TOOLBAR_NAME, DEFAULT_PROPS };
 
 const Toolbar = defineComponent(
     (props: ToolbarProps, { slots }) => {
@@ -35,7 +35,7 @@ const Toolbar = defineComponent(
         };
     },
     {
-        name: 'LumxToolbar',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<ToolbarProps>()('class'),
     },

--- a/packages/lumx-vue/src/components/toolbar/index.ts
+++ b/packages/lumx-vue/src/components/toolbar/index.ts
@@ -1,3 +1,2 @@
 export { default as Toolbar } from './Toolbar';
 export type { ToolbarProps } from './Toolbar';
-export { TOOLBAR_NAME } from './Toolbar';

--- a/packages/lumx-vue/src/components/tooltip/Tooltip.tsx
+++ b/packages/lumx-vue/src/components/tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import {
     type TooltipPlacement,
     DEFAULT_PROPS,
     ARROW_SIZE,
+    COMPONENT_NAME,
 } from '@lumx/core/js/components/Tooltip';
 
 import { useId } from '../../composables/useId';
@@ -15,7 +16,7 @@ import { useCallbackOnEscape } from '../../composables/useCallbackOnEscape';
 import { useTooltipOpen } from './useTooltipOpen';
 import { useInjectTooltipRef } from './useInjectTooltipRef';
 import { provideTooltipContext } from './context';
-import { keysOf, type ClassValue } from '../../utils/VueToJSX';
+import { getName, keysOf, type ClassValue } from '../../utils/VueToJSX';
 import { Portal } from '../../utils/Portal';
 
 export type { TooltipPlacement };
@@ -116,7 +117,7 @@ export const Tooltip = defineComponent(
         };
     },
     {
-        name: 'LumxTooltip',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<TooltipProps>()(
             'label',

--- a/packages/lumx-vue/src/components/uploader/Uploader.tsx
+++ b/packages/lumx-vue/src/components/uploader/Uploader.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
 import { useDisableStateProps } from '../../composables/useDisableStateProps';
 import { useId } from '../../composables/useId';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 
 type VueFileInputProps = {
     /** Accepted file types. */
@@ -117,7 +117,7 @@ const Uploader = defineComponent(
         };
     },
     {
-        name: 'LumxUploader',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<UploaderProps>()(
             'class',

--- a/packages/lumx-vue/src/components/user-block/UserBlock.tsx
+++ b/packages/lumx-vue/src/components/user-block/UserBlock.tsx
@@ -19,7 +19,7 @@ import type { JSXElement } from '@lumx/core/js/types';
 
 import { useTheme } from '../../composables/useTheme';
 import { useClassName } from '../../composables/useClassName';
-import { keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
 import { classNames } from '@lumx/core/js/utils';
 
 import { Avatar, type AvatarProps } from '../avatar';
@@ -179,7 +179,7 @@ const UserBlock = defineComponent(
         };
     },
     {
-        name: 'LumxUserBlock',
+        name: getName(COMPONENT_NAME),
         inheritAttrs: false,
         props: keysOf<UserBlockProps>()(
             'avatarProps',

--- a/packages/lumx-vue/src/utils/VueToJSX.ts
+++ b/packages/lumx-vue/src/utils/VueToJSX.ts
@@ -29,6 +29,14 @@ export type VueToJSXProps<Props, OmitProps extends keyof Props = never> = Omit<
  */
 export type HyphenatedAriaProps = 'aria-current' | 'aria-expanded' | 'aria-haspopup' | 'aria-label' | 'aria-pressed';
 
+/**
+ * Build a Vue component `name` from its component name, prefixed with `Lumx`.
+ *
+ * The prefix avoids collisions with native HTML/SVG tags (e.g. `button`, `dialog`, `link`, `table`,
+ * `text`) and namespaces LumX components in Vue devtools / `<KeepAlive>`.
+ */
+export const getName = (componentName: string) => `Lumx${componentName}` as const;
+
 export const keysOf = <T>() => {
     return <K extends readonly (keyof T)[]>(
         ...keys: [keyof T] extends [K[number]]


### PR DESCRIPTION

# General summary

Standardizing the vue component names

Add a `getName(componentName)` helper (`Lumx${componentName}`) in `utils/VueToJSX` and use `name: getName(COMPONENT_NAME)` across all Vue components.

The `Lumx` prefix avoids collisions with native HTML/SVG tags (button, dialog, link, table, text, switch) and namespaces components in Vue devtools.

Also normalizes the previously-unprefixed names (Checkbox, Icon, Heading, Flag, Message, etc.) and documents the convention in the package CLAUDE.md.

StoryBook lumx-vue: https://2fa0113b2--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://2fa0113b2--5fbfb1d508c0520021560f10.chromatic.com/