### PR TITLE
fix(vue): remove selection chip on close icon click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `MenuButton`/`MenuPopover`: the menu popover now defaults to `fitToAnchorWidth="minWidth"` (was `false`), so the menu is at least as wide as its trigger. The prop can now be overridden via `MenuButton`'s `popoverProps` or directly on `MenuPopover`.
     -   `UserBlock`: improve `fields` wrapper render with a more semantic `<p>` instead of `<div>`
 
+### Fixed
+
+-   `@lumx/vue`:
+    -   `SelectTextField`: fix removing the chip when clicking its close icon in multiple selection mode.
+
 ## [4.21.0][] - 2026-08-25
 
 ### Fixed

--- a/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
+++ b/packages/lumx-core/src/js/components/SelectTextField/Tests.tsx
@@ -957,6 +957,23 @@ export default function selectTextFieldTests({ components, renderWithState }: Se
             });
         });
 
+        it('should remove a chip by clicking its close icon', async () => {
+            renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[2]] }); // Apple, Banana
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(2);
+            });
+
+            // The close icon sits in the chip `after` element. A click there must also remove the chip.
+            const closeIcon = getChips()[0]!.querySelector<HTMLElement>('.lumx-chip__after')!;
+            expect(closeIcon).toBeTruthy();
+            await userEvent.click(closeIcon);
+
+            await waitFor(() => {
+                expect(getChips().length).toBe(1);
+            });
+        });
+
         it('should render pre-selected values as chips', async () => {
             renderWithState(multiTemplate, { value: [FRUITS[0], FRUITS[3], FRUITS[7]] }); // Apple, Blueberry, Orange
             const input = getInput();

--- a/packages/lumx-vue/src/components/chip/Chip.tsx
+++ b/packages/lumx-vue/src/components/chip/Chip.tsx
@@ -56,8 +56,13 @@ const Chip = defineComponent(
             emit('click', event);
         };
 
+        /*
+         * The core template always attaches this handler on the `after` element. Only stop
+         * propagation when a listener is registered, else a click on the `after` element never
+         * reaches a parent that uses event delegation (example: SelectionChipGroup).
+         */
         const handleAfterClick = (event: MouseEvent) => {
-            if (isAnyDisabled.value) {
+            if (isAnyDisabled.value || !hasAfterClick) {
                 return;
             }
 
@@ -65,8 +70,9 @@ const Chip = defineComponent(
             event?.stopPropagation();
         };
 
+        /* Same rule as `handleAfterClick` above, for the `before` element. */
         const handleBeforeClick = (event: MouseEvent) => {
-            if (isAnyDisabled.value) {
+            if (isAnyDisabled.value || !hasBeforeClick) {
                 return;
             }
 


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

A click on the close icon of a chip did not remove the chip in the Vue `SelectTextField` in multiple mode. The React version works.

-   `@lumx/vue` `Chip`: `handleAfterClick` and `handleBeforeClick` called `stopPropagation()` in every case. They now do this only when a listener is registered. The React `Chip` already behaves this way through `useStopPropagation`.
-   Cause: the core `Chip` template always binds these two handlers. `SelectionChipGroup` removes a chip through one delegated `click` listener on the group container. The close icon lives in the chip `after` element, so the click never reached the container.
-   `@lumx/core`: new shared `SelectTextField` test that clicks the chip close icon. React and Vue both run this suite. The test fails without the fix.
-   Manual testing is not required. The new test covers the bug.

**Non-regression:** the change touches the Vue `Chip` `before` and `after` click handling. A consumer that registers `@afterClick` or `@beforeClick` keeps the same behavior, because propagation still stops in that case. All unit tests pass (1442).

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-storybook-react` or `need: deploy-storybook-vue` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->


StoryBook lumx-react: https://a7749f228--5fbfb1d508c0520021560f10.chromatic.com/

StoryBook lumx-vue: https://a7749f228--697a023f84e832e23544fb3c.chromatic.com/