### PR TITLE
chore(ci): pin commit-message-validator to 1.5.7 [CF-1795]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
               uses: actions/checkout@v6
 
             - name: 'Commit message validation'
-              uses: lumapps/commit-message-validator@master
+              uses: lumapps/commit-message-validator@1.5.7
               with:
                   no_jira: true
               env:


### PR DESCRIPTION
# General summary

<!-- Please describe the PR content -->

Pins the `Commit-message-validation` CI job to an immutable tag instead of the floating `@master` ref, so the job's behavior is reproducible and not silently affected by future pushes to `lumapps/commit-message-validator`'s `master` branch.

-   `uses: lumapps/commit-message-validator@master` → `uses: lumapps/commit-message-validator@1.5.7` in `.github/workflows/ci.yml`, `no_jira: true` left untouched
-   Tag `1.5.7` was verified to point at the same commit currently resolved by `@master`, so this is a no-op behavior change — only the resolution mechanism becomes immutable

# Screenshots

<!-- (If applicable) Please provide screenshots and/or gif demonstrating the modification visually -->

<!--
# Check list

Add/Remove/Update the following check list depending on your submission:

-   [ ] (if has style) Add `need: review-integration` label
-   [ ] (if has textual documentation) Add `need: review-doc` label
-   [ ] (if has code) Add `need: review` label
-   [ ] (if has react) Check through the [react dev check list]
-   [ ] (if fix or feature) Add `need: test` label
-   [ ] (if you need a storybook and/or visual diff) Add `need: deploy-storybook-react` or `need: deploy-storybook-vue` label

Check out the [contribution guide] for general guidelines for submissions to the design system.

[contribution guide]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md
[react dev check list]: https://github.com/lumapps/design-system/blob/master/CONTRIBUTING.md#react-developpment-check-list
-->
