### PR TITLE
fix(clickaway): ignore mouse presses landing on a scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `@lumx/core`, `@lumx/react`, `@lumx/vue`:
+    -   Click away: keep popovers open when a mouse press lands on a scrollbar. Pressing the scrollbar of a scrolling ancestor, or of the page itself, no longer counts as a click away. This affects every component that closes on click away, such as `Dropdown`, `Select`, `Combobox`, `PopoverDialog` and `Lightbox`.
+
 ## [4.20.0][] - 2026-07-24
 
 ### Added

--- a/packages/lumx-core/src/js/utils/ClickAway/TestStories.tsx
+++ b/packages/lumx-core/src/js/utils/ClickAway/TestStories.tsx
@@ -49,11 +49,8 @@ export function setup({
     };
 
     /**
-     * This story showcases how click away behaves around a scrollable container: scrolling a panel
-     * is not a click away, whichever way you scroll it, while pressing content is.
-     *
-     * The scrollbar is forced to take layout space, so that the story still offers a gutter to press
-     * on a system that draws overlay scrollbars.
+     * This story showcases that scrolling a container is not a click away, however you scroll it.
+     * The scrollbar takes layout space on purpose: overlay scrollbars leave no gutter to press.
      */
     const ScrollableClickAway = {
         render: () => (

--- a/packages/lumx-core/src/js/utils/ClickAway/TestStories.tsx
+++ b/packages/lumx-core/src/js/utils/ClickAway/TestStories.tsx
@@ -49,6 +49,65 @@ export function setup({
     };
 
     /**
+     * This story showcases how click away behaves around a scrollable container: scrolling a panel
+     * is not a click away, whichever way you scroll it, while pressing content is.
+     *
+     * The scrollbar is forced to take layout space, so that the story still offers a gutter to press
+     * on a system that draws overlay scrollbars.
+     */
+    const ScrollableClickAway = {
+        render: () => (
+            <>
+                <style>{`
+                    [data-demo-scroller]::-webkit-scrollbar { width: 15px; height: 15px; }
+                    [data-demo-scroller]::-webkit-scrollbar-track { background: #eee; }
+                    [data-demo-scroller]::-webkit-scrollbar-thumb { background: #888; }
+                `}</style>
+                <p>
+                    Scrolling a panel is not a click away. Open a level, then scroll the panel below with the wheel, or
+                    by dragging its grey scrollbar. The level stays open either way.
+                </p>
+                <p>
+                    Pressing anything else closes the level: the panel content, and the thick borders of the two blocks
+                    on the right. Those two blocks overflow their box without ever rendering a scrollbar.
+                </p>
+                {/* Every length carries an explicit unit: Vue does not append `px` to a bare number. */}
+                <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start' }}>
+                    <section
+                        data-demo-scroller=""
+                        style={{
+                            height: '200px',
+                            width: '320px',
+                            overflowY: 'auto',
+                            border: '1px solid #ccc',
+                            padding: '8px',
+                        }}
+                    >
+                        <ButtonWithCard level={0} />
+                        {Array.from({ length: 30 }, (_, index) => (
+                            <p key={index}>panel line {index + 1}</p>
+                        ))}
+                    </section>
+                    <div style={{ width: '180px', border: '12px solid #999', padding: '8px' }}>
+                        Block with a 12px border and no overflow.
+                    </div>
+                    <div
+                        style={{
+                            width: '180px',
+                            border: '12px solid #999',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        Truncated text that overflows its box without ever showing a scrollbar
+                    </div>
+                </div>
+            </>
+        ),
+    };
+
+    /**
      * Test: clicking outside closes the level
      */
     const TestClickAwayCloses = {
@@ -95,5 +154,5 @@ export function setup({
         },
     };
 
-    return { meta, NestedClickAway, InShadowDOM, TestClickAwayCloses, TestNestedClickAway };
+    return { meta, NestedClickAway, InShadowDOM, ScrollableClickAway, TestClickAwayCloses, TestNestedClickAway };
 }

--- a/packages/lumx-core/src/js/utils/ClickAway/index.test.ts
+++ b/packages/lumx-core/src/js/utils/ClickAway/index.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { type Mock, vi } from 'vitest';
+
+import { setupClickAway } from './index';
+
+/** A 400x300 panel with a 1px border and a 15px vertical scrollbar, as measured in Chrome. */
+const SCROLLER_GEOMETRY = {
+    clientLeft: 1,
+    clientTop: 1,
+    clientWidth: 383,
+    clientHeight: 298,
+    scrollWidth: 383,
+    scrollHeight: 1012,
+};
+
+describe(setupClickAway.name, () => {
+    let teardown: (() => void) | undefined;
+    let callback: Mock<EventListener>;
+    let scroller: HTMLElement;
+    let popover: HTMLElement;
+
+    beforeEach(() => {
+        // jsdom runs no layout, so every geometry value the guard reads has to be stubbed.
+        scroller = document.createElement('section');
+        Object.entries(SCROLLER_GEOMETRY).forEach(([property, value]) =>
+            Object.defineProperty(scroller, property, { value, configurable: true }),
+        );
+        scroller.getBoundingClientRect = () => new DOMRect(16, 16, 400, 300);
+        // jsdom does not expand the `overflow` shorthand in `getComputedStyle`.
+        scroller.style.overflowX = 'auto';
+        scroller.style.overflowY = 'auto';
+
+        popover = document.createElement('div');
+        scroller.appendChild(popover);
+        document.body.appendChild(scroller);
+
+        callback = vi.fn<EventListener>();
+        teardown = setupClickAway(() => [popover], callback);
+    });
+
+    afterEach(() => {
+        teardown?.();
+        scroller.remove();
+    });
+
+    const press = (target: HTMLElement, clientX: number, clientY: number) =>
+        target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX, clientY }));
+
+    it('should call the callback on a press outside the elements', () => {
+        press(scroller, 216, 266);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call the callback on a press inside the elements', () => {
+        press(popover, 216, 266);
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should not call the callback on a press in the scrollbar gutter of an ancestor', () => {
+        press(scroller, 407, 266);
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should call the callback on a touch outside the elements', () => {
+        scroller.dispatchEvent(new Event('touchstart', { bubbles: true }));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/lumx-core/src/js/utils/ClickAway/index.ts
+++ b/packages/lumx-core/src/js/utils/ClickAway/index.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Falsy } from '@lumx/core/js/types';
+import { isScrollbarPress } from '@lumx/core/js/utils/ClickAway/isScrollbarPress';
 
 /** Event types that trigger click away detection. */
 export const CLICK_AWAY_EVENT_TYPES = ['mousedown', 'touchstart'] as const;
@@ -16,14 +17,20 @@ export const CLICK_AWAY_EVENT_TYPES = ['mousedown', 'touchstart'] as const;
 export type ClickAwayCallback = EventListener | Falsy;
 
 /**
- * Check if the click event targets are outside all the given elements.
+ * Check if a press event is a click away from all the given elements.
  *
+ * @param event - The press event.
  * @param targets - The event target elements (from `event.target` and `event.composedPath()`).
  * @param elements - The elements considered "inside" the click away context.
- * @returns `true` if the click is outside all elements (i.e. a click away).
+ * @returns `true` if the press is a click away.
  */
-export function isClickAway(targets: HTMLElement[], elements: HTMLElement[]): boolean {
-    return !elements.some((element) => element instanceof Node && targets.some((target) => element.contains(target)));
+export function isClickAway(event: Event, targets: HTMLElement[], elements: HTMLElement[]): boolean {
+    // Containment first: it costs no layout work and rules out most presses.
+    if (elements.some((element) => element instanceof Node && targets.some((target) => element.contains(target)))) {
+        return false;
+    }
+    // Pressing a scrollbar lands outside the click away context but is not a click away.
+    return !targets.some((target) => isScrollbarPress(event, target));
 }
 
 /**
@@ -49,7 +56,7 @@ export function setupClickAway(
     const listener: EventListener = (evt) => {
         const targets = [evt.composedPath?.()[0], evt.target].filter((t): t is HTMLElement => t instanceof Node);
         const elements = getElements();
-        if (isClickAway(targets, elements)) {
+        if (isClickAway(evt, targets, elements)) {
             callback(evt);
         }
     };

--- a/packages/lumx-core/src/js/utils/ClickAway/isScrollbarPress.test.ts
+++ b/packages/lumx-core/src/js/utils/ClickAway/isScrollbarPress.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { isScrollbarPress } from './isScrollbarPress';
+
+interface Geometry {
+    /** Border box position in viewport coordinates. */
+    left?: number;
+    top?: number;
+    /** Distance from the border edge to the padding edge, scrollbar included. */
+    clientLeft?: number;
+    clientTop?: number;
+    clientWidth: number;
+    clientHeight: number;
+    scrollWidth: number;
+    scrollHeight: number;
+    /** Border box size in layout pixels. Defaults to the client box. */
+    offsetWidth?: number;
+    offsetHeight?: number;
+    /** Scale a CSS transform applies to the border box on screen. */
+    scale?: number;
+    /** Computed `overflow`, which decides whether the overflow renders a scrollbar. */
+    overflow?: string;
+}
+
+/** jsdom runs no layout, so every geometry value the guard reads has to be stubbed. */
+function stubGeometry(
+    element: HTMLElement,
+    { left = 0, top = 0, clientLeft = 0, clientTop = 0, scale = 1, overflow = 'auto', ...geometry }: Geometry,
+) {
+    const box = {
+        offsetWidth: geometry.clientWidth,
+        offsetHeight: geometry.clientHeight,
+        ...geometry,
+    };
+    const rect = new DOMRect(left, top, box.offsetWidth * scale, box.offsetHeight * scale);
+    Object.entries({ clientLeft, clientTop, ...box, getBoundingClientRect: () => rect }).forEach(([property, value]) =>
+        Object.defineProperty(element, property, { value, configurable: true }),
+    );
+    // jsdom does not expand the `overflow` shorthand in `getComputedStyle`, so set both longhands.
+    element.setAttribute('style', `overflow-x: ${overflow}; overflow-y: ${overflow}`);
+    return element;
+}
+
+const stubElement = (geometry: Geometry) => stubGeometry(document.createElement('div'), geometry);
+
+const press = (clientX: number, clientY: number) => new MouseEvent('mousedown', { clientX, clientY });
+
+/** A 400x300 panel with a 1px border and a 15px vertical scrollbar, as measured in Chrome. */
+const VERTICAL_SCROLLER: Geometry = {
+    left: 16,
+    top: 16,
+    clientLeft: 1,
+    clientTop: 1,
+    clientWidth: 383,
+    clientHeight: 298,
+    offsetWidth: 400,
+    offsetHeight: 300,
+    scrollWidth: 383,
+    scrollHeight: 1012,
+};
+
+describe(isScrollbarPress.name, () => {
+    describe('vertical scrollbar', () => {
+        it('should detect a press in the right gutter', () => {
+            expect(isScrollbarPress(press(407, 266), stubElement(VERTICAL_SCROLLER))).toBe(true);
+        });
+
+        it('should ignore a press inside the client box', () => {
+            expect(isScrollbarPress(press(216, 266), stubElement(VERTICAL_SCROLLER))).toBe(false);
+        });
+
+        it('should ignore a press on the last pixel column of the client box', () => {
+            expect(isScrollbarPress(press(400, 266), stubElement(VERTICAL_SCROLLER))).toBe(false);
+        });
+
+        it('should detect a press in the left gutter of a right-to-left layout', () => {
+            // A left-hand scrollbar sits between the border edge and the padding edge, so `clientLeft`
+            // covers the 1px border plus the 15px scrollbar.
+            const element = stubElement({ ...VERTICAL_SCROLLER, left: 1184, clientLeft: 16 });
+            expect(isScrollbarPress(press(1192, 266), element)).toBe(true);
+        });
+    });
+
+    describe('horizontal scrollbar', () => {
+        /** A 400px wide panel with a 1px border and a 15px horizontal scrollbar. */
+        const HORIZONTAL_SCROLLER: Geometry = {
+            left: 16,
+            top: 16,
+            clientLeft: 1,
+            clientTop: 1,
+            clientWidth: 398,
+            clientHeight: 76,
+            scrollWidth: 1216,
+            scrollHeight: 76,
+        };
+
+        it('should detect a press in the bottom gutter', () => {
+            expect(isScrollbarPress(press(316, 100), stubElement(HORIZONTAL_SCROLLER))).toBe(true);
+        });
+
+        it('should ignore a press inside the client box', () => {
+            expect(isScrollbarPress(press(316, 60), stubElement(HORIZONTAL_SCROLLER))).toBe(false);
+        });
+
+        it('should ignore a press below an element that overflows only vertically', () => {
+            // A vertical scrollbar shows up on the X axis. Crossing the axes makes the guard useless.
+            expect(isScrollbarPress(press(216, 330), stubElement(VERTICAL_SCROLLER))).toBe(false);
+        });
+    });
+
+    describe('element without a scrollbar', () => {
+        /** A 200x120 block with a 12px border and no overflow. */
+        const NON_SCROLLER: Geometry = {
+            left: 720,
+            top: 16,
+            clientLeft: 12,
+            clientTop: 12,
+            clientWidth: 176,
+            clientHeight: 96,
+            scrollWidth: 176,
+            scrollHeight: 96,
+        };
+
+        it('should ignore a press on the border', () => {
+            expect(isScrollbarPress(press(909, 76), stubElement(NON_SCROLLER))).toBe(false);
+        });
+
+        it('should ignore a press below the border', () => {
+            expect(isScrollbarPress(press(800, 130), stubElement(NON_SCROLLER))).toBe(false);
+        });
+
+        it('should ignore a press on the border of a clipped element', () => {
+            // `overflow: hidden` reports content beyond the client box but renders nothing to press,
+            // and a bordered block of truncated text is a common shape.
+            const clipped = stubElement({ ...NON_SCROLLER, scrollHeight: 480, overflow: 'hidden' });
+            expect(isScrollbarPress(press(909, 76), clipped)).toBe(false);
+        });
+
+        it('should ignore a press on the border of an element with visible overflow', () => {
+            const visible = stubElement({ ...NON_SCROLLER, scrollHeight: 480, overflow: 'visible' });
+            expect(isScrollbarPress(press(909, 76), visible)).toBe(false);
+        });
+
+        it('should detect a press on the always-on scrollbar of a scroll element', () => {
+            const scroller = stubElement({ ...NON_SCROLLER, scrollHeight: 480, overflow: 'scroll' });
+            expect(isScrollbarPress(press(909, 76), scroller)).toBe(true);
+        });
+    });
+
+    describe('scaled ancestor', () => {
+        /** A 300x200 panel with a 1px border and a 15px scrollbar, under `scale(1.5)`. */
+        const SCALED_SCROLLER: Geometry = {
+            left: 16,
+            top: 16,
+            clientLeft: 1,
+            clientTop: 1,
+            clientWidth: 283,
+            clientHeight: 198,
+            offsetWidth: 300,
+            offsetHeight: 200,
+            scrollWidth: 283,
+            scrollHeight: 772,
+            scale: 1.5,
+        };
+
+        it('should detect a press in the gutter', () => {
+            expect(isScrollbarPress(press(453, 280), stubElement(SCALED_SCROLLER))).toBe(true);
+        });
+
+        it('should ignore a press in the padding, near the client box edge', () => {
+            // `getBoundingClientRect` is scaled while `clientWidth` is not, so an unscaled press
+            // reads as 419 against a client box of 283 and swallows a real dismissal.
+            expect(isScrollbarPress(press(436, 280), stubElement(SCALED_SCROLLER))).toBe(false);
+        });
+    });
+
+    describe('root element', () => {
+        /** A 1600x1000 viewport with a 15px root scrollbar, scrolled down by 1400px. */
+        const ROOT: Geometry = {
+            top: -1400,
+            clientWidth: 1585,
+            clientHeight: 985,
+            scrollWidth: 4056,
+            scrollHeight: 2612,
+            // The root hands its overflow to the viewport, which reports `visible` while scrolling.
+            overflow: 'visible',
+        };
+
+        it('should detect a press on the root scrollbar', () => {
+            expect(isScrollbarPress(press(1592, 400), stubGeometry(document.documentElement, ROOT))).toBe(true);
+        });
+
+        it('should ignore a press inside a scrolled root element', () => {
+            // The root element scrolls the viewport, so its border box moves out of view. Measuring
+            // against that box reads every press below the fold as a press in the bottom gutter.
+            expect(isScrollbarPress(press(20, 500), stubGeometry(document.documentElement, ROOT))).toBe(false);
+        });
+    });
+
+    describe('presses that carry no scrollbar geometry', () => {
+        it('should ignore a touch press', () => {
+            expect(isScrollbarPress(new Event('touchstart'), stubElement(VERTICAL_SCROLLER))).toBe(false);
+        });
+
+        it('should ignore a target that is not an element', () => {
+            expect(isScrollbarPress(press(407, 266), document)).toBe(false);
+        });
+
+        it('should ignore a null target', () => {
+            expect(isScrollbarPress(press(407, 266), null)).toBe(false);
+        });
+
+        it('should ignore a target with no client box', () => {
+            const detached = stubElement({ clientWidth: 0, clientHeight: 0, scrollWidth: 0, scrollHeight: 200 });
+            expect(isScrollbarPress(press(-5, 10), detached)).toBe(false);
+        });
+    });
+});

--- a/packages/lumx-core/src/js/utils/ClickAway/isScrollbarPress.ts
+++ b/packages/lumx-core/src/js/utils/ClickAway/isScrollbarPress.ts
@@ -1,0 +1,73 @@
+/** Border box of the root element: the viewport, at any document scroll position. */
+const VIEWPORT_BOX = { left: 0, top: 0, scaleX: 1, scaleY: 1 };
+
+/** Computed overflow values that render a scrollbar. `overlay` is legacy but still in the wild. */
+const SCROLLABLE_OVERFLOW = ['auto', 'scroll', 'overlay'];
+
+/**
+ * Border box of an element in viewport coordinates, with the scale its CSS transform applies.
+ *
+ * `getBoundingClientRect` is transformed while the `client*` metrics are not, so a press has to be
+ * scaled back into layout space before the two are compared.
+ */
+function getBorderBox(target: HTMLElement) {
+    const { left, top, width, height } = target.getBoundingClientRect();
+    const { offsetWidth, offsetHeight } = target;
+    return {
+        left,
+        top,
+        scaleX: offsetWidth ? width / offsetWidth : 1,
+        scaleY: offsetHeight ? height / offsetHeight : 1,
+    };
+}
+
+/** Check if an axis renders a scrollbar. `hidden`, `clip` and `visible` overflow without one. */
+function rendersScrollbar(overflow: string, isRoot: boolean): boolean {
+    // The root element hands its overflow to the viewport, where `visible` behaves as `auto`.
+    return SCROLLABLE_OVERFLOW.includes(overflow) || (isRoot && overflow === 'visible');
+}
+
+/**
+ * Check if a mouse press landed in the scrollbar gutter of the element it targets.
+ *
+ * A browser dispatches a `mousedown` on the scrolling element when you press its scrollbar, and that
+ * element is an ancestor of any popover it holds, so click away detection has to ignore the press.
+ *
+ * Touch is out of scope: a touch has no scrollbar to hit, and `TouchEvent` carries no coordinates.
+ *
+ * @param event - The press event.
+ * @param target - The element the press landed on.
+ * @returns `true` if the press landed on a scrollbar of `target`.
+ */
+export function isScrollbarPress(event: Event, target: EventTarget | null): boolean {
+    if (!(event instanceof MouseEvent) || !(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    const { clientLeft, clientTop, clientWidth, clientHeight, scrollWidth, scrollHeight } = target;
+    // A hidden or detached element has no client box, so it renders no scrollbar.
+    if (!clientWidth && !clientHeight) {
+        return false;
+    }
+
+    // The root element's border box moves with the scroll position, so measure against the viewport.
+    const isRoot = target === target.ownerDocument.documentElement;
+    const { left, top, scaleX, scaleY } = isRoot ? VIEWPORT_BOX : getBorderBox(target);
+    // `clientLeft` and `clientTop` cover a scrollbar placed before the padding edge, as in RTL.
+    const offsetX = (event.clientX - left) / scaleX - clientLeft;
+    const offsetY = (event.clientY - top) / scaleY - clientTop;
+
+    // A vertical scrollbar sits beside the client box, so it shows up on X. Horizontal mirrors it.
+    const beyondClientBoxX = offsetX < 0 || offsetX > clientWidth;
+    const beyondClientBoxY = offsetY < 0 || offsetY > clientHeight;
+    if (!beyondClientBoxX && !beyondClientBoxY) {
+        return false;
+    }
+
+    // The border sits outside the client box too, hence the overflow checks.
+    const { overflowX, overflowY } = getComputedStyle(target);
+    return (
+        (beyondClientBoxX && scrollHeight > clientHeight && rendersScrollbar(overflowY, isRoot)) ||
+        (beyondClientBoxY && scrollWidth > clientWidth && rendersScrollbar(overflowX, isRoot))
+    );
+}

--- a/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.stories.tsx
+++ b/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.stories.tsx
@@ -47,5 +47,6 @@ export default {
 
 export const NestedClickAway = { ...stories.NestedClickAway };
 export const InShadowDOM = { ...stories.InShadowDOM };
+export const ScrollableClickAway = { ...stories.ScrollableClickAway };
 export const TestClickAwayCloses = { ...stories.TestClickAwayCloses };
 export const TestNestedClickAway = { ...stories.TestNestedClickAway };

--- a/packages/lumx-vue/src/utils/ClickAway/ClickAwayProvider.stories.tsx
+++ b/packages/lumx-vue/src/utils/ClickAway/ClickAwayProvider.stories.tsx
@@ -62,5 +62,6 @@ export default {
 
 export const NestedClickAway = { ...stories.NestedClickAway };
 export const InShadowDOM = { ...stories.InShadowDOM };
+export const ScrollableClickAway = { ...stories.ScrollableClickAway };
 export const TestClickAwayCloses = { ...stories.TestClickAwayCloses };
 export const TestNestedClickAway = { ...stories.TestNestedClickAway };


### PR DESCRIPTION
# General summary

A press on a scrollbar closes any open popover.

Click away detection asked a single question: does any registered element contain the event target. A
browser dispatches a real `mousedown` on the scrolling element when you press its scrollbar, and a
scrolling element is an ancestor of the popover it holds. An ancestor is never contained by its own
descendant, so the press counted as a click away and the popover closed. Wheel and trackpad
scrolling dispatch no `mousedown`, which is why they never showed the problem.

`isClickAway` now also asks where on the target the press landed. A press that lands in the target's
own scrollbar gutter is not a click away. The check lives in `@lumx/core`, so one change covers
`@lumx/react`, `@lumx/vue`, and every component built on them.

# See it

## Before the fix

-   React: https://f0c5197d6--5fbfb1d508c0520021560f10.chromatic.com/iframe.html?id=utils-clickaway-clickawayprovider--scrollable-click-away&viewMode=story
-   Vue: https://f0c5197d6--697a023f84e832e23544fb3c.chromatic.com/iframe.html?id=utils-clickaway-clickawayprovider--scrollable-click-away&viewMode=story

This build carries the story and none of the fix, so it shows the old behaviour.

To reproduce, click **Open level 1** inside the scrolling panel, then press and hold the grey
scrollbar on the panel's right edge.

Observe two things. The card disappears the moment the mouse button goes down, before you move the
mouse at all. The panel scrolls behind it, so the press did reach the scrollbar and did its job. Now
reopen the card and scroll the same panel with a wheel or a trackpad: the card stays open. That
contrast between the two ways of scrolling the same panel is the bug.

## What it breaks in lumapps-web

Open the page writer, then open the content settings panel. That panel has a fixed height and its own
scrollbar, and it holds a column of fields.

Open any dropdown in it, then reach for the panel's scrollbar to bring a field further down into
view. The dropdown closes before you have scrolled anywhere. Users lose the selection they were about
to make, and the only way to scroll while a dropdown is open is a wheel or a trackpad, which is not
discoverable. The bug reads as "dropdowns disappear during scroll".

Measured in the app under trusted input:

| measurement | value |
| --- | --- |
| `event.target` | the scrolling panel itself, not the dropdown or its anchor |
| `offsetX` against `clientWidth` | 393 against 385, so inside the 15px gutter |
| `scrollTop` when the dismissal fires | 0 |
| press on the track below the thumb | panel scrolls 0 to 195 **and** the dropdown closes |

The dropdown needs no relationship to the panel. A popover anchored elsewhere on the page closed too,
so this is not a nesting problem. The date picker closes the same way through a different popover
path, which is what rules out a fix in any single component.

## After the fix

-   React: https://495ba0e46--5fbfb1d508c0520021560f10.chromatic.com/iframe.html?id=utils-clickaway-clickawayprovider--scrollable-click-away&viewMode=story
-   Vue: https://495ba0e46--697a023f84e832e23544fb3c.chromatic.com/iframe.html?id=utils-clickaway-clickawayprovider--scrollable-click-away&viewMode=story

Same story, same presses. The card now stays open while you drag the scrollbar, and the panel still
scrolls. Pressing the panel content still closes the card.

# How to verify

Story: **utils / clickaway / ClickAwayProvider → Scrollable click away**.

Click **Open level 1** inside the panel, then:

| press | expected |
| --- | --- |
| scrollbar thumb, and drag it | stays open, panel scrolls |
| scrollbar track below the thumb | stays open, panel jumps down |
| wheel or trackpad over the panel | stays open |
| any line of panel content | closes |
| thick border of the middle block | closes |
| thick border of the truncated text block | closes |

The last two rows are the interesting controls. Both blocks overflow their box without ever rendering
a scrollbar, which is the case that made an earlier version of this guard swallow legitimate
dismissals.

The story forces the scrollbar to 15px with a `::-webkit-scrollbar` rule. Without it, a machine that
draws overlay scrollbars leaves no gutter to press and the story shows nothing. The same trap applies
to automated tests: a headless run without that rule passes on a broken build.

# Implementation notes

The new `isScrollbarPress` guard is geometric, never platform-based, and never calls
`preventDefault`, so dragging a scrollbar keeps working. Three conditions have to hold together:

-   the press lands outside the target's client box, measured with `clientLeft` and `clientTop` so a
    right-to-left layout with a left-hand scrollbar falls into the negative branches;
-   the axis overflows **and** its computed `overflow` actually renders a scrollbar, which excludes
    `hidden`, `clip`, and `visible`, so a bordered block of truncated text still dismisses;
-   coordinates are scaled back into layout space, because `getBoundingClientRect` is transformed
    while `clientWidth` is not.

The root element is measured against the viewport rather than against its own border box, which moves
with the scroll position. `visible` counts as scrollable there, because the root hands its overflow to
the viewport and still owns the window scrollbar.

`touchstart` is deliberately out of scope. A touch has no scrollbar to hit, and `TouchEvent` carries
no coordinates on the event itself, so the guard returns early for anything that is not a
`MouseEvent`.

Known limit: on an element that genuinely scrolls, its own border pixels beyond the client box read
as scrollbar. A 1px border has zero exposure, because the comparison is strict. The dead zone is
`borderWidth - 1` pixels, so only a chunky border on a scrollable container is affected.

Tests cover the geometry directly, since jsdom has no layout and every metric has to be stubbed: both
gutters, both axes, right-to-left, a scaled ancestor, the root element scrolled out of view, clipped
and visible overflow, a non-element target, and a target with no client box. The listener's decision
is covered through `setupClickAway`.

<!-- These two lines are rewritten by CI on every deploy and always point at the latest commit. -->

StoryBook lumx-react: https://495ba0e46--5fbfb1d508c0520021560f10.chromatic.com/
StoryBook lumx-vue: https://495ba0e46--697a023f84e832e23544fb3c.chromatic.com/

# Check list

-   [ ] Add `need: review-frontend` label
-   [ ] Add `need: test` label

