### PR TITLE
fix(user-block): render fields wrapper as semantic <p>

### DIFF
--- a/packages/lumx-core/src/js/components/UserBlock/Tests.ts
+++ b/packages/lumx-core/src/js/components/UserBlock/Tests.ts
@@ -38,6 +38,11 @@ export default (renderOptions: SetupOptions<any>) => {
                 expect(screen.getByText('Field 1')).toBeInTheDocument();
                 expect(screen.getByText('Field 2')).toBeInTheDocument();
             });
+
+            it('should render fields wrapper as a `p` element', () => {
+                const { fields } = setup({ fields: ['Field 1', 'Field 2'] }, renderOptions);
+                expect(fields?.tagName).toBe('P');
+            });
         });
     });
 };

--- a/packages/lumx-core/src/js/components/UserBlock/index.tsx
+++ b/packages/lumx-core/src/js/components/UserBlock/index.tsx
@@ -23,6 +23,8 @@ export interface UserBlockProps extends HasClassName, HasTheme {
     /**
      * Additional fields to display below the user's name.
      * Typically used for role, department, or other user metadata.
+     * Rendered inside a `<p>`, so only phrasing content (plain strings) is valid here —
+     * use `additionalFields` for block-level content.
      */
     fields?: string[];
 
@@ -222,13 +224,13 @@ export const UserBlock = (props: UserBlockProps) => {
     const shouldDisplayFields = componentSize !== Size.s && componentSize !== Size.xs;
 
     const fieldsBlock = fields && shouldDisplayFields && (
-        <div className={element('fields')}>
+        <Text as="p" className={element('fields')}>
             {fields.map((field: string, idx: number) => (
                 <Text as="span" key={idx} className={element('field')}>
                     {field}
                 </Text>
             ))}
-        </div>
+        </Text>
     );
 
     const eventHandlers = {


### PR DESCRIPTION
## General summary

<!--- Provide a more detailed description of the feature you have developed / the issue you have fixed here. -->
- `UserBlock`: the `.lumx-user-block__fields` wrapper now renders as a `<p>` instead of a `<div>`, so it's valid to nest phrasing content (plain strings) inside — previously downstream consumers were pushing block-level content into an adjacent slot that gets merged into this wrapper, producing invalid DOM nesting (e.g. a `<p>` or `<Button>` landing inside what will now be another `<p>`).
- Per-field `<span>` rendering is unchanged; only the wrapping element changed.
- Added a JSDoc note on `UserBlockProps.fields` clarifying it only accepts phrasing content — block-level content should go through `additionalFields` (the safe sibling slot), documented as a companion change in `lumapps-web`.
- Added a unit test asserting the fields wrapper tag is `p`.

## Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->
No visual change expected — CSS targets the `.lumx-user-block__fields` class, and LumX resets `p { margin: 0 }`.

StoryBook lumx-react: https://fcace1cfc--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://fcace1cfc--697a023f84e832e23544fb3c.chromatic.com/