### PR TITLE
fix(image-lightbox): add aria-haspopup="dialog" to trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   `@lumx/react`:
+    -   `ImageLightbox`: `useImageLightbox`'s `getTriggerProps` now always includes `aria-haspopup="dialog"` to warn screen reader users that activating the trigger opens a modal dialog.
+
 ## [4.22.0][] - 2026-09-03
 
 ### Changed

--- a/packages/lumx-react/src/components/image-lightbox/useImageLightbox.test.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/useImageLightbox.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useImageLightbox } from './useImageLightbox';
+
+const TestComponent = () => {
+    const { getTriggerProps, imageLightboxProps } = useImageLightbox({
+        images: [{ image: 'https://example.com/image.png', alt: 'Image 1' }],
+    });
+    return (
+        <>
+            <button type="button" {...(getTriggerProps() as any)}>
+                Open
+            </button>
+            <div data-testid="is-open">{String(imageLightboxProps.isOpen)}</div>
+        </>
+    );
+};
+
+describe('useImageLightbox', () => {
+    it('should set aria-haspopup="dialog" on trigger props', () => {
+        render(<TestComponent />);
+        expect(screen.getByRole('button', { name: 'Open' })).toHaveAttribute('aria-haspopup', 'dialog');
+    });
+
+    it('should open the lightbox on trigger click', async () => {
+        render(<TestComponent />);
+        expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+
+        await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+        expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+    });
+});

--- a/packages/lumx-react/src/components/image-lightbox/useImageLightbox.tsx
+++ b/packages/lumx-react/src/components/image-lightbox/useImageLightbox.tsx
@@ -34,7 +34,11 @@ export function useImageLightbox<P extends Partial<ImageLightboxProps>>(
      * Generates trigger props
      * @param index Provide an index to choose which image to display when the image lightbox opens.
      * */
-    getTriggerProps: (options?: TriggerOptions) => { onClick: (ev?: React.MouseEvent) => void; ref: React.Ref<any> };
+    getTriggerProps: (options?: TriggerOptions) => {
+        onClick: (ev?: React.MouseEvent) => void;
+        ref: React.Ref<any>;
+        'aria-haspopup': 'dialog';
+    };
     /** Props to forward to the ImageLightbox */
     imageLightboxProps: ManagedProps & P;
 } {
@@ -134,6 +138,7 @@ export function useImageLightbox<P extends Partial<ImageLightboxProps>>(
             onClick(e?: React.MouseEvent) {
                 open(e?.target as HTMLElement, options);
             },
+            'aria-haspopup': 'dialog' as const,
         }));
     }, []);
 


### PR DESCRIPTION
## Summary

- `useImageLightbox`'s `getTriggerProps` now returns `'aria-haspopup': 'dialog'` alongside `ref`/`onClick`, so screen reader users are told the trigger opens a modal dialog before activating it.
- Static value, unconditional — every consumer spreading `getTriggerProps()` (Mosaic thumbnails, file list, image gallery widget, wrex image gallery, Storybook demos) picks it up automatically with no caller-side changes.
- Added `useImageLightbox.test.tsx` (no dedicated test file existed for this hook yet) covering the new attribute and a smoke test that the trigger still opens the lightbox.

## Testing

- `yarn test:react -- useImageLightbox.test.tsx` — 2 new tests pass
- `yarn test:react -- image-lightbox` — 16 tests pass (no regressions)
- `yarn type-check` — passes
- `yarn lint` — passes for changed files (pre-existing unrelated SCSS lint failures on master, untouched by this change)

A11Y-256

StoryBook lumx-react: https://a715ef127--5fbfb1d508c0520021560f10.chromatic.com/