### PR TITLE
feat(menu): make MenuPopover fitToAnchorWidth overridable, default to minWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `@lumx/react`, `@lumx/vue`:
+    -   `MenuButton`/`MenuPopover`: the menu popover now defaults to `fitToAnchorWidth="minWidth"` (was `false`), so the menu is at least as wide as its trigger. The prop can now be overridden via `MenuButton`'s `popoverProps` or directly on `MenuPopover`.
+
 ## [4.21.0][] - 2026-08-25
 
 ### Fixed

--- a/packages/lumx-core/src/js/components/Menu/MenuPopover.tsx
+++ b/packages/lumx-core/src/js/components/Menu/MenuPopover.tsx
@@ -1,12 +1,12 @@
 import type { HasClassName, JSXElement, LumxClassName } from '../../types';
-import type { Placement } from '../Popover/constants';
+import { FitAnchorWidth, type Placement } from '../Popover/constants';
 import { classNames } from '../../utils';
 import { PopoverProps } from '../Popover';
 
 /** MenuPopover props. */
 export interface MenuPopoverProps
     extends HasClassName,
-        Pick<PopoverProps, 'placement' | 'anchorRef' | 'isOpen' | 'handleClose'> {
+        Pick<PopoverProps, 'placement' | 'anchorRef' | 'isOpen' | 'handleClose' | 'fitToAnchorWidth'> {
     /** Popover content (a `Menu`). */
     children?: JSXElement;
 }
@@ -31,6 +31,7 @@ export const MenuPopover = (props: MenuPopoverProps, { Popover, FlexBox }: MenuP
         className,
         isOpen,
         placement = 'bottom-start' as Placement,
+        fitToAnchorWidth = FitAnchorWidth.MIN_WIDTH,
         anchorRef,
         handleClose,
         ...forwardedProps
@@ -49,7 +50,7 @@ export const MenuPopover = (props: MenuPopoverProps, { Popover, FlexBox }: MenuP
             focusAnchorOnClose
             withFocusTrap={false}
             closeMode="hide"
-            fitToAnchorWidth={false}
+            fitToAnchorWidth={fitToAnchorWidth}
             className={block([className])}
         >
             <FlexBox orientation="vertical" className={element('scroll')}>

--- a/packages/lumx-react/src/components/menu-button/MenuButton.tsx
+++ b/packages/lumx-react/src/components/menu-button/MenuButton.tsx
@@ -23,7 +23,7 @@ import { Link, type LinkProps } from '../link';
 /** Props that MenuButton explicitly declares. */
 type MenuButtonBase = ReactToJSX<UIProps, 'triggerProps' | 'variant'> & {
     children?: React.ReactNode;
-    popoverProps?: MenuPopoverProps;
+    popoverProps?: Omit<MenuPopoverProps, 'children'>;
     onOpen?: (isOpen: boolean) => void;
     label: string;
 };

--- a/packages/lumx-vue/src/components/menu-button/MenuPopover.tsx
+++ b/packages/lumx-vue/src/components/menu-button/MenuPopover.tsx
@@ -45,7 +45,7 @@ const MenuPopover = defineComponent(
     {
         name: getName(MENU_POPOVER_COMPONENT_NAME),
         inheritAttrs: false,
-        props: keysOf<MenuPopoverProps>()('placement', 'class'),
+        props: keysOf<MenuPopoverProps>()('placement', 'fitToAnchorWidth', 'class'),
     },
 );
 


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Make the menu popover width configurable and give it a sensible default.

-   `MenuPopover` (core): `fitToAnchorWidth` is now part of the props and forwarded to `Popover` instead of being hardcoded to `false` — it can be overridden via `MenuButton`'s `popoverProps` or directly on `MenuPopover`.
-   Default changed to `"minWidth"`, so a menu is now at least as wide as its trigger (previously it sized purely to its content).
-   `@lumx/vue`: added `fitToAnchorWidth` to `MenuPopover`'s declared props — Vue would otherwise drop it as a fallthrough attribute.
-   React needed no wrapper change: its props type is derived from the core `MenuPopoverProps`.
-   CHANGELOG entry added under `Unreleased > Changed`.

**Testing:** `yarn type-check`, `yarn test` and `yarn test:storybook -- MenuButton` all pass. Visual baselines may need a refresh since menus can now render wider.

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-storybook-react` or `need: deploy-storybook-vue` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook lumx-react: https://3e3255294--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://3e3255294--697a023f84e832e23544fb3c.chromatic.com/