### PR TITLE
feat(card): add Card component to core, react and vue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `@lumx/react`:
     -   `Slider`: support dragging the handle on touch devices.
 
+### Added
+
+-   `@lumx/core`, `@lumx/react`, `@lumx/vue`:
+    -   Add `Card` component: a simple elevated container (`elevation` prop, 1–5, defaults to none).
+
 ## [4.20.0][] - 2026-07-24
 
 ### Added

--- a/dev-packages/docgen/vue/docgen.js
+++ b/dev-packages/docgen/vue/docgen.js
@@ -5,6 +5,46 @@ const { extractDiscriminatedUnionProps, extractConditionalSelectionVariants, ext
 const { getJsDocFromDeclaration, getJsDocDeprecatedFromDeclaration } = require('../internal/jsdoc.js');
 
 /**
+ * Resolve an expression used as the `name` option into a plain string.
+ *
+ * Handles the three shapes found in the codebase:
+ *   1. a string literal (`name: 'Button'`)
+ *   2. a `getName(COMPONENT_NAME)` call — the documented name is the wrapped
+ *      component name, without the `Lumx` prefix `getName` adds at runtime
+ *   3. an identifier pointing at a string constant, declared locally or imported
+ *      (e.g. `COMPONENT_NAME` re-exported from `@lumx/core`)
+ *
+ * @param {Node} node - The expression assigned to the `name` option
+ * @returns {string|null} - The resolved name, or null if it can't be resolved statically
+ */
+function resolveNameExpression(node) {
+    if (!node) return null;
+
+    const kind = node.getKindName();
+
+    if (kind === 'StringLiteral' || kind === 'NoSubstitutionTemplateLiteral') {
+        return node.getLiteralValue();
+    }
+
+    // `getName(COMPONENT_NAME)` — resolve the wrapped argument.
+    if (kind === 'CallExpression') {
+        const args = node.getArguments();
+        return args.length === 1 ? resolveNameExpression(args[0]) : null;
+    }
+
+    // Identifier — follow it to its declaration (across imports) and read the literal.
+    if (kind === 'Identifier') {
+        for (const definition of node.getDefinitionNodes()) {
+            if (definition.getKindName() !== 'VariableDeclaration') continue;
+            const resolved = resolveNameExpression(definition.getInitializer());
+            if (resolved) return resolved;
+        }
+    }
+
+    return null;
+}
+
+/**
  * Get the Vue component name from defineComponent options.
  * Looks for the `name` property in the second argument of defineComponent().
  *
@@ -29,9 +69,9 @@ function getVueComponentName(sourceFile) {
 
         for (const prop of optionsArg.getProperties()) {
             if (prop.getKindName() === 'PropertyAssignment' && prop.getName() === 'name') {
-                const value = prop.getInitializer()?.getText();
+                const value = resolveNameExpression(prop.getInitializer());
                 if (value) {
-                    return value.replace(/^['"]|['"]$/g, '');
+                    return value;
                 }
             }
         }

--- a/packages/lumx-core/src/js/components/Card/Stories.tsx
+++ b/packages/lumx-core/src/js/components/Card/Stories.tsx
@@ -1,0 +1,36 @@
+import type { SetupStoriesOptions } from '@lumx/core/stories/types';
+import { getSelectArgType } from '@lumx/core/stories/controls/selectArgType';
+
+import { DEFAULT_PROPS } from '.';
+import { Elevation } from '../../types';
+
+/**
+ * Setup Card stories for a specific framework (React or Vue).
+ * This function creates all the stories with the appropriate decorators.
+ * Framework-specific render functions or args can be injected via `overrides`.
+ */
+export function setup({
+    component: Card,
+}: SetupStoriesOptions<{
+    decorators?: never;
+}>) {
+    return {
+        meta: {
+            component: Card,
+            render: (args: any) => <Card {...args}>Card content</Card>,
+            args: DEFAULT_PROPS,
+            argTypes: {
+                elevation: getSelectArgType<Elevation>([1, 2, 3, 4, 5]),
+            },
+        },
+
+        /** Default card */
+        Default: {},
+
+        /** Elevated card */
+        Elevation: { args: { elevation: 3 } },
+
+        /** Card rendered as a custom element */
+        AsElement: { args: { as: 'article' } },
+    };
+}

--- a/packages/lumx-core/src/js/components/Card/Tests.ts
+++ b/packages/lumx-core/src/js/components/Card/Tests.ts
@@ -1,0 +1,64 @@
+import { SetupOptions } from '../../../testing';
+import { getByClassName } from '../../../testing/queries';
+import { CardProps, CLASSNAME } from '.';
+
+type SetupProps = Partial<CardProps>;
+
+/**
+ * Mounts the component and returns common DOM elements / data needed in multiple tests further down.
+ */
+export const setup = (propsOverride: SetupProps = {}, { render, ...options }: SetupOptions<CardProps>) => {
+    const props: CardProps = {
+        ...propsOverride,
+    };
+
+    render(props, options);
+
+    const card = getByClassName(document.body, CLASSNAME);
+
+    return { card, props };
+};
+
+export default (renderOptions: SetupOptions<CardProps>) => {
+    describe('Props', () => {
+        it('should render correctly', () => {
+            const { card } = setup({}, renderOptions);
+            expect(card).toBeInTheDocument();
+            expect(card).toHaveClass(CLASSNAME);
+        });
+
+        it('should render children', () => {
+            setup({ children: 'Card content' }, renderOptions);
+            expect(renderOptions.screen.getByText('Card content')).toBeInTheDocument();
+        });
+
+        it('should render with custom className', () => {
+            const { card } = setup({ className: 'custom-class' }, renderOptions);
+            expect(card).toHaveClass(CLASSNAME);
+            expect(card).toHaveClass('custom-class');
+        });
+
+        it('should not apply an elevation modifier by default', () => {
+            const { card } = setup({}, renderOptions);
+            expect(card.className).not.toMatch(`${CLASSNAME}--elevation-`);
+        });
+
+        it('should render as a div by default', () => {
+            const { card } = setup({}, renderOptions);
+            expect(card.tagName).toBe('DIV');
+        });
+
+        it('should render as the given element', () => {
+            const { card } = setup({ as: 'article' }, renderOptions);
+            expect(card.tagName).toBe('ARTICLE');
+            expect(card).toHaveClass(CLASSNAME);
+        });
+
+        ([1, 2, 3, 4, 5] as const).forEach((elevation) => {
+            it(`should apply elevation ${elevation} modifier`, () => {
+                const { card } = setup({ elevation }, renderOptions);
+                expect(card).toHaveClass(`${CLASSNAME}--elevation-${elevation}`);
+            });
+        });
+    });
+};

--- a/packages/lumx-core/src/js/components/Card/index.tsx
+++ b/packages/lumx-core/src/js/components/Card/index.tsx
@@ -1,0 +1,57 @@
+import type { LumxClassName, HasClassName, CommonRef, JSXElement, Elevation } from '../../types';
+import { classNames } from '../../utils';
+
+/**
+ * Defines the props of the component.
+ */
+export interface CardProps extends HasClassName {
+    /** Customize the rendered root element (e.g. `div`, `article`, `section`, `li`, `aside`), defaults to `div`. */
+    as?: any;
+    /** Content of the card. */
+    children?: JSXElement;
+    /** Elevation depth of the card, defaults to no elevation. */
+    elevation?: Elevation;
+    /** reference to the root element */
+    ref?: CommonRef;
+}
+
+/**
+ * Component display name.
+ */
+export const COMPONENT_NAME = 'Card';
+
+/**
+ * Component default class name and class prefix.
+ */
+export const CLASSNAME: LumxClassName<typeof COMPONENT_NAME> = 'lumx-card';
+const { block } = classNames.bem(CLASSNAME);
+
+/**
+ * Component default props.
+ */
+export const DEFAULT_PROPS = {
+    as: 'div',
+} as const;
+
+/** Root element rendered when no `as` prop is provided. */
+export type DefaultCardTag = typeof DEFAULT_PROPS.as;
+
+/**
+ * Card component.
+ *
+ * @param  props Component props.
+ * @return JSX element.
+ */
+export const Card = (props: CardProps) => {
+    const { className, children, elevation, ref, as: Element = DEFAULT_PROPS.as, ...forwardedProps } = props;
+
+    return (
+        <Element
+            ref={ref}
+            {...forwardedProps}
+            className={classNames.join(className, block({ [`elevation-${elevation}`]: Boolean(elevation) }))}
+        >
+            {children}
+        </Element>
+    );
+};

--- a/packages/lumx-core/src/js/components/Popover/types.ts
+++ b/packages/lumx-core/src/js/components/Popover/types.ts
@@ -11,10 +11,7 @@ export interface Offset {
     away?: number;
 }
 
-/**
- * Popover elevation index.
- */
-export type Elevation = 1 | 2 | 3 | 4 | 5;
+export type { Elevation } from '../../types';
 
 /** Popover size value — pixel value, or "t-shirt" size token. */
 export type PopoverSize = PXSize | (typeof POPOVER_SIZES)[number];

--- a/packages/lumx-core/src/js/types/Elevation.ts
+++ b/packages/lumx-core/src/js/types/Elevation.ts
@@ -1,0 +1,4 @@
+/**
+ * Elevation index, used to derive a box-shadow depth.
+ */
+export type Elevation = 1 | 2 | 3 | 4 | 5;

--- a/packages/lumx-core/src/js/types/index.ts
+++ b/packages/lumx-core/src/js/types/index.ts
@@ -14,6 +14,7 @@ export type { TextElement } from './TextElement';
 export type { ValueOf } from './ValueOf';
 export type { LumxClassName } from './LumxClassName';
 export type { Direction } from './Direction';
+export type { Elevation } from './Elevation';
 export type { Spacing } from './Spacing';
 export type { NestedComponents, ComponentLike } from './NestedComponents';
 export type { ObjectValues } from './ObjectValues';

--- a/packages/lumx-core/src/scss/_components_classes.scss
+++ b/packages/lumx-core/src/scss/_components_classes.scss
@@ -1,6 +1,7 @@
 @import "./components/avatar/index";
 @import "./components/badge/index";
 @import "./components/button/index";
+@import "./components/card/index";
 @import "./components/checkbox/index";
 @import "./components/chip/index";
 @import "./components/combobox/index";

--- a/packages/lumx-core/src/scss/components/card/_index.scss
+++ b/packages/lumx-core/src/scss/components/card/_index.scss
@@ -1,0 +1,15 @@
+/* ==========================================================================
+   Card
+   ========================================================================== */
+
+.#{$lumx-base-prefix}-card {
+    background-color: $lumx-color-light-N;
+    border-radius: var(--lumx-border-radius);
+    padding: $lumx-spacing-unit-huge;
+
+    @each $depth, $shadow in $lumx-elevation-shadows {
+        &--elevation-#{$depth} {
+            @include lumx-elevation($depth);
+        }
+    }
+}

--- a/packages/lumx-react/src/components/card/Card.stories.tsx
+++ b/packages/lumx-react/src/components/card/Card.stories.tsx
@@ -1,0 +1,15 @@
+import { setup } from '@lumx/core/js/components/Card/Stories';
+
+import { Card } from '@lumx/react';
+
+const { meta, ...stories } = setup({
+    component: Card,
+});
+export default {
+    title: 'LumX components/card/Card',
+    ...meta,
+};
+
+export const Default = { ...stories.Default };
+export const Elevation = { ...stories.Elevation };
+export const AsElement = { ...stories.AsElement };

--- a/packages/lumx-react/src/components/card/Card.test.tsx
+++ b/packages/lumx-react/src/components/card/Card.test.tsx
@@ -1,0 +1,60 @@
+import { commonTestsSuiteRTL, SetupRenderOptions } from '@lumx/react/testing/utils';
+import BaseCardTests, { setup } from '@lumx/core/js/components/Card/Tests';
+import { CardProps } from '@lumx/core/js/components/Card';
+
+import { render, screen } from '@testing-library/react';
+import { expectTypeOf } from 'vitest';
+import { Card, CardProps as ReactCardProps } from './Card';
+
+const CLASSNAME = Card.className as string;
+
+describe(`<${Card.displayName}>`, () => {
+    // Adapter for core tests
+    const renderCard = (props: CardProps, options?: SetupRenderOptions) => {
+        return render(<Card {...props} />, options);
+    };
+
+    // Run core tests
+    BaseCardTests({ render: renderCard, screen });
+
+    const setupCard = (props: Partial<CardProps> = {}, options: SetupRenderOptions = {}) =>
+        setup(props, { ...options, render: renderCard, screen });
+
+    describe('React', () => {
+        it('should render empty children', () => {
+            const { card } = setupCard({ children: null });
+            expect(card).toBeInTheDocument();
+            expect(card).toBeEmptyDOMElement();
+        });
+    });
+
+    // Common tests suite.
+    commonTestsSuiteRTL(setupCard, {
+        baseClassName: CLASSNAME,
+        forwardClassName: 'card',
+        forwardAttributes: 'card',
+        forwardRef: 'card',
+    });
+});
+
+// ── Type-level tests ──────────────────────────────────────────
+describe('Type tests', () => {
+    /**
+     * Note: `CardProps` extends `GenericProps`, whose `[propName: string]: any` index signature makes
+     * *every* key present on the type. So `toHaveProperty` would pass vacuously — these assertions
+     * check the resolved property **type** instead, which the index signature does not widen.
+     */
+    it('should expose anchor prop types with as="a"', () => {
+        expectTypeOf<ReactCardProps<'a'>['href']>().toEqualTypeOf<string | undefined>();
+        expectTypeOf<ReactCardProps<'a'>['target']>().toEqualTypeOf<React.HTMLAttributeAnchorTarget | undefined>();
+    });
+
+    it('should expose button prop types with as="button"', () => {
+        expectTypeOf<ReactCardProps<'button'>['type']>().toEqualTypeOf<'button' | 'submit' | 'reset' | undefined>();
+    });
+
+    it('should not type anchor props on the default element', () => {
+        // `any` (from the GenericProps index signature), not `string` — anchor typing is not applied here
+        expectTypeOf<ReactCardProps<'div'>['href']>().toEqualTypeOf<any>();
+    });
+});

--- a/packages/lumx-react/src/components/card/Card.tsx
+++ b/packages/lumx-react/src/components/card/Card.tsx
@@ -1,0 +1,41 @@
+import { ElementType, ReactNode } from 'react';
+
+import {
+    Card as UI,
+    CardProps as UIProps,
+    type DefaultCardTag,
+    CLASSNAME,
+    COMPONENT_NAME,
+    DEFAULT_PROPS,
+} from '@lumx/core/js/components/Card';
+import { ComponentRef, GenericProps, HasPolymorphicAs } from '@lumx/react/utils/type';
+import { forwardRefPolymorphic } from '@lumx/react/utils/react/forwardRefPolymorphic';
+import { ReactToJSX } from '@lumx/react/utils/type/ReactToJSX';
+
+/**
+ * Defines the props of the component.
+ */
+export type CardProps<E extends ElementType = DefaultCardTag> = GenericProps &
+    ReactToJSX<UIProps, 'as'> &
+    HasPolymorphicAs<E> & {
+        /** Card content. */
+        children?: ReactNode;
+    };
+
+/**
+ * Card component.
+ *
+ * @param  props Component props.
+ * @param  ref   Component ref.
+ * @return React element.
+ */
+export const Card = Object.assign(
+    forwardRefPolymorphic(<E extends ElementType = DefaultCardTag>(props: CardProps<E>, ref: ComponentRef<E>) => {
+        return UI({ ...props, ref });
+    }),
+    {
+        displayName: COMPONENT_NAME,
+        className: CLASSNAME,
+        defaultProps: DEFAULT_PROPS,
+    },
+);

--- a/packages/lumx-react/src/components/card/index.ts
+++ b/packages/lumx-react/src/components/card/index.ts
@@ -1,0 +1,1 @@
+export * from './Card';

--- a/packages/lumx-react/src/index.ts
+++ b/packages/lumx-react/src/index.ts
@@ -10,6 +10,7 @@ export * from './components/autocomplete';
 export * from './components/avatar';
 export * from './components/badge';
 export * from './components/button';
+export * from './components/card';
 export * from './components/checkbox';
 export * from './components/chip';
 export * from './components/combobox';

--- a/packages/lumx-vue/src/components/card/Card.stories.ts
+++ b/packages/lumx-vue/src/components/card/Card.stories.ts
@@ -1,0 +1,15 @@
+import { setup } from '@lumx/core/js/components/Card/Stories';
+
+import { Card } from '@lumx/vue';
+
+const { meta, ...stories } = setup({
+    component: Card,
+});
+export default {
+    title: 'LumX components/card/Card',
+    ...meta,
+};
+
+export const Default = { ...stories.Default };
+export const Elevation = { ...stories.Elevation };
+export const AsElement = { ...stories.AsElement };

--- a/packages/lumx-vue/src/components/card/Card.test.ts
+++ b/packages/lumx-vue/src/components/card/Card.test.ts
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/vue';
+import { expectTypeOf } from 'vitest';
+
+import BaseCardTests from '@lumx/core/js/components/Card/Tests';
+import { CLASSNAME, CardProps } from '@lumx/core/js/components/Card';
+import { commonTestsSuiteVTL, SetupRenderOptions } from '@lumx/vue/testing';
+
+import { Card } from '.';
+import type { CardProps as VueCardProps } from './Card';
+
+describe('<Card />', () => {
+    const renderCard = ({ children, ...props }: any, options?: SetupRenderOptions<CardProps>) =>
+        render(Card, {
+            ...options,
+            props,
+            slots: children ? { default: children } : undefined,
+        });
+
+    BaseCardTests({ render: renderCard, screen });
+
+    const setupCard = (props: Partial<CardProps> = {}, options: SetupRenderOptions<CardProps> = {}) => {
+        const result = renderCard(props, options);
+
+        const card = result.container.querySelector(`.${CLASSNAME}`) as HTMLElement;
+
+        return { card, props };
+    };
+
+    // Common tests suite.
+    commonTestsSuiteVTL(setupCard, {
+        baseClassName: CLASSNAME,
+        forwardClassName: 'card',
+        forwardAttributes: 'card',
+    });
+});
+
+// ── Type-level tests ──────────────────────────────────────────
+// Enforced by `vue-tsc` during `yarn type-check`; no runtime effect here, as the
+// Vue vitest config has no `typecheck` block (so `expectTypeOf` is a runtime no-op).
+describe('Type tests', () => {
+    it('should expose anchor prop types with as="a"', () => {
+        expectTypeOf<VueCardProps<'a'>['href']>().toEqualTypeOf<string | undefined>();
+        expectTypeOf<VueCardProps<'a'>['target']>().toEqualTypeOf<string | undefined>();
+    });
+
+    it('should expose button prop types with as="button"', () => {
+        expectTypeOf<VueCardProps<'button'>['type']>().toEqualTypeOf<'button' | 'submit' | 'reset' | undefined>();
+    });
+
+    it('should keep its own props on every branch', () => {
+        expectTypeOf<VueCardProps<'a'>['elevation']>().toEqualTypeOf<VueCardProps['elevation']>();
+    });
+});

--- a/packages/lumx-vue/src/components/card/Card.tsx
+++ b/packages/lumx-vue/src/components/card/Card.tsx
@@ -1,0 +1,59 @@
+import { defineComponent, useAttrs, type NativeElements, type PublicProps } from 'vue';
+
+import {
+    Card as CardUI,
+    type CardProps as UIProps,
+    type DefaultCardTag,
+    COMPONENT_NAME,
+} from '@lumx/core/js/components/Card';
+import { type JSXElement } from '@lumx/core/js/types';
+
+import { useClassName } from '../../composables/useClassName';
+import { getName, keysOf, VueToJSXProps } from '../../utils/VueToJSX';
+
+/** Any intrinsic HTML/SVG tag name known to Vue's JSX. */
+type CardTag = keyof NativeElements;
+
+/** Public props: polymorphic on `as`, which also types the forwarded element attributes. */
+export type CardProps<E extends CardTag = DefaultCardTag> = Omit<NativeElements[E], 'class'> &
+    VueToJSXProps<UIProps, 'as'> & {
+        /** Customize the rendered root element (e.g. `div`, `article`, `section`, `li`, `aside`), defaults to `div`. */
+        as?: E;
+    };
+
+/** Props actually declared at runtime (non-polymorphic subset). */
+type CardOwnProps = VueToJSXProps<UIProps, 'as'> & { as?: CardTag };
+
+/**
+ * Card component.
+ *
+ * @param  props Component props.
+ * @return Vue element.
+ */
+const Card = defineComponent(
+    (props: CardOwnProps, { slots }) => {
+        const attrs = useAttrs();
+        const className = useClassName(() => props.class);
+
+        return () => (
+            <CardUI {...attrs} {...props} className={className.value} children={slots.default?.() as JSXElement} />
+        );
+    },
+    {
+        name: getName(COMPONENT_NAME),
+        inheritAttrs: false,
+        // Redefine properties so that they come in as `props` on the `defineComponent` function
+        props: keysOf<CardOwnProps>()('class', 'elevation', 'as'),
+    },
+);
+
+/**
+ * Vue's `defineComponent` setup-fn overload cannot carry an unbound generic from the setup
+ * signature to the resulting component constructor (it collapses as soon as a runtime `props`
+ * option is present), so the generic is layered on via cast
+ */
+interface CardConstructor {
+    new <E extends CardTag = DefaultCardTag>(props: CardProps<E> & PublicProps): { $props: CardProps<E> };
+}
+
+export default Card as unknown as CardConstructor & typeof Card;

--- a/packages/lumx-vue/src/components/card/index.ts
+++ b/packages/lumx-vue/src/components/card/index.ts
@@ -1,0 +1,2 @@
+export { default as Card } from './Card';
+export type { CardProps } from './Card';

--- a/packages/lumx-vue/src/index.ts
+++ b/packages/lumx-vue/src/index.ts
@@ -6,6 +6,7 @@ export * from './components/avatar';
 export * from './components/combobox';
 export * from './components/badge';
 export * from './components/button';
+export * from './components/card';
 export * from './components/checkbox';
 export * from './components/chip';
 export * from './components/dialog';

--- a/packages/site-demo/content/product/components/card/index.mdx
+++ b/packages/site-demo/content/product/components/card/index.mdx
@@ -1,0 +1,41 @@
+---
+title: Card
+frameworks: ['react', 'vue']
+---
+
+import * as ReactDemoDefault from './react/default.tsx';
+import * as ReactDemoElevation from './react/elevation.tsx';
+import * as VueDemoDefault from './vue/default.vue';
+import * as VueDemoElevation from './vue/elevation.vue';
+import ReactCard from 'lumx-docs:@lumx/react/components/card/Card';
+import VueCard from 'lumx-docs:@lumx/vue/components/card/Card';
+
+**Cards group related content into a single, contained surface.**
+
+<DemoBlock demo={{ react: ReactDemoDefault, vue: VueDemoDefault }} theme="dark" withThemeSwitcher />
+
+## Elevation
+
+Use the `elevation` property to raise a card above the surface, from `1` to `5`. Cards have no elevation
+by default. Higher elevations draw more attention, so reserve them for content that should stand out from
+the rest of the page.
+
+<DemoBlock demo={{ react: ReactDemoElevation, vue: VueDemoElevation }} withThemeSwitcher />
+
+### Accessibility concerns
+
+Cards are plain containers with no implicit semantic or ARIA role. A `<div>` conveys nothing to assistive
+technology, which is the right default for a purely visual grouping.
+
+When a card *is* meaningful on its own, give it the matching element through `as` rather than adding a role.
+Use `article` for content that stands alone, or `section` together with an accessible name (`aria-labelledby`
+pointing at a heading inside the card) for a thematic grouping — an unnamed `section` is ignored by most
+screen readers.
+
+Cards are not interactive. If the whole surface needs to be clickable, put a link or a button inside the
+card rather than making the card itself clickable, so that keyboard focus and screen reader semantics stay
+correct.
+
+## Properties
+
+<PropTable docs={{ react: ReactCard, vue: VueCard }} />

--- a/packages/site-demo/content/product/components/card/react/default.tsx
+++ b/packages/site-demo/content/product/components/card/react/default.tsx
@@ -1,0 +1,3 @@
+import { Card } from '@lumx/react';
+
+export default () => <Card>Card content</Card>;

--- a/packages/site-demo/content/product/components/card/react/elevation.tsx
+++ b/packages/site-demo/content/product/components/card/react/elevation.tsx
@@ -1,0 +1,13 @@
+import { Card, FlexBox, Text } from '@lumx/react';
+
+const ELEVATIONS = [1, 2, 3, 4, 5] as const;
+
+export default () => (
+    <FlexBox orientation="horizontal" gap="big" wrap>
+        {ELEVATIONS.map((elevation) => (
+            <Card key={elevation} elevation={elevation}>
+                <Text as="span">Elevation {elevation}</Text>
+            </Card>
+        ))}
+    </FlexBox>
+);

--- a/packages/site-demo/content/product/components/card/vue/default.vue
+++ b/packages/site-demo/content/product/components/card/vue/default.vue
@@ -1,0 +1,7 @@
+<template>
+    <Card>Card content</Card>
+</template>
+
+<script setup lang="ts">
+import { Card } from '@lumx/vue';
+</script>

--- a/packages/site-demo/content/product/components/card/vue/elevation.vue
+++ b/packages/site-demo/content/product/components/card/vue/elevation.vue
@@ -1,0 +1,13 @@
+<template>
+    <FlexBox orientation="horizontal" gap="big" :wrap="true">
+        <Card v-for="elevation in ELEVATIONS" :key="elevation" :elevation="elevation">
+            <Text as="span">Elevation {{ elevation }}</Text>
+        </Card>
+    </FlexBox>
+</template>
+
+<script setup lang="ts">
+import { Card, FlexBox, Text } from '@lumx/vue';
+
+const ELEVATIONS = [1, 2, 3, 4, 5] as const;
+</script>

--- a/packages/site-demo/src/components/content/PropTable/PropTable.tsx
+++ b/packages/site-demo/src/components/content/PropTable/PropTable.tsx
@@ -309,8 +309,12 @@ export const PropTable: React.FC<PropTableProps> = ({ docs }) => {
 
     const allProperties = discriminantProp ? [...filteredProperties, discriminantProp] : properties;
 
-    const [forwardedProps, others] = partition(allProperties, (prop) =>
-        prop.declarations?.some(({ fileName }) => fileName.match(/@types\/react/)),
+    const [forwardedProps, others] = partition(
+        allProperties,
+        (prop) =>
+            prop.declarations?.some(
+                ({ fileName }) => fileName.match(/@types\/react/) || fileName.match(/@vue\/runtime-dom/),
+            ) && !prop.declarations?.some(({ fileName }) => fileName.match(/lumx-(vue|react|core)/)),
     );
 
     return (


### PR DESCRIPTION
## Summary

- `@lumx/core`, `@lumx/react`, `@lumx/vue`: add a new `Card` component — a plain `<div>` with a non-customizable light background, customizable border-radius, and an optional `elevation` prop (1–5, defaults to none, box-shadow only).
- Moved `Elevation` type out of `Popover/types.ts` into the shared `@lumx/core/js/types` barrel so both `Popover` and `Card` can consume it; `Popover/types` re-exports it, so no breaking change for existing consumers.
- Card follows the `Divider` template (core-owned rendering, ref/class forwarding) and reuses the `Popover`/`Dropdown` elevation SCSS conventions (`lumx-elevation` box-shadow mixin).
- Added Storybook stories (`Default`, `Elevation`) and unit tests (shared core `Tests.ts` + React/Vue-specific suites) for the new component.

## Testing

- `yarn type-check` — passes across all packages.
- `yarn test:core -- Card`, `yarn test:react -- Card`, `yarn test:vue -- Card` — all pass.
- `yarn test -- Popover` — confirms the `Elevation` type relocation is behavior-preserving.

StoryBook lumx-vue: https://e567fbc08--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://e567fbc08--5fbfb1d508c0520021560f10.chromatic.com/