### PR TITLE
fix(clickaway): detect click away on click instead of mousedown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   Popover, Dialog & Lightbox: detect a click away on `click` instead of `mousedown`. Should fix click away incorrectly activaing when clicking scrollbars.
+
 ## [4.21.0][] - 2026-08-25
 
 ### Fixed
@@ -142,7 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/vue`:
     -   Create the `SelectButton` component
-       `InputLabel`: Added prop `as` to specify the HTML element to use for rendering
+        `InputLabel`: Added prop `as` to specify the HTML element to use for rendering
 -   `@lumx/react`:
     -   Create the `TimePickerField` component
     -   `InputLabel`: Added prop `as` to specify the HTML element to use for rendering
@@ -225,13 +230,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   Moved `Lightbox` from `@lumx/react`
     -   `setupRovingTabIndex`: add MutationObserver-based tabindex normalization (mount, removal recovery, insertion, disabled-state, selection)
     -   `Combobox`: replace `autoFilter` boolean with `filter` prop (`'auto'` | `'manual'` | `'off'`) and add `openOnFocus` prop
--  `@lumx/react`:
-    -  `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
+-   `@lumx/react`:
+    -   `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
     -   `Combobox.Input`: replace `autoFilter` with `filter` and `openOnFocus` props
     -   `SelectionChipGroup`: simplify chip labeling; remove unused `inputLabel` and `scope` props
     -   `SelectionChipGroup`: implement ARIA listbox pattern
--  `@lumx/vue`:
-    -  `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
+-   `@lumx/vue`:
+    -   `TextField`: improve clear button a11y linking it to the input label via `aria-describedby`
     -   `Combobox.Input`: replace `autoFilter` with `filter` and `openOnFocus` props
     -   Create the `SelectionChipGroup` component
 

--- a/packages/lumx-core/src/js/utils/ClickAway/TestStories.tsx
+++ b/packages/lumx-core/src/js/utils/ClickAway/TestStories.tsx
@@ -49,6 +49,43 @@ export function setup({
     };
 
     /**
+     * This story showcases that scrolling a container is not a click away, however you scroll it.
+     * The scrollbar takes layout space on purpose: overlay scrollbars leave no gutter to press.
+     */
+    const ScrollableClickAway = {
+        render: () => (
+            <>
+                <style>{`
+                    [data-demo-scroller]::-webkit-scrollbar { width: 15px; height: 15px; }
+                    [data-demo-scroller]::-webkit-scrollbar-track { background: #eee; }
+                    [data-demo-scroller]::-webkit-scrollbar-thumb { background: #888; }
+                `}</style>
+                <p>
+                    Scrolling a panel is not a click away. Open a level, then scroll the panel below with the wheel, or
+                    by dragging its grey scrollbar. The level stays open either way.
+                </p>
+                <p>Clicking the panel content closes the level.</p>
+                {/* Every length carries an explicit unit: Vue does not append `px` to a bare number. */}
+                <section
+                    data-demo-scroller=""
+                    style={{
+                        height: '200px',
+                        width: '320px',
+                        overflowY: 'auto',
+                        border: '1px solid #ccc',
+                        padding: '8px',
+                    }}
+                >
+                    <ButtonWithCard level={0} />
+                    {Array.from({ length: 30 }, (_, index) => (
+                        <p key={index}>panel line {index + 1}</p>
+                    ))}
+                </section>
+            </>
+        ),
+    };
+
+    /**
      * Test: clicking outside closes the level
      */
     const TestClickAwayCloses = {
@@ -95,5 +132,5 @@ export function setup({
         },
     };
 
-    return { meta, NestedClickAway, InShadowDOM, TestClickAwayCloses, TestNestedClickAway };
+    return { meta, NestedClickAway, InShadowDOM, ScrollableClickAway, TestClickAwayCloses, TestNestedClickAway };
 }

--- a/packages/lumx-core/src/js/utils/ClickAway/index.test.ts
+++ b/packages/lumx-core/src/js/utils/ClickAway/index.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { type Mock, vi } from 'vitest';
+
+import { setupClickAway } from './index';
+
+describe(setupClickAway.name, () => {
+    let teardown: (() => void) | undefined;
+    let callback: Mock<EventListener>;
+    let outside: HTMLElement;
+    let popover: HTMLElement;
+
+    beforeEach(() => {
+        outside = document.createElement('section');
+        popover = document.createElement('div');
+        document.body.append(outside, popover);
+
+        callback = vi.fn<EventListener>();
+        teardown = setupClickAway(() => [popover], callback);
+    });
+
+    afterEach(() => {
+        teardown?.();
+        outside.remove();
+        popover.remove();
+    });
+
+    it('should call the callback on a click outside the elements', () => {
+        outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call the callback on a click inside the elements', () => {
+        popover.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should call the callback on a click whose propagation is stopped', () => {
+        // The listener runs in the capture phase, so an app-level handler cannot prevent dismissal.
+        outside.addEventListener('click', (event) => event.stopPropagation());
+
+        outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call the callback on a touch outside the elements', () => {
+        outside.dispatchEvent(new Event('touchstart', { bubbles: true }));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop listening after teardown', () => {
+        teardown?.();
+
+        outside.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+});

--- a/packages/lumx-core/src/js/utils/ClickAway/index.ts
+++ b/packages/lumx-core/src/js/utils/ClickAway/index.ts
@@ -9,8 +9,17 @@
 
 import type { Falsy } from '@lumx/core/js/types';
 
-/** Event types that trigger click away detection. */
-export const CLICK_AWAY_EVENT_TYPES = ['mousedown', 'touchstart'] as const;
+/**
+ * Event types that trigger click away detection.
+ *
+ * `click` rather than `mousedown`: pressing a scrollbar dispatches a `mousedown` on the scrolling
+ * element, which is an ancestor of any popover it holds, but never dispatches a `click`. Scrolling
+ * therefore cannot be mistaken for a click away.
+ *
+ * `touchstart` is kept because iOS Safari does not dispatch `click` for taps on non-interactive
+ * elements, which would leave popovers open on tap away.
+ */
+export const CLICK_AWAY_EVENT_TYPES = ['click', 'touchstart'] as const;
 
 /** Callback triggered when a click away is detected. */
 export type ClickAwayCallback = EventListener | Falsy;
@@ -28,7 +37,7 @@ export function isClickAway(targets: HTMLElement[], elements: HTMLElement[]): bo
 
 /**
  * Imperative setup for click away detection.
- * Adds mousedown/touchstart listeners on `document` and calls the callback when a click
+ * Adds click/touchstart listeners on `document` and calls the callback when a click
  * occurs outside the elements returned by `getElements`.
  *
  * Note: when `getElements` returns an empty array, any click is considered a click away.
@@ -54,8 +63,9 @@ export function setupClickAway(
         }
     };
 
-    CLICK_AWAY_EVENT_TYPES.forEach((evtType) => document.addEventListener(evtType, listener));
+    // Capture phase: a `stopPropagation` on an app-level click handler must not prevent dismissal.
+    CLICK_AWAY_EVENT_TYPES.forEach((evtType) => document.addEventListener(evtType, listener, true));
     return () => {
-        CLICK_AWAY_EVENT_TYPES.forEach((evtType) => document.removeEventListener(evtType, listener));
+        CLICK_AWAY_EVENT_TYPES.forEach((evtType) => document.removeEventListener(evtType, listener, true));
     };
 }

--- a/packages/lumx-react/src/components/dialog/Dialog.test.tsx
+++ b/packages/lumx-react/src/components/dialog/Dialog.test.tsx
@@ -175,7 +175,6 @@ describe(`<${Dialog.displayName}>`, () => {
             // Click the overlay (which is outside the wrapper)
             // The overlay class is .lumx-dialog__overlay
             const overlay = document.querySelector(`.${CLASSNAME}__overlay`);
-            fireEvent.mouseDown(overlay!);
             fireEvent.click(overlay!);
             expect(onClose).toHaveBeenCalled();
         });
@@ -184,7 +183,6 @@ describe(`<${Dialog.displayName}>`, () => {
             const onClose = vi.fn();
             setup({ isOpen: true, onClose, children: <button type="submit">Inside</button> });
             const insideBtn = screen.getByRole('button', { name: 'Inside' });
-            fireEvent.mouseDown(insideBtn);
             fireEvent.click(insideBtn);
             expect(onClose).not.toHaveBeenCalled();
         });

--- a/packages/lumx-react/src/components/lightbox/Lightbox.test.tsx
+++ b/packages/lumx-react/src/components/lightbox/Lightbox.test.tsx
@@ -78,7 +78,7 @@ describe(`<${Lightbox.displayName}>`, () => {
             it('should trigger onClose on click away', () => {
                 const onClose = vi.fn();
                 setup({ onClose });
-                fireEvent.mouseDown(document.body);
+                fireEvent.click(document.body);
                 expect(onClose).toHaveBeenCalled();
             });
         });

--- a/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.stories.tsx
+++ b/packages/lumx-react/src/utils/ClickAwayProvider/ClickAwayProvider.stories.tsx
@@ -47,5 +47,6 @@ export default {
 
 export const NestedClickAway = { ...stories.NestedClickAway };
 export const InShadowDOM = { ...stories.InShadowDOM };
+export const ScrollableClickAway = { ...stories.ScrollableClickAway };
 export const TestClickAwayCloses = { ...stories.TestClickAwayCloses };
 export const TestNestedClickAway = { ...stories.TestNestedClickAway };

--- a/packages/lumx-vue/src/components/alert-dialog/AlertDialog.test.ts
+++ b/packages/lumx-vue/src/components/alert-dialog/AlertDialog.test.ts
@@ -37,7 +37,6 @@ describe('<AlertDialog />', () => {
                 props: { isOpen: true, confirmProps: { label: 'OK', onClick: vi.fn() } },
             });
             const overlay = document.querySelector('.lumx-dialog__overlay');
-            fireEvent.mouseDown(overlay!);
             fireEvent.click(overlay!);
             expect(emitted('close')).toBeTruthy();
         });

--- a/packages/lumx-vue/src/components/dialog/Dialog.test.tsx
+++ b/packages/lumx-vue/src/components/dialog/Dialog.test.tsx
@@ -144,7 +144,6 @@ describe('<Dialog />', () => {
             it('should emit close when clicking outside (overlay)', () => {
                 const { emitted } = render(Dialog, { props: { isOpen: true, disableBodyScroll: false } });
                 const overlay = document.querySelector(`.${CLASSNAME}__overlay`);
-                fireEvent.mouseDown(overlay!);
                 fireEvent.click(overlay!);
                 expect(emitted('close')).toBeTruthy();
             });
@@ -154,7 +153,6 @@ describe('<Dialog />', () => {
                     props: { isOpen: true, disableBodyScroll: false },
                 });
                 const content = document.querySelector(`.${CLASSNAME}__content`);
-                fireEvent.mouseDown(content!);
                 fireEvent.click(content!);
                 expect(emitted('close')).toBeFalsy();
             });

--- a/packages/lumx-vue/src/components/lightbox/Lightbox.test.tsx
+++ b/packages/lumx-vue/src/components/lightbox/Lightbox.test.tsx
@@ -64,7 +64,7 @@ describe('<Lightbox />', () => {
                 const { emitted } = render(Lightbox, {
                     props: { isOpen: true, parentElement: document.createElement('div') },
                 });
-                fireEvent.mouseDown(document.body);
+                fireEvent.click(document.body);
                 expect(emitted('close')).toBeTruthy();
             });
         });

--- a/packages/lumx-vue/src/utils/ClickAway/ClickAwayProvider.stories.tsx
+++ b/packages/lumx-vue/src/utils/ClickAway/ClickAwayProvider.stories.tsx
@@ -62,5 +62,6 @@ export default {
 
 export const NestedClickAway = { ...stories.NestedClickAway };
 export const InShadowDOM = { ...stories.InShadowDOM };
+export const ScrollableClickAway = { ...stories.ScrollableClickAway };
 export const TestClickAwayCloses = { ...stories.TestClickAwayCloses };
 export const TestNestedClickAway = { ...stories.TestNestedClickAway };


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Pressing the scrollbar of a scrolling element closed any open popover. The browser dispatches a real `mousedown` on the scrolling element, and that element is an ancestor of the popover it holds, so the press looked like a click away. Wheel and trackpad scrolling dispatch no `mousedown`, which is why they were unaffected.

-   `@lumx/core` click away: `CLICK_AWAY_EVENT_TYPES` listens for `click` instead of `mousedown`. A scrollbar press dispatches no `click`, so the case disappears without any geometry guard reconstructing the scrollbar gutter from client metrics, transforms and computed overflow.
-   The listener moves to the **capture phase**, so a `stopPropagation` on an app-level click handler cannot leave a popover open.
-   `touchstart` stays in the list: iOS Safari dispatches no `click` for taps on non-interactive elements, which would leave popovers open on tap away.
-   Affects every component closing on click away (`Dropdown`, `Select`, `Combobox`, `PopoverDialog`, `Lightbox`, …) in both React and Vue.
-   New scrollable click away story in `ClickAwayProvider.stories.tsx` (React + Vue) covering the scrolling panel case.

**Behaviour change to be aware of:** dismissal now happens on the click that _follows_ the press, not on the press itself — one gesture later. Nothing observable in the test suites, but it is a real timing shift for consumers.

# Testing

1.  Open the `ClickAwayProvider` scrollable story, open the popover, then press and drag the scrolling panel's scrollbar → the popover stays open.
2.  Click anywhere else outside the popover → it closes.
3.  Same checks on iOS Safari (tap away closes via `touchstart`).

# Non-regression testing

Anything that dismisses on click away: `Dropdown`, `Select`, `Combobox`, `PopoverDialog`, `Dialog`, `Lightbox`, and any app-level click handler that calls `stopPropagation`.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-storybook-react` or `need: deploy-storybook-vue` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook lumx-vue: https://e90acf947--697a023f84e832e23544fb3c.chromatic.com/

StoryBook lumx-react: https://e90acf947--5fbfb1d508c0520021560f10.chromatic.com/