### PR TITLE
fix(user-block): render fields wrapper as a <p> element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `@lumx/react`, `@lumx/vue`:
     -   `MenuButton`/`MenuPopover`: the menu popover now defaults to `fitToAnchorWidth="minWidth"` (was `false`), so the menu is at least as wide as its trigger. The prop can now be overridden via `MenuButton`'s `popoverProps` or directly on `MenuPopover`.
+    -   `UserBlock`: improve `fields` wrapper render with a more semantic `<p>` instead of `<div>`
 
 ## [4.21.0][] - 2026-08-25
 

--- a/packages/lumx-core/src/js/components/UserBlock/Tests.ts
+++ b/packages/lumx-core/src/js/components/UserBlock/Tests.ts
@@ -38,6 +38,11 @@ export default (renderOptions: SetupOptions<any>) => {
                 expect(screen.getByText('Field 1')).toBeInTheDocument();
                 expect(screen.getByText('Field 2')).toBeInTheDocument();
             });
+
+            it('should render fields as a <p> element', () => {
+                const { fields } = setup({ fields: ['Field 1', 'Field 2'] }, renderOptions);
+                expect(fields?.tagName).toBe('P');
+            });
         });
     });
 };

--- a/packages/lumx-core/src/js/components/UserBlock/index.tsx
+++ b/packages/lumx-core/src/js/components/UserBlock/index.tsx
@@ -222,13 +222,13 @@ export const UserBlock = (props: UserBlockProps) => {
     const shouldDisplayFields = componentSize !== Size.s && componentSize !== Size.xs;
 
     const fieldsBlock = fields && shouldDisplayFields && (
-        <div className={element('fields')}>
+        <p className={element('fields')}>
             {fields.map((field: string, idx: number) => (
                 <Text as="span" key={idx} className={element('field')}>
                     {field}
                 </Text>
             ))}
-        </div>
+        </p>
     );
 
     const eventHandlers = {


### PR DESCRIPTION
## Summary

- `UserBlock`: fields wrapper now renders as `<p class="lumx-user-block__fields">` instead of a generic `<div>`, for correct semantics (matches the existing `ListSection` title pattern).
- Per-field `<span class="lumx-user-block__field">` rendering is unchanged.
- No visual regression: the global base reset already zeroes `p` margin/padding, and the component SCSS sets no margins on `&__fields`.
- Added a core test asserting the fields wrapper tag name is `P`, covered automatically for both `@lumx/react` and `@lumx/vue` via the shared `Tests.ts` suite.

## Changes

- `packages/lumx-core/src/js/components/UserBlock/index.tsx`
- `packages/lumx-core/src/js/components/UserBlock/Tests.ts`

## Testing

- `yarn test:react -- UserBlock` — 18 passed
- `yarn test:vue -- UserBlock` — 23 passed
- `yarn type-check` — passed across all projects

CF-1782

StoryBook lumx-react: https://87cdce924--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://87cdce924--697a023f84e832e23544fb3c.chromatic.com/